### PR TITLE
Sep model identity from provider + GPU mem display

### DIFF
--- a/super-stt-app/src/core/app.rs
+++ b/super-stt-app/src/core/app.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use super_stt_shared::UdpAuth;
+use super_stt_shared::models::provider::{OnlineProvider, Provider};
 use super_stt_shared::stt_model::STTModel;
 use tokio::net::UdpSocket;
 use tokio::time::Duration;
@@ -109,6 +110,8 @@ pub struct AppModel {
     pub current_device: String,
     /// Available devices from daemon
     pub available_devices: Vec<String>,
+    /// GPU memory info: (free, total) in bytes. None if CUDA unavailable.
+    pub gpu_memory: super_stt_shared::daemon::client::GpuMemoryInfo,
     /// Device switching state
     pub device_state: DeviceState,
     /// Timestamp of last device switch to avoid polling too soon
@@ -237,6 +240,7 @@ impl cosmic::Application for AppModel {
             // Initialize device state
             current_device: String::new(), // Empty until loaded from daemon
             available_devices: vec!["cpu".to_string()], // Default until loaded from daemon
+            gpu_memory: None,
             device_state: DeviceState::Ready,
             last_device_switch: None,
             last_event_timestamp: None,
@@ -335,11 +339,33 @@ impl cosmic::Application for AppModel {
                     self.device_state,
                     DeviceState::Switching { .. } | DeviceState::Cooldown
                 );
-                // Filter online models out when the toggle is off
+                let gpu_enabled = self.current_device == "cuda";
+                let has_openai = self.has_openai_api_key;
+                let has_mistral = self.has_mistral_api_key;
+                let has_deepgram = self.has_deepgram_api_key;
+
                 let filtered_models: Vec<STTModel> = self
                     .available_models
                     .iter()
-                    .filter(|m| self.allow_online_models || !m.is_online())
+                    .filter(|m| {
+                        // Hide models that require GPU when GPU is off
+                        if m.requires_gpu() && !gpu_enabled {
+                            return false;
+                        }
+                        // For each model, at least one of its providers must be usable
+                        m.providers().iter().any(|p| match p {
+                            Provider::Local => true,
+                            Provider::Online(OnlineProvider::OpenAI) => {
+                                self.allow_online_models && has_openai
+                            }
+                            Provider::Online(OnlineProvider::Mistral) => {
+                                self.allow_online_models && has_mistral
+                            }
+                            Provider::Online(OnlineProvider::Deepgram) => {
+                                self.allow_online_models && has_deepgram
+                            }
+                        })
+                    })
                     .copied()
                     .collect();
                 context_drawer::context_drawer(
@@ -347,6 +373,8 @@ impl cosmic::Application for AppModel {
                         filtered_models,
                         self.current_model,
                         &self.model_search,
+                        gpu_enabled,
+                        self.gpu_memory,
                     ),
                     Message::ToggleContextPage(ContextPage::ModelSelection),
                 )
@@ -356,6 +384,7 @@ impl cosmic::Application for AppModel {
                     &self.current_device,
                     &self.available_devices,
                     device_switching,
+                    self.gpu_memory,
                 ))
             }
         })
@@ -495,7 +524,7 @@ impl cosmic::Application for AppModel {
             message,
             Message::DeviceSelected(_)
                 | Message::DeviceLoaded(_)
-                | Message::DeviceInfoLoaded(_, _)
+                | Message::DeviceInfoLoaded(_, _, _)
                 | Message::DeviceError(_)
         ) {
             return self.handle_device_messages(message);
@@ -612,6 +641,18 @@ impl cosmic::Application for AppModel {
                 } else {
                     self.context_page = context_page;
                     self.core.window.show_context = true;
+                }
+
+                // Refresh device info (including GPU free memory) when opening model drawer
+                if context_page == ContextPage::ModelSelection && self.core.window.show_context {
+                    return Task::perform(get_current_device(self.socket_path.clone()), |result| {
+                        match result {
+                            Ok((device, available_devices, gpu_memory)) => cosmic::Action::App(
+                                Message::DeviceInfoLoaded(device, available_devices, gpu_memory),
+                            ),
+                            Err(e) => cosmic::Action::App(Message::DeviceError(e)),
+                        }
+                    });
                 }
             }
 
@@ -850,16 +891,25 @@ impl AppModel {
                     }
                 }
 
-                // Fetch daemon configuration to sync settings
+                // Reload models, device info, and daemon config on reconnect
                 let socket_path = self.socket_path.clone();
