### PR TITLE
feat(docs): add quick installer and shortcut setup to README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+    name: Build Linux Binaries
+    strategy:
+      matrix:
+        include:
+          # x86_64 builds
+          - target: x86_64-unknown-linux-gnu
+            features: ""
+            suffix: cpu
+            runner: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            features: "cuda"
+            suffix: cuda
+            runner: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            features: "cuda,cudnn"
+            suffix: cuda-cudnn
+            runner: ubuntu-latest
+
+          # aarch64 builds
+          - target: aarch64-unknown-linux-gnu
+            features: ""
+            suffix: cpu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            features: "cuda"
+            suffix: cuda
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            features: "cuda,cudnn"
+            suffix: cuda-cudnn
+            runner: ubuntu-latest
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libxkbcommon-x11-dev \
+            libegl1-mesa-dev \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libglib2.0-dev \
+            libgtk-4-dev \
+            libspeechd-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxss-dev \
+            libasound2-dev \
+            pkg-config
+
+      - name: Install cross-compilation tools for aarch64
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install CUDA (if needed)
+        if: contains(matrix.features, 'cuda')
+        uses: Jimver/cuda-toolkit@7263c89f6aa4f1c5247a0947b8e9f8eedfce66a5
+        with:
+          cuda: "12.4.0"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build daemon binary
+        run: |
+          if [ -z "${{ matrix.features }}" ]; then
+            cargo build --release --target ${{ matrix.target }} --bin super-stt
+          else
+            cargo build --release --target ${{ matrix.target }} --bin super-stt --features "${{ matrix.features }}"
+          fi
+
+      - name: Build app binary
+        run: |
+          cargo build --release --target ${{ matrix.target }} --bin super-stt-app
+
+      - name: Build applet binary
+        run: |
+          cargo build --release --target ${{ matrix.target }} --bin super-stt-cosmic-applet
+
+      - name: Create tarball
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/super-stt dist/
+          cp target/${{ matrix.target }}/release/super-stt-app dist/
+          cp target/${{ matrix.target }}/release/super-stt-cosmic-applet dist/
+
+          # Include systemd service files
+          mkdir -p dist/systemd
+          if [ -f super-stt/systemd/super-stt.service ]; then
+            cp super-stt/systemd/super-stt.service dist/systemd/
+          fi
+
+          # Create tarball with architecture and feature suffix
+          tar -czf super-stt-${{ matrix.target }}-${{ matrix.suffix }}.tar.gz -C dist .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: super-stt-${{ matrix.target }}-${{ matrix.suffix }}
+          path: super-stt-${{ matrix.target }}-${{ matrix.suffix }}.tar.gz
+
+  create-release:
+    name: Create Release
+    needs: build-linux
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/**/*.tar.gz
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,530 @@
+#!/bin/bash
+
+# Super STT Installation Script
+# This script downloads and installs the appropriate pre-built binaries
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Print functions
+print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Detect system architecture
+detect_arch() {
+    local arch=$(uname -m)
+    case "$arch" in
+        x86_64) echo "x86_64-unknown-linux-gnu" ;;
+        aarch64|arm64) echo "aarch64-unknown-linux-gnu" ;;
+        *) print_error "Unsupported architecture: $arch"; exit 1 ;;
+    esac
+}
+
+# Detect CUDA/cuDNN availability
+detect_cuda() {
+    if command -v nvidia-smi &> /dev/null; then
+        print_info "NVIDIA GPU detected" >&2
+        if nvidia-smi --version &> /dev/null && nvidia-smi | grep -q "CUDA Version"; then
+            CUDA_VERSION=$(nvidia-smi | grep "CUDA Version" | sed 's/.*CUDA Version: \([0-9.]*\).*/\1/')
+            print_info "CUDA runtime $CUDA_VERSION detected" >&2
+
+            CUDNN_FOUND=false
+            if [ -f /usr/local/cuda/include/cudnn.h ] || [ -f /usr/include/cudnn.h ] || \
+               [ -f /usr/local/include/cudnn.h ] || ldconfig -p 2>/dev/null | grep -q libcudnn || \
+               find /usr -name "libcudnn.so*" 2>/dev/null | grep -q .; then
+                CUDNN_FOUND=true
+            fi
+
+            if [ "$CUDNN_FOUND" = true ]; then
+                print_info "cuDNN found - using cuda-cudnn variant" >&2
+                echo "cuda-cudnn"
+            else
+                print_info "cuDNN not found - using cuda variant" >&2
+                echo "cuda"
+            fi
+        else
+            print_warn "NVIDIA GPU found but CUDA runtime not available - using CPU variant" >&2
+            echo "cpu"
+        fi
+    else
+        print_info "No NVIDIA GPU detected - using CPU variant" >&2
+        echo "cpu"
+    fi
+}
+
+# Setup stt group for secure daemon access
+setup_stt_group() {
+    if command -v groupadd &> /dev/null; then
+        if ! getent group stt > /dev/null 2>&1; then
+            print_info "Creating stt group..."
+            sudo groupadd stt || true
+        fi
+        print_info "Adding current user to stt group..."
+        sudo usermod -a -G stt "$(whoami)" || true
+    fi
+}
+
+# Install daemon and CLI components
+install_daemon() {
+    local temp_dir="$1"
+    local install_prefix="$2"
+
+    if [ ! -f "$temp_dir/super-stt" ]; then
+        print_error "super-stt binary not found"
+        return 1
+    fi
+
+    # Setup group and directories
+    setup_stt_group
+    mkdir -p "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/stt"
+    mkdir -p "$HOME/.local/share/stt/logs"
+    mkdir -p "$HOME/.config/systemd/user"
+
+    # Install daemon binary
+    print_info "Installing daemon and CLI..."
+    mkdir -p "$install_prefix/bin"
+
+    if [ -w "$install_prefix/bin" ]; then
+        install -m 755 "$temp_dir/super-stt" "$install_prefix/bin/"
+    else
+        sudo install -m 755 "$temp_dir/super-stt" "$install_prefix/bin/"
+    fi
+
+    # Create wrapper script for group switching
+    cat > "$temp_dir/stt" << EOF
+#!/bin/bash
+# Super STT Daemon Wrapper
+exec sg stt -c "$install_prefix/bin/super-stt \\$*"
+EOF
+
+    if [ -w "$install_prefix/bin" ]; then
+        install -m 755 "$temp_dir/stt" "$install_prefix/bin/"
+    else
+        sudo install -m 755 "$temp_dir/stt" "$install_prefix/bin/"
+    fi
+}
+
+# Install desktop app
+install_app() {
+    local temp_dir="$1"
+    local install_prefix="$2"
+
+    if [ ! -f "$temp_dir/super-stt-app" ]; then
+        print_warn "Desktop app binary not found - skipping"
+        return 0
+    fi
+
+    print_info "Installing desktop app..."
+    mkdir -p "$install_prefix/bin"
+
+    if [ -w "$install_prefix/bin" ]; then
+        install -m 755 "$temp_dir/super-stt-app" "$install_prefix/bin/"
+    else
+        sudo install -m 755 "$temp_dir/super-stt-app" "$install_prefix/bin/"
+    fi
+}
+
+# Install COSMIC applet
+install_applet() {
+    local temp_dir="$1"
+    local install_prefix="$2"
+
+    if [ ! -f "$temp_dir/super-stt-cosmic-applet" ]; then
+        print_warn "COSMIC applet binary not found - skipping"
+        return 0
+    fi
+
+    if ! command -v cosmic-panel &> /dev/null; then
+        print_warn "COSMIC panel not found - skipping applet installation"
+        return 0
+    fi
+
+    print_info "Installing COSMIC applet..."
+    mkdir -p "$install_prefix/bin"
+
+    if [ -w "$install_prefix/bin" ]; then
+        install -m 755 "$temp_dir/super-stt-cosmic-applet" "$install_prefix/bin/"
+    else
+        sudo install -m 755 "$temp_dir/super-stt-cosmic-applet" "$install_prefix/bin/"
+    fi
+}
+
+# Install systemd service
+install_service() {
+    local temp_dir="$1"
+
+    if ! command -v systemctl &> /dev/null; then
+        print_warn "Systemd not detected - skipping service installation"
+        return 0
+    fi
+
+    if [ ! -f "$temp_dir/systemd/super-stt.service" ]; then
+        print_warn "Service file not found - skipping"
+        return 0
+    fi
+
+    print_info "Installing systemd service..."
+    USER_SYSTEMD_DIR="$HOME/.config/systemd/user"
+    mkdir -p "$USER_SYSTEMD_DIR"
+    cp "$temp_dir/systemd/super-stt.service" "$USER_SYSTEMD_DIR/"
+    systemctl --user daemon-reload
+}
+
+# Update PATH if needed
+update_path() {
+    local bin_dir="$1"
+
+    if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
+        print_warn "Add $bin_dir to your PATH:"
+        print_warn "  export PATH=\"$bin_dir:\$PATH\""
+
+        # Try to add to shell config for user installations
+        if [[ "$bin_dir" == "$HOME"* ]]; then
+            SHELL_CONFIG=""
+            if [ -f "$HOME/.bashrc" ]; then
+                SHELL_CONFIG="$HOME/.bashrc"
+            elif [ -f "$HOME/.zshrc" ]; then
+                SHELL_CONFIG="$HOME/.zshrc"
+            fi
+
+            if [ -n "$SHELL_CONFIG" ]; then
+                if ! grep -q "$bin_dir" "$SHELL_CONFIG"; then
+                    echo "export PATH=\"$bin_dir:\$PATH\"" >> "$SHELL_CONFIG"
+                    print_info "Added PATH update to $SHELL_CONFIG"
+                fi
+            fi
+        fi
+    fi
+}
+
+# Configure COSMIC keyboard shortcut
+configure_cosmic_shortcut() {
+    local install_prefix="$1"
+
+    # Check if we're on COSMIC desktop
+    if ! command -v cosmic-panel &> /dev/null; then
+        return 0
+    fi
+
+    COSMIC_SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1"
+    COSMIC_SHORTCUTS_FILE="$COSMIC_SHORTCUTS_DIR/custom"
+
+    # Ask user if they want to add the shortcut
+    echo -n "Add COSMIC keyboard shortcut (Super+Space)? [Y/n]: "
+    read -r add_shortcut
+
+    if [[ "$add_shortcut" =~ ^[Nn]$ ]]; then
+        return 0
+    fi
+
+    # Create the shortcuts directory if it doesn't exist
+    mkdir -p "$COSMIC_SHORTCUTS_DIR"
+
+    # Use the full path to the stt wrapper for reliability
+    local stt_command="$install_prefix/bin/stt record --write"
+
+    # Check if shortcuts file exists and has content
+    if [ -f "$COSMIC_SHORTCUTS_FILE" ] && [ -s "$COSMIC_SHORTCUTS_FILE" ]; then
+        # File exists with content, check if our shortcut is already there
+        if grep -q "Super STT" "$COSMIC_SHORTCUTS_FILE"; then
+            return 0
+        fi
+
+        # Check if Super+Space is already used
+        if grep -q 'key: "space"' "$COSMIC_SHORTCUTS_FILE" && grep -A5 -B5 'key: "space"' "$COSMIC_SHORTCUTS_FILE" | grep -q 'Super'; then
+            return 0
+        fi
+
+        # Create a backup
+        cp "$COSMIC_SHORTCUTS_FILE" "$COSMIC_SHORTCUTS_FILE.backup"
+
+        # Create a temporary file with the new shortcut entry
+        local temp_file=$(mktemp)
+
+        # Check if the file is empty (just {}) and handle accordingly
+        if grep -q '^{}$' "$COSMIC_SHORTCUTS_FILE"; then
+            # File is empty, replace entirely
+            echo '{' > "$temp_file"
+        else
+            # File has content, remove the closing brace and add our shortcut
+            head -n -1 "$COSMIC_SHORTCUTS_FILE" > "$temp_file"
+        fi
+
+        cat >> "$temp_file" << EOFSHORTCUT
+    (
+        modifiers: [
+            Super,
+        ],
+        key: "space",
+        description: Some("Super STT"),
+    ): Spawn("$stt_command"),
+}
+EOFSHORTCUT
+
+        # Replace the original file
+        mv "$temp_file" "$COSMIC_SHORTCUTS_FILE"
+
+        # Verify the file is valid by checking it has proper structure
+        if ! grep -q '^{' "$COSMIC_SHORTCUTS_FILE" || ! grep -q '^}' "$COSMIC_SHORTCUTS_FILE"; then
+            mv "$COSMIC_SHORTCUTS_FILE.backup" "$COSMIC_SHORTCUTS_FILE"
+            return 1
+        fi
+
+        # Remove backup if successful
+        rm -f "$COSMIC_SHORTCUTS_FILE.backup"
+    else
+        # Create new shortcuts file with our shortcut
+
+        cat > "$COSMIC_SHORTCUTS_FILE" << EOF
+{
+    (
+        modifiers: [
+            Super,
+        ],
+        key: "space",
+        description: Some("Super STT"),
+    ): Spawn("$stt_command"),
+}
+EOF
+    fi
+
+}
+
+# Default values
+INSTALL_PREFIX="$HOME/.local"
+GITHUB_REPO="jorge-menjivar/super-stt"
+VERSION="latest"
+INSTALL_OPTION="all"
+
+# Parse arguments
+INTERACTIVE=true
+for arg in "$@"; do
+    case $arg in
+        --non-interactive)
+            INTERACTIVE=false
+            shift
+            ;;
+        --version=*)
+            VERSION="${arg#*=}"
+            shift
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+    esac
+done
+
+# Interactive menu function
+show_menu() {
+    clear
+    echo "============================================="
+    echo "         Super STT Installation Menu"
+    echo "============================================="
+    echo ""
+    echo "Detected system:"
+    echo "  Architecture: $ARCH"
+    echo "  Optimal variant: $VARIANT"
+    echo ""
+    echo "What would you like to install?"
+    echo ""
+    echo "1. All $([ ! command -v cosmic-panel &> /dev/null ] && echo "(skip COSMIC applet)" || echo "(includes COSMIC applet)") [DEFAULT]"
+    echo "2. Daemon + CLI only"
+    echo "3. Desktop App only"
+    echo "4. COSMIC Applet only $([ ! command -v cosmic-panel &> /dev/null ] && echo "(not available)")"
+    echo ""
+    echo "q. Quit"
+    echo ""
+    echo "============================================="
+}
+
+handle_menu() {
+    while true; do
+        show_menu
+        echo -n "Select option [1-4, q] (default: 1): "
+        read -r choice
+
+        # Default to option 1 if empty
+        if [ -z "$choice" ]; then
+            choice="1"
+        fi
+
+        case $choice in
+            1)
+                INSTALL_OPTION="all"
+                break
+                ;;
+            2)
+                INSTALL_OPTION="daemon"
+                break
+                ;;
+            3)
+                INSTALL_OPTION="app"
+                break
+                ;;
+            4)
+                if ! command -v cosmic-panel &> /dev/null; then
+                    print_warn "COSMIC panel not found - applet not available"
+                    sleep 1
+                else
+                    INSTALL_OPTION="applet"
+                    break
+                fi
+                ;;
+            q|Q)
+                print_info "Installation cancelled"
+                exit 0
+                ;;
+            *)
+                print_warn "Invalid option. Please try again."
+                sleep 1
+                ;;
+        esac
+    done
+}
+
+# Show interactive menu if in interactive mode
+if [ "$INTERACTIVE" = true ] && [ -t 0 ]; then
+    # Do minimal detection for menu display
+    ARCH=$(detect_arch)
+    VARIANT=$(detect_cuda)
+    handle_menu
+    clear
+fi
+
+# Check if we need sudo and prompt early for daemon installations
+if [ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]; then
+    print_info "Daemon installation requires sudo to create the stt group"
+    print_info "You will be prompted for your password..."
+    # Test sudo access early
+    if ! sudo -v; then
+        print_error "Sudo access required for daemon installation"
+        exit 1
+    fi
+fi
+
+# Detect what we need based on install option
+ARCH=$(detect_arch)
+print_info "Detected architecture: $ARCH"
+
+if [ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]; then
+    # Need optimal daemon variant
+    VARIANT=$(detect_cuda)
+    print_info "Using variant: $VARIANT"
+else
+    # For app/applet-only, just use CPU variant (app/applet are identical in all variants)
+    VARIANT="cpu"
+fi
+
+# Get the latest release version if not specified
+if [ "$VERSION" = "latest" ]; then
+    print_info "Fetching latest release version..."
+    VERSION=$(curl -s "https://api.github.com/repos/$GITHUB_REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+    if [ -z "$VERSION" ]; then
+        print_error "Failed to fetch latest version"
+        exit 1
+    fi
+fi
+
+print_info "Installing Super STT $VERSION"
+
+# Construct download URL
+TARBALL_NAME="super-stt-${ARCH}-${VARIANT}.tar.gz"
+DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/$TARBALL_NAME"
+
+print_info "Downloading from: $DOWNLOAD_URL"
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Download the tarball
+if ! curl -L -o "$TEMP_DIR/$TARBALL_NAME" "$DOWNLOAD_URL"; then
+    print_error "Failed to download $TARBALL_NAME"
+    exit 1
+fi
+
+# Extract the tarball
+print_info "Extracting binaries..."
+tar -xzf "$TEMP_DIR/$TARBALL_NAME" -C "$TEMP_DIR"
+
+# Install components based on selection
+case $INSTALL_OPTION in
+    "all")
+        # Install everything (skip applet if COSMIC not available)
+        install_daemon "$TEMP_DIR" "$INSTALL_PREFIX"
+        install_app "$TEMP_DIR" "$INSTALL_PREFIX"
+        if command -v cosmic-panel &> /dev/null; then
+            install_applet "$TEMP_DIR" "$INSTALL_PREFIX"
+        fi
+        install_service "$TEMP_DIR"
+        ;;
+    "daemon")
+        # Install daemon + CLI + service
+        install_daemon "$TEMP_DIR" "$INSTALL_PREFIX"
+        install_service "$TEMP_DIR"
+        ;;
+    "app")
+        # Install app only
+        install_app "$TEMP_DIR" "$INSTALL_PREFIX"
+        ;;
+    "applet")
+        # Install applet only
+        install_applet "$TEMP_DIR" "$INSTALL_PREFIX"
+        ;;
+esac
+
+# Add to PATH if installing to non-standard location
+if [ "$INSTALL_PREFIX" != "/usr/local" ] && [ "$INSTALL_PREFIX" != "/usr" ]; then
+    update_path "$INSTALL_PREFIX/bin"
+fi
+
+# Configure COSMIC shortcut if daemon was installed and in interactive mode
+if [ "$INTERACTIVE" = true ] && ([ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]); then
+    configure_cosmic_shortcut "$INSTALL_PREFIX"
+fi
+
+print_info ""
+print_info "Installation complete!"
+print_info ""
+print_info "Installed components:"
+
+case $INSTALL_OPTION in
+    "all")
+        print_info "  ✅ super-stt (daemon + CLI) [$VARIANT variant]"
+        print_info "  ✅ stt (convenience wrapper)"
+        [ -f "$INSTALL_PREFIX/bin/super-stt-app" ] && print_info "  ✅ super-stt-app (desktop app)"
+        [ -f "$INSTALL_PREFIX/bin/super-stt-cosmic-applet" ] && print_info "  ✅ super-stt-cosmic-applet (COSMIC applet)"
+        print_info "  ✅ systemd user service"
+        print_info ""
+        print_info "Remember to log out and back in, or run: newgrp stt"
+        print_info ""
+        print_info "Then run 'stt record --write' to get started"
+        ;;
+    "daemon")
+        print_info "  ✅ super-stt (daemon + CLI) [$VARIANT variant]"
+        print_info "  ✅ stt (convenience wrapper)"
+        print_info "  ✅ systemd user service"
+        print_info ""
+        print_info "Remember to log out and back in, or run: newgrp stt"
+        print_info ""
+        print_info "Then run 'stt record --write' to get started"
+        ;;
+    "app")
+        [ -f "$INSTALL_PREFIX/bin/super-stt-app" ] && print_info "  ✅ super-stt-app (desktop app)"
+        print_info ""
+        print_info "Desktop app installed. Note: You'll need the daemon to use Super STT functionality."
+        ;;
+    "applet")
+        [ -f "$INSTALL_PREFIX/bin/super-stt-cosmic-applet" ] && print_info "  ✅ super-stt-cosmic-applet (COSMIC applet)"
+        print_info ""
+        print_info "COSMIC applet installed. Note: You'll need the daemon to use Super STT functionality."
+        ;;
+esac

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ applet_icon_name := 'com.github.jorge-menjivar.super_stt_cosmic_applet.svg'
 # Installation paths
 home_dir := env_var('HOME')
 user_bin_dir := home_dir / '.local' / 'bin'
