### PR TITLE
Fix uninstall button: correct daemon route and surface failures

### DIFF
--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -52,6 +52,12 @@ impl AppModel {
                             .insert((backend.source.clone(), secret.name.clone()), configured);
                     }
                 }
+                // Drop uninstall errors for backends no longer present — a
+                // backend that left the catalog is one whose uninstall
+                // ultimately succeeded, so its stale error must not linger.
+                self.registry
+                    .uninstall_errors
+                    .retain(|src, _| backends.iter().any(|b| &b.source == src));
                 self.backends = backends;
                 Task::none()
             }

--- a/super-stt-app/src/core/app/handlers/models_page/install.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/install.rs
@@ -103,12 +103,38 @@ impl AppModel {
                 )
             }
 
+            _ => Task::none(),
+        }
+    }
+
+    /// Uninstall lifecycle: kick off the request and surface its failure.
+    pub(in crate::core::app) fn handle_models_uninstall(
+        &mut self,
+        message: Message,
+    ) -> Task<cosmic::Action<Message>> {
+        match message {
             Message::UninstallBackend(source) => {
+                // Clear any stale failure so the row reads "in progress" on retry.
+                self.registry.uninstall_errors.remove(&source);
                 let s = source.clone();
                 Task::perform(
                     async move { crate::daemon::registry::uninstall(&s).await },
-                    |_| cosmic::Action::App(Message::BackendsReload),
+                    move |res| {
+                        cosmic::Action::App(match res {
+                            Ok(_) => Message::BackendsReload,
+                            Err(error) => Message::UninstallFailed {
+                                source: source.clone(),
+                                error,
+                            },
+                        })
+                    },
                 )
+            }
+
+            Message::UninstallFailed { source, error } => {
+                log::error!("uninstall({source}) failed: {error}");
+                self.registry.uninstall_errors.insert(source, error);
+                Task::none()
             }
 
             _ => Task::none(),

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -42,8 +42,11 @@ impl AppModel {
             | Message::InstallBackendFromRepoUrl(_)
             | Message::InstallAccepted { .. }
             | Message::InstallFailedToStart { .. }
-            | Message::UpdateBackend(_)
-            | Message::UninstallBackend(_) => self.handle_models_install_lifecycle(message),
+            | Message::UpdateBackend(_) => self.handle_models_install_lifecycle(message),
+
+            Message::UninstallBackend(_) | Message::UninstallFailed { .. } => {
+                self.handle_models_uninstall(message)
+            }
 
             Message::InstallProgress { .. }
             | Message::InstallCompleted { .. }

--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -79,6 +79,7 @@ impl AppModel {
                 | Message::InstallFailed { .. }
                 | Message::UpdateBackend(_)
                 | Message::UninstallBackend(_)
+                | Message::UninstallFailed { .. }
                 | Message::RefreshRegistry
                 | Message::RegistryListLoaded(_)
                 | Message::RegistryListFailed(_)

--- a/super-stt-app/src/daemon/client/v1/registry/uninstall.rs
+++ b/super-stt-app/src/daemon/client/v1/registry/uninstall.rs
@@ -3,7 +3,7 @@ use crate::daemon::client::internal::session::with_settings_token;
 use super_stt_shared::daemon::http_client::transport;
 use super_stt_shared::registry::UninstallResponse;
 
-/// `DELETE /registry/backends/{source}` — uninstall a backend.
+/// `DELETE /backends/{source}` — uninstall a backend.
 pub async fn uninstall(source: &str) -> Result<UninstallResponse, String> {
     let encoded = urlencoding::encode(source).into_owned();
     with_settings_token(move |socket, token| {
@@ -12,7 +12,7 @@ pub async fn uninstall(source: &str) -> Result<UninstallResponse, String> {
             transport::delete_json::<UninstallResponse>(
                 socket,
                 &token,
-                &format!("/registry/backends/{encoded}"),
+                &format!("/backends/{encoded}"),
             )
             .await
             .map_err(String::from)

--- a/super-stt-app/src/state/registry.rs
+++ b/super-stt-app/src/state/registry.rs
@@ -12,6 +12,10 @@ pub struct RegistryState {
     pub generated_at: Option<String>,
     pub filters: Filters,
     pub installs: HashMap<String, InstallStatus>,
+    /// Uninstall failures keyed by `source`, surfaced on the installed card.
+    /// Cleared when the user retries that backend or it disappears from the
+    /// reloaded catalog (i.e. the uninstall ultimately succeeded).
+    pub uninstall_errors: HashMap<String, String>,
     pub last_refresh: Option<RefreshOutcome>,
     /// In-progress URL text for the Custom-repo input in the Download tab.
     pub custom_repo_input: String,

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -143,6 +143,12 @@ pub enum Message {
     UpdateBackend(String),
     /// User clicked Uninstall.
     UninstallBackend(String),
+    /// An uninstall request failed; carries the backend `source` and a
+    /// human-readable error to surface on the installed card.
+    UninstallFailed {
+        source: String,
+        error: String,
+    },
     /// User clicked Retry on the Download-tab empty state, or any other refresh trigger.
     RefreshRegistry,
     /// Initial fetch of /registry/backends succeeded.

--- a/super-stt-app/src/ui/views/models/installed.rs
+++ b/super-stt-app/src/ui/views/models/installed.rs
@@ -116,8 +116,20 @@ pub(super) fn installed_card<'a>(
     actions.push(overflow.into());
 
     let card = backend_header(backend.name.clone(), backend.source.clone(), actions);
+    let surface = card_surface(card, false);
 
-    card_surface(card, false)
+    // Surface a failed uninstall directly under its card until the user
+    // retries (or it succeeds and the backend leaves the catalog).
+    match app.registry.uninstall_errors.get(source.as_str()) {
+        Some(err) => column(vec![
+            surface,
+            text::caption(format!("Uninstall failed: {err}")).into(),
+        ])
+        .spacing(cosmic::theme::spacing().space_xxxs)
+        .width(Length::Fill)
+        .into(),
+        None => surface,
+    }
 }
 
 /// The popup body for an installed card's "⋯" overflow menu: Configure, an


### PR DESCRIPTION
## Problem

The Uninstall button in the settings app did nothing — no removal, no error, nothing in the daemon log except the follow-up catalog reload.

**Root cause:** the app's uninstall client called `DELETE /registry/backends/{source}`, but the daemon serves uninstall at `DELETE /backends/{source}` (per `docs/protocol/endpoints/v1/backends.md`). The registry router has no DELETE, so the request 404'd. The app then discarded the result and unconditionally fired `BackendsReload`, so the click silently vanished.

## Fix

- Point the client at the canonical `/backends/{source}` route.
- Stop discarding the uninstall result: a failure now logs `uninstall(<source>) failed: …` and shows an error caption on that backend's installed card (cleared on retry, or dropped once the backend leaves the catalog after a successful uninstall).

Implemented with a new `UninstallFailed` message routed to a dedicated `handle_models_uninstall` handler, a per-source `uninstall_errors` map in registry state, and a caption on the installed card — mirroring the existing install-error surface.

## Verification

- `cargo fmt --check` clean
- `cargo clippy -p super-stt-app --all-features -- -W clippy::pedantic -D warnings` clean
- `cargo test -p super-stt-app` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)