### PR TITLE
Fix synthesized backend.toml missing model language fields

### DIFF
--- a/super-stt-daemon/src/registry/custom_repo.rs
+++ b/super-stt-daemon/src/registry/custom_repo.rs
@@ -152,6 +152,9 @@ pub async fn resolve(gh: &GitHub, repo_url: &str) -> Result<IndexBackend, Resolv
             .map(|m| IndexModel {
                 name: m.name,
                 provider: m.provider,
+                multilingual: m.multilingual,
+                primary_language: m.primary_language,
+                supported_languages: m.supported_languages,
                 supported_devices: m.supported_devices,
             })
             .collect(),
@@ -333,8 +336,18 @@ struct Network {
 struct Model {
     name: String,
     provider: String,
+    #[serde(default = "default_true")]
+    multilingual: bool,
+    #[serde(default)]
+    primary_language: String,
+    #[serde(default)]
+    supported_languages: Vec<String>,
     #[serde(default)]
     supported_devices: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize)]
@@ -386,6 +399,9 @@ mod tests {
         Model {
             name: name.into(),
             provider: provider.into(),
+            multilingual: true,
+            primary_language: "en".into(),
+            supported_languages: vec!["en".into()],
             supported_devices: devices.iter().map(|s| (*s).to_string()).collect(),
         }
     }