+user_prefix := home_dir / '.local'
 system_bin_dir := '/usr/local/bin'
 user_systemd_dir := home_dir / '.config' / 'systemd' / 'user'
 run_dir := env_var('XDG_RUNTIME_DIR') / 'stt'
@@ -97,7 +98,7 @@ run-app *args:
 # Run the daemon for testing purposes
 # Usage: just run-daemon [--model MODEL] [other args]
 run-daemon *args:
-    env RUST_BACKTRACE=full cargo run --bin {{daemon_name}} -v {{args}}
+    env RUST_BACKTRACE=full RUST_LOG=debug cargo run --bin {{daemon_name}} -v {{args}}
 
 # Run security audit to check for vulnerabilities
 audit:
@@ -337,42 +338,14 @@ install-daemon *args:
     mkdir -p {{log_dir}}
     mkdir -p {{user_systemd_dir}}
 
-    # Create user systemd service file
-    echo "Creating user systemd service file..."
-    cat > {{service_dst}} << 'EOF'
-    [Unit]
-    Description=Super STT Daemon - Speech-to-text service
-    Documentation=https://github.com/jorge-menjivar/super-stt
-    After=pipewire.service pulseaudio.service graphical-session.target
-    Requires=graphical-session.target
-
-    [Service]
-    Type=simple
-    ExecStartPre=/bin/sh -c 'while [ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; do sleep 0.1; done'
-    ExecStart={{wrapper_dst}} --socket {{run_dir}}/super-stt.sock
-    ExecReload=/bin/kill -HUP $MAINPID
-    Restart=always
-    RestartSec=5
-    TimeoutStartSec=60
-    TimeoutStopSec=10
-
-    # Environment
-    Environment=CUDA_PATH=/opt/cuda
-    Environment=LD_LIBRARY_PATH=/opt/cuda/lib64:/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu
-
-    # Output to user journal
-    StandardOutput=journal
-    StandardError=journal
-    SyslogIdentifier=stt-daemon
-
-    [Install]
-    WantedBy=default.target
-    EOF
+    # Copy the service file from the repo
+    echo "Installing user systemd service file..."
+    cp super-stt/systemd/super-stt.service {{service_dst}}
 
     # Add model parameter to ExecStart if specified
     if [[ -n "$model" ]]; then
         echo "Configuring daemon to use model: $model"