-                Task::perform(fetch_daemon_config(socket_path), |result| match result {
-                    Ok(config) => cosmic::Action::App(Message::DaemonConfigReceived(config)),
-                    Err(err) => {
-                        warn!("Failed to fetch daemon config: {err}");
-                        // Config fetch failed but continue - model state maintained via events
-                        cosmic::Action::App(Message::RefreshDaemonStatus)
-                    }
-                })
+                let config_task =
+                    Task::perform(fetch_daemon_config(socket_path), |result| match result {
+                        Ok(config) => cosmic::Action::App(Message::DaemonConfigReceived(config)),
+                        Err(err) => {
+                            warn!("Failed to fetch daemon config: {err}");
+                            cosmic::Action::App(Message::RefreshDaemonStatus)
+                        }
+                    });
+
+                if was_disconnected {
+                    Task::batch([
+                        self.handle_model_messages(Message::LoadInitialData),
+                        config_task,
+                    ])
+                } else {
+                    config_task
+                }
             }
 
             Message::DaemonConfigReceived(config) => {
@@ -1247,10 +1297,11 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::DeviceInfoLoaded(device, available_devices) => {
+            Message::DeviceInfoLoaded(device, available_devices, gpu_memory) => {
                 info!("DeviceInfoLoaded: device={device}, available_devices={available_devices:?}");
                 self.current_device.clone_from(&device);
                 self.available_devices.clone_from(&available_devices);
+                self.gpu_memory = gpu_memory;
 
                 if matches!(self.device_state, DeviceState::Switching { .. }) {
                     info!("Device switch completed to: {device}");
@@ -1413,13 +1464,14 @@ impl AppModel {
                     ),
                     Task::perform(get_current_device(self.socket_path.clone()), |result| {
                         match result {
-                            Ok((device, available_devices)) => {
+                            Ok((device, available_devices, gpu_memory)) => {
                                 info!(
                                     "Initial device load successful: device={device}, available_devices={available_devices:?}"
                                 );
                                 cosmic::Action::App(Message::DeviceInfoLoaded(
                                     device,
                                     available_devices,
+                                    gpu_memory,
                                 ))
                             }
                             Err(e) => {

--- a/super-stt-app/src/daemon/client.rs
+++ b/super-stt-app/src/daemon/client.rs
@@ -220,8 +220,17 @@ pub async fn get_download_status(
     super_stt_shared::daemon::client::get_download_status(socket_path, get_client_id()).await
 }
 
-/// Get current device and available devices from daemon
-pub async fn get_current_device(socket_path: PathBuf) -> Result<(String, Vec<String>), String> {
+/// Get current device, available devices, and GPU memory info from daemon
+pub async fn get_current_device(
+    socket_path: PathBuf,
+) -> Result<
+    (
+        String,
+        Vec<String>,
+        super_stt_shared::daemon::client::GpuMemoryInfo,
+    ),
+    String,
+> {
     super_stt_shared::daemon::client::get_current_device(socket_path, get_client_id()).await
 }
 

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -57,10 +57,14 @@ pub enum Message {
     ModelError(String),
 
     // Device management messages
-    DeviceSelected(String),                // "cpu" or "cuda"
-    DeviceLoaded(String),                  // Current device from daemon
-    DeviceInfoLoaded(String, Vec<String>), // Current device and available devices from daemon
-    DeviceError(String),                   // Device switching error
+    DeviceSelected(String), // "cpu" or "cuda"
+    DeviceLoaded(String),   // Current device from daemon
+    DeviceInfoLoaded(
+        String,
+        Vec<String>,
+        super_stt_shared::daemon::client::GpuMemoryInfo,
+    ), // Current device, available devices, GPU memory (free, total)
+    DeviceError(String),    // Device switching error
 
     // Download progress messages
     DownloadProgressUpdate(super_stt_shared::models::protocol::DownloadProgress),

--- a/super-stt-app/src/ui/views/models.rs
+++ b/super-stt-app/src/ui/views/models.rs
@@ -4,6 +4,7 @@ use cosmic::iced_widget::{column, row};
 use cosmic::widget::{self, button, settings, space::horizontal as horizontal_space, text};
 use cosmic::{Apply, Element};
 use super_stt_shared::models::protocol::DownloadProgress;
+use super_stt_shared::models::provider::{OnlineProvider, Provider};
 use super_stt_shared::stt_model::STTModel;
 
 use super::common::{go_next_with_item, page_layout};
@@ -206,8 +207,29 @@ fn model_device_switching_section<'a>(
         .into()
 }
 
-/// Build a model row for the selection list
-fn model_row(model: STTModel, current_model: STTModel) -> Element<'static, Message> {
+/// Format bytes as a human-readable size string (always in GB)
+#[allow(clippy::cast_precision_loss)]
+fn format_size(bytes: u64) -> String {
+    const GB: f64 = 1_073_741_824.0;
+    if bytes == 0 {
+        return String::new();
+    }
+    let gb = bytes as f64 / GB;
+    if gb >= 10.0 {
+        format!("{gb:.0} GB")
+    } else {
+        format!("{gb:.1} GB")
+    }
+}
+
+/// Build a model row for the selection list.
+/// `effective_free_vram` is the GPU memory that would be available after unloading
+/// the current model (None if GPU is off or unknown).
+fn model_row(
+    model: STTModel,
+    current_model: STTModel,
+    effective_free_vram: Option<u64>,
+) -> Element<'static, Message> {
     let selected = model == current_model;
 
     let svg_accent = |theme: &cosmic::theme::Theme| {
@@ -217,7 +239,12 @@ fn model_row(model: STTModel, current_model: STTModel) -> Element<'static, Messa
         }
     };
 
-    settings::item_row(vec![
+    let vram_required = model.estimated_vram_bytes();
+    let size_label = format_size(vram_required);
+    let wont_fit =
+        vram_required > 0 && effective_free_vram.is_some_and(|free| vram_required > free);
+
+    let mut items: Vec<Element<'static, Message>> = vec![
         text::body(model.to_string())
             .class(if selected {
                 cosmic::theme::Text::Accent
@@ -226,32 +253,59 @@ fn model_row(model: STTModel, current_model: STTModel) -> Element<'static, Messa
             })
             .width(Length::Fill)
             .into(),
-        if selected {
-            cosmic::widget::icon::from_name("object-select-symbolic")
+    ];
+
+    if wont_fit {
+        items.push(
+            cosmic::widget::icon::from_name("dialog-warning-symbolic")
                 .size(16)
                 .icon()
-                .class(cosmic::theme::Svg::Custom(std::rc::Rc::new(Box::new(
-                    svg_accent,
-                ))))
-                .into()
-        } else {
-            horizontal_space().width(16.).into()
-        },
-    ])
-    .apply(widget::container)
-    .class(cosmic::theme::Container::List)
-    .apply(widget::button::custom)
-    .class(cosmic::theme::Button::Transparent)
-    .on_press(Message::ModelSelected(model))
-    .into()
+                .into(),
+        );
+    }
+
+    if !size_label.is_empty() {
+        items.push(text::caption(size_label).into());
+    }
+
+    items.push(if selected {
+        cosmic::widget::icon::from_name("object-select-symbolic")
+            .size(16)
+            .icon()
+            .class(cosmic::theme::Svg::Custom(std::rc::Rc::new(Box::new(
+                svg_accent,
+            ))))
+            .into()
+    } else {
+        horizontal_space().width(16.).into()
+    });
+
+    settings::item_row(items)
+        .apply(widget::container)
+        .width(Length::Fill)
+        .class(cosmic::theme::Container::List)
+        .apply(widget::button::custom)
+        .width(Length::Fill)
+        .class(cosmic::theme::Button::Transparent)
+        .on_press(Message::ModelSelected(model))
+        .into()
 }
 
-/// Build the model selection list for the context drawer (font-picker pattern)
+/// Build the model selection list for the context drawer (font-picker pattern).
+/// `gpu_memory` is `Some((free, total))` when GPU is enabled, used to warn about models that won't fit.
 pub fn model_selection_list(
     available_models: Vec<STTModel>,
     current_model: STTModel,
     search: &str,
+    gpu_enabled: bool,
+    gpu_memory: super_stt_shared::daemon::client::GpuMemoryInfo,
 ) -> Element<'static, Message> {
+    // Effective free VRAM = current free + what the current model uses (it gets unloaded on switch)
+    let effective_free_vram = if gpu_enabled {
+        gpu_memory.map(|(free, _total)| free + current_model.estimated_vram_bytes())
+    } else {
+        None
+    };
     let search_lower = search.to_lowercase();
     let models: Vec<STTModel> = if search.is_empty() {
         available_models
@@ -262,22 +316,36 @@ pub fn model_selection_list(
             .collect()
     };
 
-    let local: Vec<STTModel> = models.iter().filter(|m| !m.is_online()).copied().collect();
+    let local: Vec<STTModel> = models
+        .iter()
+        .filter(|m| m.providers().contains(&Provider::Local))
+        .copied()
+        .collect();
 
     // Group online models by provider
     let openai: Vec<STTModel> = models
         .iter()
-        .filter(|m| m.is_online() && m.api_provider() == "openai")
+        .filter(|m| {
+            m.providers()
+                .contains(&Provider::Online(OnlineProvider::OpenAI))
+        })
         .copied()
         .collect();
     let mistral: Vec<STTModel> = models
         .iter()
-        .filter(|m| m.is_online() && m.api_provider() == "mistral")
+        .filter(|m| {
+            m.providers()
+                .contains(&Provider::Online(OnlineProvider::Mistral))
+                && !m.providers().contains(&Provider::Local)
+        })
         .copied()
         .collect();
     let deepgram: Vec<STTModel> = models
         .iter()
-        .filter(|m| m.is_online() && m.api_provider() == "deepgram")
+        .filter(|m| {
+            m.providers()
+                .contains(&Provider::Online(OnlineProvider::Deepgram))
+        })
         .copied()
         .collect();
 
@@ -287,7 +355,7 @@ pub fn model_selection_list(
         let list = local
             .into_iter()
             .fold(widget::list_column(), |list, model| {
-                list.add(model_row(model, current_model))
+                list.add(model_row(model, current_model, effective_free_vram))
             });
         sections.push(
             column![text::title4("Local"), list]
@@ -300,7 +368,7 @@ pub fn model_selection_list(
         let list = openai
             .into_iter()
             .fold(widget::list_column(), |list, model| {
-                list.add(model_row(model, current_model))
+                list.add(model_row(model, current_model, effective_free_vram))
             });
         sections.push(
             column![text::title4("OpenAI (online)"), list]
@@ -313,7 +381,7 @@ pub fn model_selection_list(
         let list = mistral
             .into_iter()
             .fold(widget::list_column(), |list, model| {
-                list.add(model_row(model, current_model))
+                list.add(model_row(model, current_model, effective_free_vram))
             });
         sections.push(
             column![text::title4("Mistral (online)"), list]
@@ -326,7 +394,7 @@ pub fn model_selection_list(
         let list = deepgram
             .into_iter()
             .fold(widget::list_column(), |list, model| {
-                list.add(model_row(model, current_model))
+                list.add(model_row(model, current_model, effective_free_vram))
             });
         sections.push(
             column![text::title4("Deepgram (online)"), list]
@@ -337,6 +405,7 @@ pub fn model_selection_list(
 
     column(sections)
         .spacing(cosmic::theme::spacing().space_m)
+        .width(Length::Fill)
         .into()
 }
 
@@ -346,6 +415,7 @@ pub fn model_drawer_header<'a>(
     current_device: &'a str,
     available_devices: &'a [String],
     device_switching: bool,
+    gpu_memory: super_stt_shared::daemon::client::GpuMemoryInfo,
 ) -> Element<'a, Message> {
     let has_gpu = available_devices.contains(&"cuda".to_string());
     let gpu_enabled = current_device == "cuda";
@@ -366,14 +436,27 @@ pub fn model_drawer_header<'a>(
         });
     }
 
-    column![
+    let mut items = column![].spacing(cosmic::theme::spacing().space_s);
+
+    items = items.push(
         settings::item::builder("GPU Acceleration")
-            .description("Use CUDA GPU for faster transcription")
+            .description("Enable to use more powerful models and faster transcriptions")
             .control(toggler),
-        search_input,
-    ]
-    .spacing(cosmic::theme::spacing().space_s)
-    .into()
+    );
+
+    if let Some((free, total)) = gpu_memory.filter(|_| gpu_enabled) {
+        let used = total.saturating_sub(free);
+        let mem_text = format!(
+            "GPU Memory: {} / {} used",
+            format_size(used),
+            format_size(total)
+        );
+        items = items.push(text::caption(mem_text));
+    }
+
+    items = items.push(search_input);
+
+    items.into()
 }
 
 /// Models page view

--- a/super-stt-shared/src/daemon/client.rs
+++ b/super-stt-shared/src/daemon/client.rs
@@ -380,13 +380,18 @@ pub async fn get_download_status(
 
 /// Get current device and available devices from daemon
 ///
+/// GPU memory info returned from the daemon (free, total) in bytes.
+pub type GpuMemoryInfo = Option<(u64, u64)>;
+
+/// Get current device and available devices from daemon
+///
 /// # Errors
 ///
 /// Returns an error if the request fails.
 pub async fn get_current_device(
     socket_path: PathBuf,
     client_id: &str,
-) -> Result<(String, Vec<String>), String> {
+) -> Result<(String, Vec<String>, GpuMemoryInfo), String> {
     let request = create_daemon_request("get_device", client_id);
     let response = send_daemon_request(&socket_path, request).await?;
 
@@ -395,7 +400,11 @@ pub async fn get_current_device(
         let available_devices = response
             .available_devices
             .unwrap_or_else(|| vec!["cpu".to_string()]);
-        Ok((device, available_devices))
+        let gpu_memory = match (response.gpu_free_memory, response.gpu_total_memory) {
+            (Some(free), Some(total)) => Some((free, total)),
+            _ => None,
+        };
+        Ok((device, available_devices, gpu_memory))
     } else {
         Err(response
             .message

--- a/super-stt-shared/src/models/mod.rs
+++ b/super-stt-shared/src/models/mod.rs
@@ -2,6 +2,7 @@
 pub mod audio;
 pub mod daemon_state;
 pub mod protocol;
+pub mod provider;
 pub mod recording_stop_mode;
 pub mod stt;
 pub mod stt_model;

--- a/super-stt-shared/src/models/protocol.rs
+++ b/super-stt-shared/src/models/protocol.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, str::FromStr};
 
+use crate::models::provider::Provider;
 use crate::models::recording_stop_mode::RecordingStopMode;
 use crate::models::theme::AudioTheme;
 use crate::models::write_method::WriteMethod;
@@ -52,9 +53,19 @@ pub struct DaemonResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_model: Option<STTModel>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_provider: Option<Provider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub available_models: Option<Vec<STTModel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_devices: Option<Vec<String>>,
+
+    /// Free GPU memory in bytes (only set when CUDA is available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_free_memory: Option<u64>,
+
+    /// Total GPU memory in bytes (only set when CUDA is available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_total_memory: Option<u64>,
 
     // Notification system fields
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -148,8 +159,11 @@ impl DaemonResponse {
             device: None,
             model_loaded: None,
             current_model: None,
+            current_provider: None,
             available_models: None,
             available_devices: None,
+            gpu_free_memory: None,
+            gpu_total_memory: None,
             subscribed_to: None,
             total_subscribers: None,
             events: None,
@@ -200,8 +214,11 @@ impl DaemonResponse {
             device: None,
             model_loaded: None,
             current_model: None,
+            current_provider: None,
             available_models: None,
             available_devices: None,
+            gpu_free_memory: None,
+            gpu_total_memory: None,
             subscribed_to: None,
             total_subscribers: None,
             events: None,
@@ -243,6 +260,12 @@ impl DaemonResponse {
     #[must_use]
     pub fn with_current_model(mut self, model: STTModel) -> Self {
         self.current_model = Some(model);
+        self
+    }
+
+    #[must_use]
+    pub fn with_current_provider(mut self, provider: Provider) -> Self {
+        self.current_provider = Some(provider);
         self
     }
 
@@ -309,6 +332,18 @@ impl DaemonResponse {
     #[must_use]
     pub fn with_available_devices(mut self, devices: Vec<String>) -> Self {
         self.available_devices = Some(devices);
+        self
+    }
+
+    #[must_use]
+    pub fn with_gpu_free_memory(mut self, bytes: u64) -> Self {
+        self.gpu_free_memory = Some(bytes);
+        self
+    }
+
+    #[must_use]
+    pub fn with_gpu_total_memory(mut self, bytes: u64) -> Self {
+        self.gpu_total_memory = Some(bytes);
         self
     }
 
@@ -405,6 +440,7 @@ pub enum Command {
     TestAudioTheme,
     SetModel {
         model: STTModel,
+        provider: Provider,
     },
     GetModel,
     ListModels,
@@ -677,22 +713,54 @@ mod tests {
     #[test]
     fn set_model_parses_online_models() {
         for model_name in [
-            "openai-whisper-1",
-            "openai-gpt-4o-transcribe",
-            "openai-gpt-4o-mini-transcribe",
-            "mistral-voxtral-mini-transcribe-v2",
-            "deepgram-nova-3",
+            "whisper-1",
+            "gpt-4o-transcribe",
+            "gpt-4o-mini-transcribe",
+            "voxtral-mini-transcribe-v2",
+            "nova-3",
         ] {
             let request = make_request("set_model", Some(json!({ "model": model_name })));
             let command = Command::try_from(request)
                 .unwrap_or_else(|e| panic!("set_model should parse {model_name}: {e}"));
             match command {
-                Command::SetModel { model } => {
+                Command::SetModel { model, provider } => {
                     assert_eq!(model.to_string(), model_name);
-                    assert!(model.is_online());
+                    assert!(provider.is_online());
                 }
                 _ => panic!("expected Command::SetModel for {model_name}"),
             }
+        }
+    }
+
+    #[test]
+    fn set_model_with_explicit_provider() {
+        let request = make_request(
+            "set_model",
+            Some(json!({ "model": "voxtral-mini", "provider": "mistral" })),
+        );
+        let command = Command::try_from(request).expect("should parse");
+        match command {
+            Command::SetModel { model, provider } => {
+                assert_eq!(model, STTModel::VoxtralMini);
+                assert_eq!(
+                    provider,
+                    Provider::Online(crate::models::provider::OnlineProvider::Mistral)
+                );
+            }
+            _ => panic!("expected Command::SetModel"),
+        }
+    }
+
+    #[test]
+    fn set_model_defaults_provider_for_local() {
+        let request = make_request("set_model", Some(json!({ "model": "whisper-tiny" })));
+        let command = Command::try_from(request).expect("should parse");
+        match command {
+            Command::SetModel { model, provider } => {
+                assert_eq!(model, STTModel::WhisperTiny);
+                assert_eq!(provider, Provider::Local);
+            }
+            _ => panic!("expected Command::SetModel"),
         }
     }
 
@@ -960,10 +1028,17 @@ fn cmd_set_model(request: &DaemonRequest) -> Result<Command, String> {
     let model_value = request.data.as_ref().and_then(|data| data.get("model"));
     let model_str = model_value.and_then(|v| v.as_str());
     if let Some(model_str) = model_str {
-        match STTModel::from_str(model_str) {
-            Ok(model) => Ok(Command::SetModel { model }),
-            Err(err) => Err(format!("Failed to parse model: {err}")),
-        }
+        let model =
+            STTModel::from_str(model_str).map_err(|err| format!("Failed to parse model: {err}"))?;
+        let provider = request
+            .data
+            .as_ref()
+            .and_then(|data| data.get("provider"))
+            .and_then(|v| v.as_str())
+            .map(|s| Provider::from_str(s).map_err(|e| format!("Failed to parse provider: {e}")))
+            .transpose()?
+            .unwrap_or_else(|| model.default_provider());
+        Ok(Command::SetModel { model, provider })
     } else {
         Err("Model string is empty".to_string())
     }

--- a/super-stt-shared/src/models/provider.rs
+++ b/super-stt-shared/src/models/provider.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// An online API provider with guaranteed API configuration.
+/// Every variant has a key name and base URL — no panics possible.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum OnlineProvider {
+    OpenAI,
+    Mistral,
+    Deepgram,
+}
+
+impl OnlineProvider {
+    /// Provider name used for keyring API key lookups.
+    #[must_use]
+    pub fn api_key_name(&self) -> &'static str {
+        match self {
+            Self::OpenAI => "openai",
+            Self::Mistral => "mistral",
+            Self::Deepgram => "deepgram",
+        }
+    }
+
+    /// Base URL for this provider's API.
+    #[must_use]
+    pub fn api_base_url(&self) -> &'static str {
+        match self {
+            Self::OpenAI => "https://api.openai.com",
+            Self::Mistral => "https://api.mistral.ai",
+            Self::Deepgram => "https://api.deepgram.com",
+        }
+    }
+}
+
+impl fmt::Display for OnlineProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OpenAI => write!(f, "openai"),
+            Self::Mistral => write!(f, "mistral"),
+            Self::Deepgram => write!(f, "deepgram"),
+        }
+    }
+}
+
+impl FromStr for OnlineProvider {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "openai" => Ok(Self::OpenAI),
+            "mistral" => Ok(Self::Mistral),
+            "deepgram" => Ok(Self::Deepgram),
+            _ => Err(format!("Unknown online provider: {s}")),
+        }
+    }
+}
+
+/// How a model is served: locally or via an online API provider.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Provider {
+    #[default]
+    Local,
+    Online(OnlineProvider),
+}
+
+impl Provider {
+    #[must_use]
+    pub fn is_online(&self) -> bool {
+        matches!(self, Self::Online(_))
+    }
+
+    /// Returns the inner `OnlineProvider` if this is an online provider.
+    #[must_use]
+    pub fn as_online(&self) -> Option<OnlineProvider> {
+        match self {
+            Self::Online(p) => Some(*p),
+            Self::Local => None,
+        }
+    }
+}
+
+impl From<OnlineProvider> for Provider {
+    fn from(p: OnlineProvider) -> Self {
+        Self::Online(p)
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Local => write!(f, "local"),
+            Self::Online(p) => write!(f, "{p}"),
+        }
+    }
+}
+
+impl FromStr for Provider {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "local" => Ok(Self::Local),
+            other => OnlineProvider::from_str(other).map(Self::Online),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_is_not_online() {
+        assert!(!Provider::Local.is_online());
+        assert!(Provider::Local.as_online().is_none());
+    }
+
+    #[test]
+    fn online_providers_are_online() {
+        assert!(Provider::Online(OnlineProvider::OpenAI).is_online());
+        assert!(Provider::Online(OnlineProvider::Mistral).is_online());
+        assert!(Provider::Online(OnlineProvider::Deepgram).is_online());
+    }
+
+    #[test]
+    fn as_online_returns_inner() {
+        let p = Provider::Online(OnlineProvider::OpenAI);
+        assert_eq!(p.as_online(), Some(OnlineProvider::OpenAI));
+    }
+
+    #[test]
+    fn from_online_provider() {
+        let p: Provider = OnlineProvider::Mistral.into();
+        assert_eq!(p, Provider::Online(OnlineProvider::Mistral));
+    }
+
+    #[test]
+    fn display_round_trips() {
+        for provider in [
+            Provider::Local,
+            Provider::Online(OnlineProvider::OpenAI),
+            Provider::Online(OnlineProvider::Mistral),
+            Provider::Online(OnlineProvider::Deepgram),
+        ] {
+            let s = provider.to_string();
+            let parsed: Provider = s.parse().unwrap();
+            assert_eq!(provider, parsed);
+        }
+    }
+
+    #[test]
+    fn online_provider_display_round_trips() {
+        for op in [
+            OnlineProvider::OpenAI,
+            OnlineProvider::Mistral,
+            OnlineProvider::Deepgram,
+        ] {
+            let s = op.to_string();
+            let parsed: OnlineProvider = s.parse().unwrap();
+            assert_eq!(op, parsed);
+        }
+    }
+
+    #[test]
+    fn api_key_names() {
+        assert_eq!(OnlineProvider::OpenAI.api_key_name(), "openai");
+        assert_eq!(OnlineProvider::Mistral.api_key_name(), "mistral");
+        assert_eq!(OnlineProvider::Deepgram.api_key_name(), "deepgram");
+    }
+
+    #[test]
+    fn api_base_urls() {
+        assert!(
+            OnlineProvider::OpenAI
+                .api_base_url()
+                .starts_with("https://")
+        );
+        assert!(
+            OnlineProvider::Mistral
+                .api_base_url()
+                .starts_with("https://")
+        );
+        assert!(
+            OnlineProvider::Deepgram
+                .api_base_url()
+                .starts_with("https://")
+        );
+    }
+
+    #[test]
+    fn default_is_local() {
+        assert_eq!(Provider::default(), Provider::Local);
+    }
+}

--- a/super-stt-shared/src/models/stt_model.rs
+++ b/super-stt-shared/src/models/stt_model.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use strum_macros::{AsRefStr, EnumCount, EnumIter, VariantArray, VariantNames};
 
+use super::provider::{OnlineProvider, Provider};
+
 #[derive(
     Serialize,
     Deserialize,
@@ -53,27 +55,23 @@ pub enum STTModel {
     #[value(name = "whisper-distil-large-v3")]
     WhisperDistilLargeV3,
 
-    // Voxtral models
+    // Voxtral models (local + Mistral API)
     #[value(name = "voxtral-small")]
     VoxtralSmall,
     #[value(name = "voxtral-mini")]
     VoxtralMini,
 
-    // OpenAI API models (online — requires allow_online_models)
-    #[value(name = "openai-whisper-1")]
-    OpenAIWhisper1,
-    #[value(name = "openai-gpt-4o-transcribe")]
-    OpenAIGpt4oTranscribe,
-    #[value(name = "openai-gpt-4o-mini-transcribe")]
-    OpenAIGpt4oMiniTranscribe,
-
-    // Mistral API models (online — requires allow_online_models)
-    #[value(name = "mistral-voxtral-mini-transcribe-v2")]
-    MistralVoxtralMiniTranscribeV2,
-
-    // Deepgram API models (online — requires allow_online_models)
-    #[value(name = "deepgram-nova-3")]
-    DeepgramNova3,
+    // Online-only models
+    #[value(name = "whisper-1")]
+    Whisper1,
+    #[value(name = "gpt-4o-transcribe")]
+    Gpt4oTranscribe,
+    #[value(name = "gpt-4o-mini-transcribe")]
+    Gpt4oMiniTranscribe,
+    #[value(name = "voxtral-mini-transcribe-v2")]
+    VoxtralMiniTranscribeV2,
+    #[value(name = "nova-3")]
+    Nova3,
 }
 
 impl std::fmt::Display for STTModel {
@@ -96,134 +94,130 @@ impl std::fmt::Display for STTModel {
             Self::WhisperDistilLargeV3 => write!(f, "whisper-distil-large-v3"),
             Self::VoxtralSmall => write!(f, "voxtral-small"),
             Self::VoxtralMini => write!(f, "voxtral-mini"),
-            Self::OpenAIWhisper1 => write!(f, "openai-whisper-1"),
-            Self::OpenAIGpt4oTranscribe => write!(f, "openai-gpt-4o-transcribe"),
-            Self::OpenAIGpt4oMiniTranscribe => write!(f, "openai-gpt-4o-mini-transcribe"),
-            Self::MistralVoxtralMiniTranscribeV2 => {
-                write!(f, "mistral-voxtral-mini-transcribe-v2")
-            }
-            Self::DeepgramNova3 => write!(f, "deepgram-nova-3"),
+            Self::Whisper1 => write!(f, "whisper-1"),
+            Self::Gpt4oTranscribe => write!(f, "gpt-4o-transcribe"),
+            Self::Gpt4oMiniTranscribe => write!(f, "gpt-4o-mini-transcribe"),
+            Self::VoxtralMiniTranscribeV2 => write!(f, "voxtral-mini-transcribe-v2"),
+            Self::Nova3 => write!(f, "nova-3"),
         }
     }
 }
 
 impl STTModel {
+    /// Returns the providers that support this model.
+    /// The first provider in the list is the default.
     #[must_use]
-    pub fn is_multilingual(&self) -> bool {
+    pub fn providers(&self) -> &[Provider] {
         match self {
+            // Local-only whisper models
             Self::WhisperTiny
+            | Self::WhisperTinyEn
             | Self::WhisperBase
+            | Self::WhisperBaseEn
             | Self::WhisperSmall
+            | Self::WhisperSmallEn
             | Self::WhisperMedium
+            | Self::WhisperMediumEn
             | Self::WhisperLarge
             | Self::WhisperLargeV2
             | Self::WhisperLargeV3
             | Self::WhisperLargeV3Turbo
+            | Self::WhisperDistilMediumEn
             | Self::WhisperDistilLargeV2
-            | Self::WhisperDistilLargeV3
-            | Self::VoxtralSmall
-            | Self::VoxtralMini
-            | Self::OpenAIWhisper1
-            | Self::OpenAIGpt4oTranscribe
-            | Self::OpenAIGpt4oMiniTranscribe
-            | Self::MistralVoxtralMiniTranscribeV2
-            | Self::DeepgramNova3 => true,
-            Self::WhisperTinyEn
-            | Self::WhisperBaseEn
-            | Self::WhisperSmallEn
-            | Self::WhisperMediumEn
-            | Self::WhisperDistilMediumEn => false,
+            | Self::WhisperDistilLargeV3 => &[Provider::Local],
+
+            // Voxtral models available locally and via Mistral API
+            Self::VoxtralSmall | Self::VoxtralMini => {
+                &[Provider::Local, Provider::Online(OnlineProvider::Mistral)]
+            }
+
+            // OpenAI-only models
+            Self::Whisper1 | Self::Gpt4oTranscribe | Self::Gpt4oMiniTranscribe => {
+                &[Provider::Online(OnlineProvider::OpenAI)]
+            }
+
+            // Mistral-only online model
+            Self::VoxtralMiniTranscribeV2 => &[Provider::Online(OnlineProvider::Mistral)],
+
+            // Deepgram-only model
+            Self::Nova3 => &[Provider::Online(OnlineProvider::Deepgram)],
         }
+    }
+
+    /// Returns the default provider for this model (first in the providers list).
+    #[must_use]
+    pub fn default_provider(&self) -> Provider {
+        self.providers()[0]
+    }
+
+    /// Returns the API model ID string for a given online provider, or `None`
+    /// if this model is not available via that provider.
+    #[must_use]
+    pub fn api_model_id(&self, provider: OnlineProvider) -> Option<&'static str> {
+        match (self, provider) {
+            (Self::Whisper1, OnlineProvider::OpenAI) => Some("whisper-1"),
+            (Self::Gpt4oTranscribe, OnlineProvider::OpenAI) => Some("gpt-4o-transcribe"),
+            (Self::Gpt4oMiniTranscribe, OnlineProvider::OpenAI) => Some("gpt-4o-mini-transcribe"),
+            (Self::VoxtralMini | Self::VoxtralMiniTranscribeV2, OnlineProvider::Mistral) => {
+                Some("voxtral-mini-latest")
+            }
+            (Self::VoxtralSmall, OnlineProvider::Mistral) => Some("voxtral-small-latest"),
+            (Self::Nova3, OnlineProvider::Deepgram) => Some("nova-3"),
+            _ => None,
+        }
+    }
+
+    /// Whether this model requires GPU acceleration for local inference.
+    /// Voxtral models need GPU; whisper models can run on CPU.
+    #[must_use]
+    pub fn requires_gpu(&self) -> bool {
+        self.is_voxtral()
+    }
+
+    #[must_use]
+    pub fn is_multilingual(&self) -> bool {
+        !matches!(
+            self,
+            Self::WhisperTinyEn
+                | Self::WhisperBaseEn
+                | Self::WhisperSmallEn
+                | Self::WhisperMediumEn
+                | Self::WhisperDistilMediumEn
+        )
     }
 
     #[must_use]
     pub fn is_voxtral(&self) -> bool {
-        match self {
-            Self::VoxtralSmall | Self::VoxtralMini => true,
-            Self::WhisperTiny
-            | Self::WhisperBase
-            | Self::WhisperSmall
-            | Self::WhisperMedium
-            | Self::WhisperLarge
-            | Self::WhisperLargeV2
-            | Self::WhisperLargeV3
-            | Self::WhisperLargeV3Turbo
-            | Self::WhisperDistilLargeV2
-            | Self::WhisperDistilLargeV3
-            | Self::WhisperTinyEn
-            | Self::WhisperBaseEn
-            | Self::WhisperSmallEn
-            | Self::WhisperMediumEn
-            | Self::WhisperDistilMediumEn
-            | Self::OpenAIWhisper1
-            | Self::OpenAIGpt4oTranscribe
-            | Self::OpenAIGpt4oMiniTranscribe
-            | Self::MistralVoxtralMiniTranscribeV2
-            | Self::DeepgramNova3 => false,
-        }
+        matches!(self, Self::VoxtralSmall | Self::VoxtralMini)
     }
 
-    /// Returns true if this model requires an online API (audio leaves the device).
+    /// Estimated GPU VRAM required to load this model, in bytes.
+    /// Returns 0 for online-only models (they don't use local GPU).
+    /// These are conservative estimates that include model weights plus
+    /// overhead for KV-cache, activations, and CUDA context.
     #[must_use]
-    pub fn is_online(&self) -> bool {
-        matches!(
-            self,
-            Self::OpenAIWhisper1
-                | Self::OpenAIGpt4oTranscribe
-                | Self::OpenAIGpt4oMiniTranscribe
-                | Self::MistralVoxtralMiniTranscribeV2
-                | Self::DeepgramNova3
-        )
-    }
-
-    /// Returns the API model ID string used in transcription requests.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called on a non-online model.
-    #[must_use]
-    pub fn api_model_id(&self) -> &'static str {
+    pub fn estimated_vram_bytes(&self) -> u64 {
+        const GB: u64 = 1_073_741_824;
+        const MB: u64 = 1_048_576;
         match self {
-            Self::OpenAIWhisper1 => "whisper-1",
-            Self::OpenAIGpt4oTranscribe => "gpt-4o-transcribe",
-            Self::OpenAIGpt4oMiniTranscribe => "gpt-4o-mini-transcribe",
-            Self::MistralVoxtralMiniTranscribeV2 => "voxtral-mini-latest",
-            Self::DeepgramNova3 => "nova-3",
-            _ => panic!("api_model_id called on non-online model: {self}"),
-        }
-    }
-
-    /// Returns the provider name for keyring API key lookups (e.g. `"openai"`, `"mistral"`).
-    ///
-    /// # Panics
-    ///
-    /// Panics if called on a non-online model.
-    #[must_use]
-    pub fn api_provider(&self) -> &'static str {
-        match self {
-            Self::OpenAIWhisper1
-            | Self::OpenAIGpt4oTranscribe
-            | Self::OpenAIGpt4oMiniTranscribe => "openai",
-            Self::MistralVoxtralMiniTranscribeV2 => "mistral",
-            Self::DeepgramNova3 => "deepgram",
-            _ => panic!("api_provider called on non-online model: {self}"),
-        }
-    }
-
-    /// Returns the base URL for this model's API.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called on a non-online model.
-    #[must_use]
-    pub fn api_base_url(&self) -> &'static str {
-        match self {
-            Self::OpenAIWhisper1
-            | Self::OpenAIGpt4oTranscribe
-            | Self::OpenAIGpt4oMiniTranscribe => "https://api.openai.com",
-            Self::MistralVoxtralMiniTranscribeV2 => "https://api.mistral.ai",
-            Self::DeepgramNova3 => "https://api.deepgram.com",
-            _ => panic!("api_base_url called on non-online model: {self}"),
+            // Whisper models (weights loaded in f32)
+            Self::WhisperTiny | Self::WhisperTinyEn => 250 * MB,
+            Self::WhisperBase | Self::WhisperBaseEn => 500 * MB,
+            Self::WhisperSmall | Self::WhisperSmallEn => GB,
+            Self::WhisperMedium | Self::WhisperMediumEn | Self::WhisperDistilMediumEn => 2 * GB,
+            Self::WhisperLarge | Self::WhisperLargeV2 | Self::WhisperLargeV3 => 4 * GB,
+            Self::WhisperLargeV3Turbo | Self::WhisperDistilLargeV2 | Self::WhisperDistilLargeV3 => {
+                3 * GB
+            }
+            // Voxtral models
+            Self::VoxtralMini => 8 * GB,
+            Self::VoxtralSmall => 50 * GB,
+            // Online-only models don't use local VRAM
+            Self::Whisper1
+            | Self::Gpt4oTranscribe
+            | Self::Gpt4oMiniTranscribe
+            | Self::VoxtralMiniTranscribeV2
+            | Self::Nova3 => 0,
         }
     }
 
@@ -247,12 +241,12 @@ impl STTModel {
             Self::WhisperDistilLargeV3 => ("distil-whisper/distil-large-v3", "main"),
             Self::VoxtralSmall => ("mistralai/Voxtral-Small-24B-2507", "main"),
             Self::VoxtralMini => ("mistralai/Voxtral-Mini-3B-2507", "main"),
-            // Online models don't have HuggingFace repos
-            Self::OpenAIWhisper1 => ("openai/whisper-1", ""),
-            Self::OpenAIGpt4oTranscribe => ("openai/gpt-4o-transcribe", ""),
-            Self::OpenAIGpt4oMiniTranscribe => ("openai/gpt-4o-mini-transcribe", ""),
-            Self::MistralVoxtralMiniTranscribeV2 => ("mistralai/voxtral-mini-transcribe-v2", ""),
-            Self::DeepgramNova3 => ("deepgram/nova-3", ""),
+            // Online-only models don't have HuggingFace repos
+            Self::Whisper1 => ("openai/whisper-1", ""),
+            Self::Gpt4oTranscribe => ("openai/gpt-4o-transcribe", ""),
+            Self::Gpt4oMiniTranscribe => ("openai/gpt-4o-mini-transcribe", ""),
+            Self::VoxtralMiniTranscribeV2 => ("mistralai/voxtral-mini-transcribe-v2", ""),
+            Self::Nova3 => ("deepgram/nova-3", ""),
         }
     }
 
@@ -260,11 +254,17 @@ impl STTModel {
     #[must_use]
     pub fn get_processing_interval(&self) -> std::time::Duration {
         match self {
-            // Fast models - can handle frequent updates
-            Self::WhisperTiny | Self::WhisperTinyEn => std::time::Duration::from_millis(1000),
+            // Fast models and online models
+            Self::WhisperTiny
+            | Self::WhisperTinyEn
+            | Self::Whisper1
+            | Self::Gpt4oTranscribe
+            | Self::Gpt4oMiniTranscribe
+            | Self::VoxtralMiniTranscribeV2
+            | Self::Nova3 => std::time::Duration::from_millis(1000),
             Self::WhisperBase | Self::WhisperBaseEn => std::time::Duration::from_millis(1500),
 
-            // Semi-fast models - can handle frequent updates but with a slight delay
+            // Semi-fast models
             Self::VoxtralMini
             | Self::WhisperSmall
             | Self::WhisperSmallEn
@@ -282,13 +282,6 @@ impl STTModel {
             Self::WhisperLarge | Self::WhisperLargeV2 | Self::WhisperLargeV3 => {
                 std::time::Duration::from_millis(5000)
             }
-
-            // Online models - network latency dependent
-            Self::OpenAIWhisper1
-            | Self::OpenAIGpt4oTranscribe
-            | Self::OpenAIGpt4oMiniTranscribe
-            | Self::MistralVoxtralMiniTranscribeV2
-            | Self::DeepgramNova3 => std::time::Duration::from_millis(3000),
         }
     }
 }
@@ -315,11 +308,11 @@ impl FromStr for STTModel {
             "whisper-distil-large-v3" => Ok(Self::WhisperDistilLargeV3),
             "voxtral-small" => Ok(Self::VoxtralSmall),
             "voxtral-mini" => Ok(Self::VoxtralMini),
-            "openai-whisper-1" => Ok(Self::OpenAIWhisper1),
-            "openai-gpt-4o-transcribe" => Ok(Self::OpenAIGpt4oTranscribe),
-            "openai-gpt-4o-mini-transcribe" => Ok(Self::OpenAIGpt4oMiniTranscribe),
-            "mistral-voxtral-mini-transcribe-v2" => Ok(Self::MistralVoxtralMiniTranscribeV2),
-            "deepgram-nova-3" => Ok(Self::DeepgramNova3),
+            "whisper-1" => Ok(Self::Whisper1),
+            "gpt-4o-transcribe" => Ok(Self::Gpt4oTranscribe),
+            "gpt-4o-mini-transcribe" => Ok(Self::Gpt4oMiniTranscribe),
+            "voxtral-mini-transcribe-v2" => Ok(Self::VoxtralMiniTranscribeV2),
+            "nova-3" => Ok(Self::Nova3),
             _ => Err(format!("Unknown model: {s}")),
         }
     }
@@ -330,167 +323,111 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_online_returns_true_for_openai_models() {
-        assert!(STTModel::OpenAIWhisper1.is_online());
-        assert!(STTModel::OpenAIGpt4oTranscribe.is_online());
-        assert!(STTModel::OpenAIGpt4oMiniTranscribe.is_online());
+    fn providers_local_models() {
+        assert_eq!(STTModel::WhisperTiny.providers(), &[Provider::Local]);
+        assert_eq!(STTModel::WhisperLargeV3.providers(), &[Provider::Local]);
     }
 
     #[test]
-    fn is_online_returns_false_for_local_models() {
-        assert!(!STTModel::WhisperTiny.is_online());
-        assert!(!STTModel::WhisperLargeV3.is_online());
-        assert!(!STTModel::VoxtralSmall.is_online());
-        assert!(!STTModel::VoxtralMini.is_online());
-        assert!(!STTModel::WhisperDistilLargeV3.is_online());
+    fn providers_voxtral_has_local_and_mistral() {
+        let providers = STTModel::VoxtralMini.providers();
+        assert!(providers.contains(&Provider::Local));
+        assert!(providers.contains(&Provider::Online(OnlineProvider::Mistral)));
+    }
+
+    #[test]
+    fn providers_online_only_models() {
+        assert_eq!(
+            STTModel::Whisper1.providers(),
+            &[Provider::Online(OnlineProvider::OpenAI)]
+        );
+        assert_eq!(
+            STTModel::Gpt4oTranscribe.providers(),
+            &[Provider::Online(OnlineProvider::OpenAI)]
+        );
+        assert_eq!(
+            STTModel::VoxtralMiniTranscribeV2.providers(),
+            &[Provider::Online(OnlineProvider::Mistral)]
+        );
+        assert_eq!(
+            STTModel::Nova3.providers(),
+            &[Provider::Online(OnlineProvider::Deepgram)]
+        );
+    }
+
+    #[test]
+    fn default_provider_is_local_when_available() {
+        assert_eq!(STTModel::WhisperTiny.default_provider(), Provider::Local);
+        assert_eq!(STTModel::VoxtralMini.default_provider(), Provider::Local);
+    }
+
+    #[test]
+    fn default_provider_online_only() {
+        assert_eq!(
+            STTModel::Whisper1.default_provider(),
+            Provider::Online(OnlineProvider::OpenAI)
+        );
+        assert_eq!(
+            STTModel::Nova3.default_provider(),
+            Provider::Online(OnlineProvider::Deepgram)
+        );
     }
 
     #[test]
     fn api_model_id_returns_correct_strings() {
-        assert_eq!(STTModel::OpenAIWhisper1.api_model_id(), "whisper-1");
         assert_eq!(
-            STTModel::OpenAIGpt4oTranscribe.api_model_id(),
-            "gpt-4o-transcribe"
+            STTModel::Whisper1.api_model_id(OnlineProvider::OpenAI),
+            Some("whisper-1")
         );
         assert_eq!(
-            STTModel::OpenAIGpt4oMiniTranscribe.api_model_id(),
-            "gpt-4o-mini-transcribe"
+            STTModel::Gpt4oTranscribe.api_model_id(OnlineProvider::OpenAI),
+            Some("gpt-4o-transcribe")
         );
         assert_eq!(
-            STTModel::MistralVoxtralMiniTranscribeV2.api_model_id(),
-            "voxtral-mini-latest"
+            STTModel::Gpt4oMiniTranscribe.api_model_id(OnlineProvider::OpenAI),
+            Some("gpt-4o-mini-transcribe")
         );
-    }
-
-    #[test]
-    fn api_provider_returns_correct_strings() {
-        assert_eq!(STTModel::OpenAIWhisper1.api_provider(), "openai");
-        assert_eq!(STTModel::OpenAIGpt4oTranscribe.api_provider(), "openai");
         assert_eq!(
-            STTModel::MistralVoxtralMiniTranscribeV2.api_provider(),
-            "mistral"
+            STTModel::VoxtralMiniTranscribeV2.api_model_id(OnlineProvider::Mistral),
+            Some("voxtral-mini-latest")
+        );
+        assert_eq!(
+            STTModel::Nova3.api_model_id(OnlineProvider::Deepgram),
+            Some("nova-3")
         );
     }
 
     #[test]
-    fn api_base_url_returns_correct_urls() {
+    fn api_model_id_voxtral_via_mistral() {
         assert_eq!(
-            STTModel::OpenAIWhisper1.api_base_url(),
-            "https://api.openai.com"
-        );
-        assert_eq!(
-            STTModel::MistralVoxtralMiniTranscribeV2.api_base_url(),
-            "https://api.mistral.ai"
+            STTModel::VoxtralMini.api_model_id(OnlineProvider::Mistral),
+            Some("voxtral-mini-latest")
         );
     }
 
     #[test]
-    fn from_str_round_trips_for_online_models() {
-        let models = [
-            STTModel::OpenAIWhisper1,
-            STTModel::OpenAIGpt4oTranscribe,
-            STTModel::OpenAIGpt4oMiniTranscribe,
-            STTModel::MistralVoxtralMiniTranscribeV2,
-            STTModel::DeepgramNova3,
-        ];
-        for model in &models {
-            let s = model.to_string();
-            let parsed: STTModel = s.parse().unwrap();
-            assert_eq!(*model, parsed);
-        }
-    }
-
-    #[test]
-    fn online_models_are_multilingual() {
-        assert!(STTModel::OpenAIWhisper1.is_multilingual());
-        assert!(STTModel::OpenAIGpt4oTranscribe.is_multilingual());
-        assert!(STTModel::OpenAIGpt4oMiniTranscribe.is_multilingual());
-        assert!(STTModel::MistralVoxtralMiniTranscribeV2.is_multilingual());
-        assert!(STTModel::DeepgramNova3.is_multilingual());
-    }
-
-    #[test]
-    fn online_models_are_not_voxtral() {
-        assert!(!STTModel::OpenAIWhisper1.is_voxtral());
-        assert!(!STTModel::OpenAIGpt4oTranscribe.is_voxtral());
-        assert!(!STTModel::OpenAIGpt4oMiniTranscribe.is_voxtral());
-        assert!(!STTModel::MistralVoxtralMiniTranscribeV2.is_voxtral());
-        assert!(!STTModel::DeepgramNova3.is_voxtral());
-    }
-
-    #[test]
-    fn is_online_returns_true_for_mistral_models() {
-        assert!(STTModel::MistralVoxtralMiniTranscribeV2.is_online());
-    }
-
-    #[test]
-    fn is_online_returns_true_for_deepgram_models() {
-        assert!(STTModel::DeepgramNova3.is_online());
-    }
-
-    #[test]
-    fn deepgram_api_methods() {
-        assert_eq!(STTModel::DeepgramNova3.api_model_id(), "nova-3");
-        assert_eq!(STTModel::DeepgramNova3.api_provider(), "deepgram");
+    fn api_model_id_returns_none_for_wrong_provider() {
         assert_eq!(
-            STTModel::DeepgramNova3.api_base_url(),
-            "https://api.deepgram.com"
+            STTModel::WhisperTiny.api_model_id(OnlineProvider::OpenAI),
+            None
+        );
+        assert_eq!(
+            STTModel::Whisper1.api_model_id(OnlineProvider::Mistral),
+            None
         );
     }
 
     #[test]
-    fn default_model_is_not_online() {
-        assert!(!STTModel::default().is_online());
+    fn is_voxtral() {
+        assert!(STTModel::VoxtralSmall.is_voxtral());
+        assert!(STTModel::VoxtralMini.is_voxtral());
+        assert!(!STTModel::WhisperTiny.is_voxtral());
+        assert!(!STTModel::Whisper1.is_voxtral());
     }
 
     #[test]
-    #[should_panic(expected = "api_model_id called on non-online model")]
-    fn api_model_id_panics_for_local_model() {
-        let _ = STTModel::WhisperTiny.api_model_id();
-    }
-
-    #[test]
-    #[should_panic(expected = "api_provider called on non-online model")]
-    fn api_provider_panics_for_local_model() {
-        let _ = STTModel::WhisperTiny.api_provider();
-    }
-
-    #[test]
-    #[should_panic(expected = "api_base_url called on non-online model")]
-    fn api_base_url_panics_for_local_model() {
-        let _ = STTModel::WhisperTiny.api_base_url();
-    }
-
-    #[test]
-    fn all_online_models_have_consistent_api_methods() {
-        use strum::VariantArray;
-        for model in STTModel::VARIANTS {
-            if model.is_online() {
-                // These should not panic for any online model
-                let _ = model.api_model_id();
-                let _ = model.api_provider();
-                let url = model.api_base_url();
-                assert!(
-                    url.starts_with("https://"),
-                    "{model}: api_base_url should start with https://"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn no_local_model_is_online() {
-        use strum::VariantArray;
-        for model in STTModel::VARIANTS {
-            if !model.is_online() {
-                // Local models should be either whisper or voxtral
-                let name = model.to_string();
-                assert!(
-                    name.starts_with("whisper-") || name.starts_with("voxtral-"),
-                    "{model}: unexpected local model prefix"
-                );
-            }
-        }
+    fn default_model_is_local() {
+        assert_eq!(STTModel::default().default_provider(), Provider::Local);
     }
 
     #[test]
@@ -502,6 +439,29 @@ mod tests {
                 panic!("{model}: FromStr failed for '{s}': {e}");
             });
             assert_eq!(*model, parsed);
+        }
+    }
+
+    #[test]
+    fn every_model_has_at_least_one_provider() {
+        use strum::VariantArray;
+        for model in STTModel::VARIANTS {
+            assert!(!model.providers().is_empty(), "{model}: has no providers");
+        }
+    }
+
+    #[test]
+    fn online_only_models_have_api_model_id() {
+        use strum::VariantArray;
+        for model in STTModel::VARIANTS {
+            for provider in model.providers() {
+                if let Provider::Online(op) = provider {
+                    assert!(
+                        model.api_model_id(*op).is_some(),
+                        "{model} with {provider}: missing api_model_id"
+                    );
+                }
+            }
         }
     }
 }

--- a/super-stt/src/config.rs
+++ b/super-stt/src/config.rs
@@ -3,6 +3,7 @@ use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use super_stt_shared::models::provider::Provider;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::models::write_method::WriteMethod;
 use super_stt_shared::stt_model::STTModel;
@@ -44,6 +45,8 @@ pub struct OnlineConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionConfig {
     pub preferred_model: STTModel,
+    #[serde(default)]
+    pub preferred_provider: Provider,
     pub write_mode: bool, // Auto-type transcriptions
     #[serde(default)] // For backwards compatibility with existing configs
     pub preview_typing_enabled: bool, // Beta feature: show preview while typing
@@ -67,6 +70,7 @@ impl Default for DaemonConfig {
             },
             transcription: TranscriptionConfig {
                 preferred_model: STTModel::default(),
+                preferred_provider: Provider::default(),
                 write_mode: false,             // Default to not auto-typing
                 preview_typing_enabled: false, // Default to disabled (beta feature)
                 recording_stop_mode: RecordingStopMode::default(),
@@ -148,9 +152,10 @@ impl DaemonConfig {
         }
     }
 
-    /// Update preferred model and save to disk
-    pub fn update_preferred_model(&mut self, model: STTModel) {
+    /// Update preferred model and provider, and save to disk
+    pub fn update_preferred_model(&mut self, model: STTModel, provider: Provider) {
         self.transcription.preferred_model = model;
+        self.transcription.preferred_provider = provider;
         if let Err(e) = self.save() {
             error!("Failed to save config after model update: {e}");
         }
@@ -251,25 +256,22 @@ write_method = "Auto"
     fn config_with_online_model_preferred_round_trips() {
         let mut config = DaemonConfig::default();
         config.online.allow_online_models = true;
-        config.transcription.preferred_model = STTModel::OpenAIWhisper1;
+        config.transcription.preferred_model = STTModel::Whisper1;
 
         let toml_str = toml::to_string_pretty(&config).expect("should serialize");
         let parsed: DaemonConfig = toml::from_str(&toml_str).expect("should deserialize");
         assert!(parsed.online.allow_online_models);
-        assert_eq!(
-            parsed.transcription.preferred_model,
-            STTModel::OpenAIWhisper1
-        );
+        assert_eq!(parsed.transcription.preferred_model, STTModel::Whisper1);
     }
 
     #[test]
     fn config_preserves_all_online_model_variants() {
         for model in [
-            STTModel::OpenAIWhisper1,
-            STTModel::OpenAIGpt4oTranscribe,
-            STTModel::OpenAIGpt4oMiniTranscribe,
-            STTModel::MistralVoxtralMiniTranscribeV2,
-            STTModel::DeepgramNova3,
+            STTModel::Whisper1,
+            STTModel::Gpt4oTranscribe,
+            STTModel::Gpt4oMiniTranscribe,
+            STTModel::VoxtralMiniTranscribeV2,
+            STTModel::Nova3,
         ] {
             let mut config = DaemonConfig::default();
             config.transcription.preferred_model = model;

--- a/super-stt/src/daemon/core.rs
+++ b/super-stt/src/daemon/core.rs
@@ -73,7 +73,7 @@ impl SuperSTTDaemon {
             Command::SetAudioTheme { theme } => self.handle_set_audio_theme(theme),
             Command::GetAudioTheme => self.handle_get_audio_theme(),
             Command::TestAudioTheme => self.handle_test_audio_theme().await,
-            Command::SetModel { model } => self.handle_set_model(model).await,
+            Command::SetModel { model, provider } => self.handle_set_model(model, provider).await,
             Command::GetModel => self.handle_get_model().await,
             Command::ListModels => self.handle_list_models(),
             Command::SetDevice { device } => self.handle_set_device(device).await,
@@ -269,6 +269,7 @@ mod tests {
             socket_path,
             model,
             model_type,
+            model_provider: Arc::new(tokio::sync::RwLock::new(None)),
             notification_manager,
             audio_processor,
             shutdown_tx,
@@ -603,7 +604,7 @@ mod tests {
             since_timestamp: None,
             limit: None,
             event_type: None,
-            data: Some(serde_json::json!({ "model": "openai-whisper-1" })),
+            data: Some(serde_json::json!({ "model": "whisper-1" })),
             language: None,
             enabled: None,
         };
@@ -631,7 +632,7 @@ mod tests {
         let daemon = test_daemon().await;
 
         let mut request = make_request("set_model");
-        request.data = Some(serde_json::json!({ "model": "mistral-voxtral-mini-transcribe-v2" }));
+        request.data = Some(serde_json::json!({ "model": "voxtral-mini-transcribe-v2" }));
 
         let response = daemon.handle_command(request).await;
         assert_eq!(response.status, "error");
@@ -642,7 +643,7 @@ mod tests {
         let daemon = test_daemon().await;
 
         let mut request = make_request("set_model");
-        request.data = Some(serde_json::json!({ "model": "deepgram-nova-3" }));
+        request.data = Some(serde_json::json!({ "model": "nova-3" }));
 
         let response = daemon.handle_command(request).await;
         assert_eq!(response.status, "error");
@@ -691,17 +692,17 @@ mod tests {
         let models = response.available_models.expect("should have models");
         // Should include online models in the list
         assert!(
-            models.iter().any(|m| m.to_string() == "openai-whisper-1"),
+            models.iter().any(|m| m.to_string() == "whisper-1"),
             "list should include OpenAI models"
         );
         assert!(
             models
                 .iter()
-                .any(|m| m.to_string() == "mistral-voxtral-mini-transcribe-v2"),
+                .any(|m| m.to_string() == "voxtral-mini-transcribe-v2"),
             "list should include Mistral models"
         );
         assert!(
-            models.iter().any(|m| m.to_string() == "deepgram-nova-3"),
+            models.iter().any(|m| m.to_string() == "nova-3"),
             "list should include Deepgram models"
         );
     }

--- a/super-stt/src/daemon/device_management.rs
+++ b/super-stt/src/daemon/device_management.rs
@@ -30,6 +30,23 @@ impl SuperSTTDaemon {
         // Get context for the device switch
         let (current_preferred, model_to_reload) = self.get_device_switch_context(&device).await;
 
+        // Online models don't use local GPU — just update the preference
+        let current_provider = self.model_provider.read().await;
+        if current_provider.is_some_and(|p| p.is_online()) {
+            drop(current_provider);
+            info!("Current model uses online provider, updating device preference only");
+            *self.preferred_device.write().await = device.clone();
+            {
+                let mut config = self.config.write().await;
+                config.update_preferred_device(device.clone());
+            }
+            let _ = self.broadcast_config_change().await;
+            return DaemonResponse::success()
+                .with_device(device)
+                .with_message("Device preference updated (online model unaffected)".to_string());
+        }
+        drop(current_provider);
+
         info!(
             "Starting device switch from {current_preferred} to {device} (will reload model: {model_to_reload})"
         );
@@ -414,9 +431,38 @@ impl SuperSTTDaemon {
             format!("Device: {actual_device} (preferred and actual match)")
         };
 
-        DaemonResponse::success()
+        let mut response = DaemonResponse::success()
             .with_device(actual_device)
             .with_available_devices(available_devices)
-            .with_message(message)
+            .with_message(message);
+
+        // Include GPU memory info when CUDA is available
+        match Self::get_gpu_memory_info() {
+            Ok((free, total)) => {
+                response = response
+                    .with_gpu_free_memory(free)
+                    .with_gpu_total_memory(total);
+            }
+            Err(e) => {
+                info!("GPU memory query unavailable: {e}");
+            }
+        }
+
+        response
+    }
+
+    #[cfg(feature = "cuda")]
+    fn get_gpu_memory_info() -> Result<(u64, u64), anyhow::Error> {
+        use candle_core::cuda_backend::cudarc::driver::{result, safe::CudaContext};
+        let _ctx =
+            CudaContext::new(0).map_err(|e| anyhow::anyhow!("CUDA context init failed: {e}"))?;
+        let (free, total) =
+            result::mem_get_info().map_err(|e| anyhow::anyhow!("CUDA mem_get_info: {e}"))?;
+        Ok((free as u64, total as u64))
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    fn get_gpu_memory_info() -> Result<(u64, u64), anyhow::Error> {
+        Err(anyhow::anyhow!("CUDA not available"))
     }
 }

--- a/super-stt/src/daemon/handlers.rs
+++ b/super-stt/src/daemon/handlers.rs
@@ -395,12 +395,15 @@ impl SuperSTTDaemon {
         // If disabling online models and current model is online, revert to default
         if !enabled {
             let current_is_online = {
-                let model_type = self.model_type.read().await;
-                model_type.as_ref().is_some_and(STTModel::is_online)
+                let provider = self.model_provider.read().await;
+                provider.is_some_and(|p| p.is_online())
             };
             if current_is_online {
                 info!("Online models disabled; reverting to default local model");
-                let _ = self.handle_set_model(STTModel::default()).await;
+                let default_model = STTModel::default();
+                let _ = self
+                    .handle_set_model(default_model, default_model.default_provider())
+                    .await;
             }
         }
 

--- a/super-stt/src/daemon/model_management.rs
+++ b/super-stt/src/daemon/model_management.rs
@@ -8,6 +8,7 @@ use chrono::Utc;
 use log::{error, info, warn};
 use std::sync::Arc;
 use super_stt_shared::models::protocol::DaemonResponse;
+use super_stt_shared::models::provider::{OnlineProvider, Provider};
 use super_stt_shared::stt_model::STTModel;
 
 impl SuperSTTDaemon {
@@ -104,9 +105,15 @@ impl SuperSTTDaemon {
         let model_type_guard = self.model_type.read().await;
 
         if let Some(model) = model_type_guard.as_ref() {
+            let provider = self
+                .model_provider
+                .read()
+                .await
+                .unwrap_or(model.default_provider());
             info!("Current model requested: {model}");
             DaemonResponse::success()
                 .with_current_model(*model)
+                .with_current_provider(provider)
                 .with_message(format!("Current model: {model}"))
         } else {
             warn!("No model is currently loaded");
@@ -115,21 +122,24 @@ impl SuperSTTDaemon {
     }
 
     /// Handle set model command - switch to a different model
-    pub async fn handle_set_model(&self, model: STTModel) -> DaemonResponse {
-        self.handle_set_model_impl(model).await
+    pub async fn handle_set_model(&self, model: STTModel, provider: Provider) -> DaemonResponse {
+        self.handle_set_model_impl(model, provider).await
     }
 
     /// Internal implementation for model switching (split to reduce public fn size)
-    async fn handle_set_model_impl(&self, model: STTModel) -> DaemonResponse {
-        info!("Model switch requested: {model}");
+    async fn handle_set_model_impl(&self, model: STTModel, provider: Provider) -> DaemonResponse {
+        info!("Model switch requested: {model} via {provider}");
         if let Some(resp) = self.preflight_model_switch(model).await {
             return resp;
         }
 
-        // Online models have a separate fast path (no download needed)
-        if model.is_online() {
-            return self.handle_set_online_model(model).await;
+        // Online providers have a separate fast path (no download needed)
+        if let Provider::Online(online) = provider {
+            return self.handle_set_online_model(model, online).await;
         }
+
+        // Remember previous model so we can restore it on failure
+        let previous_model = *self.model_type.read().await;
 
         self.broadcast_model_loading_status(model).await;
         let tracker = self.create_progress_tracker(model);
@@ -144,12 +154,17 @@ impl SuperSTTDaemon {
             .await
         {
             Ok(instance) => {
-                self.finalize_model_switch_success(model, instance, &tracker)
+                self.finalize_model_switch_success(model, provider, instance, &tracker)
                     .await
             }
             Err(e) => {
                 error!("Model switch failed: {e}");
                 self.download_manager.clear_download();
+                // Restore previous model so the daemon isn't left without one
+                if let Some(prev) = previous_model {
+                    warn!("Restoring previous model: {prev}");
+                    self.restore_model(prev).await;
+                }
                 DaemonResponse::error(&format!("Model switch failed: {e}"))
             }
         }
@@ -158,7 +173,11 @@ impl SuperSTTDaemon {
 
 impl SuperSTTDaemon {
     /// Handle switching to an online model (no download, instant creation).
-    async fn handle_set_online_model(&self, model: STTModel) -> DaemonResponse {
+    async fn handle_set_online_model(
+        &self,
+        model: STTModel,
+        online: OnlineProvider,
+    ) -> DaemonResponse {
         // Guard: online models must be explicitly enabled
         let config = self.config.read().await;
         if !config.online.allow_online_models {
@@ -169,12 +188,12 @@ impl SuperSTTDaemon {
         drop(config);
 
         // Guard: API key must be configured in the system keyring
-        let provider = model.api_provider();
-        let api_key = match crate::keyring::get_api_key(provider) {
+        let key_name = online.api_key_name();
+        let api_key = match crate::keyring::get_api_key(key_name) {
             Ok(Some(key)) if !key.is_empty() => key,
             Ok(_) => {
                 return DaemonResponse::error(&format!(
-                    "{provider} API key is not configured. Add your API key in the Online Models settings."
+                    "{key_name} API key is not configured. Add your API key in the Online Models settings."
                 ));
             }
             Err(e) => {
@@ -182,18 +201,28 @@ impl SuperSTTDaemon {
             }
         };
 
+        let api_model_id = match model.api_model_id(online) {
+            Some(id) => id.to_string(),
+            None => {
+                return DaemonResponse::error(&format!(
+                    "Model {model} is not available via {online}"
+                ));
+            }
+        };
+
+        let provider = Provider::Online(online);
         self.broadcast_model_loading_status(model).await;
         self.unload_current_model().await;
 
-        let instance =
-            Self::create_online_instance(provider, api_key, model.api_model_id().to_string());
+        let instance = Self::create_online_instance(online, api_key, api_model_id);
 
         // Store and broadcast
         *self.model.write().await = Some(instance);
         *self.model_type.write().await = Some(model);
+        *self.model_provider.write().await = Some(provider);
         {
             let mut config_guard = self.config.write().await;
-            config_guard.update_preferred_model(model);
+            config_guard.update_preferred_model(model, provider);
         }
         if let Err(e) = self.broadcast_config_change().await {
             warn!("Failed to broadcast config change after online model switch: {e}");
@@ -206,16 +235,17 @@ impl SuperSTTDaemon {
                 serde_json::json!({
                     "status": "ready",
                     "model_loaded": true,
-                    "model_type": provider,
+                    "provider": provider.to_string(),
                     "model_name": model.to_string(),
                     "timestamp": chrono::Utc::now().to_rfc3339()
                 }),
             )
             .await;
 
-        info!("Switched to online model: {model}");
+        info!("Switched to online model: {model} via {provider}");
         DaemonResponse::success()
             .with_current_model(model)
+            .with_current_provider(provider)
             .with_message(format!("Successfully switched to online model: {model}"))
     }
 
@@ -306,7 +336,38 @@ impl SuperSTTDaemon {
     /// Register a download tracker with the download manager.
     ///
     /// # Errors
-    /// This function will return an error if the download tracker fails to register.
+    /// Restore a previously loaded model after a failed switch.
+    /// Best-effort: if this also fails, the daemon remains without a model.
+    async fn restore_model(&self, model: STTModel) {
+        let tracker = self.create_progress_tracker(model);
+        if self.register_download(&tracker).is_err() {
+            error!("Cannot restore model: another download in progress");
+            return;
+        }
+        let start_time = std::time::Instant::now();
+        match self
+            .download_and_load_model(model, Arc::clone(&tracker), start_time)
+            .await
+        {
+            Ok(instance) => {
+                let provider = model.default_provider();
+                tracker.mark_completed();
+                self.download_manager.clear_download();
+                *self.model.write().await = Some(instance);
+                *self.model_type.write().await = Some(model);
+                *self.model_provider.write().await = Some(provider);
+                info!("Previous model {model} restored successfully");
+            }
+            Err(e) => {
+                self.download_manager.clear_download();
+                error!("Failed to restore previous model {model}: {e}");
+            }
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if another download is already in progress.
     pub fn register_download(
         &self,
         tracker: &Arc<DownloadProgressTracker>,
@@ -338,6 +399,38 @@ impl SuperSTTDaemon {
         let override_ref = override_path;
         info!("Override path for model loading: {override_ref:?}");
         info!("Loading model with device preference: {preferred_device} (force_cpu={force_cpu})");
+
+        // Pre-flight VRAM check: if CUDA is requested, verify sufficient free memory
+        // before attempting to load. This prevents candle from panicking on OOM.
+        if !force_cpu {
+            let required = model.estimated_vram_bytes();
+            if required > 0 {
+                match Self::get_cuda_free_memory() {
+                    Ok(free) => {
+                        if free < required {
+                            #[allow(clippy::cast_precision_loss)]
+                            let free_gb = free as f64 / 1_073_741_824.0;
+                            #[allow(clippy::cast_precision_loss)]
+                            let required_gb = required as f64 / 1_073_741_824.0;
+                            error!(
+                                "Insufficient GPU memory for {model}: {free_gb:.1} GB free, \
+                                 {required_gb:.1} GB required"
+                            );
+                            anyhow::bail!(
+                                "Not enough GPU memory to load {model}. \
+                                 {free_gb:.1} GB free, {required_gb:.1} GB required. \
+                                 Try a smaller model or switch to CPU."
+                            );
+                        }
+                        let free_mb = free / (1024 * 1024);
+                        info!("GPU memory check passed: {free_mb} MB free");
+                    }
+                    Err(e) => {
+                        info!("Could not query GPU memory ({e}), proceeding with CUDA attempt");
+                    }
+                }
+            }
+        }
 
         // Attempt to load model with preferred device
         let initial_result = match model {
@@ -378,6 +471,22 @@ impl SuperSTTDaemon {
                 Err(e)
             }
         }
+    }
+
+    /// Query free CUDA GPU memory in bytes.
+    #[cfg(feature = "cuda")]
+    fn get_cuda_free_memory() -> Result<u64> {
+        use candle_core::cuda_backend::cudarc::driver::{result, safe::CudaContext};
+        let _ctx =
+            CudaContext::new(0).map_err(|e| anyhow::anyhow!("CUDA context init failed: {e}"))?;
+        let (free, _total) =
+            result::mem_get_info().map_err(|e| anyhow::anyhow!("CUDA mem_get_info: {e}"))?;
+        Ok(free as u64)
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    fn get_cuda_free_memory() -> Result<u64> {
+        Err(anyhow::anyhow!("CUDA not available"))
     }
 
     /// Download and load a model.
@@ -449,6 +558,7 @@ impl SuperSTTDaemon {
     async fn finalize_model_switch_success(
         &self,
         model: STTModel,
+        provider: Provider,
         instance: STTModelInstance,
         tracker: &Arc<DownloadProgressTracker>,
     ) -> DaemonResponse {
@@ -471,9 +581,10 @@ impl SuperSTTDaemon {
             let mut model_type_guard = self.model_type.write().await;
             *model_type_guard = Some(model);
         }
+        *self.model_provider.write().await = Some(provider);
         {
             let mut config_guard = self.config.write().await;
-            config_guard.update_preferred_model(model);
+            config_guard.update_preferred_model(model, provider);
         }
         if let Err(e) = self.broadcast_config_change().await {
             warn!("Failed to broadcast config change after model switch: {e}");
@@ -507,6 +618,7 @@ impl SuperSTTDaemon {
             .await;
         DaemonResponse::success()
             .with_current_model(model)
+            .with_current_provider(provider)
             .with_message(format!("Successfully switched to model: {model}"))
     }
 }

--- a/super-stt/src/daemon/types.rs
+++ b/super-stt/src/daemon/types.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use super_stt_shared::NotificationManager;
+use super_stt_shared::models::provider::{OnlineProvider, Provider};
 use super_stt_shared::resource_management::ResourceManager;
 use super_stt_shared::stt_model::STTModel;
 use super_stt_shared::theme::AudioTheme;
@@ -114,6 +115,7 @@ pub struct SuperSTTDaemon {
     pub socket_path: PathBuf,
     pub model: Arc<tokio::sync::RwLock<Option<STTModelInstance>>>,
     pub model_type: Arc<tokio::sync::RwLock<Option<super_stt_shared::stt_model::STTModel>>>,
+    pub model_provider: Arc<tokio::sync::RwLock<Option<Provider>>>,
     pub notification_manager: Arc<NotificationManager>,
     pub audio_processor: Arc<AudioProcessor>,
     pub shutdown_tx: broadcast::Sender<()>,
@@ -242,6 +244,9 @@ impl SuperSTTDaemon {
             model_type: Arc::new(tokio::sync::RwLock::new(Some(
                 config.transcription.preferred_model,
             ))),
+            model_provider: Arc::new(tokio::sync::RwLock::new(Some(
+                config.transcription.preferred_provider,
+            ))),
             notification_manager,
             audio_processor,
             shutdown_tx,
@@ -283,26 +288,28 @@ impl SuperSTTDaemon {
         Self::broadcast_loading_status(&daemon.notification_manager).await;
 
         // Load the appropriate STT model based on config preferences
-        // If the preferred model is online but the toggle is off or no key, fall back to default
-        let model_to_load = {
+        // If the preferred provider is online but the toggle is off or no key, fall back to default
+        let (model_to_load, provider_to_load) = {
             let config_guard = daemon.config.read().await;
             let preferred = config_guard.transcription.preferred_model;
-            if preferred.is_online() {
+            let preferred_provider = config_guard.transcription.preferred_provider;
+            if let Provider::Online(online) = preferred_provider {
                 if config_guard.online.allow_online_models
-                    && crate::keyring::has_api_key(preferred.api_provider()).unwrap_or(false)
+                    && crate::keyring::has_api_key(online.api_key_name()).unwrap_or(false)
                 {
-                    preferred
+                    (preferred, preferred_provider)
                 } else {
                     warn!(
-                        "Preferred model is online but online models are disabled or no API key; falling back to default"
+                        "Preferred provider is online but online models are disabled or no API key; falling back to default"
                     );
-                    STTModel::default()
+                    let default = STTModel::default();
+                    (default, default.default_provider())
                 }
             } else {
-                preferred
+                (preferred, preferred_provider)
             }
         };
-        Self::load_initial_model_and_broadcast(&daemon, model_to_load).await?;
+        Self::load_initial_model_and_broadcast(&daemon, model_to_load, provider_to_load).await?;
 
         Ok(daemon)
     }
@@ -372,21 +379,26 @@ impl SuperSTTDaemon {
     async fn load_initial_model_and_broadcast(
         daemon: &SuperSTTDaemon,
         model_to_load: STTModel,
+        provider: Provider,
     ) -> Result<()> {
         daemon.broadcast_model_loading_status(model_to_load).await;
 
-        // Online models don't need downloading — create instance directly
-        if model_to_load.is_online() {
-            let provider = model_to_load.api_provider();
-            let api_key = crate::keyring::get_api_key(provider)
+        // Online providers don't need downloading — create instance directly
+        if let Provider::Online(online) = provider {
+            let key_name = online.api_key_name();
+            let api_key = crate::keyring::get_api_key(key_name)
                 .map_err(|e| anyhow::anyhow!(e))?
-                .ok_or_else(|| anyhow::anyhow!("{provider} API key not configured"))?;
+                .ok_or_else(|| anyhow::anyhow!("{key_name} API key not configured"))?;
 
-            let model_id = model_to_load.api_model_id().to_string();
-            let instance = Self::create_online_instance(provider, api_key, model_id);
+            let model_id = model_to_load
+                .api_model_id(online)
+                .ok_or_else(|| anyhow::anyhow!("{model_to_load} not available via {provider}"))?
+                .to_string();
+            let instance = Self::create_online_instance(online, api_key, model_id);
             info!("{provider} model {model_to_load} loaded successfully");
             *daemon.model.write().await = Some(instance);
             *daemon.model_type.write().await = Some(model_to_load);
+            *daemon.model_provider.write().await = Some(provider);
 
             if let Err(e) = daemon
                 .notification_manager
@@ -396,7 +408,7 @@ impl SuperSTTDaemon {
                     serde_json::json!({
                         "status": "ready",
                         "model_loaded": true,
-                        "model_type": provider,
+                        "provider": provider.to_string(),
                         "timestamp": chrono::Utc::now().to_rfc3339()
                     }),
                 )
@@ -461,23 +473,22 @@ impl SuperSTTDaemon {
     }
 
     /// Create the appropriate online model instance based on provider.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provider string is not a recognized online provider.
     #[must_use]
     pub fn create_online_instance(
-        provider: &str,
+        provider: OnlineProvider,
         api_key: String,
         model_id: String,
     ) -> STTModelInstance {
         match provider {
-            "openai" => STTModelInstance::OpenAI(Box::new(OpenAIModel::new(api_key, model_id))),
-            "mistral" => STTModelInstance::Mistral(Box::new(MistralModel::new(api_key, model_id))),
-            "deepgram" => {
+            OnlineProvider::OpenAI => {
+                STTModelInstance::OpenAI(Box::new(OpenAIModel::new(api_key, model_id)))
+            }
+            OnlineProvider::Mistral => {
+                STTModelInstance::Mistral(Box::new(MistralModel::new(api_key, model_id)))
+            }
+            OnlineProvider::Deepgram => {
                 STTModelInstance::Deepgram(Box::new(DeepgramModel::new(api_key, model_id)))
             }
-            _ => panic!("Unknown online provider: {provider}"),
         }
     }
 
@@ -715,7 +726,7 @@ mod tests {
     #[test]
     fn create_online_instance_openai() {
         let instance = SuperSTTDaemon::create_online_instance(
-            "openai",
+            OnlineProvider::OpenAI,
             "test-key".to_string(),
             "whisper-1".to_string(),
         );
@@ -726,7 +737,7 @@ mod tests {
     #[test]
     fn create_online_instance_mistral() {
         let instance = SuperSTTDaemon::create_online_instance(
-            "mistral",
+            OnlineProvider::Mistral,
             "test-key".to_string(),
             "voxtral-mini-latest".to_string(),
         );
@@ -737,7 +748,7 @@ mod tests {
     #[test]
     fn create_online_instance_deepgram() {
         let instance = SuperSTTDaemon::create_online_instance(
-            "deepgram",
+            OnlineProvider::Deepgram,
             "test-key".to_string(),
             "nova-3".to_string(),
         );
@@ -746,19 +757,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Unknown online provider")]
-    fn create_online_instance_unknown_panics() {
-        let _ = SuperSTTDaemon::create_online_instance(
-            "unknown",
-            "test-key".to_string(),
-            "model".to_string(),
-        );
-    }
-
-    #[test]
     fn online_instance_transcribe_sync_returns_error() {
         let mut instance = SuperSTTDaemon::create_online_instance(
-            "openai",
+            OnlineProvider::OpenAI,
             "key".to_string(),
             "whisper-1".to_string(),
         );
@@ -775,7 +776,7 @@ mod tests {
     #[test]
     fn online_instance_device_returns_cpu() {
         let instance = SuperSTTDaemon::create_online_instance(
-            "openai",
+            OnlineProvider::OpenAI,
             "key".to_string(),
             "whisper-1".to_string(),
         );


### PR DESCRIPTION
Introduce a Provider enum (Local, OpenAI, Mistral, Deepgram) to decouple model identity from how it runs. Models like VoxtralMini can now be served by multiple providers. The protocol and config track both model and provider.

Add pre-flight GPU memory check before loading models on CUDA to prevent OOM panics. Display model VRAM estimates and live GPU memory usage in the model selection UI.