--- a/super-stt-daemon/src/registry/index_schema.rs
+++ b/super-stt-daemon/src/registry/index_schema.rs
@@ -119,7 +119,22 @@ pub struct IndexBackend {
 pub struct IndexModel {
     pub name: String,
     pub provider: String,
+    /// Whether the model accepts more than one language. Default `true`.
+    /// Defaulted when reading an index published before this field existed.
+    #[serde(default = "default_true")]
+    pub multilingual: bool,
+    /// Default language code; must appear in `supported_languages`. Empty when
+    /// an older index omitted it — the installer falls back to a valid default.
+    #[serde(default)]
+    pub primary_language: String,
+    /// Language codes the model accepts; must include `primary_language`.
+    #[serde(default)]
+    pub supported_languages: Vec<String>,
     pub supported_devices: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -451,6 +451,34 @@ fn synthesize_backend_toml(entry: &IndexBackend) -> String {
         out.push_str("\n[[models]]\n");
         let _ = writeln!(out, "name = \"{}\"", toml_escape(&md.name));
         let _ = writeln!(out, "provider = \"{}\"", toml_escape(&md.provider));
+        // Language metadata is required by the manifest parser and cross-checked
+        // by the daemon's runtime validation (`primary_language` must be in
+        // `supported_languages`; a non-multilingual model lists exactly its
+        // primary language). Reconstruct an always-consistent block, falling
+        // back to English-only when an older index omitted these fields.
+        let primary = if md.primary_language.is_empty() {
+            "en".to_string()
+        } else {
+            md.primary_language.clone()
+        };
+        let langs = if md.multilingual {
+            let mut l = md.supported_languages.clone();
+            if l.is_empty() {
+                l.push(primary.clone());
+            } else if !l.contains(&primary) {
+                l.insert(0, primary.clone());
+            }
+            l
+        } else {
+            vec![primary.clone()]
+        };
+        let _ = writeln!(out, "multilingual = {}", md.multilingual);
+        let _ = writeln!(out, "primary_language = \"{}\"", toml_escape(&primary));
+        let langs_lit: Vec<String> = langs
+            .iter()
+            .map(|l| format!("\"{}\"", toml_escape(l)))
+            .collect();
+        let _ = writeln!(out, "supported_languages = [{}]", langs_lit.join(", "));
         let devs: Vec<String> = md
             .supported_devices
             .iter()
@@ -524,6 +552,74 @@ mod tests {
         assert!(s.contains("source = \"github.com/x/y\""));
         assert!(s.contains("kind = \"wasm\""));
         assert!(s.contains("api.openai.com"));
+    }
+
+    /// The synthesized `backend.toml` must parse with the same canonical
+    /// manifest type discovery uses and pass the daemon's runtime validation —
+    /// the loop that previously broke (a synthesized manifest missing the
+    /// required `primary_language` / `supported_languages` was rejected by the
+    /// very daemon that wrote it).
+    #[test]
+    fn synthesized_model_block_parses_and_validates() {
+        use crate::stt_models::backends::manifest::{Manifest, validate_runtime};
+        let mut entry = minimal_entry();
+        entry.models = vec![IndexModel {
+            name: "m1".into(),
+            provider: "local_x".into(),
+            multilingual: true,
+            primary_language: "en".into(),
+            supported_languages: vec!["en".into(), "es".into()],
+            supported_devices: vec!["cuda".into()],
+        }];
+        let text = synthesize_backend_toml(&entry);
+        let m: Manifest = toml::from_str(&text).expect("synthesized backend.toml must parse");
+        validate_runtime(&m).expect("synthesized backend.toml must pass runtime validation");
+        assert_eq!(m.models[0].primary_language, "en");
+        assert_eq!(m.models[0].supported_languages, vec!["en", "es"]);
+        assert!(m.models[0].multilingual);
+    }
+
+    /// An index published before the language fields existed deserializes with
+    /// empty defaults; the synthesizer must still emit a valid English-only
+    /// block rather than an unparseable manifest.
+    #[test]
+    fn synthesized_model_falls_back_when_index_omits_language() {
+        use crate::stt_models::backends::manifest::{Manifest, validate_runtime};
+        let mut entry = minimal_entry();
+        entry.models = vec![IndexModel {
+            name: "m1".into(),
+            provider: "local_x".into(),
+            multilingual: true,
+            primary_language: String::new(),
+            supported_languages: vec![],
+            supported_devices: vec!["cpu".into()],
+        }];
+        let text = synthesize_backend_toml(&entry);
+        let m: Manifest = toml::from_str(&text).expect("synthesized backend.toml must parse");
+        validate_runtime(&m).expect("synthesized backend.toml must pass runtime validation");
+        assert_eq!(m.models[0].primary_language, "en");
+        assert_eq!(m.models[0].supported_languages, vec!["en"]);
+    }
+
+    /// A non-multilingual model must serialize exactly `[primary_language]` so
+    /// runtime validation accepts it even if the index over-declares languages.
+    #[test]
+    fn synthesized_non_multilingual_model_is_primary_only() {
+        use crate::stt_models::backends::manifest::{Manifest, validate_runtime};
+        let mut entry = minimal_entry();
+        entry.models = vec![IndexModel {
+            name: "m1".into(),
+            provider: "local_x".into(),
+            multilingual: false,
+            primary_language: "en".into(),
+            supported_languages: vec!["en".into(), "es".into()],
+            supported_devices: vec!["cpu".into()],
+        }];
+        let text = synthesize_backend_toml(&entry);
+        let m: Manifest = toml::from_str(&text).expect("parses");
+        validate_runtime(&m).expect("validates");
+        assert!(!m.models[0].multilingual);
+        assert_eq!(m.models[0].supported_languages, vec!["en"]);
     }
 
     fn minimal_entry() -> IndexBackend {

--- a/super-stt-daemon/src/registry/local_dir.rs
+++ b/super-stt-daemon/src/registry/local_dir.rs
@@ -97,6 +97,9 @@ pub fn resolve(local_path: &Path) -> Result<IndexBackend, ResolveError> {
             .map(|md| IndexModel {
                 name: md.name.clone(),
                 provider: md.provider.to_string(),
+                multilingual: md.multilingual,
+                primary_language: md.primary_language.clone(),
+                supported_languages: md.supported_languages.clone(),
                 supported_devices: md
                     .supported_devices
                     .iter()

--- a/super-stt-indexer/src/index_json.rs
+++ b/super-stt-indexer/src/index_json.rs
@@ -48,7 +48,21 @@ pub struct IndexBackend {
 pub struct IndexModel {
     pub name: String,
     pub provider: String,
+    /// Whether the model accepts more than one language. Default `true`.
+    #[serde(default = "default_true")]
+    pub multilingual: bool,
+    /// Default language code; must appear in `supported_languages`. Defaulted
+    /// (empty) when reading an older index that predates this field.
+    #[serde(default)]
+    pub primary_language: String,
+    /// Language codes the model accepts; must include `primary_language`.
+    #[serde(default)]
+    pub supported_languages: Vec<String>,
     pub supported_devices: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,5 +162,32 @@ mod tests {
         let back: Index = serde_json::from_str(&s).unwrap();
         assert_eq!(back.backends.len(), 1);
         assert_eq!(back.backends[0].id, "openai");
+    }
+
+    #[test]
+    fn model_roundtrips_language_fields_and_tolerates_old_index() {
+        let m = IndexModel {
+            name: "m".into(),
+            provider: "local_x".into(),
+            multilingual: false,
+            primary_language: "en".into(),
+            supported_languages: vec!["en".into()],
+            supported_devices: vec!["cpu".into()],
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        assert!(s.contains("primary_language"));
+        let back: IndexModel = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.supported_languages, vec!["en".to_string()]);
+        assert!(!back.multilingual);
+
+        // An index published before these fields existed still deserializes,
+        // defaulting `multilingual` to true and leaving the rest empty.
+        let old: IndexModel = serde_json::from_str(
+            r#"{"name":"m","provider":"local_x","supported_devices":["cpu"]}"#,
+        )
+        .unwrap();
+        assert!(old.multilingual);
+        assert!(old.primary_language.is_empty());
+        assert!(old.supported_languages.is_empty());
     }
 }

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -281,6 +281,9 @@ pub(crate) fn into_index_backend(
             .map(|md| index_json::IndexModel {
                 name: md.name,
                 provider: md.provider.to_string(),
+                multilingual: md.multilingual,
+                primary_language: md.primary_language,
+                supported_languages: md.supported_languages,
                 supported_devices: md
                     .supported_devices
                     .iter()


### PR DESCRIPTION
The registry installer synthesized a backend.toml from index.json that omitted the required primary_language/supported_languages, so the daemon skipped every registry-installed backend. Carry the language fields through the indexer and daemon index models and emit them when synthesizing, with an English-only fallback for indexes published before these fields existed.