-        sed -i "s|--socket {{run_dir}}/super-stt.sock|--socket {{run_dir}}/super-stt.sock --model $model|" {{service_dst}}
+        sed -i "s|--socket %t/stt/super-stt.sock|--socket %t/stt/super-stt.sock --model $model|" {{service_dst}}
     fi
 
     # Create wrapper script for automatic group switching
@@ -383,6 +356,56 @@ install-daemon *args:
     echo '' >> {{wrapper_dst}}
     echo 'exec sg stt -c "{{daemon_dst}} $*"' >> {{wrapper_dst}}
     chmod +x {{wrapper_dst}}
+
+    # Setup COSMIC keyboard shortcut if available
+    # Setup COSMIC keyboard shortcut
+    if command -v cosmic-panel &> /dev/null; then
+        COSMIC_SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1"
+        COSMIC_SHORTCUTS_FILE="$COSMIC_SHORTCUTS_DIR/custom"
+        
+        echo -n "Add COSMIC keyboard shortcut (Super+Space)? [Y/n]: "
+        read -r add_shortcut
+        
+        if [[ ! "$add_shortcut" =~ ^[Nn]$ ]]; then
+            mkdir -p "$COSMIC_SHORTCUTS_DIR"
+            stt_command="{{user_bin_dir}}/stt record --write"
+            
+            if [ -f "$COSMIC_SHORTCUTS_FILE" ] && [ -s "$COSMIC_SHORTCUTS_FILE" ]; then
+                if ! grep -q "Super STT" "$COSMIC_SHORTCUTS_FILE"; then
+                    if ! (grep -q 'key: "space"' "$COSMIC_SHORTCUTS_FILE" && grep -A5 -B5 'key: "space"' "$COSMIC_SHORTCUTS_FILE" | grep -q 'Super'); then
+                        cp "$COSMIC_SHORTCUTS_FILE" "$COSMIC_SHORTCUTS_FILE.backup"
+                        temp_file=$(mktemp)
+                        if grep -q '^{}$' "$COSMIC_SHORTCUTS_FILE"; then
+                            echo '{' > "$temp_file"
+                        else
+                            head -n -1 "$COSMIC_SHORTCUTS_FILE" > "$temp_file"
+                        fi
+                        echo '    (' >> "$temp_file"
+                        echo '        modifiers: [' >> "$temp_file"
+                        echo '            Super,' >> "$temp_file"
+                        echo '        ],' >> "$temp_file"
+                        echo '        key: "space",' >> "$temp_file"
+                        echo '        description: Some("Super STT"),' >> "$temp_file"
+                        echo "    ): Spawn(\"$stt_command\")," >> "$temp_file"
+                        echo '}' >> "$temp_file"
+                        mv "$temp_file" "$COSMIC_SHORTCUTS_FILE"
+                        rm -f "$COSMIC_SHORTCUTS_FILE.backup"
+                        rm -f "$COSMIC_SHORTCUTS_FILE.backup"
+                    fi
+                fi
+            else
+                echo '{' > "$COSMIC_SHORTCUTS_FILE"
+                echo '    (' >> "$COSMIC_SHORTCUTS_FILE"
+                echo '        modifiers: [' >> "$COSMIC_SHORTCUTS_FILE"
+                echo '            Super,' >> "$COSMIC_SHORTCUTS_FILE"
+                echo '        ],' >> "$COSMIC_SHORTCUTS_FILE"
+                echo '        key: "space",' >> "$COSMIC_SHORTCUTS_FILE"
+                echo '        description: Some("Super STT"),' >> "$COSMIC_SHORTCUTS_FILE"
+                echo "    ): Spawn(\"$stt_command\")," >> "$COSMIC_SHORTCUTS_FILE"
+                echo '}' >> "$COSMIC_SHORTCUTS_FILE"
+            fi
+        fi
+    fi || true
 
     # Update PATH in user's shell config
     shell_config="$HOME/.bashrc"
