### PR TITLE
Dedicated error screen for model operation fail

### DIFF
--- a/super-stt-app/src/core/app.rs
+++ b/super-stt-app/src/core/app.rs
@@ -43,6 +43,8 @@ pub enum ModelOperationState {
         target_model: STTModel,
         status_message: String,
     },
+    /// Model operation failed
+    Error { message: String },
 }
 
 /// Device switching state
@@ -1568,17 +1570,13 @@ impl AppModel {
             }
 
             Message::ModelError(err) => {
-                // Handle error from model switching - reset to Ready
                 warn!("Model operation failed: {err}");
-                self.model_operation_state = ModelOperationState::Ready;
-
-                // Display sanitized error message to user
-                let sanitized_error = err
+                let sanitized = err
                     .replace(&std::env::var("HOME").unwrap_or_default(), "$HOME")
                     .chars()
                     .take(200)
                     .collect::<String>();
-                self.transcription_text = format!("Model Error: {sanitized_error}");
+                self.model_operation_state = ModelOperationState::Error { message: sanitized };
                 Task::none()
             }
 

--- a/super-stt-app/src/ui/views/models.rs
+++ b/super-stt-app/src/ui/views/models.rs
@@ -180,6 +180,27 @@ fn model_loading_section(target_model: STTModel, status_message: &str) -> Elemen
         .into()
 }
 
+/// Model section when an error occurred
+fn model_error_section(error_message: &str) -> Element<'_, Message> {
+    let error_widget = column![
+        row![
+            cosmic::widget::icon::from_name("dialog-warning-symbolic")
+                .size(20)
+                .icon(),
+            text::body(error_message),
+        ]
+        .spacing(cosmic::theme::spacing().space_xs)
+        .align_y(cosmic::iced::Alignment::Center),
+        widget::button::standard("Dismiss").on_press(Message::ModelChanged(STTModel::default())),
+    ]
+    .spacing(cosmic::theme::spacing().space_s);
+
+    settings::section()
+        .title("Speech-to-Text Model")
+        .add(settings::flex_item("Error", error_widget))
+        .into()
+}
+
 /// Model section when device is switching
 fn model_device_switching_section<'a>(
     target_device: &'a str,
@@ -488,6 +509,7 @@ pub fn page<'a>(
             target_model,
             status_message,
         } => model_loading_section(*target_model, status_message),
+        ModelOperationState::Error { message } => model_error_section(message),
     };
 
     let storage_section = model_storage_section(


### PR DESCRIPTION
Add Error variant to ModelOperationState with a warning icon and dismiss button instead of writing errors to the transcription text.