### PR TITLE
Harden daemon keyring startup and bound app daemon I/O

### DIFF
--- a/super-stt-daemon/src/daemon/device_management.rs
+++ b/super-stt-daemon/src/daemon/device_management.rs
@@ -206,7 +206,13 @@ impl SuperSTTDaemon {
                 .expect("Model existence already validated")
         };
         let current_preferred = self.preferred_device.read().await.clone();
-        (current_preferred, model_to_reload, provider, source, is_online)
+        (
+            current_preferred,
+            model_to_reload,
+            provider,
+            source,
+            is_online,
+        )
     }
 
     /// Prepare for device switch by broadcasting status and unloading current model

--- a/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use log::{info, warn};
+use log::{error, info, warn};
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -40,6 +40,18 @@ pub(crate) fn clear_keyring_failure_flag() {
     *KEYRING_LAST_FAILURE.lock().unwrap() = None;
 }
 
+/// When set to `1`, the daemon starts even if the system keyring is
+/// unavailable, falling back to an ephemeral in-memory session store that
+/// does not survive a restart. Intended for headless / CI hosts that have
+/// no secret service. Without it, an unavailable keyring is fatal: the
+/// daemon refuses to start rather than silently run without session
+/// persistence.
+pub(crate) const ALLOW_NO_KEYRING_ENV: &str = "SUPER_STT_ALLOW_NO_KEYRING";
+
+fn allow_no_keyring() -> bool {
+    std::env::var(ALLOW_NO_KEYRING_ENV).is_ok_and(|v| v == "1")
+}
+
 /// Persistent store of issued session tokens. The in-memory `HashMap`
 /// is the hot lookup path; every mutation also writes the whole map
 /// back to the system keyring under `(super-stt, stt-sessions)` so a
