### PR TITLE
Add support for overriding model dir

### DIFF
--- a/super-stt-app/src/core/app.rs
+++ b/super-stt-app/src/core/app.rs
@@ -7,8 +7,8 @@ use crate::daemon::client::{
     get_current_model, get_download_status, get_preview_typing, get_recording_stop_mode,
     get_write_method, list_available_models, load_audio_themes, ping_daemon, record_command_stream,
     set_allow_online_models, set_and_test_audio_theme, set_audio_theme, set_device, set_model,
-    set_preview_typing, set_recording_stop_mode, set_volume, set_write_method, stop_record_command,
-    test_daemon_connection,
+    set_model_override_path, set_preview_typing, set_recording_stop_mode, set_volume,
+    set_write_method, stop_record_command, test_daemon_connection,
 };
 use crate::state::{AudioTheme, ContextPage, DaemonStatus, MenuAction, Page, RecordingStatus};
 use crate::ui::messages::Message;
@@ -129,6 +129,11 @@ pub struct AppModel {
     // Master volume (0-100)
     pub volume: u8,
 
+    // Model override path
+    pub model_override_path: Option<String>,
+    pub model_override_path_input: String,
+    pub model_override_path_editing: bool,
+
     // Online models state
     pub allow_online_models: bool,
     pub openai_api_key_input: String,
@@ -242,6 +247,11 @@ impl cosmic::Application for AppModel {
                 super_stt_shared::models::recording_stop_mode::RecordingStopMode::default(),
             write_method: super_stt_shared::models::write_method::WriteMethod::default(),
             volume: 100,
+
+            // Model override path
+            model_override_path: None,
+            model_override_path_input: String::new(),
+            model_override_path_editing: false,
 
             // Online models state
             allow_online_models: false,
@@ -390,6 +400,9 @@ impl cosmic::Application for AppModel {
                 &self.current_model,
                 &self.model_operation_state,
                 &self.device_state,
+                self.model_override_path.as_deref(),
+                &self.model_override_path_input,
+                self.model_override_path_editing,
             ),
             Page::OnlineModels => views::online_models::page(
                 self.allow_online_models,
@@ -528,6 +541,39 @@ impl cosmic::Application for AppModel {
                 | Message::WriteMethodError(_)
         ) {
             return self.handle_write_method_messages(message);
+        }
+
+        match &message {
+            Message::ModelOverridePathInput(input) => {
+                self.model_override_path_input = input.clone();
+                return Task::none();
+            }
+            Message::ModelOverridePathEdit(editing) => {
+                self.model_override_path_editing = *editing;
+                if *editing {
+                    self.model_override_path_input =
+                        self.model_override_path.clone().unwrap_or_default();
+                }
+                return Task::none();
+            }
+            Message::ModelOverridePathSet(path) => {
+                let path = path.clone();
+                self.model_override_path_input = path.as_deref().unwrap_or_default().to_string();
+                self.model_override_path_editing = false;
+                self.model_override_path.clone_from(&path);
+                return Task::perform(
+                    set_model_override_path(self.socket_path.clone(), path),
+                    |result| match result {
+                        Ok(()) => cosmic::Action::None,
+                        Err(e) => cosmic::Action::App(Message::ModelOverridePathError(e)),
+                    },
+                );
+            }
+            Message::ModelOverridePathError(err) => {
+                log::warn!("Model override path error: {err}");
+                return Task::none();
+            }
+            _ => {}
         }
 
         if matches!(
@@ -831,6 +877,20 @@ impl AppModel {
                 } else {
                     warn!("No audio theme found in daemon configuration");
                 }
+
+                // Sync custom model path from daemon config
+                let custom_path = config
+                    .get("transcription")
+                    .and_then(|t| t.get("model_override_path"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                // Only update the input if the user hasn't edited it
+                let old_committed = self.model_override_path.as_deref().unwrap_or_default();
+                if self.model_override_path_input == old_committed {
+                    self.model_override_path_input =
+                        custom_path.as_deref().unwrap_or_default().to_string();
+                }
+                self.model_override_path = custom_path;
 
                 // Sync volume from daemon config
                 if let Some(vol) = config

--- a/super-stt-app/src/daemon/client.rs
+++ b/super-stt-app/src/daemon/client.rs
@@ -282,3 +282,16 @@ pub async fn set_allow_online_models(socket_path: PathBuf, enabled: bool) -> Res
 pub async fn get_allow_online_models(socket_path: PathBuf) -> Result<bool, String> {
     super_stt_shared::daemon::client::get_allow_online_models(socket_path, get_client_id()).await
 }
+
+/// Set model override path on daemon
+pub async fn set_model_override_path(
+    socket_path: PathBuf,
+    path: Option<String>,
+) -> Result<(), String> {
+    super_stt_shared::daemon::client::set_model_override_path(
+        socket_path,
+        path.as_deref(),
+        get_client_id(),
+    )
+    .await
+}

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -92,6 +92,12 @@ pub enum Message {
     // Volume messages
     VolumeChanged(u8),
 
+    // Model override path messages
+    ModelOverridePathInput(String),
+    ModelOverridePathSet(Option<String>),
+    ModelOverridePathEdit(bool),
+    ModelOverridePathError(String),
+
     // Online models messages
     AllowOnlineModelsToggled(bool),
     AllowOnlineModelsLoaded(bool),

--- a/super-stt-app/src/ui/views/models.rs
+++ b/super-stt-app/src/ui/views/models.rs
@@ -11,6 +11,77 @@ use crate::core::app::ModelOperationState;
 use crate::state::ContextPage;
 use crate::ui::messages::Message;
 
+/// Model storage section: model override path
+fn model_storage_section<'a>(
+    model_override_path: Option<&'a str>,
+    model_override_path_input: &'a str,
+    editing: bool,
+) -> Element<'a, Message> {
+    let display_value = if editing {
+        model_override_path_input
+    } else {
+        model_override_path.unwrap_or("")
+    };
+
+    let mut input = widget::text_input("Path to model files...", display_value);
+    if editing {
+        input = input.on_input(Message::ModelOverridePathInput);
+    }
+
+    let mut buttons: Vec<Element<'_, Message>> = Vec::new();
+
+    if editing {
+        buttons.push(
+            button::standard("Apply")
+                .on_press(Message::ModelOverridePathSet(
+                    if model_override_path_input.trim().is_empty() {
+                        None
+                    } else {
+                        Some(model_override_path_input.trim().to_string())
+                    },
+                ))
+                .into(),
+        );
+        buttons.push(
+            button::text("Cancel")
+                .on_press(Message::ModelOverridePathEdit(false))
+                .into(),
+        );
+    } else {
+        buttons.push(
+            button::standard("Edit")
+                .on_press(Message::ModelOverridePathEdit(true))
+                .into(),
+        );
+        if model_override_path.is_some() {
+            buttons.push(
+                button::destructive("Reset")
+                    .on_press(Message::ModelOverridePathSet(None))
+                    .into(),
+            );
+        }
+    }
+
+    let controls = row![
+        widget::container(input).width(Length::Fill),
+        row(buttons).spacing(8),
+    ]
+    .spacing(8);
+
+    settings::section()
+        .title("Model Storage")
+        .add(
+            settings::item::builder("Model Override Path")
+                .description(
+                    "Models here override the default cache. \
+                     Copy a HuggingFace model dir renamed to its model name \
+                     (e.g. whisper-small/snapshots/main/).",
+                )
+                .flex_control(controls),
+        )
+        .into()
+}
+
 /// Model section when ready: shows model picker (context drawer)
 fn model_ready_section(current_model: &STTModel) -> Element<'_, Message> {
     settings::section()
@@ -310,8 +381,11 @@ pub fn page<'a>(
     current_model: &'a STTModel,
     model_operation_state: &'a ModelOperationState,
     device_state: &'a crate::core::app::DeviceState,
+    model_override_path: Option<&'a str>,
+    model_override_path_input: &'a str,
+    model_override_path_editing: bool,
 ) -> Element<'a, Message> {
-    let section = match model_operation_state {
+    let model_section = match model_operation_state {
         ModelOperationState::Ready => {
             if let crate::core::app::DeviceState::Switching {
                 target_device,
@@ -333,5 +407,14 @@ pub fn page<'a>(
         } => model_loading_section(*target_model, status_message),
     };
 
-    page_layout("Models", settings::view_column(vec![section]))
+    let storage_section = model_storage_section(
+        model_override_path,
+        model_override_path_input,
+        model_override_path_editing,
+    );
+
+    page_layout(
+        "Models",
+        settings::view_column(vec![model_section, storage_section]),
+    )
 }

--- a/super-stt-shared/src/daemon/client.rs
+++ b/super-stt-shared/src/daemon/client.rs
@@ -643,6 +643,32 @@ pub async fn get_allow_online_models(
     }
 }
 
+/// Set model override path on daemon
+///
+/// Pass `None` to reset to the default `HuggingFace` cache path.
+///
+/// # Errors
+///
+/// Returns an error if the request fails.
+pub async fn set_model_override_path(
+    socket_path: PathBuf,
+    path: Option<&str>,
+    client_id: &str,
+) -> Result<(), String> {
+    let mut request = create_daemon_request("set_model_override_path", client_id);
+    request.data = Some(serde_json::json!({ "path": path }));
+
+    let response = send_daemon_request(&socket_path, request).await?;
+
+    if response.status == "success" {
+        Ok(())
+    } else {
+        Err(response
+            .message
+            .unwrap_or_else(|| "Failed to set model override path".to_string()))
+    }
+}
+
 /// Get recent daemon events
 ///
 /// # Errors

--- a/super-stt-shared/src/models/protocol.rs
+++ b/super-stt-shared/src/models/protocol.rs
@@ -436,6 +436,9 @@ pub enum Command {
         enabled: bool,
     },
     GetAllowOnlineModels,
+    SetModelOverridePath {
+        path: Option<String>,
+    },
 }
 
 impl Validate for DaemonRequest {
@@ -707,6 +710,45 @@ mod tests {
             _ => panic!("expected Command::SetRecordingStopMode"),
         }
     }
+
+    #[test]
+    fn set_model_override_path_parses_with_path() {
+        let request = make_request(
+            "set_model_override_path",
+            Some(json!({ "path": "/tmp/models" })),
+        );
+        let command = Command::try_from(request).expect("command should parse");
+        match command {
+            Command::SetModelOverridePath { path } => {
+                assert_eq!(path.as_deref(), Some("/tmp/models"));
+            }
+            _ => panic!("expected Command::SetModelOverridePath"),
+        }
+    }
+
+    #[test]
+    fn set_model_override_path_parses_with_null() {
+        let request = make_request("set_model_override_path", Some(json!({ "path": null })));
+        let command = Command::try_from(request).expect("command should parse");
+        match command {
+            Command::SetModelOverridePath { path } => {
+                assert!(path.is_none());
+            }
+            _ => panic!("expected Command::SetModelOverridePath"),
+        }
+    }
+
+    #[test]
+    fn set_model_override_path_parses_without_data() {
+        let request = make_request("set_model_override_path", None);
+        let command = Command::try_from(request).expect("command should parse");
+        match command {
+            Command::SetModelOverridePath { path } => {
+                assert!(path.is_none());
+            }
+            _ => panic!("expected Command::SetModelOverridePath"),
+        }
+    }
 }
 
 impl TryFrom<DaemonRequest> for Command {
@@ -753,6 +795,7 @@ impl TryFrom<DaemonRequest> for Command {
             "get_volume" => Ok(Command::GetVolume),
             "set_allow_online_models" => cmd_set_allow_online_models(&request),
             "get_allow_online_models" => Ok(Command::GetAllowOnlineModels),
+            "set_model_override_path" => Ok(cmd_set_model_override_path(&request)),
             _ => Err(format!("Unknown command: {}", request.command)),
         }
     }
@@ -998,4 +1041,14 @@ fn cmd_set_volume(request: &DaemonRequest) -> Result<Command, String> {
         return Err("Volume must be between 0 and 100".to_string());
     }
     Ok(Command::SetVolume { volume })
+}
+
+fn cmd_set_model_override_path(request: &DaemonRequest) -> Command {
+    let path = request
+        .data
+        .as_ref()
+        .and_then(|data| data.get("path"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    Command::SetModelOverridePath { path }
 }

--- a/super-stt/src/config.rs
+++ b/super-stt/src/config.rs
@@ -51,6 +51,8 @@ pub struct TranscriptionConfig {
     pub recording_stop_mode: RecordingStopMode,
     #[serde(default)]
     pub write_method: WriteMethod,
+    #[serde(default)]
+    pub model_override_path: Option<String>,
 }
 
 impl Default for DaemonConfig {
@@ -69,6 +71,7 @@ impl Default for DaemonConfig {
                 preview_typing_enabled: false, // Default to disabled (beta feature)
                 recording_stop_mode: RecordingStopMode::default(),
                 write_method: WriteMethod::default(),
+                model_override_path: None,
             },
             online: OnlineConfig::default(),
         }
@@ -192,6 +195,14 @@ impl DaemonConfig {
             error!("Failed to save config after write method update: {e}");
         }
     }
+
+    /// Update model override path and save to disk
+    pub fn update_model_override_path(&mut self, path: Option<String>) {
+        self.transcription.model_override_path = path;
+        if let Err(e) = self.save() {
+            error!("Failed to save config after model override path update: {e}");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -273,5 +284,54 @@ write_method = "Auto"
     fn online_config_default_is_disabled() {
         let online = OnlineConfig::default();
         assert!(!online.allow_online_models);
+    }
+
+    #[test]
+    fn default_config_has_no_model_override_path() {
+        let config = DaemonConfig::default();
+        assert!(config.transcription.model_override_path.is_none());
+    }
+
+    #[test]
+    fn config_without_model_override_path_deserializes() {
+        let toml_str = r#"
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "Classic"
+volume = 100
+
+[transcription]
+preferred_model = "WhisperTiny"
+write_mode = false
+preview_typing_enabled = false
+recording_stop_mode = "SilenceAndManual"
+write_method = "Auto"
+"#;
+        let config: DaemonConfig = toml::from_str(toml_str).expect("should deserialize");
+        assert!(config.transcription.model_override_path.is_none());
+    }
+
+    #[test]
+    fn config_with_model_override_path_round_trips() {
+        let mut config = DaemonConfig::default();
+        config.transcription.model_override_path = Some("/tmp/models".to_string());
+
+        let toml_str = toml::to_string_pretty(&config).expect("should serialize");
+        let parsed: DaemonConfig = toml::from_str(&toml_str).expect("should deserialize");
+        assert_eq!(
+            parsed.transcription.model_override_path.as_deref(),
+            Some("/tmp/models")
+        );
+    }
+
+    #[test]
+    fn config_with_none_model_override_path_round_trips() {
+        let config = DaemonConfig::default();
+
+        let toml_str = toml::to_string_pretty(&config).expect("should serialize");
+        let parsed: DaemonConfig = toml::from_str(&toml_str).expect("should deserialize");
+        assert!(parsed.transcription.model_override_path.is_none());
     }
 }

--- a/super-stt/src/daemon/core.rs
+++ b/super-stt/src/daemon/core.rs
@@ -96,6 +96,9 @@ impl SuperSTTDaemon {
                 self.handle_set_allow_online_models(enabled).await
             }
             Command::GetAllowOnlineModels => self.handle_get_allow_online_models().await,
+            Command::SetModelOverridePath { path } => {
+                self.handle_set_model_override_path(path).await
+            }
         }
     }
 

--- a/super-stt/src/daemon/handlers.rs
+++ b/super-stt/src/daemon/handlers.rs
@@ -444,6 +444,32 @@ impl SuperSTTDaemon {
             .with_message("Allow online models setting retrieved".to_string())
     }
 
+    /// Handle set custom model path command
+    pub async fn handle_set_model_override_path(&self, path: Option<String>) -> DaemonResponse {
+        let path_display = path.as_deref().unwrap_or("default").to_string();
+
+        {
+            let mut config_guard = self.config.write().await;
+            config_guard.transcription.model_override_path = path;
+        }
+
+        let broadcast_result = self.broadcast_config_change().await;
+
+        match broadcast_result {
+            Ok(()) => {
+                info!("Model override path set to {path_display} and saved to config");
+                DaemonResponse::success()
+                    .with_message(format!("Model override path set to {path_display}"))
+            }
+            Err(e) => {
+                warn!("Model override path changed but failed to save: {e}");
+                DaemonResponse::success().with_message(format!(
+                    "Model override path set to {path_display} (save failed: {e})"
+                ))
+            }
+        }
+    }
+
     /// Handle cancel download command
     #[must_use]
     pub fn handle_cancel_download(&self) -> DaemonResponse {

--- a/super-stt/src/daemon/model_management.rs
+++ b/super-stt/src/daemon/model_management.rs
@@ -24,6 +24,13 @@ impl SuperSTTDaemon {
     ) -> Result<STTModelInstance> {
         let stt_model_copy = *stt_model;
         let target_device_copy = target_device.to_string();
+        let override_path = self
+            .config
+            .read()
+            .await
+            .transcription
+            .model_override_path
+            .clone();
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         info!("Loading model with target device: {target_device}");
@@ -34,7 +41,11 @@ impl SuperSTTDaemon {
 
         // Load model in a single blocking task with cancellation support
         let mut load_handle = tokio::task::spawn_blocking(move || {
-            Self::load_model_sync(stt_model_copy, &target_device_copy)
+            Self::load_model_sync(
+                stt_model_copy,
+                &target_device_copy,
+                override_path.as_deref(),
+            )
         });
 
         // Wait for either model loading completion, shutdown signal, or timeout (60 seconds)
@@ -318,19 +329,27 @@ impl SuperSTTDaemon {
 
     /// Synchronous model loading function that handles device preference and fallback
     /// This is the core blocking operation that should be run in `spawn_blocking`
-    fn load_model_sync(model: STTModel, preferred_device: &str) -> Result<STTModelInstance> {
+    fn load_model_sync(
+        model: STTModel,
+        preferred_device: &str,
+        override_path: Option<&str>,
+    ) -> Result<STTModelInstance> {
         let force_cpu = preferred_device == "cpu";
+        let override_ref = override_path;
+        info!("Override path for model loading: {override_ref:?}");
         info!("Loading model with device preference: {preferred_device} (force_cpu={force_cpu})");
 
         // Attempt to load model with preferred device
         let initial_result = match model {
             STTModel::VoxtralSmall | STTModel::VoxtralMini => {
                 info!("Loading Voxtral model...");
-                VoxtralModel::new(&model, force_cpu).map(|m| STTModelInstance::Voxtral(Box::new(m)))
+                VoxtralModel::new(&model, force_cpu, override_ref)
+                    .map(|m| STTModelInstance::Voxtral(Box::new(m)))
             }
             _ => {
                 info!("Loading Whisper model...");
-                WhisperModel::new(&model, force_cpu).map(|m| STTModelInstance::Whisper(Box::new(m)))
+                WhisperModel::new(&model, force_cpu, override_ref)
+                    .map(|m| STTModelInstance::Whisper(Box::new(m)))
             }
         };
 
@@ -343,10 +362,10 @@ impl SuperSTTDaemon {
 
                 match model {
                     STTModel::VoxtralSmall | STTModel::VoxtralMini => {
-                        VoxtralModel::new(&model, true)
+                        VoxtralModel::new(&model, true, override_ref)
                             .map(|m| STTModelInstance::Voxtral(Box::new(m)))
                     }
-                    _ => WhisperModel::new(&model, true)
+                    _ => WhisperModel::new(&model, true, override_ref)
                         .map(|m| STTModelInstance::Whisper(Box::new(m))),
                 }
                 .map_err(|cpu_e| {
@@ -371,7 +390,25 @@ impl SuperSTTDaemon {
         tracker: Arc<DownloadProgressTracker>,
         start_time: std::time::Instant,
     ) -> anyhow::Result<STTModelInstance> {
-        crate::stt_models::local::download::with_progress(&model, Arc::clone(&tracker)).await?;
+        let override_path = self
+            .config
+            .read()
+            .await
+            .transcription
+            .model_override_path
+            .clone();
+
+        // Check if model files exist in the override path; if so skip download
+        let found_in_override = override_path.as_ref().is_some_and(|p| {
+            crate::stt_models::local::download::get_model_file_paths(&model, Some(p.as_str()))
+                .is_ok()
+        });
+
+        if found_in_override {
+            info!("Model found in override path, skipping download");
+        } else {
+            crate::stt_models::local::download::with_progress(&model, Arc::clone(&tracker)).await?;
+        }
         if tracker.is_cancelled() {
             anyhow::bail!("Model loading was cancelled");
         }
@@ -381,8 +418,10 @@ impl SuperSTTDaemon {
 
         let preferred_device = self.preferred_device.read().await.clone();
         let preferred_device_clone = preferred_device.clone();
+        let custom_path_clone = override_path;
         let instance = tokio::task::spawn_blocking(move || {
-            let result = Self::load_model_sync(model, &preferred_device_clone);
+            let result =
+                Self::load_model_sync(model, &preferred_device_clone, custom_path_clone.as_deref());
             let duration = start_time.elapsed();
             info!("Model loading completed in {duration:?}");
             result

--- a/super-stt/src/stt_models/local/download.rs
+++ b/super-stt/src/stt_models/local/download.rs
@@ -299,23 +299,14 @@ pub async fn with_progress(model: &STTModel, tracker: Arc<DownloadProgressTracke
     Ok(())
 }
 
-/// Get the file paths for an already downloaded model
-///
-/// # Errors
-///
-/// Returns an error if any expected model file is missing or if
-/// cache path calculation fails.
-pub fn get_model_file_paths(model: &STTModel) -> Result<Vec<PathBuf>> {
-    let (model_id, revision) = model.model_and_revision();
-
-    // Build the file list based on the specific model
+/// Get the expected filenames for a model
+fn model_filenames(model: STTModel) -> Vec<&'static str> {
     let mut files = if model.is_voxtral() {
         vec!["config.json", "tekken.json"]
     } else {
         vec!["config.json", "tokenizer.json"]
     };
 
-    // Add model-specific safetensors files
     let safetensors_files = match model {
         STTModel::VoxtralMini => vec![
             "model-00001-of-00002.safetensors",
@@ -334,16 +325,59 @@ pub fn get_model_file_paths(model: &STTModel) -> Result<Vec<PathBuf>> {
             "model-00010-of-00011.safetensors",
             "model-00011-of-00011.safetensors",
         ],
-        _ => vec!["model.safetensors"], // Any whisper model
+        _ => vec!["model.safetensors"],
     };
 
     files.extend(safetensors_files);
+    files
+}
 
-    // Get the cache paths for all files
-    let mut file_paths = Vec::new();
+/// Check if all model files exist under the given directory.
+/// Returns `Some(paths)` if all files are present, `None` otherwise.
+fn try_resolve_files(dir: &Path, files: &[&str]) -> Option<Vec<PathBuf>> {
+    let mut paths = Vec::with_capacity(files.len());
     for filename in files {
+        let path = dir.join(filename);
+        if path.exists() {
+            paths.push(path);
+        } else {
+            info!("Missing file in override: {}/{filename}", dir.display());
+            return None;
+        }
+    }
+    Some(paths)
+}
+
+/// Get the file paths for a model, checking the override path first.
+///
+/// When `override_path` is set, looks for model files under
+/// `{override_path}/{model}/snapshots/main/` (standard `HuggingFace` cache
+/// layout without the `models--` prefix).
+/// If not found there, falls back to the default `HuggingFace` cache.
+///
+/// # Errors
+///
+/// Returns an error if the model files cannot be found in any location.
+pub fn get_model_file_paths(model: &STTModel, override_path: Option<&str>) -> Result<Vec<PathBuf>> {
+    let files = model_filenames(*model);
+    let (model_id, revision) = model.model_and_revision();
+
+    // Check override path first: {override}/{model}/snapshots/{revision}/
+    if let Some(dir) = override_path {
+        let snapshot_dir = Path::new(dir)
+            .join(model.to_string())
+            .join("snapshots")
+            .join(revision);
+        if let Some(paths) = try_resolve_files(&snapshot_dir, &files) {
+            info!("Using model override: {}", snapshot_dir.display());
+            return Ok(paths);
+        }
+    }
+
+    // Fall back to default HuggingFace cache
+    let mut file_paths = Vec::new();
+    for filename in &files {
         let (symlink_path, _blob_path) = get_cache_paths(model_id, revision, filename)?;
-        // Use symlink path if it exists, otherwise check blob path
         if symlink_path.exists() {
             file_paths.push(symlink_path);
         } else {
@@ -351,5 +385,92 @@ pub fn get_model_file_paths(model: &STTModel) -> Result<Vec<PathBuf>> {
         }
     }
 
+    if let Some(first) = file_paths.first().and_then(|p| p.parent()) {
+        info!("Using model from cache: {}", first.display());
+    }
+
     Ok(file_paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("super-stt-tests").join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn create_model_files(dir: &Path, model: &STTModel) {
+        let (_, revision) = model.model_and_revision();
+        let snapshot_dir = dir.join(model.to_string()).join("snapshots").join(revision);
+        fs::create_dir_all(&snapshot_dir).unwrap();
+        for filename in model_filenames(*model) {
+            fs::write(snapshot_dir.join(filename), b"test").unwrap();
+        }
+    }
+
+    #[test]
+    fn override_path_found() {
+        let tmp = test_dir("override_found");
+        let model = STTModel::WhisperTiny;
+        create_model_files(&tmp, &model);
+
+        let paths =
+            get_model_file_paths(&model, Some(tmp.to_str().unwrap())).expect("should find files");
+
+        assert_eq!(paths.len(), model_filenames(model).len());
+        for path in &paths {
+            assert!(path.starts_with(&tmp));
+        }
+    }
+
+    #[test]
+    fn override_path_missing_model_falls_back_to_cache() {
+        let tmp = test_dir("override_missing");
+        let model = STTModel::WhisperTiny;
+
+        let result = get_model_file_paths(&model, Some(tmp.to_str().unwrap()));
+        // Falls through to HF cache — may succeed or fail depending on local cache
+        if let Ok(paths) = &result {
+            // If it succeeded, files should NOT be in the override dir
+            for path in paths {
+                assert!(!path.starts_with(&tmp));
+            }
+        }
+    }
+
+    #[test]
+    fn override_partial_files_falls_back_to_cache() {
+        let tmp = test_dir("override_partial");
+        let model = STTModel::WhisperTiny;
+        let (_, revision) = model.model_and_revision();
+        let snapshot_dir = tmp.join(model.to_string()).join("snapshots").join(revision);
+        fs::create_dir_all(&snapshot_dir).unwrap();
+        fs::write(snapshot_dir.join("config.json"), b"test").unwrap();
+
+        let result = get_model_file_paths(&model, Some(tmp.to_str().unwrap()));
+        // Partial override — falls through to HF cache
+        if let Ok(paths) = &result {
+            for path in paths {
+                assert!(!path.starts_with(&tmp));
+            }
+        }
+    }
+
+    #[test]
+    fn override_uses_model_display_name() {
+        let tmp = test_dir("override_display_name");
+        let model = STTModel::WhisperTinyEn;
+        create_model_files(&tmp, &model);
+
+        let paths =
+            get_model_file_paths(&model, Some(tmp.to_str().unwrap())).expect("should find files");
+
+        let first = paths[0].to_str().unwrap();
+        assert!(first.contains("whisper-tiny.en"));
+    }
 }

--- a/super-stt/src/stt_models/local/voxtral/model.rs
+++ b/super-stt/src/stt_models/local/voxtral/model.rs
@@ -45,7 +45,7 @@ impl VoxtralModel {
     ///
     /// Panics if expected file names are not valid UTF-8 or missing
     /// when inspecting cached paths (due to `unwrap()` on file names).
-    pub fn new(stt_model: &STTModel, force_cpu: bool) -> Result<Self> {
+    pub fn new(stt_model: &STTModel, force_cpu: bool, override_path: Option<&str>) -> Result<Self> {
         info!("Loading Voxtral {stt_model:?} model...");
 
         // Determine device
@@ -62,7 +62,8 @@ impl VoxtralModel {
         };
 
         // Get file paths from the unified download system
-        let file_paths = crate::stt_models::local::download::get_model_file_paths(stt_model)?;
+        let file_paths =
+            crate::stt_models::local::download::get_model_file_paths(stt_model, override_path)?;
 
         // Extract the specific files we need
         let config_path = file_paths

--- a/super-stt/src/stt_models/local/whisper/model.rs
+++ b/super-stt/src/stt_models/local/whisper/model.rs
@@ -75,7 +75,7 @@ impl WhisperModel {
     /// Panics if file paths from the model cache cannot be converted to valid UTF-8
     /// or if a required path component is unexpectedly missing when extracting
     /// `config.json`, `tokenizer.json`, or `model.safetensors`.
-    pub fn new(stt_model: &STTModel, force_cpu: bool) -> Result<Self> {
+    pub fn new(stt_model: &STTModel, force_cpu: bool, override_path: Option<&str>) -> Result<Self> {
         info!("Loading Whisper {stt_model:?} model...");
 
         // Determine device
@@ -92,7 +92,8 @@ impl WhisperModel {
         };
 
         // Get file paths from the unified download system
-        let file_paths = crate::stt_models::local::download::get_model_file_paths(stt_model)?;
+        let file_paths =
+            crate::stt_models::local::download::get_model_file_paths(stt_model, override_path)?;
 
         // Extract the specific files we need
         let config_path = file_paths


### PR DESCRIPTION
Allows you to override the location path for STT models via the GUI.

For example, if you set the override path to `/home/my-user/stt-models`, you can organize it as follows:

```sh
/home/my-user/stt-models
├── whisper-small
│   ├── blobs
│   │   ├── 1d7734884874f1a1513ed9aa760a4f8e97aaa02fd6d93a3a85d27b2ae9ca596b
│   │   ├── 27fc476bfe7f17299480be2273fc0608e4d5a99aba2ab5dec5374b4482d1a566
│   │   └── e6a2b489da1b5aed65a8eb8d1e7466fa867ad5643a8bc138ba708bd56b2875c4
│   └── snapshots
│       └── main
│           ├── config.json -> ../../blobs/e6a2b489da1b5aed65a8eb8d1e7466fa867ad5643a8bc138ba708bd56b2875c4
│           ├── model.safetensors -> ../../blobs/1d7734884874f1a1513ed9aa760a4f8e97aaa02fd6d93a3a85d27b2ae9ca596b
│           └── tokenizer.json -> ../../blobs/27fc476bfe7f17299480be2273fc0608e4d5a99aba2ab5dec5374b4482d1a566
└── whisper-tiny
    ├── blobs
    │   ├── 27fc476bfe7f17299480be2273fc0608e4d5a99aba2ab5dec5374b4482d1a566
    │   ├── 7ebd0e69e78190ffe1438491fa05cc1f5c1aa3a4c4db3bc1723adbb551ea2395
    │   └── ffdccec4f3211f4c63310f2b7098f309fe70f3952cedc5e4d11e43f5b2379b98
    └── snapshots
        └── main
            ├── config.json -> ../../blobs/ffdccec4f3211f4c63310f2b7098f309fe70f3952cedc5e4d11e43f5b2379b98
            ├── model.safetensors -> ../../blobs/7ebd0e69e78190ffe1438491fa05cc1f5c1aa3a4c4db3bc1723adbb551ea2395
            └── tokenizer.json -> ../../blobs/27fc476bfe7f17299480be2273fc0608e4d5a99aba2ab5dec5374b4482d1a566
```

this would replace the huggingface `whisper-tiny` and `whisper-small` models with those in the override path instead