@@ -396,8 +419,8 @@ install-daemon *args:
         echo "⚠️  Restart your shell or run: source $shell_config"
     fi
 
-    echo "✓ Super STT installed to {{app_dst}}"
-    echo "✓ Wrapper script created at {{wrapper_dst}}
+    echo "✓ Super STT installed to {{daemon_dst}}"
+    echo "✓ Wrapper script created at {{wrapper_dst}}"
     echo "✓ Convenience shortcut 'stt' created"
     echo ""
     echo "🚀 Ready to use!"
@@ -428,6 +451,101 @@ install *args:
         exit 1
     fi
 
+# Configure COSMIC keyboard shortcut for Super STT
+setup-cosmic-shortcut:
+    #!/usr/bin/env bash
+    # Check if we're on COSMIC desktop
+    if ! command -v cosmic-panel &> /dev/null; then
+        echo "COSMIC desktop not detected"
+        exit 0
+    fi
+    
+    COSMIC_SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1"
+    COSMIC_SHORTCUTS_FILE="$COSMIC_SHORTCUTS_DIR/custom"
+    
+    # Ask user if they want to add the shortcut
+    echo -n "Add keyboard shortcut (Super+Space) for Super STT? [Y/n]: "
+    read -r add_shortcut
+    
+    if [[ "$add_shortcut" =~ ^[Nn]$ ]]; then
+        exit 0
+    fi
+    
+    # Create the shortcuts directory if it doesn't exist
+    mkdir -p "$COSMIC_SHORTCUTS_DIR"
+    
+    # Use the full path to the stt wrapper for reliability
+    stt_command="{{user_bin_dir}}/stt record --write"
+    
+    # Check if shortcuts file exists and has content
+    if [ -f "$COSMIC_SHORTCUTS_FILE" ] && [ -s "$COSMIC_SHORTCUTS_FILE" ]; then
+        # File exists with content, check if our shortcut is already there
+        if grep -q "Super STT" "$COSMIC_SHORTCUTS_FILE"; then
+            exit 0
+        fi
+        
+        # Check if Super+Space is already used
+        if grep -q 'key: "space"' "$COSMIC_SHORTCUTS_FILE" && grep -A5 -B5 'key: "space"' "$COSMIC_SHORTCUTS_FILE" | grep -q 'Super'; then
+            echo "Super+Space already in use"
+            exit 0
+        fi
+        
+        # Create a backup
+        cp "$COSMIC_SHORTCUTS_FILE" "$COSMIC_SHORTCUTS_FILE.backup"
+        
+        # Create a temporary file with the new shortcut entry
+        temp_file=$(mktemp)
+        
+        # Check if the file is empty (just {}) and handle accordingly
+        if grep -q '^{}$' "$COSMIC_SHORTCUTS_FILE"; then
+            # File is empty, replace entirely
+            echo '{' > "$temp_file"
+            echo '    (' >> "$temp_file"
+            echo '        modifiers: [' >> "$temp_file"
+            echo '            Super,' >> "$temp_file"
+            echo '        ],' >> "$temp_file"
+            echo '        key: "space",' >> "$temp_file"
+            echo '        description: Some("Super STT"),' >> "$temp_file"
+            echo "    ): Spawn(\"$stt_command\")," >> "$temp_file"
+            echo '}' >> "$temp_file"
+        else
+            # File has content, remove the closing brace and add our shortcut
+            head -n -1 "$COSMIC_SHORTCUTS_FILE" > "$temp_file"
+            echo '    (' >> "$temp_file"
+            echo '        modifiers: [' >> "$temp_file"
+            echo '            Super,' >> "$temp_file"
+            echo '        ],' >> "$temp_file"
+            echo '        key: "space",' >> "$temp_file"
+            echo '        description: Some("Super STT"),' >> "$temp_file"
+            echo "    ): Spawn(\"$stt_command\")," >> "$temp_file"
+            echo '}' >> "$temp_file"
+        fi
+        
+        # Replace the original file
+        mv "$temp_file" "$COSMIC_SHORTCUTS_FILE"
+        
+        # Verify the file is valid by checking it has proper structure
+        if ! grep -q '^{' "$COSMIC_SHORTCUTS_FILE" || ! grep -q '^}' "$COSMIC_SHORTCUTS_FILE"; then
+            mv "$COSMIC_SHORTCUTS_FILE.backup" "$COSMIC_SHORTCUTS_FILE"
+            exit 1
+        fi
+        
+        # Remove backup if successful
+        rm -f "$COSMIC_SHORTCUTS_FILE.backup"
+    else
+        
+        echo '{' > "$COSMIC_SHORTCUTS_FILE"
+        echo '    (' >> "$COSMIC_SHORTCUTS_FILE"
+        echo '        modifiers: [' >> "$COSMIC_SHORTCUTS_FILE"
+        echo '            Super,' >> "$COSMIC_SHORTCUTS_FILE"
+        echo '        ],' >> "$COSMIC_SHORTCUTS_FILE"
+        echo '        key: "space",' >> "$COSMIC_SHORTCUTS_FILE"
+        echo '        description: Some("Super STT"),' >> "$COSMIC_SHORTCUTS_FILE"
+        echo "    ): Spawn(\"$stt_command\")," >> "$COSMIC_SHORTCUTS_FILE"
+        echo '}' >> "$COSMIC_SHORTCUTS_FILE"
+    fi
+    
+
 # Install everything (daemon, app, and COSMIC applet)
 # Usage: just install-all [--cuda|--cudnn] [--model MODEL]
 install-all *args:
@@ -444,6 +562,11 @@ install-all *args:
 
     echo ""
     echo "🎉 Complete Super STT installation finished!"
+    echo ""
+    echo "⚙️  Quick Setup Tips:"
+    echo "-- If you're on COSMIC, the daemon installer already offered to set up Super+Space shortcut"
+    echo "-- For other desktop environments, add a keyboard shortcut for: stt record --write"
+    echo "-- Recommended shortcuts: Super+Space, Ctrl+Alt+S, or F12"
 
 # Uninstall the app
 uninstall-app:

--- a/super-stt/systemd/super-stt.service
+++ b/super-stt/systemd/super-stt.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Super STT Daemon - Speech-to-text service
+Documentation=https://github.com/jorge-menjivar/super-stt
+After=pipewire.service pulseaudio.service graphical-session.target
+Requires=graphical-session.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sh -c 'while [ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; do sleep 0.1; done'
+ExecStart=%h/.local/bin/stt --socket %t/stt/super-stt.sock
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=5
+TimeoutStartSec=60
+TimeoutStopSec=10
+
+# Environment
+Environment=CUDA_PATH=/opt/cuda
+Environment=LD_LIBRARY_PATH=/opt/cuda/lib64:/usr/local/cuda/lib64:/usr/lib/x86_64-linux-gnu
+
+# Output to user journal
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=stt-daemon
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Add a recommended Quick Install section with automated installer
command and detailed menu of installable components. Document installer
aviour: architecture, installation path (~/.local/bin),
CUDA/cuDNN GPU detection, systemd user service setup, creation of
stt group, and directory/log/socket setup. 

Expand and centralize keyboard shortcut instructions: add COSMIC
automatic setup notes, commands to run when building from source
(just install-daemon / just setup-cosmic-shortcut), manual COSMIC
steps, and platform-specific examples for GNOME and KDE. Clarify the
default command used by shortcuts (stt record --write) and how conflicts
are detected.

Adjust "Building from Source" and usage snippets: include daemon
systemd start/enable/status commands and a note on viewing logs. Tweak
install suggestions in the quick-start to highlight daemon options
(CUDA/cuDNN) and where to run the cosmic shortcut helper. These changes
improve onboarding and make installation and shortcut setup clearer.