### PR TITLE
Remove audio settings from applet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6269,7 +6269,7 @@ dependencies = [
 
 [[package]]
 name = "super-stt-cosmic-applet"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "clap",
  "dirs",

--- a/super-stt-cosmic-applet/Cargo.toml
+++ b/super-stt-cosmic-applet/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
     name = "super-stt-cosmic-applet"
-    version = "0.1.0"
-    edition = "2021"
+    version.workspace = true
+    authors.workspace = true
+    edition.workspace = true
     description = "Super STT client application"
     repository = "https://github.com/jorge-menjivar/super-stt"
     license = "GPL-3.0-only"

--- a/super-stt-cosmic-applet/src/app/messages.rs
+++ b/super-stt-cosmic-applet/src/app/messages.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::{iced::window, widget::segmented_button::Entity};
-use super_stt_shared::theme::AudioTheme;
 
 use crate::models::{
     state::{IsOpen, RecordingState},
@@ -30,8 +29,6 @@ pub enum Message {
     OpenGitHub,
     LaunchApp,
     RevealerToggle(IsOpen),
-    SetAudioTheme(AudioTheme),
-    AudioThemesLoaded(Vec<AudioTheme>),
     SetVisualizationTheme(VisualizationTheme),
     SetAppletWidth(u32),
     SetShowIcon(bool),

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::models::theme::{VisualizationColorConfig, VisualizationTheme};
 use crate::VisualizationSide;
+use crate::models::theme::{VisualizationColorConfig, VisualizationTheme};
 use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use super_stt_shared::models::theme::AudioTheme;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppletConfig {
     pub visualization: VisualizationConfig,
-    pub audio: AudioConfig,
     pub ui: UiConfig,
 }
 
@@ -19,11 +16,6 @@ pub struct VisualizationConfig {
     pub theme: VisualizationTheme,
     pub side: VisualizationSide, // This will be fixed per binary but stored for completeness
     pub colors: VisualizationColorConfig,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AudioConfig {
-    pub theme: AudioTheme,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,9 +34,6 @@ impl Default for AppletConfig {
                 theme: VisualizationTheme::CenteredEqualizer,
                 side: VisualizationSide::Full,
                 colors: VisualizationColorConfig::default(),
-            },
-            audio: AudioConfig {
-                theme: AudioTheme::default(),
             },
             ui: UiConfig {
                 last_popup_state: "None".to_string(),
@@ -128,14 +117,6 @@ impl AppletConfig {
         self.visualization.theme = theme;
         if let Err(e) = self.save(variant) {
             error!("Failed to save config after visualization theme update: {e}");
-        }
-    }
-
-    /// Update audio theme and save to disk
-    pub fn update_audio_theme(&mut self, theme: AudioTheme, variant: &str) {
-        self.audio.theme = theme;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after audio theme update: {e}");
         }
     }
 

--- a/super-stt-cosmic-applet/src/daemon/client.rs
+++ b/super-stt-cosmic-applet/src/daemon/client.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::path::PathBuf;
 use std::sync::OnceLock;
-use super_stt_shared::theme::AudioTheme;
 
 // Generate a unique client ID for this applet instance
 static CLIENT_ID: OnceLock<String> = OnceLock::new();
@@ -16,15 +15,6 @@ pub async fn ping_daemon(socket_path: PathBuf) -> Result<String, String> {
     super_stt_shared::daemon::client::ping_daemon(socket_path, get_client_id()).await
 }
 
-/// Set and test audio theme - convenience function
-pub async fn set_and_test_audio_theme(
-    socket_path: PathBuf,
-    theme: String,
-) -> Result<String, String> {
-    super_stt_shared::daemon::client::set_and_test_audio_theme(socket_path, &theme, get_client_id())
-        .await
-}
-
 /// Get current daemon configuration
 pub async fn fetch_daemon_config(socket_path: PathBuf) -> Result<serde_json::Value, String> {
     super_stt_shared::daemon::client::fetch_daemon_config(socket_path, get_client_id()).await
@@ -35,30 +25,4 @@ pub async fn ping_daemon_with_status(
     socket_path: PathBuf,
 ) -> Result<super_stt_shared::daemon::client::PingResponse, String> {
     super_stt_shared::daemon::client::ping_daemon_with_status(socket_path, get_client_id()).await
-}
-
-/// Load available audio themes from daemon with fallback
-pub async fn load_audio_themes(socket_path: PathBuf) -> Vec<AudioTheme> {
-    // Try to get available themes from daemon
-    if let Ok(themes) = list_available_audio_themes(socket_path.clone()).await {
-        return themes;
-    }
-
-    // Fallback to all available themes if daemon is unavailable
-    AudioTheme::all_themes()
-}
-
-/// List available audio themes from daemon
-pub async fn list_available_audio_themes(socket_path: PathBuf) -> Result<Vec<AudioTheme>, String> {
-    let theme_strings =
-        super_stt_shared::daemon::client::list_available_audio_themes(socket_path, get_client_id())
-            .await?;
-
-    // Convert strings back to AudioTheme enum
-    let themes = theme_strings
-        .into_iter()
-        .filter_map(|theme_str| theme_str.parse::<AudioTheme>().ok())
-        .collect();
-
-    Ok(themes)
 }

--- a/super-stt-cosmic-applet/src/lib.rs
+++ b/super-stt-cosmic-applet/src/lib.rs
@@ -6,10 +6,11 @@ mod models;
 mod ui;
 
 use cosmic::{
-    app as cosmic_app,
+    Element, app as cosmic_app,
     iced::{
+        Alignment, Subscription,
         platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup},
-        window, Alignment, Subscription,
+        window,
     },
     iced_widget,
     theme::{self, Button},
@@ -17,7 +18,6 @@ use cosmic::{
         self, button, container, layer_container, mouse_area,
         segmented_button::{Entity, SingleSelectModel},
     },
-    Element,
 };
 
 use futures_util::SinkExt;
@@ -35,18 +35,18 @@ use crate::ui::components::sound_visualization::VisualizationComponent;
 use crate::{app::Message, models::state::IsOpen};
 use crate::{
     config::AppletConfig,
-    ui::views::{create_popup_content, PopupContentParams},
+    ui::views::{PopupContentParams, create_popup_content},
 };
 use crate::{
     daemon::{
-        client::load_audio_themes, fetch_daemon_config, ping_daemon, ping_daemon_with_status,
-        set_and_test_audio_theme, RetryStrategy, TokenBucketRateLimiter,
+        RetryStrategy, TokenBucketRateLimiter, fetch_daemon_config, ping_daemon,
+        ping_daemon_with_status,
     },
     models::theme::ThemeConfig,
 };
 use super_stt_shared::{
-    parse_audio_samples_from_udp, parse_frequency_bands_from_udp, parse_recording_state_from_udp,
-    theme::AudioTheme, UdpAuth,
+    UdpAuth, parse_audio_samples_from_udp, parse_frequency_bands_from_udp,
+    parse_recording_state_from_udp,
 };
 
 // Connection monitoring constants
@@ -100,7 +100,6 @@ pub struct SuperSttApplet {
     theme_selector_dark: Entity,
     selected_theme_for_config: bool, // false = light, true = dark
     retry_strategy: RetryStrategy,
-    available_audio_themes: Vec<AudioTheme>,
 }
 
 impl cosmic::Application for SuperSttApplet {
@@ -120,7 +119,6 @@ impl cosmic::Application for SuperSttApplet {
         // Create theme config from loaded configuration
         let theme_config = ThemeConfig {
             visualization_theme: config.visualization.theme.clone(),
-            audio_theme: config.audio.theme,
             visualization_color_config: config.visualization.colors.clone(),
         };
 
@@ -185,7 +183,6 @@ impl cosmic::Application for SuperSttApplet {
             theme_selector_dark,
             selected_theme_for_config,
             retry_strategy: RetryStrategy::for_initial_connection(),
-            available_audio_themes: Vec::new(), // Will be loaded when daemon connects
         };
 
         // Try to ping the daemon on startup
@@ -269,28 +266,20 @@ impl cosmic::Application for SuperSttApplet {
                     self.udp_restart_counter
                 );
 
-                // Fetch daemon configuration and load available themes in parallel
+                // Fetch daemon configuration
                 let socket_path = self.socket_path.clone();
-                let socket_path_themes = self.socket_path.clone();
 
-                return cosmic_app::Task::batch([
-                    cosmic_app::Task::perform(fetch_daemon_config(socket_path), |result| {
-                        match result {
-                            Ok(config) => {
-                                cosmic::Action::App(Message::DaemonConfigReceived(config))
-                            }
-                            Err(err) => {
-                                warn!("Failed to fetch daemon config: {err}");
-                                cosmic::Action::App(Message::DaemonError(format!(
-                                    "Failed to fetch config: {err}"
-                                )))
-                            }
+                return cosmic_app::Task::perform(fetch_daemon_config(socket_path), |result| {
+                    match result {
+                        Ok(config) => cosmic::Action::App(Message::DaemonConfigReceived(config)),
+                        Err(err) => {
+                            warn!("Failed to fetch daemon config: {err}");
+                            cosmic::Action::App(Message::DaemonError(format!(
+                                "Failed to fetch config: {err}"
+                            )))
                         }
-                    }),
-                    cosmic_app::Task::perform(load_audio_themes(socket_path_themes), |themes| {
-                        cosmic::Action::App(Message::AudioThemesLoaded(themes))
-                    }),
-                ]);
+                    }
+                });
             }
             Message::PingResponse {
                 message: _,
@@ -315,25 +304,8 @@ impl cosmic::Application for SuperSttApplet {
                     });
                 }
             }
-            Message::DaemonConfigReceived(config) => {
-                // Parse daemon configuration and sync theme settings
-                if let Some(audio_config) = config
-                    .get("audio")
-                    .and_then(|audio| audio.get("theme"))
-                    .and_then(|theme| theme.as_str())
-                {
-                    let daemon_audio_theme = audio_config.parse::<AudioTheme>().unwrap_or_default();
-                    info!("Received daemon config, syncing audio theme: {daemon_audio_theme:?}");
-
-                    // Update local theme config with daemon's audio theme
-                    self.theme_config.audio_theme = daemon_audio_theme;
-
-                    // Save the updated theme config
-                    self.config
-                        .update_audio_theme(daemon_audio_theme, &self.variant_name);
-                } else {
-                    warn!("No audio theme found in daemon configuration");
-                }
+            Message::DaemonConfigReceived(_config) => {
+                // Config received from daemon — audio settings are managed by the desktop app
             }
             Message::DaemonError(err) => {
                 warn!("Daemon error: {err}");
@@ -393,23 +365,6 @@ impl cosmic::Application for SuperSttApplet {
                 } else {
                     is_open_src
                 }
-            }
-            Message::SetAudioTheme(theme) => {
-                self.theme_config.audio_theme = theme;
-                // Update and save configuration
-                self.config.update_audio_theme(theme, &self.variant_name);
-                return cosmic_app::Task::perform(
-                    set_and_test_audio_theme(self.socket_path.clone(), theme.to_string()),
-                    |result| {
-                        cosmic::Action::App(match result {
-                            Ok(_) => Message::DaemonConnected,
-                            Err(e) => Message::DaemonError(e),
-                        })
-                    },
-                );
-            }
-            Message::AudioThemesLoaded(themes) => {
-                self.available_audio_themes = themes;
             }
             Message::AudioLevelUpdate { level, is_speech } => {
                 self.audio_level = level;
@@ -572,15 +527,13 @@ impl cosmic::Application for SuperSttApplet {
                 if let Ok(output) = std::process::Command::new("which")
                     .arg("super-stt-app")
                     .output()
+                    && output.status.success()
+                    && let Ok(path) = std::str::from_utf8(&output.stdout)
                 {
-                    if output.status.success() {
-                        if let Ok(path) = std::str::from_utf8(&output.stdout) {
-                            let path = path.trim();
-                            if std::process::Command::new(path).spawn().is_ok() {
-                                info!("Successfully launched Super STT app from PATH: {path}");
-                                launched = true;
-                            }
-                        }
+                    let path = path.trim();
+                    if std::process::Command::new(path).spawn().is_ok() {
+                        info!("Successfully launched Super STT app from PATH: {path}");
+                        launched = true;
                     }
                 }
 
@@ -760,7 +713,6 @@ impl cosmic::Application for SuperSttApplet {
             icon_alignment_model: &self.icon_alignment_model,
             theme_selector_model: &self.theme_selector_model,
             selected_theme_for_config: self.selected_theme_for_config,
-            available_audio_themes: &self.available_audio_themes,
         });
 
         self.core.applet.popup_container(content).into()

--- a/super-stt-cosmic-applet/src/main.rs
+++ b/super-stt-cosmic-applet/src/main.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use clap::{Arg, Command, ValueEnum};
-use super_stt_cosmic_applet::{VisualizationSide, VERSION};
+use super_stt_cosmic_applet::{VERSION, VisualizationSide};
 
 #[derive(ValueEnum, Clone, Debug)]
 enum Side {

--- a/super-stt-cosmic-applet/src/models/state.rs
+++ b/super-stt-cosmic-applet/src/models/state.rs
@@ -16,7 +16,6 @@ pub enum DaemonConnectionState {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum IsOpen {
     None,
-    AudioTheme,
     VisualizationTheme,
     VisualizationColors,
     AppletSettings,

--- a/super-stt-cosmic-applet/src/models/theme.rs
+++ b/super-stt-cosmic-applet/src/models/theme.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::iced::Color;
 use serde::{Deserialize, Serialize};
-use super_stt_shared::theme::AudioTheme;
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub enum VisualizationTheme {
     Pulse,
@@ -297,7 +295,6 @@ impl VisualizationColorConfig {
 
 #[derive(Debug, Clone, Default)]
 pub struct ThemeConfig {
-    pub audio_theme: AudioTheme,
     pub visualization_theme: VisualizationTheme,
     pub visualization_color_config: VisualizationColorConfig,
 }

--- a/super-stt-cosmic-applet/src/ui/components/color_buttons.rs
+++ b/super-stt-cosmic-applet/src/ui/components/color_buttons.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::{
-    iced::{widget::row, Alignment, Color, Length},
-    theme,
-    widget::{container, mouse_area, text, Space},
     Apply, Element,
+    iced::{Alignment, Color, Length, widget::row},
+    theme,
+    widget::{Space, container, mouse_area, text},
 };
 
 use crate::{app::Message, models::theme::VisualizationColor};

--- a/super-stt-cosmic-applet/src/ui/components/common.rs
+++ b/super-stt-cosmic-applet/src/ui/components/common.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::app::Message;
 use cosmic::{
+    Renderer, Theme,
     applet::menu_button,
     iced::{
-        widget::{self, column},
         Length,
+        widget::{self, column},
     },
     widget::text,
-    Renderer, Theme,
 };
 
 pub fn revealer_head(

--- a/super-stt-cosmic-applet/src/ui/components/sound_visualization.rs
+++ b/super-stt-cosmic-applet/src/ui/components/sound_visualization.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::{
+    Element, Renderer, Theme,
     iced::{
-        core::{mouse, Rectangle},
+        core::{Rectangle, mouse},
         widget::{
-            canvas::{Frame, Geometry, Program},
             Canvas,
+            canvas::{Frame, Geometry, Program},
         },
     },
-    Element, Renderer, Theme,
 };
 
 use crate::{

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/centered_bars.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/centered_bars.rs
@@ -2,12 +2,12 @@
 use crate::config::FREQUENCY_NORMALIZATION_MAX;
 use crate::models::theme::{VisualizationColorConfig, VisualizationSide};
 use crate::ui::components::visualizations::{VisualizationConfig, VisualizationRenderer};
-use cosmic::iced::{
-    core::Rectangle,
-    widget::canvas::{path, stroke, Fill, Frame},
-    Point,
-};
 use cosmic::iced::{Padding, Radius};
+use cosmic::iced::{
+    Point,
+    core::Rectangle,
+    widget::canvas::{Fill, Frame, path, stroke},
+};
 use super_stt_shared::FrequencyData;
 
 pub struct CenteredBarsVisualization {

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/equalizer.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/equalizer.rs
@@ -2,12 +2,12 @@
 use crate::config::FREQUENCY_NORMALIZATION_MAX;
 use crate::models::theme::{VisualizationColorConfig, VisualizationSide};
 use crate::ui::components::visualizations::{VisualizationConfig, VisualizationRenderer};
-use cosmic::iced::{
-    core::Rectangle,
-    widget::canvas::{path, stroke, Fill, Frame},
-    Point,
-};
 use cosmic::iced::{Padding, Radius};
+use cosmic::iced::{
+    Point,
+    core::Rectangle,
+    widget::canvas::{Fill, Frame, path, stroke},
+};
 use super_stt_shared::FrequencyData;
 
 /// Bars that are aligned to the bottom of the screen.

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/mod.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/mod.rs
@@ -10,8 +10,8 @@ pub use pulse::PulseVisualization;
 pub use waveform::WaveformVisualization;
 
 use cosmic::{
-    iced::{border, core::Rectangle, widget::canvas::Frame, Padding},
     Renderer,
+    iced::{Padding, border, core::Rectangle, widget::canvas::Frame},
 };
 
 use crate::models::theme::{VisualizationColorConfig, VisualizationSide};

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/pulse.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/pulse.rs
@@ -2,12 +2,12 @@
 use crate::config::FREQUENCY_NORMALIZATION_MAX;
 use crate::models::theme::{VisualizationColorConfig, VisualizationSide};
 use crate::ui::components::visualizations::{VisualizationConfig, VisualizationRenderer};
-use cosmic::iced::{
-    core::Rectangle,
-    widget::canvas::{path, stroke, Fill, Frame},
-    Point,
-};
 use cosmic::iced::{Padding, Radius};
+use cosmic::iced::{
+    Point,
+    core::Rectangle,
+    widget::canvas::{Fill, Frame, path, stroke},
+};
 use super_stt_shared::FrequencyData;
 
 /// A horizontal line pulse that grows in height/thickness with audio intensity

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
@@ -6,9 +6,9 @@ use super_stt_shared::FrequencyData;
 
 use crate::models::theme::{VisualizationColorConfig, VisualizationSide};
 use cosmic::iced::{
-    core::Rectangle,
-    widget::canvas::{path, stroke, Fill, Frame},
     Point,
+    core::Rectangle,
+    widget::canvas::{Fill, Frame, path, stroke},
 };
 
 /// Bottom-aligned frequency waveform rendering

--- a/super-stt-cosmic-applet/src/ui/sections/app_info.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/app_info.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::app::Message;
 use cosmic::{
-    iced::{widget::row, Alignment, Length},
-    theme,
-    widget::{button, icon, text, Space},
     Element,
+    iced::{Alignment, Length, widget::row},
+    theme,
+    widget::{Space, button, icon, text},
 };
 
 // Cache GitHub icon bytes to avoid allocation on every render

--- a/super-stt-cosmic-applet/src/ui/sections/launch.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/launch.rs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::app::Message;
 use cosmic::{
-    applet::menu_button,
-    iced::{widget::column, Length},
-    widget::text,
     Element,
+    applet::menu_button,
+    iced::{Length, widget::column},
+    widget::text,
 };
 
 pub fn create_launch_section() -> Element<'static, Message> {
-    column![menu_button(text::body("Launch Super STT App"))
-        .on_press(Message::LaunchApp)
-        .width(Length::Fill)]
+    column![
+        menu_button(text::body("Launch Super STT App"))
+            .on_press(Message::LaunchApp)
+            .width(Length::Fill)
+    ]
     .spacing(4)
     .into()
 }

--- a/super-stt-cosmic-applet/src/ui/sections/settings/components/visualization_theme.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/settings/components/visualization_theme.rs
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::{
+    IsOpen,
     app::Message,
     models::theme::{VisualizationColor, VisualizationColorConfig, VisualizationTheme},
     ui::components::{
         color_buttons::{create_color_button, create_system_accent_button},
         common::{revealer, revealer_head},
     },
-    IsOpen,
 };
 use cosmic::{
+    Apply, Element, Theme,
     applet::padded_control,
     iced::{
-        widget::{column, row},
         Length,
+        widget::{column, row},
     },
     iced_widget::Row,
     theme,
-    widget::{segmented_button::SingleSelectModel, segmented_control, text, Space},
-    Apply, Element, Theme,
+    widget::{Space, segmented_button::SingleSelectModel, segmented_control, text},
 };
 
 pub fn create_visualization_theme_selector<'a>(

--- a/super-stt-cosmic-applet/src/ui/sections/settings/settings.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/settings/settings.rs
@@ -1,58 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::{
+    Apply, Element,
     applet::padded_control,
     iced::{
-        widget::{column, row, slider},
         Alignment, Length,
+        widget::{column, row, slider},
     },
     theme,
     widget::{
-        divider, segmented_button::SingleSelectModel, segmented_control, text, toggler, Space,
+        Space, divider, segmented_button::SingleSelectModel, segmented_control, text, toggler,
     },
-    Apply, Element,
 };
-use super_stt_shared::theme::AudioTheme;
 
 use crate::{
+    IsOpen,
     app::Message,
     config::AppletConfig,
     models::theme::ThemeConfig,
-    ui::{
-        components::common::revealer,
-        sections::settings::components::visualization_theme::{
-            create_visualization_color_selector, create_visualization_theme_selector,
-        },
+    ui::sections::settings::components::visualization_theme::{
+        create_visualization_color_selector, create_visualization_theme_selector,
     },
-    IsOpen,
 };
-
-pub fn create_audio_theme_selector<'a>(
-    selected_theme: AudioTheme,
-    is_open: &IsOpen,
-    available_themes: &[AudioTheme],
-) -> Element<'a, Message> {
-    // Use provided themes if available, otherwise fallback to all themes
-    let audio_themes = if available_themes.is_empty() {
-        AudioTheme::all_themes()
-    } else {
-        available_themes.to_vec()
-    };
-
-    let options: Vec<(String, String)> = audio_themes
-        .into_iter()
-        .map(|theme| (theme.to_string(), theme.pretty_name()))
-        .collect();
-
-    revealer(
-        *is_open == IsOpen::AudioTheme,
-        "Audio Theme".to_string(),
-        selected_theme.pretty_name().clone(),
-        &options,
-        Message::RevealerToggle(IsOpen::AudioTheme),
-        |theme_str| Message::SetAudioTheme(theme_str.parse::<AudioTheme>().unwrap_or_default()),
-    )
-    .apply(Element::from)
-}
 
 pub fn create_applet_settings_section<'a>(
     config: &AppletConfig,
@@ -61,15 +29,10 @@ pub fn create_applet_settings_section<'a>(
     icon_alignment_model: &'a SingleSelectModel,
     theme_selector_model: &'a SingleSelectModel,
     selected_theme_for_config: bool,
-    available_audio_themes: &[AudioTheme],
 ) -> Element<'a, Message> {
     let spacing = theme::active().cosmic().spacing;
 
     let mut settings_column = column![
-        create_audio_theme_selector(theme_config.audio_theme, is_open, available_audio_themes),
-        padded_control(divider::horizontal::default())
-            .padding([0, spacing.space_s])
-            .apply(Element::from),
         // Show visualizations toggle
         padded_control(
             row![

--- a/super-stt-cosmic-applet/src/ui/sections/status.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/status.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::{app::Message, models::state::DaemonConnectionState};
-use cosmic::{iced::widget::column, widget::text, Element};
+use cosmic::{Element, iced::widget::column, widget::text};
 
 pub fn create_status_section(daemon_state: &DaemonConnectionState) -> Element<'static, Message> {
     // Create status section with optional retry button

--- a/super-stt-cosmic-applet/src/ui/views.rs
+++ b/super-stt-cosmic-applet/src/ui/views.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::{
+    IsOpen,
     app::Message,
     config::AppletConfig,
     models::{state::DaemonConnectionState, theme::ThemeConfig},
@@ -7,16 +8,14 @@ use crate::{
         app_info::create_app_info_section, launch::create_launch_section,
         settings::settings::create_applet_settings_section, status::create_status_section,
     },
-    IsOpen,
 };
 use cosmic::{
+    Apply, Element,
     applet::{menu_control_padding, padded_control},
     iced::widget::column,
     theme,
     widget::{divider, segmented_button::SingleSelectModel},
-    Apply, Element,
 };
-use super_stt_shared::theme::AudioTheme;
 
 /// Parameters for creating popup content to avoid too many function arguments
 pub struct PopupContentParams<'a> {
@@ -27,7 +26,6 @@ pub struct PopupContentParams<'a> {
     pub icon_alignment_model: &'a SingleSelectModel,
     pub theme_selector_model: &'a SingleSelectModel,
     pub selected_theme_for_config: bool,
-    pub available_audio_themes: &'a [AudioTheme],
 }
 
 pub fn create_popup_content<'a>(params: &PopupContentParams<'a>) -> Element<'a, Message> {
@@ -49,7 +47,6 @@ pub fn create_popup_content<'a>(params: &PopupContentParams<'a>) -> Element<'a, 
                 params.icon_alignment_model,
                 params.theme_selector_model,
                 params.selected_theme_for_config,
-                params.available_audio_themes,
             )
         } else {
             padded_control(create_status_section(params.daemon_state))


### PR DESCRIPTION
Remove audio settings from the COSMIC applet, so that all audio settings live in the customization section of the main GUI app only.

This allows for a cleaner codebase and separation of concerns.