### PR TITLE
Add missing e2e/unit tests; fix per-client rate-limit reset

### DIFF
--- a/super-stt-cli/src/main.rs
+++ b/super-stt-cli/src/main.rs
@@ -28,6 +28,11 @@ const SCOPES: &[&str] = &["transcribe", "status"];
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Honor SUPER_STT_KEYRING_MOCK before any session-token access so
+    // automated shells / CI (and our own integration tests) don't block on
+    // the system secret service. No-op when the env var is unset.
+    session::install_mock_keyring_if_requested();
+
     let matches = Command::new("super-stt-cli")
         .version(env!("CARGO_PKG_VERSION"))
         .about("Super STT command-line client (HTTP protocol)")

--- a/super-stt-cli/tests/cmd_basic.rs
+++ b/super-stt-cli/tests/cmd_basic.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! End-to-end tests for the CLI's non-recording subcommands: `ping`,
+//! `status`, `stop`, and `logout`.
+//!
+//! Complements `cmd_record_toggle.rs` (which covers the `record` toggle
+//! path and is `#[ignore]`'d because it needs a real microphone). These
+//! commands are fully hermetic — none touch the audio pipeline — so they
+//! run as part of the default `cargo test` flow:
+//!
+//! - `ping`   → `GET  /v1/ping`            : liveness, prints the daemon's reply.
+//! - `status` → `GET  /v1/status`          : prints `Model:` / `Device:` lines.
+//! - `stop`   → `POST /v1/transcribe/stop` : idempotent against an idle daemon.
+//! - `logout` → local keyring only         : forgets the cached session token.
+//!
+//! Both processes run with `SUPER_STT_KEYRING_MOCK=1` (in-memory keyring,
+//! no secret-service prompt) and `SUPER_STT_AUTO_APPROVE=1` (the daemon
+//! auto-approves `/auth/request`, so no consent popup is spawned).
+//!
+//! ```bash
+//! cargo test -p super-stt-cli --test cmd_basic -- --nocapture
+//! ```
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const CLI_BIN: &str = env!("CARGO_BIN_EXE_super-stt-cli");
+
+/// Locate the daemon binary next to the CLI binary's target dir. `cargo
+/// test -p super-stt-cli` builds the daemon as a workspace dependency, so
+/// they share the same `target/<profile>/` slot.
+fn locate_daemon_bin() -> PathBuf {
+    let dir = PathBuf::from(CLI_BIN)
+        .parent()
+        .expect("cli bin parent dir")
+        .to_path_buf();
+    let candidate = dir.join("super-stt-daemon");
+    assert!(
+        candidate.exists(),
+        "expected the daemon binary at {} — run `cargo build -p super-stt-daemon` first",
+        candidate.display()
+    );
+    candidate
+}
+
+/// Monotonic per-call counter so temp paths are unique even when these
+/// tests run concurrently in the same binary.
+fn next_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static U: AtomicU64 = AtomicU64::new(0);
+    U.fetch_add(1, Ordering::Relaxed)
+}
+
+struct DaemonGuard {
+    child: Child,
+    cleanup: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        for p in &self.cleanup {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+/// Spawn a hermetic daemon on an isolated socket / config / data dir and
+/// wait for the HTTP socket to appear. Returns the guard plus the socket
+/// path the CLI should target via `--socket`.
+fn spawn_daemon() -> (DaemonGuard, PathBuf) {
+    let tmp = std::env::temp_dir();
+    let unique = format!("stt-cli-basic-{}-{}", std::process::id(), next_uniq());
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    let data_home = tmp.join(format!("{unique}-data"));
+    std::fs::create_dir_all(&config_home).expect("create config dir");
+    // Empty, isolated data dir → the daemon discovers no backends and comes
+    // up idle and fast, which is exactly what these commands need.
+    std::fs::create_dir_all(&data_home).expect("create data dir");
+
+    let child = Command::new(locate_daemon_bin())
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .arg("--device")
+        .arg("cpu")
+        .arg("--audio-theme")
+        .arg("silent")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists() {
+            // Give the listener a beat to finish binding before the CLI connects.
+            std::thread::sleep(Duration::from_millis(500));
+            return (
+                DaemonGuard {
+                    child,
+                    cleanup: vec![http_socket.clone(), config_home, data_home],
+                },
+                http_socket,
+            );
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    panic!("daemon HTTP socket did not appear within 120s");
+}
+
+/// Run the CLI binary against `socket`, blocking until it exits. Returns
+/// `(exit code, stdout, stderr)`.
+fn run_cli(socket: &Path, args: &[&str]) -> (i32, String, String) {
+    let mut full_args = vec!["--socket", socket.to_str().expect("socket utf8")];
+    full_args.extend_from_slice(args);
+
+    let mut child = Command::new(CLI_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .args(&full_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cli");
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut h) = child.stdout.take() {
+        let _ = h.read_to_string(&mut stdout);
+    }
+    if let Some(mut h) = child.stderr.take() {
+        let _ = h.read_to_string(&mut stderr);
+    }
+    let status = child.wait().expect("wait cli");
+    (status.code().unwrap_or(-1), stdout, stderr)
+}
+
+/// `ping` must reach the daemon, auto-mint a token (auto-approve), and
+/// print the daemon's liveness reply with a clean exit.
+#[test]
+fn ping_reports_daemon_alive() {
+    let (_guard, socket) = spawn_daemon();
+    let (code, stdout, stderr) = run_cli(&socket, &["ping"]);
+    assert_eq!(
+        code, 0,
+        "ping should exit 0; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+    let out = stdout.to_lowercase();
+    assert!(
+        out.contains("pong") || out.contains("running") || out.contains("alive"),
+        "ping should print a liveness reply; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+}
+
+/// `status` must print the documented `Model:` and `Device:` lines. With
+/// no backend installed the daemon is idle, so the model line reports
+/// `(none loaded)` — but both labels are always present.
+#[test]
+fn status_reports_model_and_device() {
+    let (_guard, socket) = spawn_daemon();
+    let (code, stdout, stderr) = run_cli(&socket, &["status"]);
+    assert_eq!(
+        code, 0,
+        "status should exit 0; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+    assert!(
+        stdout.contains("Model:"),
+        "status should print a Model: line; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+    assert!(
+        stdout.contains("Device:"),
+        "status should print a Device: line; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+}
+
+/// `stop` against an idle daemon is idempotent: the daemon answers
+/// `200 { message: "No recording in progress" }` and the CLI surfaces that
+/// message verbatim with a zero exit. This is the path the toggle hotkey
+/// relies on when the user double-presses after audio failed to start.
+#[test]
+fn stop_is_idempotent_when_idle() {
+    let (_guard, socket) = spawn_daemon();
+    let (code, stdout, stderr) = run_cli(&socket, &["stop"]);
+    assert_eq!(
+        code, 0,
+        "stop on idle daemon should exit 0; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+    assert!(
+        stdout.contains("No recording in progress"),
+        "stop should surface the idle message; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+}
+
+/// `logout` is local-only — it forgets the cached session token via the
+/// keyring and never contacts the daemon. Under the mock keyring there is
+/// nothing stored, but `forget` is idempotent, so it still reports success
+/// and exits cleanly. No daemon needed.
+#[test]
+fn logout_clears_cached_token() {
+    // logout ignores the socket, but `--socket` is a global flag so passing
+    // a throwaway path keeps `run_cli` uniform.
+    let throwaway = std::env::temp_dir().join(format!(
+        "stt-cli-logout-{}-{}.sock",
+        std::process::id(),
+        next_uniq()
+    ));
+    let mut child = Command::new(CLI_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .args(["--socket", throwaway.to_str().unwrap(), "logout"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cli logout");
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut h) = child.stdout.take() {
+        let _ = h.read_to_string(&mut stdout);
+    }
+    if let Some(mut h) = child.stderr.take() {
+        let _ = h.read_to_string(&mut stderr);
+    }
+    let code = child.wait().expect("wait cli").code().unwrap_or(-1);
+    assert_eq!(
+        code, 0,
+        "logout should exit 0; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+    assert!(
+        stdout.contains("Cached session token removed"),
+        "logout should confirm the token was forgotten; stdout=`{stdout}` stderr=`{stderr}`"
+    );
+}

--- a/super-stt-daemon/src/daemon/http/internal/auth/middleware.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/middleware.rs
@@ -151,3 +151,52 @@ pub(crate) async fn require_rate_limit(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Deny-cache identity. The cache short-circuits `/auth/request` to
+    //! `403 auth_denied (user_denied_cached)` so a binary the user
+    //! already rejected can't re-trigger the consent popup. Its key is
+    //! the `(exe_path, scopes)` pair — the same identity the consent
+    //! flow is verified against — so denial must be scoped to that exact
+    //! binary and that exact scope set, nothing broader.
+    use super::DenyCache;
+    use crate::daemon::http::internal::auth::consent::ConsentKey;
+    use std::path::PathBuf;
+
+    #[test]
+    fn deny_cache_remembers_a_denied_pair() {
+        let cache = DenyCache::default();
+        let key: ConsentKey = (
+            PathBuf::from("/usr/bin/evil"),
+            vec!["settings".to_string(), "transcribe".to_string()],
+        );
+        assert!(!cache.contains(&key), "a fresh cache denies nothing");
+        cache.insert(key.clone());
+        assert!(
+            cache.contains(&key),
+            "a denied (exe, scopes) pair must be remembered"
+        );
+    }
+
+    #[test]
+    fn deny_cache_is_scoped_to_exe_and_scope_set() {
+        let cache = DenyCache::default();
+        let denied: ConsentKey = (PathBuf::from("/usr/bin/evil"), vec!["settings".to_string()]);
+        cache.insert(denied.clone());
+
+        // Same scopes, different binary → not denied (a fresh consent prompt).
+        let other_exe: ConsentKey = (PathBuf::from("/usr/bin/other"), denied.1.clone());
+        assert!(
+            !cache.contains(&other_exe),
+            "denial must not leak across binaries"
+        );
+
+        // Same binary, different scope set → not denied.
+        let other_scopes: ConsentKey = (denied.0.clone(), vec!["status".to_string()]);
+        assert!(
+            !cache.contains(&other_scopes),
+            "denial must not leak across scope sets"
+        );
+    }
+}

--- a/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
@@ -309,3 +309,141 @@ pub(crate) fn generate_token() -> String {
     }
     s
 }
+
+#[cfg(test)]
+mod tests {
+    //! Session-token security semantics: expiry + eviction, the
+    //! unknown-token path, mint correctness, and revocation. `validate`
+    //! and `revoke` are the gates every authenticated request and the
+    //! `/events` exe-watch path rely on, so they're exercised directly
+    //! here. `flush_snapshot` is a no-op under `cfg!(test)` (see its
+    //! doc comment), so none of these touch the system keyring.
+    use super::{TokenMeta, TokenStore};
+    use chrono::{Duration as ChronoDuration, Utc};
+    use std::path::PathBuf;
+
+    /// Insert a token straight into the in-memory map with an arbitrary
+    /// `expires_at`, bypassing `mint`'s fixed 30-day TTL so we can pin
+    /// the expiry boundary.
+    fn insert_with_expiry(store: &TokenStore, token: &str, expires_at: chrono::DateTime<Utc>) {
+        let meta = TokenMeta {
+            app_name: "test-app".to_string(),
+            scopes: vec!["status".to_string()],
+            exe_path: PathBuf::from("/usr/bin/test-client"),
+            issued_at: Utc::now() - ChronoDuration::days(1),
+            expires_at,
+        };
+        store.inner.lock().unwrap().insert(token.to_string(), meta);
+    }
+
+    /// A freshly minted token validates, carries the scopes + exe it was
+    /// minted with, gets a ~30-day expiry, and is a 64-char hex string.
+    /// Distinct mints never collide.
+    #[test]
+    fn mint_then_validate_roundtrips() {
+        let store = TokenStore::default();
+        let scopes = vec!["transcribe".to_string(), "status".to_string()];
+        let exe = PathBuf::from("/usr/bin/super-stt-cli");
+
+        let (token, expires_at) = store.mint("Super STT CLI", &scopes, &exe);
+        assert_eq!(token.len(), 64, "token is 32 random bytes hex-encoded");
+        assert!(
+            token.chars().all(|c| c.is_ascii_hexdigit()),
+            "token must be lowercase hex: {token}"
+        );
+
+        // ~30 days out (allow a day of slack on each side for clock/runtime).
+        let now = Utc::now();
+        assert!(
+            expires_at > now + ChronoDuration::days(29)
+                && expires_at < now + ChronoDuration::days(31),
+            "mint should set a ~30-day expiry, got {expires_at}"
+        );
+
+        let meta = store.validate(&token).expect("live token must validate");
+        assert_eq!(meta.scopes, scopes, "validated scopes match minted scopes");
+        assert_eq!(meta.exe_path, exe, "validated exe matches minted exe");
+
+        // A second mint yields a different token.
+        let (token2, _) = store.mint("Super STT CLI", &scopes, &exe);
+        assert_ne!(token, token2, "each mint produces a unique token");
+    }
+
+    /// A token unknown to the store is rejected with the `unknown`
+    /// reason (this becomes `401 invalid_session (unknown)` on the wire).
+    #[test]
+    fn validate_unknown_token_is_unknown() {
+        let store = TokenStore::default();
+        assert!(
+            matches!(store.validate("never-minted"), Err("unknown")),
+            "an unknown token must be rejected as `unknown`"
+        );
+    }
+
+    /// An expired token is rejected with `expired` AND evicted from the
+    /// store, so a second presentation reports `unknown` rather than
+    /// `expired` — the daemon never keeps a dead token around.
+    #[test]
+    fn expired_token_is_rejected_and_evicted() {
+        let store = TokenStore::default();
+        insert_with_expiry(&store, "stale", Utc::now() - ChronoDuration::seconds(1));
+
+        assert!(
+            matches!(store.validate("stale"), Err("expired")),
+            "a token past its expiry must be rejected as `expired`"
+        );
+        assert!(
+            !store.inner.lock().unwrap().contains_key("stale"),
+            "an expired token must be evicted on validation"
+        );
+        assert!(
+            matches!(store.validate("stale"), Err("unknown")),
+            "the evicted token is now simply unknown"
+        );
+    }
+
+    /// A token whose expiry is still in the future validates cleanly —
+    /// the expiry check is strictly `expires_at < now`.
+    #[test]
+    fn not_yet_expired_token_validates() {
+        let store = TokenStore::default();
+        insert_with_expiry(&store, "fresh", Utc::now() + ChronoDuration::minutes(1));
+        assert!(
+            store.validate("fresh").is_ok(),
+            "a token with a future expiry must validate"
+        );
+    }
+
+    /// `revoke` immediately invalidates a live token. This is the
+    /// primitive the `/events` exe-watch task calls on `exe_changed`
+    /// (a binary swap during a long-lived widget connection), so after
+    /// revocation the session is gone and any further use is `unknown`.
+    #[test]
+    fn revoke_invalidates_a_live_token() {
+        let store = TokenStore::default();
+        let (token, _) = store.mint(
+            "widget",
+            &["status".to_string()],
+            &PathBuf::from("/usr/bin/w"),
+        );
+        assert!(store.validate(&token).is_ok(), "token valid before revoke");
+
+        store.revoke(&token);
+        assert!(
+            matches!(store.validate(&token), Err("unknown")),
+            "a revoked token must no longer validate"
+        );
+    }
+
+    /// `revoke` is idempotent: revoking an unknown token (or the same
+    /// token twice) is a harmless no-op.
+    #[test]
+    fn revoke_is_idempotent() {
+        let store = TokenStore::default();
+        store.revoke("never-existed"); // must not panic
+        let (token, _) = store.mint("app", &["status".to_string()], &PathBuf::from("/bin/a"));
+        store.revoke(&token);
+        store.revoke(&token); // second revoke is still a no-op
+        assert!(matches!(store.validate(&token), Err("unknown")));
+    }
+}

--- a/super-stt-daemon/tests/http_smoke_backends.rs
+++ b/super-stt-daemon/tests/http_smoke_backends.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Settings-scope HTTP smoke test for the **backend-management** surface:
+//! `/backends`, `/active_backend`, and `/gpu_info`. These endpoints drive
+//! the settings app's per-backend configuration section and were the
+//! largest untested slice of the settings scope (`http_smoke_settings.rs`
+//! covers the model/device/theme settings but not backend selection).
+//!
+//! Hermetic: an isolated `XDG_DATA_HOME` means the daemon discovers no
+//! installed backends, so it comes up idle. That's exactly the state these
+//! assertions pin — empty catalog, null active backend, and the documented
+//! error paths for selecting / uninstalling something that isn't there:
+//!
+//! - `GET    /backends`           → `{ status: success, backends: [] }`
+//! - `GET    /active_backend`     → `{ status: success, active_backend: null }`
+//! - `POST   /active_backend`     → `400 invalid_backend` for an unknown source
+//! - `DELETE /active_backend`     → `{ status: success }` (idempotent when idle)
+//! - `GET    /gpu_info`           → `{ status: success, gpu_info: [...] }`
+//! - `DELETE /backends/{source}`  → `404 not_found` for an unknown backend
+//! - scope enforcement            → a `client`-scope token gets `403 scope_denied`
+//!
+//! Uses `SUPER_STT_AUTO_APPROVE=1` (no GUI) and `SUPER_STT_KEYRING_MOCK=1`
+//! (in-memory keyring), so it's part of the default `cargo test` flow.
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::client::conn::http1::handshake;
+use hyper::{Method, Request, StatusCode};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use super_stt_shared::daemon::http_client;
+use tokio::net::UnixStream;
+use tokio::time::sleep;
+
+const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
+
+struct DaemonGuard {
+    child: Child,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        for p in &self.cleanup_paths {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+/// Monotonic per-call counter so concurrent tests in the same test binary
+/// get unique paths.
+fn next_test_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+    UNIQ.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn start_daemon() -> (DaemonGuard, PathBuf) {
+    let unique = format!("stt-backends-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    std::fs::create_dir_all(&config_home).expect("create test config dir");
+    // Empty, isolated data dir → no backends discovered; daemon comes up idle.
+    let data_home = tmp.join(format!("{unique}-data"));
+    std::fs::create_dir_all(&data_home).expect("create test data dir");
+
+    let child = Command::new(DAEMON_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .arg("--device")
+        .arg("cpu")
+        .arg("--audio-theme")
+        .arg("silent")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn super-stt-daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists()
+            && http_client::auth_request(http_socket.clone(), "backends-smoke", &["status"])
+                .await
+                .is_ok()
+        {
+            return (
+                DaemonGuard {
+                    child,
+                    cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+                },
+                http_socket,
+            );
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    panic!("daemon HTTP listener not ready within 120s");
+}
+
+/// Open a fresh HTTP/1 connection over the Unix socket and issue `method`
+/// to `/v1{path}` with the given bearer token and optional JSON body.
+/// Returns `(status, parsed JSON body)`.
+async fn raw_request(
+    socket_path: &PathBuf,
+    method: Method,
+    path: &str,
+    token: &str,
+    body: Option<serde_json::Value>,
+) -> (StatusCode, serde_json::Value) {
+    let stream = UnixStream::connect(socket_path).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Full<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let body_bytes = body
+        .map(|b| serde_json::to_vec(&b).expect("encode body"))
+        .unwrap_or_default();
+
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(format!("http://stt.local/v1{path}"))
+        .header("host", "stt.local")
+        .header("authorization", format!("Bearer {token}"));
+    if !body_bytes.is_empty() {
+        builder = builder
+            .header("content-type", "application/json")
+            .header("content-length", body_bytes.len().to_string());
+    }
+    let req = builder
+        .body(Full::new(Bytes::from(body_bytes)))
+        .expect("build req");
+
+    let resp = sender.send_request(req).await.expect("send req");
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+async fn get(p: &PathBuf, path: &str, token: &str) -> (StatusCode, serde_json::Value) {
+    raw_request(p, Method::GET, path, token, None).await
+}
+
+async fn post(
+    p: &PathBuf,
+    path: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    raw_request(p, Method::POST, path, token, Some(body)).await
+}
+
+async fn delete(p: &PathBuf, path: &str, token: &str) -> (StatusCode, serde_json::Value) {
+    raw_request(p, Method::DELETE, path, token, None).await
+}
+
+#[tokio::test]
+async fn backend_management_endpoints() {
+    let (_guard, sock) = start_daemon().await;
+
+    let settings_token = http_client::auth_request(sock.clone(), "backends smoke", &["settings"])
+        .await
+        .expect("auth_request settings")
+        .session_token;
+
+    // --- GET /backends: hermetic daemon → empty catalog ---
+    let (s, body) = get(&sock, "/backends", &settings_token).await;
+    assert_eq!(s, StatusCode::OK, "GET /backends: {body}");
+    assert_eq!(body["status"], "success");
+    let backends = body["backends"]
+        .as_array()
+        .unwrap_or_else(|| panic!("backends should be an array: {body}"));
+    assert!(
+        backends.is_empty(),
+        "no backends are installed in the isolated data dir, got: {body}"
+    );
+
+    // --- GET /active_backend: idle daemon → null ---
+    let (s, body) = get(&sock, "/active_backend", &settings_token).await;
+    assert_eq!(s, StatusCode::OK, "GET /active_backend: {body}");
+    assert_eq!(body["status"], "success");
+    assert!(
+        body["active_backend"].is_null(),
+        "no backend should be selected on a fresh daemon: {body}"
+    );
+
+    // --- POST /active_backend with an unknown source → 400 invalid_backend ---
+    let (s, body) = post(
+        &sock,
+        "/active_backend",
+        &settings_token,
+        serde_json::json!({ "source": "github.com/does-not/exist" }),
+    )
+    .await;
+    assert_eq!(
+        s,
+        StatusCode::BAD_REQUEST,
+        "selecting an uninstalled backend must be 400: {body}"
+    );
+    assert_eq!(body["status"], "error");
+    assert!(
+        body["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("No installed backend")),
+        "error should explain no backend serves that source: {body}"
+    );
+
+    // The failed selection must not have changed state.
+    let (_, after) = get(&sock, "/active_backend", &settings_token).await;
+    assert!(
+        after["active_backend"].is_null(),
+        "a rejected selection must leave the daemon idle: {after}"
+    );
+
+    // --- DELETE /active_backend: idempotent when already idle ---
+    let (s, body) = delete(&sock, "/active_backend", &settings_token).await;
+    assert_eq!(
+        s,
+        StatusCode::OK,
+        "clearing an already-idle backend should be 200: {body}"
+    );
+    assert_eq!(body["status"], "success");
+
+    // --- GET /gpu_info: always succeeds; array is empty when no GPU/driver ---
+    let (s, body) = get(&sock, "/gpu_info", &settings_token).await;
+    assert_eq!(s, StatusCode::OK, "GET /gpu_info: {body}");
+    assert_eq!(body["status"], "success");
+    assert!(
+        body["gpu_info"].is_array(),
+        "gpu_info must be an array (possibly empty): {body}"
+    );
+
+    // --- DELETE /backends/{source}: unknown backend → 404 not_found ---
+    // The source is a single path segment, so its slashes are percent-encoded.
+    let (s, body) = delete(
+        &sock,
+        "/backends/github.com%2Fdoes-not%2Fexist",
+        &settings_token,
+    )
+    .await;
+    assert_eq!(
+        s,
+        StatusCode::NOT_FOUND,
+        "uninstalling an unknown backend must be 404: {body}"
+    );
+    assert_eq!(body["error"], "not_found", "got: {body}");
+}
+
+/// A `client`-scope token (no `settings`) must be rejected on every
+/// backend-management endpoint with `403 scope_denied` — these are
+/// settings-scope routes.
+#[tokio::test]
+async fn backend_endpoints_reject_client_scope() {
+    let (_guard, sock) = start_daemon().await;
+
+    let client_token = http_client::auth_request(
+        sock.clone(),
+        "backends client smoke",
+        &["transcribe", "status"],
+    )
+    .await
+    .expect("auth_request client")
+    .session_token;
+
+    for (method, path) in [
+        (Method::GET, "/backends"),
+        (Method::GET, "/active_backend"),
+        (Method::GET, "/gpu_info"),
+    ] {
+        let (s, body) = raw_request(&sock, method.clone(), path, &client_token, None).await;
+        assert_eq!(
+            s,
+            StatusCode::FORBIDDEN,
+            "client token must be 403 on {method} {path}: {body}"
+        );
+        assert_eq!(
+            body["message"], "scope_denied",
+            "on {method} {path}: {body}"
+        );
+    }
+
+    // A settings POST must be rejected too.
+    let (s, body) = post(
+        &sock,
+        "/active_backend",
+        &client_token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+    assert_eq!(
+        s,
+        StatusCode::FORBIDDEN,
+        "client token must be 403 on POST: {body}"
+    );
+    assert_eq!(body["message"], "scope_denied");
+}

--- a/super-stt-daemon/tests/http_smoke_events.rs
+++ b/super-stt-daemon/tests/http_smoke_events.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! HTTP smoke test for the `GET /events` SSE endpoint's **per-topic scope
+//! gate** and topic validation.
+//!
+//! `widget_smoke.rs` covers the subscription *lifecycle* (reconnect /
+//! daemon-restart recovery) with a token that already holds every scope it
+//! needs. What it does NOT cover is the authorization boundary the handler
+//! enforces (`events.rs:66`): each requested topic is gated by a specific
+//! scope, and the whole subscription is refused if the token is missing the
+//! scope for *any* requested topic. This test pins that boundary plus the
+//! `400 invalid_topic` paths:
+//!
+//! - valid topic + matching scope          → `200` SSE + a `subscribed` ack
+//! - topic whose scope the token lacks      → `403 scope_denied`
+//! - mixed batch missing one topic's scope  → `403` (all-or-nothing)
+//! - unknown topic name                     → `400 invalid_topic { reason: <name> }`
+//! - missing / empty `?topics=`             → `400 invalid_topic { reason: missing_topics }`
+//! - bogus bearer token                     → `401 invalid_session`
+//!
+//! Topic→scope mapping under test (`daemon/events.rs::required_scope`):
+//! `recording_state` → `recording_events`, `frequency_bands` →
+//! `audio_visualization`.
+//!
+//! Hermetic: `SUPER_STT_AUTO_APPROVE=1` (no GUI) + `SUPER_STT_KEYRING_MOCK=1`
+//! (in-memory keyring), so it runs in the default `cargo test` flow.
+
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper::client::conn::http1::handshake;
+use hyper::{Method, Request, StatusCode};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use super_stt_shared::daemon::http_client;
+use tokio::net::UnixStream;
+use tokio::time::{sleep, timeout};
+
+const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
+
+struct DaemonGuard {
+    child: Child,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        for p in &self.cleanup_paths {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+fn next_test_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+    UNIQ.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn start_daemon() -> (DaemonGuard, PathBuf) {
+    let unique = format!("stt-events-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    std::fs::create_dir_all(&config_home).expect("create test config dir");
+    let data_home = tmp.join(format!("{unique}-data"));
+    std::fs::create_dir_all(&data_home).expect("create test data dir");
+
+    let child = Command::new(DAEMON_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .arg("--device")
+        .arg("cpu")
+        .arg("--audio-theme")
+        .arg("silent")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn super-stt-daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists()
+            && http_client::auth_request(http_socket.clone(), "events-smoke", &["status"])
+                .await
+                .is_ok()
+        {
+            return (
+                DaemonGuard {
+                    child,
+                    cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+                },
+                http_socket,
+            );
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    panic!("daemon HTTP listener not ready within 120s");
+}
+
+/// Mint a token with the given scopes via the (auto-approved) consent flow.
+async fn mint(sock: &PathBuf, scopes: &[&str]) -> String {
+    http_client::auth_request(sock.clone(), "events scope smoke", scopes)
+        .await
+        .expect("auth_request")
+        .session_token
+}
+
+/// Issue `GET /v1/events?<query>` and return a live HTTP/1 sender plus the
+/// response. The connection is driven by a spawned task; the caller must
+/// keep the returned `sender` alive until it has finished reading the body
+/// (dropping it early can tear down an in-flight streaming response).
+async fn open_events(
+    sock: &PathBuf,
+    query: &str,
+    token: &str,
+) -> (
+    hyper::client::conn::http1::SendRequest<Empty<Bytes>>,
+    hyper::Response<hyper::body::Incoming>,
+) {
+    let stream = UnixStream::connect(sock).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Empty<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(format!("http://stt.local/v1/events?{query}"))
+        .header("host", "stt.local")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Empty::<Bytes>::new())
+        .expect("build req");
+
+    let resp = sender.send_request(req).await.expect("send req");
+    (sender, resp)
+}
+
+/// For the error paths (`4xx`): the response body is a finite JSON document,
+/// so it's safe to collect in full. Returns `(status, parsed JSON)`.
+async fn events_error(sock: &PathBuf, query: &str, token: &str) -> (StatusCode, serde_json::Value) {
+    let (_sender, resp) = open_events(sock, query, token).await;
+    let status = resp.status();
+    let bytes = timeout(Duration::from_secs(5), resp.into_body().collect())
+        .await
+        .expect("an error response body must be finite, not an open SSE stream")
+        .expect("collect body")
+        .to_bytes();
+    let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+/// For the success path (`200`): the body is an open `text/event-stream`, so
+/// we read frames only until the immediate `subscribed` ack appears (or a
+/// short timeout), then drop the connection. Returns `(status, content-type,
+/// accumulated SSE text)`.
+async fn events_subscribe(
+    sock: &PathBuf,
+    query: &str,
+    token: &str,
+) -> (StatusCode, String, String) {
+    let (_sender, resp) = open_events(sock, query, token).await;
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+
+    let mut body = resp.into_body();
+    let mut text = String::new();
+    let read = async {
+        while let Some(frame) = body.frame().await {
+            let Ok(frame) = frame else { break };
+            if let Some(data) = frame.data_ref() {
+                text.push_str(&String::from_utf8_lossy(data));
+                // The handler acks the subscription immediately; once we've
+                // seen the full event frame we have what we need.
+                if text.contains("event: subscribed") && text.contains("\n\n") {
+                    break;
+                }
+            }
+        }
+    };
+    let _ = timeout(Duration::from_secs(5), read).await;
+    (status, content_type, text)
+}
+
+/// A valid topic with the matching scope opens the stream and gets an
+/// immediate `subscribed` ack listing the topic.
+#[tokio::test]
+async fn valid_topic_with_scope_subscribes() {
+    let (_guard, sock) = start_daemon().await;
+    let token = mint(&sock, &["recording_events"]).await;
+
+    let (status, content_type, text) =
+        events_subscribe(&sock, "topics=recording_state", &token).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "subscribe should open the stream: {text}"
+    );
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "events must be an SSE stream, got content-type `{content_type}`"
+    );
+    assert!(
+        text.contains("event: subscribed"),
+        "the stream must open with a `subscribed` ack: {text:?}"
+    );
+    assert!(
+        text.contains("recording_state"),
+        "the ack must echo the subscribed topic: {text:?}"
+    );
+}
+
+/// A token holding all the required scopes can subscribe to a mixed batch;
+/// the ack lists every requested topic.
+#[tokio::test]
+async fn multi_topic_with_all_scopes_subscribes() {
+    let (_guard, sock) = start_daemon().await;
+    let token = mint(&sock, &["recording_events", "audio_visualization"]).await;
+
+    let (status, _ct, text) =
+        events_subscribe(&sock, "topics=recording_state,frequency_bands", &token).await;
+    assert_eq!(status, StatusCode::OK, "subscribe should succeed: {text}");
+    assert!(text.contains("event: subscribed"), "missing ack: {text:?}");
+    assert!(
+        text.contains("recording_state"),
+        "ack missing recording_state: {text:?}"
+    );
+    assert!(
+        text.contains("frequency_bands"),
+        "ack missing frequency_bands: {text:?}"
+    );
+}
+
+/// Requesting a topic whose granting scope the token lacks is refused with
+/// `403 scope_denied` — even though the token IS authenticated (it holds a
+/// different, valid scope). This is the per-topic gate, distinct from the
+/// middleware's authentication check.
+#[tokio::test]
+async fn topic_without_its_scope_is_forbidden() {
+    let (_guard, sock) = start_daemon().await;
+    // Has recording_events but NOT audio_visualization.
+    let token = mint(&sock, &["recording_events"]).await;
+
+    let (status, body) = events_error(&sock, "topics=frequency_bands", &token).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "frequency_bands needs audio_visualization: {body}"
+    );
+    assert_eq!(body["message"], "scope_denied", "got: {body}");
+}
+
+/// A batch is all-or-nothing: one in-scope topic plus one out-of-scope topic
+/// refuses the *whole* subscription rather than silently dropping the
+/// ungranted one.
+#[tokio::test]
+async fn mixed_batch_missing_one_scope_is_forbidden() {
+    let (_guard, sock) = start_daemon().await;
+    let token = mint(&sock, &["recording_events"]).await;
+
+    let (status, body) =
+        events_error(&sock, "topics=recording_state,frequency_bands", &token).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "the batch must be refused because frequency_bands' scope is missing: {body}"
+    );
+    assert_eq!(body["message"], "scope_denied");
+}
+
+/// An unknown topic name is rejected with `400 invalid_topic`, echoing the
+/// offending name in `data.reason`.
+#[tokio::test]
+async fn unknown_topic_is_invalid_topic() {
+    let (_guard, sock) = start_daemon().await;
+    // A broad token so the rejection is about the topic, not the scope.
+    let token = mint(&sock, &["recording_events", "audio_visualization"]).await;
+
+    let (status, body) = events_error(&sock, "topics=not_a_real_topic", &token).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got: {body}");
+    assert_eq!(body["message"], "invalid_topic");
+    assert_eq!(
+        body["data"]["reason"], "not_a_real_topic",
+        "invalid_topic should echo the bad name: {body}"
+    );
+}
+
+/// Missing or empty `?topics=` is `400 invalid_topic { reason: missing_topics }`.
+/// Topic validation runs before the auth-context check, so it triggers even
+/// for an otherwise-fine token.
+#[tokio::test]
+async fn missing_and_empty_topics_are_invalid_topic() {
+    let (_guard, sock) = start_daemon().await;
+    let token = mint(&sock, &["recording_events"]).await;
+
+    // No `topics` query param at all.
+    let (status, body) = events_error(&sock, "", &token).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "missing topics: {body}");
+    assert_eq!(body["message"], "invalid_topic");
+    assert_eq!(body["data"]["reason"], "missing_topics");
+
+    // Present but empty.
+    let (status, body) = events_error(&sock, "topics=", &token).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "empty topics: {body}");
+    assert_eq!(body["data"]["reason"], "missing_topics");
+}
+
+/// A bogus bearer token is rejected at the middleware with `401
+/// invalid_session` before any topic/scope logic runs.
+#[tokio::test]
+async fn bogus_token_is_unauthorized() {
+    let (_guard, sock) = start_daemon().await;
+    let (status, body) = events_error(&sock, "topics=recording_state", "not-a-real-token").await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "got: {body}");
+    assert_eq!(body["message"], "invalid_session");
+}

--- a/super-stt-daemon/tests/http_smoke_ratelimit.rs
+++ b/super-stt-daemon/tests/http_smoke_ratelimit.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! End-to-end check that the daemon's per-request rate-limit middleware
+//! (`require_rate_limit`) actually surfaces `429 rate_limited` on the wire.
+//!
+//! The limiting *logic* (`ResourceManager::record_request`) has unit tests
+//! in `super-stt-shared`; this test pins the HTTP wiring — that exceeding
+//! the quota for a client turns into a `429` response rather than being
+//! silently dropped or mis-mapped.
+//!
+//! The daemon under `cargo test` is a debug build, so it uses
+//! `ResourceManager::development()` (`max_requests_per_minute: 300`); the
+//! check is `count > limit`, so the 301st request in the rolling minute is
+//! the first to be rejected. All requests here share one `client_id`
+//! (`uid:pid` of the test process) and connection registration is idempotent
+//! per client, so the flood trips the *rate* limit, not the connection limit.
+//!
+//! `/auth/request` is exempt from rate limiting, so minting the token (and
+//! the readiness probe) doesn't consume the quota the flood is measured
+//! against.
+//!
+//! Hermetic: `SUPER_STT_AUTO_APPROVE=1` + `SUPER_STT_KEYRING_MOCK=1`.
+
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper::client::conn::http1::handshake;
+use hyper::{Method, Request, StatusCode};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use super_stt_shared::daemon::http_client;
+use tokio::net::UnixStream;
+use tokio::time::sleep;
+
+const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
+
+/// `ResourceLimits::development().max_requests_per_minute` — the build the
+/// test daemon runs. Kept in sync with
+/// `super-stt-shared/src/resource_management/mod.rs`.
+const DEV_PER_MINUTE: usize = 300;
+
+struct DaemonGuard {
+    child: Child,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        for p in &self.cleanup_paths {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+fn next_test_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+    UNIQ.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn start_daemon() -> (DaemonGuard, PathBuf) {
+    let unique = format!("stt-ratelimit-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    std::fs::create_dir_all(&config_home).expect("create test config dir");
+    let data_home = tmp.join(format!("{unique}-data"));
+    std::fs::create_dir_all(&data_home).expect("create test data dir");
+
+    let child = Command::new(DAEMON_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .arg("--device")
+        .arg("cpu")
+        .arg("--audio-theme")
+        .arg("silent")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn super-stt-daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists()
+            && http_client::auth_request(http_socket.clone(), "ratelimit-smoke", &["status"])
+                .await
+                .is_ok()
+        {
+            return (
+                DaemonGuard {
+                    child,
+                    cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+                },
+                http_socket,
+            );
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    panic!("daemon HTTP listener not ready within 120s");
+}
+
+/// Send one `GET /v1/ping` on an existing keep-alive connection and drain
+/// the response body (HTTP/1 requires the prior body consumed before the
+/// next request). Returns `(status, body bytes)`.
+///
+/// Reusing a single connection is essential: the daemon registers a fresh
+/// per-client connection record on every accept
+/// (`ResourceManager::register_connection`), which resets that client's
+/// rolling request window. A new connection per request would therefore
+/// never accumulate toward the quota — the flood has to ride one connection.
+async fn ping_on(
+    sender: &mut hyper::client::conn::http1::SendRequest<Empty<Bytes>>,
+    token: &str,
+) -> (StatusCode, Vec<u8>) {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("http://stt.local/v1/ping")
+        .header("host", "stt.local")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Empty::<Bytes>::new())
+        .expect("build req");
+
+    let resp = sender.send_request(req).await.expect("send req");
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .map(|c| c.to_bytes().to_vec())
+        .unwrap_or_default();
+    (status, bytes)
+}
+
+/// Flooding `/ping` past the per-minute quota yields `429 rate_limited`,
+/// and every request up to the limit succeeds with `200`.
+#[tokio::test]
+async fn flood_trips_rate_limit() {
+    let (_guard, sock) = start_daemon().await;
+    let token = http_client::auth_request(sock.clone(), "ratelimit", &["status"])
+        .await
+        .expect("auth")
+        .session_token;
+
+    // One persistent connection for the whole flood (see `ping_on`).
+    let stream = UnixStream::connect(&sock).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Empty<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // Cap the loop well above the limit so a regression that never trips
+    // can't spin forever, but tight enough that the whole flood lands
+    // inside the rolling 60s window.
+    let cap = DEV_PER_MINUTE + 40;
+    let mut first_status = None;
+    let mut tripped_at = None;
+    let mut limited_body = Vec::new();
+
+    for i in 1..=cap {
+        let (status, body) = ping_on(&mut sender, &token).await;
+        if first_status.is_none() {
+            first_status = Some(status);
+        }
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            tripped_at = Some(i);
+            limited_body = body;
+            break;
+        }
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "request {i} should be 200 until the quota trips, got {status}"
+        );
+    }
+
+    assert_eq!(
+        first_status,
+        Some(StatusCode::OK),
+        "the very first request must succeed"
+    );
+    let tripped_at =
+        tripped_at.expect("a 429 must occur within the cap — rate limiting not wired?");
+    assert!(
+        tripped_at > DEV_PER_MINUTE,
+        "the limit is `count > {DEV_PER_MINUTE}`, so the first 429 should be request \
+         {} (>{DEV_PER_MINUTE}); tripped at {tripped_at}",
+        DEV_PER_MINUTE + 1
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&limited_body).unwrap_or_default();
+    assert_eq!(
+        json["message"], "rate_limited",
+        "429 body must carry the rate_limited identifier, got: {json}"
+    );
+
+    // Once over quota, the limit keeps rejecting — it's not a one-off blip.
+    let (status, _) = ping_on(&mut sender, &token).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "still over quota → still 429"
+    );
+}

--- a/super-stt-daemon/tests/http_smoke_transport.rs
+++ b/super-stt-daemon/tests/http_smoke_transport.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Transport-level protocol conformance for the daemon's HTTP surface —
+//! the responses to *malformed* requests, as opposed to the domain errors
+//! (`invalid_session`, `scope_denied`, unknown model/backend) the other
+//! smoke tests cover. None of these depend on daemon state, so they're
+//! fully hermetic:
+//!
+//! - unknown route                 → `404`
+//! - known route, wrong method     → `405` (both with and without auth middleware in front)
+//! - malformed / missing JSON body → `400`
+//!
+//! Uses `SUPER_STT_AUTO_APPROVE=1` (no GUI) + `SUPER_STT_KEYRING_MOCK=1`
+//! (in-memory keyring), so it runs in the default `cargo test` flow.
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::client::conn::http1::handshake;
+use hyper::{Method, Request, StatusCode};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use super_stt_shared::daemon::http_client;
+use tokio::net::UnixStream;
+use tokio::time::sleep;
+
+const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
+
+struct DaemonGuard {
+    child: Child,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        for p in &self.cleanup_paths {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+fn next_test_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+    UNIQ.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn start_daemon() -> (DaemonGuard, PathBuf) {
+    let unique = format!("stt-transport-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    std::fs::create_dir_all(&config_home).expect("create test config dir");
+    let data_home = tmp.join(format!("{unique}-data"));
+    std::fs::create_dir_all(&data_home).expect("create test data dir");
+
+    let child = Command::new(DAEMON_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .arg("--device")
+        .arg("cpu")
+        .arg("--audio-theme")
+        .arg("silent")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn super-stt-daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists()
+            && http_client::auth_request(http_socket.clone(), "transport-smoke", &["status"])
+                .await
+                .is_ok()
+        {
+            return (
+                DaemonGuard {
+                    child,
+                    cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+                },
+                http_socket,
+            );
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    panic!("daemon HTTP listener not ready within 120s");
+}
+
+/// Low-level request: any method/path, optional bearer token, optional body
+/// + content-type. Returns `(status, raw body bytes)` — callers parse JSON
+/// only when the response is expected to carry the daemon's error shape
+/// (404/405 bodies are empty or framework-generated text).
+async fn send(
+    sock: &PathBuf,
+    method: Method,
+    path: &str,
+    token: Option<&str>,
+    body: Option<&[u8]>,
+    content_type: Option<&str>,
+) -> (StatusCode, Vec<u8>) {
+    let stream = UnixStream::connect(sock).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Full<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let body_bytes = body.map(<[u8]>::to_vec).unwrap_or_default();
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(format!("http://stt.local{path}"))
+        .header("host", "stt.local");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    if let Some(ct) = content_type {
+        builder = builder.header("content-type", ct);
+    }
+    let req = builder
+        .body(Full::new(Bytes::from(body_bytes)))
+        .expect("build req");
+
+    let resp = sender.send_request(req).await.expect("send req");
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes()
+        .to_vec();
+    (status, bytes)
+}
+
+fn as_json(bytes: &[u8]) -> serde_json::Value {
+    serde_json::from_slice(bytes).unwrap_or(serde_json::Value::Null)
+}
+
+/// An unknown path returns `404`. Unmatched routes never reach the scope
+/// middleware (it's layered only on the known route groups), so this holds
+/// regardless of the token.
+#[tokio::test]
+async fn unknown_route_is_not_found() {
+    let (_guard, sock) = start_daemon().await;
+    let token = http_client::auth_request(sock.clone(), "transport", &["status"])
+        .await
+        .expect("auth")
+        .session_token;
+
+    let (status, _) = send(
+        &sock,
+        Method::GET,
+        "/v1/definitely-not-a-route",
+        Some(&token),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "unknown route must be 404");
+
+    // Also outside the /v1 namespace entirely.
+    let (status, _) = send(&sock, Method::GET, "/nope", None, None, None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// A known path hit with the wrong method returns `405`. `/auth/request`
+/// is POST-only and sits outside the auth middleware, so a GET reaches the
+/// method router directly — no token needed.
+#[tokio::test]
+async fn wrong_method_on_unauthed_route_is_405() {
+    let (_guard, sock) = start_daemon().await;
+    let (status, _) = send(&sock, Method::GET, "/v1/auth/request", None, None, None).await;
+    assert_eq!(
+        status,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "GET on the POST-only /auth/request must be 405"
+    );
+}
+
+/// Wrong method also yields `405` on a route guarded by the auth
+/// middleware, provided the token is valid: the middleware passes, then the
+/// method router rejects. `/ping` is GET-only.
+#[tokio::test]
+async fn wrong_method_behind_middleware_is_405() {
+    let (_guard, sock) = start_daemon().await;
+    let token = http_client::auth_request(sock.clone(), "transport", &["status"])
+        .await
+        .expect("auth")
+        .session_token;
+
+    let (status, _) = send(&sock, Method::POST, "/v1/ping", Some(&token), None, None).await;
+    assert_eq!(
+        status,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "POST on the GET-only /ping (with a valid token) must be 405"
+    );
+}
+
+/// A *malformed* JSON body (declared `application/json` but unparseable) is
+/// rejected with `400` by the `Json` extractor before the handler runs.
+/// (axum 0.8's `Option<Json<T>>` only maps an *absent* body to `None`; a
+/// present-but-broken body is a hard rejection — see the next test for the
+/// absent-body path.)
+#[tokio::test]
+async fn malformed_json_body_is_400() {
+    let (_guard, sock) = start_daemon().await;
+
+    let (status, _) = send(
+        &sock,
+        Method::POST,
+        "/v1/auth/request",
+        None,
+        Some(b"{ this is not json "),
+        Some("application/json"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a malformed JSON body must be rejected with 400"
+    );
+}
+
+/// An *absent* body on `/auth/request` is the handler's own
+/// `400 auth_denied (invalid_body)` path: `Option<Json<..>>` yields `None`
+/// and the handler maps that to the documented invalid-body response.
+#[tokio::test]
+async fn missing_body_is_invalid_body() {
+    let (_guard, sock) = start_daemon().await;
+
+    let (status, body) = send(&sock, Method::POST, "/v1/auth/request", None, None, None).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "missing body must be 400");
+    let json = as_json(&body);
+    assert_eq!(json["message"], "auth_denied", "got: {json}");
+    assert_eq!(json["data"]["reason"], "invalid_body", "got: {json}");
+}
+
+/// A settings endpoint uses a *mandatory* `Json<T>` extractor, so a
+/// malformed body is rejected with `400` by the extractor before the
+/// handler runs. (Auth middleware passes first — a valid settings token is
+/// required to reach the extractor.)
+#[tokio::test]
+async fn malformed_body_on_json_extractor_endpoint_is_400() {
+    let (_guard, sock) = start_daemon().await;
+    let token = http_client::auth_request(sock.clone(), "transport", &["settings"])
+        .await
+        .expect("auth settings")
+        .session_token;
+
+    let (status, _) = send(
+        &sock,
+        Method::POST,
+        "/v1/audio_theme",
+        Some(&token),
+        Some(b"}{ not json"),
+        Some("application/json"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "the Json extractor must reject a malformed body with 400"
+    );
+}

--- a/super-stt-indexer/tests/local.rs
+++ b/super-stt-indexer/tests/local.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! End-to-end test for the `super-stt-indexer local` subcommand — the
+//! offline index generator that builds an `index.json` from locally-staged
+//! `backend.toml` files (no GitHub, no Pages). It backs the daemon's
+//! download/install pipeline tests and replaced the old Python offline
+//! generator.
+//!
+//! `local`'s building blocks are unit-tested in `src/local.rs`; this is the
+//! binary-level counterpart to `tests/integration.rs` (which covers the
+//! GitHub-backed `build` path). It drives the real binary end to end:
+//! staging assets, hashing them, multi-manifest output, the
+//! `--allow-missing-assets` placeholder path, and the hard-error path when
+//! a required asset isn't staged.
+
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_super-stt-indexer");
+
+/// `[0x00, 0x61, 0x73, 0x6d]` is the WebAssembly magic number — a valid,
+/// tiny stand-in for a real `.wasm` artifact. Its SHA-256 is fixed, so the
+/// index the binary emits is fully deterministic.
+const WASM_BYTES: [u8; 4] = [0x00, 0x61, 0x73, 0x6d];
+const WASM_SHA256: &str = "cd5d4935a48c0672cb06407bb443bc0087aff947c6b864bac886982c73b3027f";
+
+fn manifest(source: &str, name: &str, version: &str, wasm_file: &str) -> String {
+    format!(
+        r#"
+[backend]
+source = "{source}"
+name = "{name}"
+version = "{version}"
+kind = "wasm"
+entrypoint = "{wasm_file}"
+contract = "v1"
+license = "Apache-2.0"
+
+[assets]
+wasm = "{wasm_file}"
+
+[[models]]
+name = "m-1"
+provider = "openai"
+primary_language = "en"
+supported_languages = ["en"]
+supported_devices = ["none"]
+"#
+    )
+}
+
+/// Happy path: a real staged `.wasm` is hashed and given a URL under the
+/// `--base-url`, and `<out>/index.json` matches the published `build`
+/// shape (id from the source's last segment, `vX.Y.Z` tag, real sha256).
+#[test]
+fn local_indexes_a_staged_wasm_backend() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path();
+
+    // Stage the asset in the output dir, where `local` looks for it.
+    std::fs::write(out.join("dummy.wasm"), WASM_BYTES).unwrap();
+    // The manifest can live anywhere; pass its path on the command line.
+    let manifest_path = dir.path().join("backend.toml");
+    std::fs::write(
+        &manifest_path,
+        manifest(
+            "github.com/jorge-menjivar/dummy",
+            "Dummy",
+            "1.2.3",
+            "dummy.wasm",
+        ),
+    )
+    .unwrap();
+
+    let status = Command::new(BIN)
+        .arg("local")
+        .arg("--out")
+        .arg(out)
+        .arg("--base-url")
+        .arg("http://localhost:8787")
+        .arg(&manifest_path)
+        .status()
+        .expect("run indexer local");
+    assert!(status.success(), "indexer local failed");
+
+    let text = std::fs::read_to_string(out.join("index.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+    assert_eq!(v["backends"].as_array().map(Vec::len), Some(1));
+    let b = &v["backends"][0];
+    // Registry keys entries by the last path segment of `source`.
+    assert_eq!(b["id"], "dummy");
+    assert_eq!(b["source"], "github.com/jorge-menjivar/dummy");
+    assert_eq!(b["version"], "1.2.3");
+    assert_eq!(b["tag"], "v1.2.3");
+    assert_eq!(b["kind"], "wasm");
+    assert_eq!(b["license"], "Apache-2.0");
+    // Only-`none` model → the backend is an online provider.
+    assert_eq!(b["online"], true);
+
+    let wasm = &b["assets"]["wasm"];
+    assert_eq!(wasm["url"], "http://localhost:8787/dummy.wasm");
+    assert_eq!(wasm["size"], WASM_BYTES.len());
+    assert_eq!(wasm["sha256"], WASM_SHA256);
+}
+
+/// `--allow-missing-assets` lets listing/read tests build an index without
+/// staging artifacts: the missing asset gets a zeroed placeholder sha and
+/// `size: 0`, but the entry is otherwise complete.
+#[test]
+fn local_emits_placeholder_for_missing_asset() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path();
+    let manifest_path = dir.path().join("backend.toml");
+    std::fs::write(
+        &manifest_path,
+        manifest("github.com/x/ghost", "Ghost", "0.1.0", "ghost.wasm"),
+    )
+    .unwrap();
+
+    let status = Command::new(BIN)
+        .arg("local")
+        .arg("--out")
+        .arg(out)
+        .arg("--allow-missing-assets")
+        .arg(&manifest_path)
+        .status()
+        .expect("run indexer local --allow-missing-assets");
+    assert!(status.success(), "indexer local with placeholder failed");
+
+    let text = std::fs::read_to_string(out.join("index.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let wasm = &v["backends"][0]["assets"]["wasm"];
+    assert_eq!(wasm["size"], 0, "missing asset → placeholder size 0");
+    assert_eq!(
+        wasm["sha256"], "0000000000000000000000000000000000000000000000000000000000000000",
+        "missing asset → all-zero placeholder sha"
+    );
+    // The URL is still derived from the (default) base-url + declared file.
+    assert_eq!(wasm["url"], "http://localhost:8787/ghost.wasm");
+}
+
+/// Without `--allow-missing-assets`, a declared-but-unstaged wasm asset is
+/// a hard error: the binary exits non-zero and writes no index.
+#[test]
+fn local_errors_on_unstaged_asset_without_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path();
+    let manifest_path = dir.path().join("backend.toml");
+    std::fs::write(
+        &manifest_path,
+        manifest("github.com/x/ghost", "Ghost", "0.1.0", "ghost.wasm"),
+    )
+    .unwrap();
+
+    let output = Command::new(BIN)
+        .arg("local")
+        .arg("--out")
+        .arg(out)
+        .arg(&manifest_path)
+        .output()
+        .expect("run indexer local (missing asset)");
+    assert!(
+        !output.status.success(),
+        "a missing required asset must fail the build"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ghost.wasm") || stderr.to_lowercase().contains("not found"),
+        "error should name the missing asset; stderr=`{stderr}`"
+    );
+    assert!(
+        !out.join("index.json").exists(),
+        "no index.json should be written when a required asset is missing"
+    );
+}
+
+/// Multiple `backend.toml` paths produce one index entry each, in order.
+#[test]
+fn local_indexes_multiple_manifests() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path();
+    std::fs::write(out.join("a.wasm"), WASM_BYTES).unwrap();
+    std::fs::write(out.join("b.wasm"), WASM_BYTES).unwrap();
+
+    let m_a = dir.path().join("a.toml");
+    let m_b = dir.path().join("b.toml");
+    std::fs::write(
+        &m_a,
+        manifest("github.com/x/alpha", "Alpha", "1.0.0", "a.wasm"),
+    )
+    .unwrap();
+    std::fs::write(
+        &m_b,
+        manifest("github.com/x/bravo", "Bravo", "2.0.0", "b.wasm"),
+    )
+    .unwrap();
+
+    let status = Command::new(BIN)
+        .arg("local")
+        .arg("--out")
+        .arg(out)
+        .arg(&m_a)
+        .arg(&m_b)
+        .status()
+        .expect("run indexer local (multi)");
+    assert!(status.success(), "indexer local multi-manifest failed");
+
+    let text = std::fs::read_to_string(out.join("index.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let backends = v["backends"].as_array().expect("backends array");
+    assert_eq!(backends.len(), 2, "one entry per manifest");
+    let ids: Vec<&str> = backends.iter().filter_map(|b| b["id"].as_str()).collect();
+    assert!(ids.contains(&"alpha"), "alpha indexed: {ids:?}");
+    assert!(ids.contains(&"bravo"), "bravo indexed: {ids:?}");
+}

--- a/super-stt-shared/src/daemon/session.rs
+++ b/super-stt-shared/src/daemon/session.rs
@@ -67,6 +67,23 @@ fn cache_clear(app_id: AppId) {
     TOKEN_CACHE.lock().unwrap().remove(app_id.0);
 }
 
+/// When `SUPER_STT_KEYRING_MOCK` is set, route all client-side keyring
+/// access (the session-token store this module manages) to an in-memory
+/// mock instead of the system secret service.
+///
+/// This is the client-side twin of the daemon's
+/// `install_mock_if_requested`: the CLI / settings app / applet reach the
+/// keyring through this module's `load`/`save`/`forget`, and an automated
+/// shell or CI run has no unlocked secret service — touching the real one
+/// there blocks on an unlock prompt or fails. Call this once at process
+/// startup, before any keyring access, as it sets the process-wide default
+/// credential builder.
+pub fn install_mock_keyring_if_requested() {
+    if std::env::var_os("SUPER_STT_KEYRING_MOCK").is_some() {
+        keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+    }
+}
+
 /// Read the cached token for `app_id`, or None if no token is stored.
 #[must_use]
 pub fn load(app_id: AppId) -> Option<String> {

--- a/super-stt-shared/src/resource_management/manager.rs
+++ b/super-stt-shared/src/resource_management/manager.rs
@@ -57,10 +57,21 @@ impl ResourceManager {
         Self::with_limits(ResourceLimits::production())
     }
 
-    /// Register a new connection and check connection limits
+    /// Register a connection for `client_id`, enforcing the connection cap.
+    ///
+    /// **Idempotent per `client_id`.** A client (keyed by `uid:pid`) may
+    /// open several connections over its lifetime — a long-lived
+    /// `/v1/events` stream alongside short `/v1/ping` calls, or simply a
+    /// fresh connection per request. Re-registering an existing client is a
+    /// no-op: its [`ConnectionInfo`] — and crucially its rolling
+    /// `request_history` — is preserved, so the rate-limit window spans all
+    /// of that client's connections rather than being reset by each new one.
+    /// Only a genuinely new `client_id` allocates an entry and is subject to
+    /// the connection cap (an existing client is already counted).
     ///
     /// # Errors
-    /// Returns an error if the connection limit is exceeded.
+    /// Returns an error if registering a *new* client would exceed
+    /// `max_connections`.
     pub async fn register_connection(
         &self,
         client_id: String,
@@ -68,7 +79,12 @@ impl ResourceManager {
     ) -> Result<(), ResourceError> {
         let mut connections = self.connections.write().await;
 
-        // Check connection limit
+        // Existing client → keep its accumulated state untouched.
+        if connections.contains_key(&client_id) {
+            return Ok(());
+        }
+
+        // New client → enforce the cap before allocating its entry.
         if connections.len() >= self.limits.max_connections {
             return Err(ResourceError::ConnectionLimitExceeded {
                 current: connections.len(),
@@ -76,9 +92,8 @@ impl ResourceManager {
             });
         }
 
-        // Register the connection
         let conn_info = ConnectionInfo::new(client_id.clone(), client_addr);
-        connections.insert(client_id.clone(), conn_info);
+        connections.insert(client_id, conn_info);
 
         Ok(())
     }
@@ -267,6 +282,79 @@ mod tests {
 
         // Fourth request should fail (rate limit exceeded)
         assert!(manager.record_request("client1").await.is_err());
+    }
+
+    /// Re-registering an existing client (e.g. it opened a second
+    /// connection, or reconnected for the next request) must NOT reset its
+    /// rolling request window. Regression guard: when `register_connection`
+    /// overwrote the entry, a client could defeat the rate limit entirely by
+    /// reconnecting between requests, and a sibling connection would wipe the
+    /// accumulated history of an open one.
+    #[tokio::test]
+    async fn reregistering_a_client_preserves_its_rate_window() {
+        let limits = ResourceLimits {
+            max_requests_per_minute: 3,
+            max_requests_per_hour: 10,
+            ..Default::default()
+        };
+        let manager = ResourceManager::with_limits(limits);
+
+        manager
+            .register_connection("client1".to_string(), None)
+            .await
+            .unwrap();
+
+        // Consume the whole per-minute budget on the first connection.
+        for _ in 0..3 {
+            assert!(manager.record_request("client1").await.is_ok());
+        }
+
+        // A second connection for the same client_id (re-registration) must
+        // be a no-op that keeps the existing window — not a fresh start.
+        manager
+            .register_connection("client1".to_string(), None)
+            .await
+            .unwrap();
+
+        // So the next request is still over quota. Before the fix this
+        // reset the count and erroneously returned Ok.
+        assert!(
+            manager.record_request("client1").await.is_err(),
+            "re-registration must not hand the client a fresh rate-limit budget"
+        );
+    }
+
+    /// Re-registration is also exempt from the connection cap: an existing
+    /// client that reconnects while the table is full is still allowed,
+    /// since it's already counted. (A genuinely new client at the cap is
+    /// rejected — covered by `test_connection_limiting`.)
+    #[tokio::test]
+    async fn reregistering_at_capacity_is_allowed() {
+        let limits = ResourceLimits {
+            max_connections: 1,
+            ..Default::default()
+        };
+        let manager = ResourceManager::with_limits(limits);
+
+        manager
+            .register_connection("client1".to_string(), None)
+            .await
+            .unwrap();
+        // Table is full, but re-registering the SAME client must succeed.
+        assert!(
+            manager
+                .register_connection("client1".to_string(), None)
+                .await
+                .is_ok(),
+            "an already-registered client must not be rejected by the cap"
+        );
+        // A different client at capacity is still rejected.
+        assert!(
+            manager
+                .register_connection("client2".to_string(), None)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fills the largest gaps in automated test coverage across the workspace, and fixes a rate-limiter bug surfaced while writing the rate-limit test.

### Test coverage (commit 1)
Hermetic, run under the default `cargo test` flow (no mic/GPU/display/network):

- **CLI** (`cmd_basic.rs`) — `ping`, `status`, `stop` (idempotent on idle), `logout`. Previously only the `record` toggle was tested, and it's `#[ignore]`d (needs a mic).
- **Daemon backend management** (`http_smoke_backends.rs`) — `GET /backends`, `GET/POST/DELETE /active_backend`, `GET /gpu_info`, `DELETE /backends/{source}`, plus scope enforcement.
- **Daemon events per-topic scope** (`http_smoke_events.rs`) — per-topic `403 scope_denied`, all-or-nothing batches, `400 invalid_topic`, and a successful `subscribed` ack. Complements `widget_smoke.rs` (which only covers the lifecycle with an all-scope token).
- **Daemon transport conformance** (`http_smoke_transport.rs`) — `404` unknown route, `405` wrong method (with and without auth middleware in front), `400` malformed/missing JSON body.
- **Daemon rate limit** (`http_smoke_ratelimit.rs`) — flooding past the dev quota yields `429 rate_limited`.
- **Session-token security** (unit tests in `tokens.rs` / `middleware.rs`) — token expiry + eviction, `revoke` (backs the `/events` `exe_changed` path), and the deny-cache identity. `tokens.rs` previously had no tests.
- **Indexer** (`local.rs`) — the offline `local` subcommand: real staged-asset hashing, `--allow-missing-assets` placeholders, the missing-asset error, and multi-manifest output.

Also adds `session::install_mock_keyring_if_requested()` (the client-side twin of the daemon's `install_mock_if_requested`) wired into the CLI's `main()`, so the CLI's keyring access is hermetic under `SUPER_STT_KEYRING_MOCK=1`.

### Rate-limiter fix (commit 2)
`ResourceManager::register_connection` overwrote a client's `ConnectionInfo` on every accept, wiping its rolling `request_history`. Because the limiter keys on `client_id` (`uid:pid`), a client that reconnects per request — or simply opens a second connection — reset its own rate-limit window, defeating the per-minute/hour limits. This contradicted the documented intent in `server.rs` ("don't brick the sibling's rate-limit lookup"). Re-registration is now idempotent: an existing client's window is preserved, and the connection cap applies only to genuinely new clients. Regression tests added.

## Verification
- All new tests pass; existing tests unaffected.
- `cargo fmt --all` clean; `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)