@@ -70,22 +82,44 @@ pub(crate) struct SessionsFile {
 impl TokenStore {
     /// Load any persisted sessions from the keyring, prune anything
     /// already past its `expires_at`, and write the cleaned set back if
-    /// pruning removed entries. Failure at any step (missing entry,
-    /// keyring unavailable, parse error, version mismatch) yields an
-    /// empty store — the daemon must not refuse to start because the
-    /// keyring is unhappy.
-    pub(crate) fn load_persisted() -> Self {
+    /// pruning removed entries.
+    ///
+    /// A *missing entry*, parse error, or version mismatch is recoverable
+    /// and yields an empty store — those are data conditions, not keyring
+    /// faults. An *unavailable keyring* (no secret service, or a locked
+    /// keyring whose unlock prompt was dismissed), however, is fatal: the
+    /// daemon refuses to start so it never runs unable to persist or
+    /// validate sessions. Set [`ALLOW_NO_KEYRING_ENV`] to downgrade that
+    /// to an ephemeral in-memory store for headless / CI hosts.
+    ///
+    /// # Errors
+    /// Returns an error when the system keyring is unavailable and
+    /// [`ALLOW_NO_KEYRING_ENV`] is not set, so the daemon aborts startup.
+    pub(crate) fn load_persisted() -> anyhow::Result<Self> {
         let store = Self::default();
 
         let blob = match crate::keyring::get_sessions_blob() {
             Ok(Some(b)) => b,
             Ok(None) => {
                 info!("No persisted sessions found; starting with empty store");
-                return store;
+                return Ok(store);
+            }
+            Err(e) if allow_no_keyring() => {
+                warn!(
+                    "System keyring unavailable ({e}); {ALLOW_NO_KEYRING_ENV}=1 set — \
+                     starting with an ephemeral in-memory session store (sessions will \
+                     not survive a daemon restart)"
+                );
+                return Ok(store);
             }
             Err(e) => {
-                warn!("Failed to read persisted sessions ({e}); starting with empty store");
-                return store;
+                error!(
+                    "System keyring is unavailable or missing ({e}). Super STT requires \
+                     an accessible secret-service keyring to persist sessions and will \
+                     not start without one. Unlock or enable your keyring, or set \
+                     {ALLOW_NO_KEYRING_ENV}=1 to start without persistence (headless/CI)."
+                );
+                return Err(anyhow::anyhow!("keyring unavailable: {e}"));
             }
         };
 
@@ -93,7 +127,7 @@ impl TokenStore {
             Ok(p) => p,
             Err(e) => {
                 warn!("Failed to parse persisted sessions ({e}); starting with empty store");
-                return store;
+                return Ok(store);
             }
         };
 
@@ -102,7 +136,7 @@ impl TokenStore {
                 "Persisted sessions schema version {} != expected {}; ignoring",
                 parsed.version, SESSIONS_SCHEMA_VERSION
             );
-            return store;
+            return Ok(store);
         }
 
         let now = Utc::now();
@@ -133,7 +167,7 @@ impl TokenStore {
         }
 
         *store.inner.lock().unwrap() = live;
-        store
+        Ok(store)
     }
 
     /// Persist the current sessions map to the keyring. Callers must

--- a/super-stt-daemon/src/daemon/http/server.rs
+++ b/super-stt-daemon/src/daemon/http/server.rs
@@ -114,15 +114,42 @@ pub async fn start_http_server(
     socket_path: PathBuf,
     shutdown_tx: broadcast::Sender<()>,
 ) -> Result<tokio::task::JoinHandle<()>> {
+    // Build the application state first. This loads the persisted session
+    // store from the system keyring; if the keyring is unavailable the
+    // daemon refuses to start (see `TokenStore::load_persisted`). Doing it
+    // before binding the listener guarantees we never leave a
+    // listening-but-unserviced socket behind on a keyring failure.
+    //
+    // That keyring read is a *blocking* secret-service call: on a locked
+    // keyring it waits on the D-Bus unlock prompt for as long as the user
+    // takes. Run it on the blocking pool and race it against the shutdown
+    // signal so the wait stays interruptible — otherwise a Ctrl+C during
+    // the unlock wait is swallowed (the supervision `select!` is only
+    // reached once startup finishes) and the daemon can't be stopped.
+    let state = {
+        let daemon = Arc::clone(&daemon);
+        let mut shutdown_rx = shutdown_tx.subscribe();
+        let load = tokio::task::spawn_blocking(move || AppState::new(daemon));
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.recv() => {
+                // The blocking load is still parked on the keyring prompt;
+                // a dropped runtime would join (and hang on) it, so exit
+                // the process directly. Nothing is bound or in flight yet.
+                info!("Shutdown requested during session-store load; exiting");
+                std::process::exit(130);
+            }
+            res = load => res.context("session-store load task panicked")??,
+        }
+    };
+    let app = crate::daemon::http::v1::router(state);
+
     let listener = bind_listener(&socket_path).await?;
 
     info!(
         "HTTP daemon listening on socket: {} (side-by-side with legacy listener)",
         socket_path.display()
     );
-
-    let state = AppState::new(Arc::clone(&daemon));
-    let app = crate::daemon::http::v1::router(state);
 
     let cleanup_path = socket_path.clone();
     let handle = tokio::spawn(async move {

--- a/super-stt-daemon/src/daemon/http/state.rs
+++ b/super-stt-daemon/src/daemon/http/state.rs
@@ -49,14 +49,19 @@ pub(crate) struct AppState {
 impl AppState {
     /// Construct the default application state from a daemon handle.
     /// The registry client is configured from environment variables.
-    pub(crate) fn new(daemon: Arc<SuperSTTDaemon>) -> Self {
-        Self {
+    ///
+    /// # Errors
+    /// Returns an error if the system keyring is unavailable while loading
+    /// the persisted session store, so the daemon refuses to start. See
+    /// [`TokenStore::load_persisted`].
+    pub(crate) fn new(daemon: Arc<SuperSTTDaemon>) -> anyhow::Result<Self> {
+        Ok(Self {
             daemon,
-            tokens: TokenStore::load_persisted(),
+            tokens: TokenStore::load_persisted()?,
             consent_locks: ConsentLocks::default(),
             deny_cache: DenyCache::default(),
             registry_client: Arc::new(crate::registry::client::Client::from_env()),
             install_inflight: Arc::new(ParkingRwLock::new(HashSet::new())),
-        }
+        })
     }
 }

--- a/super-stt-daemon/src/daemon/model_management/switch.rs
+++ b/super-stt-daemon/src/daemon/model_management/switch.rs
@@ -162,7 +162,10 @@ impl SuperSTTDaemon {
         source: String,
     ) -> DaemonResponse {
         info!("Model switch requested: {model} via {provider} (source={source:?})");
-        if let Some(resp) = self.preflight_model_switch(&model, &provider, &source).await {
+        if let Some(resp) = self
+            .preflight_model_switch(&model, &provider, &source)
+            .await
+        {
             return resp;
         }
 

--- a/super-stt-daemon/src/daemon/types.rs
+++ b/super-stt-daemon/src/daemon/types.rs
@@ -255,9 +255,13 @@ impl SuperSTTDaemon {
         if let Some((name, provider, source)) = self.pick_startup_model().await {
             let bg = self.clone();
             tokio::spawn(async move {
-                if let Err(e) =
-                    Self::load_initial_model_and_broadcast(&bg, name.clone(), provider.clone(), source)
-                        .await
+                if let Err(e) = Self::load_initial_model_and_broadcast(
+                    &bg,
+                    name.clone(),
+                    provider.clone(),
+                    source,
+                )
+                .await
                 {
                     warn!(
                         "Failed to load startup model {name} via {provider}: {e}; daemon is idle"

--- a/super-stt-daemon/src/keyring.rs
+++ b/super-stt-daemon/src/keyring.rs
@@ -10,7 +10,7 @@
 //! `(super-stt, stt-sessions)` — see `daemon::http::internal::auth::tokens::TokenStore` and
 //! `get_sessions_blob`/`set_sessions_blob` below.
 
-use log::{debug, warn};
+use log::{debug, info, warn};
 
 const SERVICE_NAME: &str = "super-stt";
 
@@ -78,6 +78,15 @@ pub fn get_sessions_blob() -> Result<Option<String>, String> {
     let entry = keyring::Entry::new(SERVICE_NAME, SESSIONS_KEY)
         .map_err(|e| format!("Failed to access keyring entry for sessions: {e}"))?;
 
+    // Surface the read before it happens: on a *locked* keyring this call
+    // blocks on the secret-service unlock prompt, potentially for a long
+    // time. Logging first means a stalled startup is explained in the
+    // journal ("waiting on keyring unlock") instead of looking like a
+    // silent hang.
+    info!(
+        "Reading the persisted session store from the system keyring; if the keyring \
+         is locked, the daemon will wait here until it is unlocked"
+    );
     match entry.get_password() {
         Ok(blob) => {
             debug!("Loaded persisted session blob from keyring");

--- a/super-stt-daemon/src/registry/index_schema.rs
+++ b/super-stt-daemon/src/registry/index_schema.rs
@@ -210,7 +210,11 @@ mod tests {
             return;
         };
         let dummy = repo_root().join("registry/scripts/fixtures/dummy-backend.toml");
-        assert!(dummy.exists(), "dummy manifest missing at {}", dummy.display());
+        assert!(
+            dummy.exists(),
+            "dummy manifest missing at {}",
+            dummy.display()
+        );
 
         let out = tempfile::tempdir().unwrap();
         let status = Command::new(&indexer)

--- a/super-stt-daemon/src/registry/local_dir.rs
+++ b/super-stt-daemon/src/registry/local_dir.rs
@@ -57,7 +57,10 @@ pub fn resolve(local_path: &Path) -> Result<IndexBackend, ResolveError> {
     let m = Manifest::load(local_path).map_err(anyhow::Error::from)?;
     crate::stt_models::backends::manifest::validate_runtime(&m)?;
 
-    let online = m.models.iter().any(super_stt_registry_types::manifest::ModelEntry::is_online);
+    let online = m
+        .models
+        .iter()
+        .any(super_stt_registry_types::manifest::ModelEntry::is_online);
 
     let id = id_from_source(&m.backend.source);
     if !super_stt_shared::registry::is_safe_component(&id) {

--- a/super-stt-daemon/src/stt_models/backends/mod_tests.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod_tests.rs
@@ -113,8 +113,13 @@ processing_interval_ms = 2000
     );
 
     // Empty source matches the first backend serving (name, provider).
-    let (_, vox) = find_model(&backends, "voxtral-mini", &Provider::from("local_voxtral"), "")
-        .expect("resolve voxtral-mini with empty source");
+    let (_, vox) = find_model(
+        &backends,
+        "voxtral-mini",
+        &Provider::from("local_voxtral"),
+        "",
+    )
+    .expect("resolve voxtral-mini with empty source");
     assert_eq!(vox.source, "github.com/super-stt/voxtral");
     assert_eq!(vox.estimated_vram_bytes, 8_589_934_592);
     assert_eq!(vox.processing_interval, Duration::from_millis(2000));
@@ -484,8 +489,13 @@ processing_interval_ms = 1500
         vec!["cpu".to_string(), "cuda".to_string()]
     );
 
-    let (_, big) = find_model(&backends, "qwen3-asr-1.7b", &Provider::from("local_qwen3_asr"), "")
-        .expect("resolve qwen3-asr-1.7b with empty source");
+    let (_, big) = find_model(
+        &backends,
+        "qwen3-asr-1.7b",
+        &Provider::from("local_qwen3_asr"),
+        "",
+    )
+    .expect("resolve qwen3-asr-1.7b with empty source");
     assert_eq!(big.estimated_vram_bytes, 6_000_000_000);
     assert_eq!(big.processing_interval, Duration::from_millis(1500));
 }

--- a/super-stt-registry-types/src/provider.rs
+++ b/super-stt-registry-types/src/provider.rs
@@ -105,7 +105,14 @@ mod tests {
 
     #[test]
     fn accepts_any_snake_case_identifier() {
-        for s in ["local_whisper", "openai", "groq", "my_custom_engine", "x", "a1_b2"] {
+        for s in [
+            "local_whisper",
+            "openai",
+            "groq",
+            "my_custom_engine",
+            "x",
+            "a1_b2",
+        ] {
             assert_eq!(s.parse::<Provider>().unwrap().as_str(), s);
         }
     }
@@ -113,8 +120,18 @@ mod tests {
     #[test]
     fn rejects_malformed_non_empty_values() {
         // Uppercase, hyphens, a leading digit/underscore, spaces, non-ASCII.
-        for bad in ["OpenAI", "local-whisper", "1foo", "has space", "_lead", "Café"] {
-            assert!(bad.parse::<Provider>().is_err(), "{bad:?} should be rejected");
+        for bad in [
+            "OpenAI",
+            "local-whisper",
+            "1foo",
+            "has space",
+            "_lead",
+            "Café",
+        ] {
+            assert!(
+                bad.parse::<Provider>().is_err(),
+                "{bad:?} should be rejected"
+            );
         }
     }
 

--- a/super-stt-shared/src/daemon/http_client/internal/transport.rs
+++ b/super-stt-shared/src/daemon/http_client/internal/transport.rs
@@ -127,11 +127,33 @@ pub(crate) async fn check_subscribe_status(
     )))
 }
 
+/// Upper bound on how long a **non-interactive** request waits for the
+/// daemon's response headers. A daemon that accepts the connection but
+/// never answers — e.g. wedged mid-startup, before its accept loop is
+/// serving — would otherwise hang the caller forever. That is exactly how
+/// a stuck daemon used to freeze the app's startup probe with no error.
+///
+/// Deliberately *not* applied to the consent-bearing `/auth/request`
+/// (see [`open`]'s `timeout` param): that call is held open while a human
+/// clicks Allow/Deny and may type a keyring password, so a machine timer
+/// must never race it. Sized generously even for the machine calls so a
+/// slow model reload still completes; a daemon that is simply *down*
+/// fails fast at `connect()` and never reaches this bound.
+pub(crate) const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
 /// Open an HTTP/1.1 connection over a fresh Unix socket, run one request,
 /// and return the streaming response. Shared by every call path.
+///
+/// `timeout` bounds the wait for the daemon's response headers. Pass
+/// `Some(_)` for machine-to-machine calls so a wedged daemon can't hang
+/// the caller forever. Pass `None` for `/auth/request`, which the daemon
+/// legitimately holds open while the user responds to the consent popup
+/// (and possibly a keyring-unlock prompt) — bounding it would cut the user
+/// off mid-decision.
 pub(crate) async fn open(
     socket_path: &std::path::PathBuf,
     req: hyper::Request<RequestBody>,
+    timeout: Option<std::time::Duration>,
 ) -> HttpResult<hyper::Response<hyper::body::Incoming>> {
     let stream = tokio::net::UnixStream::connect(socket_path)
         .await
@@ -144,19 +166,32 @@ pub(crate) async fn open(
             _ => HttpError::Other(format!("Connection failed: {e}")),
         })?;
     let io = hyper_util::rt::TokioIo::new(stream);
-    let (sender, conn) = hyper::client::conn::http1::handshake(io)
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
         .await
         .map_err(|e| HttpError::Other(format!("HTTP handshake failed: {e}")))?;
-    let mut sender = sender;
-    tokio::spawn(async move {
+    let conn_task = tokio::spawn(async move {
         if let Err(e) = conn.await {
             log::debug!("http connection ended: {e}");
         }
     });
-    sender
-        .send_request(req)
-        .await
-        .map_err(|e| HttpError::Other(format!("Request failed: {e}")))
+    // On success `conn_task` keeps driving the connection so the body
+    // (incl. long-lived `/events` streams) can be read; on timeout we abort
+    // it so a dead connection doesn't leak a background task.
+    let send = sender.send_request(req);
+    let result = match timeout {
+        Some(dur) => match tokio::time::timeout(dur, send).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                conn_task.abort();
+                return Err(HttpError::Other(format!(
+                    "Daemon did not respond within {}s (it may be stuck or still starting up)",
+                    dur.as_secs()
+                )));
+            }
+        },
+        None => send.await,
+    };
+    result.map_err(|e| HttpError::Other(format!("Request failed: {e}")))
 }
 
 /// Collect a response body to bytes.
@@ -177,7 +212,7 @@ pub(crate) async fn send_request<T: DeserializeOwned>(
     socket_path: &std::path::PathBuf,
     req: hyper::Request<RequestBody>,
 ) -> HttpResult<T> {
-    let response = open(socket_path, req).await?;
+    let response = open(socket_path, req, Some(REQUEST_TIMEOUT)).await?;
     let status = response.status();
     let body = collect_body(response).await?;
     if status == hyper::StatusCode::UNAUTHORIZED {

--- a/super-stt-shared/src/daemon/http_client/v1/auth/request.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/auth/request.rs
@@ -35,8 +35,11 @@ pub async fn auth_request(
 
     // /auth/request returns its own JSON shape (not a `DaemonResponse`),
     // so we issue the request directly here and parse on top of the raw
-    // body.
-    let response = transport::open(&socket_path, req).await?;
+    // body. No timeout: the daemon holds this request open while the user
+    // responds to the consent popup (and may type a keyring password), so
+    // a machine timer must not race human input — bounding it would cut
+    // the user off mid-decision.
+    let response = transport::open(&socket_path, req, None).await?;
 
     let status = response.status();
     let body = transport::collect_body(response).await?;

--- a/super-stt-shared/src/daemon/http_client/v1/events.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/events.rs
@@ -42,7 +42,10 @@ pub async fn events_stream(
         ));
     }
     let req = build_events_request(token, topics)?;
-    let response = transport::open(&socket_path, req).await?;
+    // Machine-to-machine: bound the wait for response headers so a wedged
+    // daemon surfaces a Disconnected (and the subscription reconnects)
+    // instead of hanging the stream open forever.
+    let response = transport::open(&socket_path, req, Some(transport::REQUEST_TIMEOUT)).await?;
     transport::check_subscribe_status(response)
         .await
         .map(parse_widget_event_stream)

--- a/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
@@ -98,7 +98,7 @@ pub async fn transcribe_stream(
     }
     let req = transport::build_post_json("/transcribe", &data, Some(token))?;
 
-    let response = transport::open(&socket_path, req).await?;
+    let response = transport::open(&socket_path, req, Some(transport::REQUEST_TIMEOUT)).await?;
 
     let status = response.status();
     if status == hyper::StatusCode::UNAUTHORIZED {


### PR DESCRIPTION
A locked keyring made the daemon block forever in the secret-service unlock prompt during HTTP-server startup — before the accept loop spawned — so it listened but never accepted, and Ctrl+C was ignored.

Daemon: load the session store off the runtime thread before binding the socket, raced against shutdown so the unlock wait stays interruptible; refuse to start (with a clear log) when the keyring is unavailable, overridable via SUPER_STT_ALLOW_NO_KEYRING for headless/CI.

App: add per-call timeouts to http_client so a wedged daemon surfaces an error instead of hanging the UI; leave auth_request unbounded so the consent/keyring prompt is never cut off.