### PR TITLE
Standardize backend.toml model-file downloads

### DIFF
--- a/backends/qwen3-asr/backend.toml
+++ b/backends/qwen3-asr/backend.toml
@@ -68,21 +68,16 @@
     estimated_vram_bytes = 2500000000
     processing_interval_ms = 1000
 
-    [[models.files]]
-        source = "huggingface"
-        repo = "Qwen/Qwen3-ASR-0.6B"
-        revision = "main"
-        files = [
-            "config.json",
-            "generation_config.json",
-            "preprocessor_config.json",
-            "chat_template.json",
-            "tokenizer_config.json",
-            "vocab.json",
-            "merges.txt",
-            "model.safetensors",
-        ]
-        dest = "models/qwen3-asr-0.6b"
+    files = [
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/config.json", destination = "models/qwen3-asr-0.6b/config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/generation_config.json", destination = "models/qwen3-asr-0.6b/generation_config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/preprocessor_config.json", destination = "models/qwen3-asr-0.6b/preprocessor_config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/chat_template.json", destination = "models/qwen3-asr-0.6b/chat_template.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/tokenizer_config.json", destination = "models/qwen3-asr-0.6b/tokenizer_config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/vocab.json", destination = "models/qwen3-asr-0.6b/vocab.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/merges.txt", destination = "models/qwen3-asr-0.6b/merges.txt" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-0.6B/resolve/main/model.safetensors", destination = "models/qwen3-asr-0.6b/model.safetensors" },
+    ]
 
 [[models]]
     name = "qwen3-asr-1.7b"
@@ -125,20 +120,15 @@
     estimated_vram_bytes = 6000000000
     processing_interval_ms = 1500
 
-    [[models.files]]
-        source = "huggingface"
-        repo = "Qwen/Qwen3-ASR-1.7B"
-        revision = "main"
-        files = [
-            "config.json",
-            "generation_config.json",
-            "preprocessor_config.json",
-            "chat_template.json",
-            "tokenizer_config.json",
-            "vocab.json",
-            "merges.txt",
-            "model.safetensors.index.json",
-            "model-00001-of-00002.safetensors",
-            "model-00002-of-00002.safetensors",
-        ]
-        dest = "models/qwen3-asr-1.7b"
+    files = [
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/config.json", destination = "models/qwen3-asr-1.7b/config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/generation_config.json", destination = "models/qwen3-asr-1.7b/generation_config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/preprocessor_config.json", destination = "models/qwen3-asr-1.7b/preprocessor_config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/chat_template.json", destination = "models/qwen3-asr-1.7b/chat_template.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/tokenizer_config.json", destination = "models/qwen3-asr-1.7b/tokenizer_config.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/vocab.json", destination = "models/qwen3-asr-1.7b/vocab.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/merges.txt", destination = "models/qwen3-asr-1.7b/merges.txt" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/model.safetensors.index.json", destination = "models/qwen3-asr-1.7b/model.safetensors.index.json" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/model-00001-of-00002.safetensors", destination = "models/qwen3-asr-1.7b/model-00001-of-00002.safetensors" },
+        { url = "https://huggingface.co/Qwen/Qwen3-ASR-1.7B/resolve/main/model-00002-of-00002.safetensors", destination = "models/qwen3-asr-1.7b/model-00002-of-00002.safetensors" },
+    ]

--- a/backends/whisper/backend.toml
+++ b/backends/whisper/backend.toml
@@ -23,13 +23,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 1073741824
     processing_interval_ms = 1000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-tiny"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-tiny"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/config.json", destination = "models/whisper-tiny/config.json" },
+        { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/tokenizer.json", destination = "models/whisper-tiny/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/model.safetensors", destination = "models/whisper-tiny/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-tiny.en"
@@ -40,13 +38,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 1073741824
     processing_interval_ms = 1000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-tiny.en"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-tiny.en"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-tiny.en/resolve/main/config.json", destination = "models/whisper-tiny.en/config.json" },
+        { url = "https://huggingface.co/openai/whisper-tiny.en/resolve/main/tokenizer.json", destination = "models/whisper-tiny.en/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-tiny.en/resolve/main/model.safetensors", destination = "models/whisper-tiny.en/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-base"
@@ -57,13 +53,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 1073741824
     processing_interval_ms = 1500
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-base"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-base"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-base/resolve/main/config.json", destination = "models/whisper-base/config.json" },
+        { url = "https://huggingface.co/openai/whisper-base/resolve/main/tokenizer.json", destination = "models/whisper-base/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-base/resolve/main/model.safetensors", destination = "models/whisper-base/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-base.en"
@@ -74,13 +68,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 1073741824
     processing_interval_ms = 1500
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-base.en"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-base.en"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-base.en/resolve/main/config.json", destination = "models/whisper-base.en/config.json" },
+        { url = "https://huggingface.co/openai/whisper-base.en/resolve/main/tokenizer.json", destination = "models/whisper-base.en/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-base.en/resolve/main/model.safetensors", destination = "models/whisper-base.en/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-small"
@@ -91,13 +83,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 2147483648
     processing_interval_ms = 2000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-small"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-small"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-small/resolve/main/config.json", destination = "models/whisper-small/config.json" },
+        { url = "https://huggingface.co/openai/whisper-small/resolve/main/tokenizer.json", destination = "models/whisper-small/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-small/resolve/main/model.safetensors", destination = "models/whisper-small/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-small.en"
@@ -108,13 +98,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 2147483648
     processing_interval_ms = 2000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-small.en"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-small.en"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-small.en/resolve/main/config.json", destination = "models/whisper-small.en/config.json" },
+        { url = "https://huggingface.co/openai/whisper-small.en/resolve/main/tokenizer.json", destination = "models/whisper-small.en/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-small.en/resolve/main/model.safetensors", destination = "models/whisper-small.en/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-medium"
@@ -125,13 +113,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 5368709120
     processing_interval_ms = 2000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-medium"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-medium"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-medium/resolve/main/config.json", destination = "models/whisper-medium/config.json" },
+        { url = "https://huggingface.co/openai/whisper-medium/resolve/main/tokenizer.json", destination = "models/whisper-medium/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-medium/resolve/main/model.safetensors", destination = "models/whisper-medium/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-medium.en"
@@ -142,13 +128,11 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 5368709120
     processing_interval_ms = 2000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-medium.en"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-medium.en"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-medium.en/resolve/main/config.json", destination = "models/whisper-medium.en/config.json" },
+        { url = "https://huggingface.co/openai/whisper-medium.en/resolve/main/tokenizer.json", destination = "models/whisper-medium.en/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-medium.en/resolve/main/model.safetensors", destination = "models/whisper-medium.en/model.safetensors" },
+    ]
 
 [[models]]
     name                   = "whisper-large"
@@ -159,10 +143,8 @@
     supported_devices      = ["cpu", "cuda"]
     estimated_vram_bytes   = 10737418240
     processing_interval_ms = 5000
-
-    [[models.files]]
-        source   = "huggingface"
-        repo     = "openai/whisper-large"
-        revision = "main"
-        files    = ["config.json", "tokenizer.json", "model.safetensors"]
-        dest     = "models/whisper-large"
+    files = [
+        { url = "https://huggingface.co/openai/whisper-large/resolve/main/config.json", destination = "models/whisper-large/config.json" },
+        { url = "https://huggingface.co/openai/whisper-large/resolve/main/tokenizer.json", destination = "models/whisper-large/tokenizer.json" },
+        { url = "https://huggingface.co/openai/whisper-large/resolve/main/model.safetensors", destination = "models/whisper-large/model.safetensors" },
+    ]

--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -274,28 +274,39 @@ contradiction and the manifest is rejected.
 
 ### `[[models.files]]`
 
-Files a model needs, and where to place them. Each entry is one download
-group. The daemon fetches the files into `dest` (relative to the backend
-directory) before calling `POST /v1/load`. Cloud models declare no files.
+The files a model needs, and where to place them. `files` is an array in which
+each entry describes **one file**: a download URL and the path to write it to.
+The daemon fetches every file before calling `POST /v1/load`. Files are fetched
+the same way regardless of host — no source is given special treatment. Cloud
+models declare no files.
+
+Written compactly as an inline-table array on the model:
+
+```toml
+files = [
+    { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/config.json",
+      destination = "models/whisper-tiny/config.json" },
+    { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/model.safetensors",
+      destination = "models/whisper-tiny/model.safetensors", sha256 = "9f86d0…" },
+]
+```
+
+The block form is identical TOML and may be used instead:
 
 ```toml
 [[models.files]]
-source   = "huggingface"
-repo     = "openai/whisper-tiny"
-revision = "main"
-files    = ["config.json", "tokenizer.json", "model.safetensors"]
-dest     = "models/whisper-tiny"
+url         = "https://huggingface.co/openai/whisper-tiny/resolve/main/config.json"
+destination = "models/whisper-tiny/config.json"
 ```
 
-| Field      | Type            | Required | Notes                                                              |
-|------------|-----------------|----------|--------------------------------------------------------------------|
-| `source`   | string          | no       | `huggingface` (default) or `url`.                                  |
-| `repo`     | string          | for `huggingface` | Hugging Face repo id, e.g. `openai/whisper-tiny`.         |
-| `revision` | string          | no       | Hugging Face revision; default `main`.                             |
-| `url`      | string          | for `url` | Direct download URL for a single file.                            |
-| `files`    | array of string | for `huggingface` | Filenames to fetch from the repo.                         |
-| `dest`     | string          | yes      | Directory, relative to the backend dir, to place the files in.     |
-| `sha256`   | string          | no       | Expected SHA-256 for integrity verification.                       |
+| Field         | Type   | Required | Notes                                                                |
+|---------------|--------|----------|---------------------------------------------------------------------|
+| `url`         | string | yes      | Full download URL for the file. Any host.                            |
+| `destination` | string | yes      | Relative file path (including filename) under the backend directory. |
+| `sha256`      | string | no       | Expected SHA-256, hex-encoded; verified after download.              |
+
+`destination` must be a relative path that stays inside the backend directory:
+absolute paths, `..` traversal, and backslashes are rejected.
 
 ## Example: local backend (subprocess)
 
@@ -325,13 +336,14 @@ supported_languages    = ["en", "es", "fr", "de", "zh"]  # abbreviated
 supported_devices      = ["cpu", "cuda"]
 estimated_vram_bytes   = 262144000
 processing_interval_ms = 1000
-
-[[models.files]]
-source   = "huggingface"
-repo     = "openai/whisper-tiny"
-revision = "main"
-files    = ["config.json", "tokenizer.json", "model.safetensors"]
-dest     = "models/whisper-tiny"
+files = [
+    { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/config.json",
+      destination = "models/whisper-tiny/config.json" },
+    { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/tokenizer.json",
+      destination = "models/whisper-tiny/tokenizer.json" },
+    { url = "https://huggingface.co/openai/whisper-tiny/resolve/main/model.safetensors",
+      destination = "models/whisper-tiny/model.safetensors" },
+]
 
 [[models]]
 name                   = "voxtral-mini"
@@ -345,17 +357,16 @@ processing_interval_ms = 2000
 
 # Voxtral ships tekken.json instead of tokenizer.json, and multi-shard
 # weights.
-[[models.files]]
-source   = "huggingface"
-repo     = "mistralai/Voxtral-Mini-3B-2507"
-revision = "main"
-files    = [
-    "config.json",
-    "tekken.json",
-    "model-00001-of-00002.safetensors",
-    "model-00002-of-00002.safetensors",
+files = [
+    { url = "https://huggingface.co/mistralai/Voxtral-Mini-3B-2507/resolve/main/config.json",
+      destination = "models/voxtral-mini/config.json" },
+    { url = "https://huggingface.co/mistralai/Voxtral-Mini-3B-2507/resolve/main/tekken.json",
+      destination = "models/voxtral-mini/tekken.json" },
+    { url = "https://huggingface.co/mistralai/Voxtral-Mini-3B-2507/resolve/main/model-00001-of-00002.safetensors",
+      destination = "models/voxtral-mini/model-00001-of-00002.safetensors" },
+    { url = "https://huggingface.co/mistralai/Voxtral-Mini-3B-2507/resolve/main/model-00002-of-00002.safetensors",
+      destination = "models/voxtral-mini/model-00002-of-00002.safetensors" },
 ]
-dest     = "models/voxtral-mini"
 ```
 
 ## Example: cloud backend (WASM)

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -93,15 +93,15 @@ impl SuperSTTDaemon {
         device_pref: &str,
     ) -> Result<Box<dyn Transcribe>> {
         // Count the files we'll provision so the tracker's denominator is
-        // accurate from the first broadcast (vs. growing as we discover more
-        // `[[models.files]]` blocks). Empty-files models (cloud-only) skip
-        // the tracker entirely — there is nothing to download.
+        // accurate from the first broadcast. Each `[[models.files]]` entry is
+        // one file. Empty-files models (cloud-only) skip the tracker entirely —
+        // there is nothing to download.
         let manifest = crate::stt_models::backends::manifest::Manifest::load(&backend.dir)?;
         let total_files = manifest
             .models
             .iter()
             .find(|m| m.name == name)
-            .map_or(0, |m| m.files.iter().map(|s| s.files.len()).sum::<usize>());
+            .map_or(0, |m| m.files.len());
 
         let tracker = if total_files == 0 {
             None

--- a/super-stt-daemon/src/stt_models/download.rs
+++ b/super-stt-daemon/src/stt_models/download.rs
@@ -2,176 +2,233 @@
 //! Model-file provisioning for backends.
 //!
 //! Backends declare the files they need in `backend.toml` (`[[models.files]]`).
-//! The daemon downloads those files into the per-backend directory before
-//! spawning the backend, so a sandboxed backend never needs network access of
-//! its own. This is the only downloader the daemon keeps now that model
-//! inference lives entirely in out-of-tree backends.
+//! Each file is a plain URL plus a `destination` path; the daemon downloads it
+//! into the per-backend directory before spawning the backend, so a sandboxed
+//! backend never needs network access of its own. Files are fetched the same
+//! way regardless of host — no source is given special treatment. This is the
+//! only downloader the daemon keeps now that model inference lives entirely in
+//! out-of-tree backends.
 
 use anyhow::Result;
 use futures::StreamExt;
 use log::info;
-use std::path::Path;
+use ring::digest::{Context, SHA256};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use tokio::fs;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::download_progress::DownloadProgressTracker;
 
-/// Build the `HuggingFace` Hub download URL for a single file.
-fn hf_url(repo: &str, revision: &str, filename: &str) -> String {
-    format!("https://huggingface.co/{repo}/resolve/{revision}/{filename}")
+/// One file to provision: a URL, the absolute path to write it to, and an
+/// optional expected SHA-256 (hex) for integrity verification.
+pub struct DownloadItem {
+    /// Full download URL. Any host.
+    pub url: String,
+    /// Absolute path to write the file to (the caller has already joined the
+    /// manifest `destination` onto the backend directory).
+    pub destination: PathBuf,
+    /// Expected SHA-256, hex-encoded, when the manifest declares one.
+    pub sha256: Option<String>,
 }
 
-/// Download a model's files from `HuggingFace` into a flat directory.
+/// Hex-encoded SHA-256 of a file on disk, streamed so large weights don't load
+/// into memory.
+async fn sha256_hex_of_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path).await?;
+    let mut ctx = Context::new(&SHA256);
+    let mut buf = vec![0u8; 1024 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        ctx.update(&buf[..n]);
+    }
+    Ok(hex::encode(ctx.finish().as_ref()))
+}
+
+/// If `dest` already holds a usable copy (non-empty, and matching `sha256` when
+/// one is declared), returns its size. Returns `None` when the file is absent,
+/// empty, or fails verification — in which case it should be re-downloaded.
+async fn usable_existing(dest: &Path, sha256: Option<&str>) -> Result<Option<u64>> {
+    let Ok(md) = fs::metadata(dest).await else {
+        return Ok(None);
+    };
+    if md.len() == 0 {
+        return Ok(None);
+    }
+    if let Some(expected) = sha256 {
+        let actual = sha256_hex_of_file(dest).await?;
+        if !actual.eq_ignore_ascii_case(expected) {
+            info!(
+                "Hash mismatch for existing {} (expected {expected}, got {actual}); re-downloading",
+                dest.display()
+            );
+            return Ok(None);
+        }
+    }
+    Ok(Some(md.len()))
+}
+
+/// Best-effort total file size for the progress bar.
 ///
-/// Used to provision a backend's per-backend model directory (the manifest
-/// `dest`). Skips files already present (non-zero size) and writes plain
-/// `dest_dir/<filename>` files so a sandboxed backend can load them directly.
+/// Some CDNs serve large files with chunked transfer encoding, so
+/// `Content-Length` is often missing. Hugging Face, for one, sets a custom
+/// `X-Linked-Size` header on its resolve endpoint with the underlying file
+/// size; we read it first (simply absent, and harmless, on other hosts), then
+/// fall back to `Content-Length`, then to an explicit HEAD.
+async fn resolve_total_size(
+    client: &reqwest::Client,
+    response: &reqwest::Response,
+    url: &str,
+) -> Option<u64> {
+    fn from_headers(h: &reqwest::header::HeaderMap) -> Option<u64> {
+        h.get("x-linked-size")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+    }
+    if let Some(n) = from_headers(response.headers()).or_else(|| response.content_length()) {
+        return Some(n);
+    }
+    let head = client.head(url).send().await.ok()?;
+    from_headers(head.headers()).or_else(|| head.content_length())
+}
+
+/// Download a single file to `item.destination`, verifying its SHA-256 when one
+/// is declared and reporting progress through `tracker` when present.
+async fn download_one(
+    client: &reqwest::Client,
+    item: &DownloadItem,
+    tracker: Option<&Arc<DownloadProgressTracker>>,
+    file_index: usize,
+) -> Result<()> {
+    let dest = &item.destination;
+    let name = dest.file_name().map_or_else(
+        || dest.to_string_lossy().into_owned(),
+        |s| s.to_string_lossy().into_owned(),
+    );
+    let parent = dest.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).await?;
+
+    // Skip a file that's already on disk (verified against `sha256` when set).
+    // Per-file counters: both totals are this file's size so the UI shows
+    // "X.X / X.X MB" at 100%, then the file_index advances next iteration.
+    if let Some(len) = usable_existing(dest, item.sha256.as_deref()).await? {
+        info!("Already present: {}", dest.display());
+        if let Some(t) = tracker {
+            t.start_file(&name, file_index);
+            t.bytes_downloaded.store(len, Ordering::Relaxed);
+            t.total_bytes.store(len, Ordering::Relaxed);
+            t.broadcast_progress();
+        }
+        return Ok(());
+    }
+
+    let url = &item.url;
+    info!("Downloading {url} -> {}", dest.display());
+    if let Some(t) = tracker {
+        t.start_file(&name, file_index);
+    }
+    let response = client.get(url).send().await?;
+    if !response.status().is_success() {
+        anyhow::bail!("Download failed with status {}: {url}", response.status());
+    }
+
+    if let Some(t) = tracker {
+        match resolve_total_size(client, &response, url).await {
+            Some(len) => {
+                info!("Resolved size for {name}: {len} bytes");
+                // `start_file` already zeroed the per-file counters; a plain
+                // store of the resolved total is what we want. Broadcast at
+                // once so the UI's MB display flips before the first chunk.
+                t.total_bytes.store(len, Ordering::Relaxed);
+                t.broadcast_progress();
+            }
+            None => info!(
+                "No size header for {name} (X-Linked-Size + Content-Length absent on GET and HEAD); progress will only update at file boundaries"
+            ),
+        }
+    }
+
+    let tmp = parent.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
+    let mut file = fs::File::create(&tmp).await?;
+    let mut hasher = item.sha256.as_ref().map(|_| Context::new(&SHA256));
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        if let Some(t) = tracker
+            && t.is_cancelled()
+        {
+            let _ = fs::remove_file(&tmp).await;
+            anyhow::bail!("download cancelled");
+        }
+        let bytes = chunk?;
+        file.write_all(&bytes).await?;
+        if let Some(h) = hasher.as_mut() {
+            h.update(&bytes);
+        }
+        if let Some(t) = tracker {
+            t.bytes_downloaded
+                .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+            // The tracker throttles to 1% increments, so per-chunk is fine.
+            t.broadcast_progress();
+        }
+    }
+    file.flush().await?;
+    file.sync_all().await?;
+    drop(file);
+
+    // Verify before publishing the file at its final path.
+    if let (Some(h), Some(expected)) = (hasher, item.sha256.as_ref()) {
+        let actual = hex::encode(h.finish().as_ref());
+        if !actual.eq_ignore_ascii_case(expected) {
+            let _ = fs::remove_file(&tmp).await;
+            anyhow::bail!("SHA-256 mismatch for {name}: expected {expected}, got {actual}");
+        }
+    }
+
+    fs::rename(&tmp, dest).await?;
+    Ok(())
+}
+
+/// Download a model's files into the backend directory.
 ///
-/// When `tracker` is `Some`, per-file and per-byte progress is reported
-/// through it (`start_file` → `bytes_downloaded`/`total_bytes` → broadcast). When
-/// `None`, downloads run silently (used by unit tests and one-off calls
-/// that don't go through the daemon's `DownloadStateManager`).
+/// Each item carries its own URL and absolute `destination`; parent
+/// directories are created as needed. A file already present (non-zero size,
+/// and matching its declared `sha256`) is skipped; otherwise it is downloaded
+/// and, when a `sha256` is declared, verified.
 ///
-/// `starting_file_index` lets the caller compose multiple
-/// `download_files_to_dir` calls against a single tracker so the file
-/// counter stays monotonic — pass `0` for the first call and the running
-/// total for subsequent ones.
+/// When `tracker` is `Some`, per-file and per-byte progress is reported through
+/// it. When `None`, downloads run silently (used by unit tests and one-off
+/// calls that don't go through the daemon's `DownloadStateManager`).
+///
+/// `starting_file_index` lets the caller compose multiple `download_files`
+/// calls against a single tracker so the file counter stays monotonic — pass
+/// `0` for the first call and the running total for subsequent ones.
 ///
 /// # Errors
 ///
-/// Returns an error on network/IO failure, a non-success HTTP status, or
-/// cancellation via `tracker.is_cancelled()`.
-pub async fn download_files_to_dir(
-    repo: &str,
-    revision: &str,
-    files: &[String],
-    dest_dir: &Path,
+/// Returns an error on network/IO failure, a non-success HTTP status, a
+/// SHA-256 mismatch, or cancellation via `tracker.is_cancelled()`.
+pub async fn download_files(
+    items: &[DownloadItem],
     tracker: Option<&Arc<DownloadProgressTracker>>,
     starting_file_index: usize,
 ) -> Result<()> {
-    fs::create_dir_all(dest_dir).await?;
     crate::install_crypto_provider();
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_hours(1))
         .connect_timeout(std::time::Duration::from_secs(30))
         .build()?;
 
-    for (offset, filename) in files.iter().enumerate() {
+    for (offset, item) in items.iter().enumerate() {
         if let Some(t) = tracker
             && t.is_cancelled()
         {
             anyhow::bail!("download cancelled");
         }
-
-        let file_index = starting_file_index + offset;
-        let dest = dest_dir.join(filename);
-        if let Ok(md) = fs::metadata(&dest).await
-            && md.len() > 0
-        {
-            info!("Already present: {}", dest.display());
-            // Reflect this file as "done" in the tracker. Per-file
-            // counters: both `total_bytes` and `bytes_downloaded` are
-            // this file's size (so the UI shows "X.X / X.X MB" at
-            // 100%), then the file_index advances on the next iteration.
-            if let Some(t) = tracker {
-                t.start_file(filename, file_index);
-                t.bytes_downloaded.store(md.len(), Ordering::Relaxed);
-                t.total_bytes.store(md.len(), Ordering::Relaxed);
-                t.broadcast_progress();
-            }
-            continue;
-        }
-
-        let url = hf_url(repo, revision, filename);
-        info!("Downloading {url} -> {}", dest.display());
-        if let Some(t) = tracker {
-            t.start_file(filename, file_index);
-        }
-        let response = client.get(&url).send().await?;
-        if !response.status().is_success() {
-            anyhow::bail!("Download failed with status {}: {url}", response.status());
-        }
-
-        // Resolve the total file size so the progress bar fills smoothly.
-        //
-        // HuggingFace's CDN serves large `.safetensors` with chunked
-        // transfer encoding, so `Content-Length` is often missing — but HF
-        // sets a custom `X-Linked-Size` header on the resolve endpoint that
-        // gives the underlying file size. After reqwest follows the
-        // CDN redirect, the *final* response's headers are what we see,
-        // and the CDN passes `X-Linked-Size` through. If that's missing
-        // too, we make an explicit HEAD against the resolve URL — HF's
-        // HEAD reliably returns `Content-Length`.
-        let resolved_size = if tracker.is_some() {
-            let from_get = response
-                .headers()
-                .get("x-linked-size")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-                .or_else(|| response.content_length());
-            let size = if let Some(n) = from_get {
-                Some(n)
-            } else {
-                // Fall back to a HEAD: same URL, redirects followed,
-                // and check both `X-Linked-Size` and `Content-Length`.
-                let head = client.head(&url).send().await.ok();
-                head.as_ref().and_then(|r| {
-                    r.headers()
-                        .get("x-linked-size")
-                        .and_then(|v| v.to_str().ok())
-                        .and_then(|s| s.parse::<u64>().ok())
-                        .or_else(|| r.content_length())
-                })
-            };
-            match size {
-                Some(n) => info!("Resolved size for {filename}: {n} bytes"),
-                None => info!(
-                    "No size header for {filename} (X-Linked-Size + Content-Length absent on GET and HEAD); progress will only update at file boundaries"
-                ),
-            }
-            size
-        } else {
-            None
-        };
-        if let Some(t) = tracker
-            && let Some(len) = resolved_size
-        {
-            // Per-file size, not an aggregate — `start_file` already
-            // zeroed `total_bytes` and `bytes_downloaded` for this
-            // file, so a plain `store` is what we want here.
-            t.total_bytes.store(len, Ordering::Relaxed);
-            // Broadcast immediately so the UI's MB display flips from
-            // "0.0 / 0.0 MB" to the real total before the first chunk
-            // lands. `broadcast_progress` detects the `total_bytes`
-            // change and bypasses its 1%-percentage throttle.
-            t.broadcast_progress();
-        }
-
-        let tmp = dest_dir.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
-        let mut file = fs::File::create(&tmp).await?;
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            if let Some(t) = tracker
-                && t.is_cancelled()
-            {
-                anyhow::bail!("download cancelled");
-            }
-            let bytes = chunk?;
-            file.write_all(&bytes).await?;
-            if let Some(t) = tracker {
-                t.bytes_downloaded
-                    .fetch_add(bytes.len() as u64, Ordering::Relaxed);
-                // The tracker itself throttles to 1% increments, so calling
-                // every chunk is fine — the SSE subscribers won't see a flood.
-                t.broadcast_progress();
-            }
-        }
-        file.flush().await?;
-        file.sync_all().await?;
-        drop(file);
-        fs::rename(&tmp, &dest).await?;
+        download_one(&client, item, tracker, starting_file_index + offset).await?;
     }
 
     Ok(())

--- a/super-stt-daemon/src/stt_models/subprocess/mod.rs
+++ b/super-stt-daemon/src/stt_models/subprocess/mod.rs
@@ -23,7 +23,7 @@ use tokio::net::UnixStream;
 
 use super_stt_shared::utils::audio::{ResampleQuality, resample};
 
-use crate::stt_models::backends::manifest::{FileSource, Manifest};
+use crate::stt_models::backends::manifest::Manifest;
 use crate::stt_models::transcribe::{ModelInfo, ModelInfoData, ModelState, Transcribe};
 
 const SAMPLE_RATE: u32 = 16000;
@@ -62,37 +62,28 @@ impl SubprocessBackend {
             .ok_or_else(|| anyhow!("model {model_name} not declared in backend.toml"))?;
 
         // Provision ONLY the selected model's files (lazy per model). The
-        // tracker (when present) reports per-file and per-byte progress
-        // through `DownloadStateManager` so the settings app's progress bar
-        // updates in real time. A shared file-index counter spans multiple
-        // `[[models.files]]` blocks; pass it as `starting_file_index` so the
-        // counter stays monotonic across blocks.
-        let mut file_offset = 0usize;
-        for spec in &model.files {
-            match spec.source {
-                FileSource::Url => anyhow::bail!(
-                    "model {model_name}: [[models.files]] source = \"url\" is not supported yet"
-                ),
-                FileSource::Huggingface => {}
-            }
-            let dest_dir = backend_dir.join(&spec.dest);
-            info!(
-                "provisioning {model_name}: {} files -> {}",
-                spec.files.len(),
-                dest_dir.display()
-            );
-            crate::stt_models::download::download_files_to_dir(
-                &spec.repo,
-                &spec.revision,
-                &spec.files,
-                &dest_dir,
-                tracker,
-                file_offset,
-            )
+        // tracker (when present) reports per-file and per-byte progress through
+        // `DownloadStateManager` so the settings app's progress bar updates in
+        // real time. Each file carries its own URL and destination; `parse`
+        // already validated every `destination` as a safe relative path, so the
+        // join below cannot escape the backend dir.
+        let items: Vec<_> = model
+            .files
+            .iter()
+            .map(|spec| crate::stt_models::download::DownloadItem {
+                url: spec.url.clone(),
+                destination: backend_dir.join(&spec.destination),
+                sha256: spec.sha256.clone(),
+            })
+            .collect();
+        info!(
+            "provisioning {model_name}: {} files into {}",
+            items.len(),
+            backend_dir.display()
+        );
+        crate::stt_models::download::download_files(&items, tracker, 0)
             .await
             .with_context(|| format!("provisioning {model_name}"))?;
-            file_offset += spec.files.len();
-        }
 
         // All files are on disk. Spawning the sandboxed unit and loading
         // weights onto the device is the slow tail (tens of seconds for a

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -331,10 +331,10 @@ pub struct ModelEntry {
     /// `[capabilities] websocket = true`. Default `false`.
     #[serde(default)]
     pub realtime: bool,
-    /// Files the model needs, provisioned into `dest` before
-    /// `POST /v1/load`. Cloud models declare none.
+    /// Files the model needs, each provisioned to its own `destination`
+    /// before `POST /v1/load`. Cloud models declare none.
     #[serde(default)]
-    pub files: Vec<FilesSpec>,
+    pub files: Vec<FileSpec>,
 }
 
 impl ModelEntry {
@@ -387,54 +387,28 @@ impl std::str::FromStr for Device {
     }
 }
 
-/// One `[[models.files]]` download group.
+/// One `[[models.files]]` entry: a single file to download and where to put it.
+///
+/// Source-agnostic — a file is just a URL, fetched the same way regardless of
+/// host. Hugging Face is reached by writing its plain resolve URL, with no
+/// special treatment.
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct FilesSpec {
-    /// Where the files come from. Default `huggingface`.
-    #[serde(default)]
-    pub source: FileSource,
-    /// Hugging Face repo id, e.g. `openai/whisper-tiny`. Required when
-    /// `source = "huggingface"`.
-    #[serde(default)]
-    pub repo: String,
-    /// Hugging Face revision. Default `main`.
-    #[serde(default = "default_revision")]
-    pub revision: String,
-    /// Filenames to fetch from the repo. Required when
-    /// `source = "huggingface"`.
-    #[serde(default)]
-    pub files: Vec<String>,
-    /// Direct download URL for a single file. Required when
-    /// `source = "url"`.
-    #[serde(default)]
-    pub url: Option<String>,
-    /// Directory, relative to the backend dir, to place the files in
-    /// (e.g. `models/whisper-tiny`).
-    pub dest: String,
-    /// Expected SHA-256 of the downloaded file, for integrity verification.
+pub struct FileSpec {
+    /// Full download URL for this file, e.g.
+    /// `https://huggingface.co/openai/whisper-tiny/resolve/main/config.json`.
+    pub url: String,
+    /// Relative file path (including filename) under the backend directory to
+    /// write the download to, e.g. `models/whisper-tiny/config.json`.
+    /// Validated as a safe relative path so it cannot escape the backend dir.
+    pub destination: String,
+    /// Expected SHA-256 of the file, hex-encoded, for integrity verification.
     #[serde(default)]
     pub sha256: Option<String>,
 }
 
-/// Source of a `[[models.files]]` download group.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum FileSource {
-    /// Fetch `files` from the Hugging Face repo `repo` at `revision`.
-    #[default]
-    Huggingface,
-    /// Fetch a single file from `url`.
-    Url,
-}
-
 fn default_true() -> bool {
     true
-}
-
-fn default_revision() -> String {
-    "main".to_string()
 }
 
 /// Errors from reading/parsing a `backend.toml`.
@@ -463,6 +437,9 @@ pub enum ManifestError {
     /// The `entrypoint` field is not a safe relative path.
     #[error("backend.toml entrypoint {0:?} is not a safe relative path")]
     UnsafeEntrypoint(String),
+    /// A `[[models.files]]` `destination` is not a safe relative path.
+    #[error("backend.toml file destination {0:?} is not a safe relative path")]
+    UnsafeDestination(String),
 }
 
 impl Manifest {
@@ -478,6 +455,16 @@ impl Manifest {
         let m: Self = toml::from_str(text)?;
         if !crate::is_safe_relative_path(&m.backend.entrypoint) {
             return Err(ManifestError::UnsafeEntrypoint(m.backend.entrypoint));
+        }
+        // Each file's `destination` is joined onto the backend dir before the
+        // daemon writes the download; reject any value that would escape it.
+        // The guard lives in the canonical parser so every consumer inherits it.
+        for model in &m.models {
+            for file in &model.files {
+                if !crate::is_safe_relative_path(&file.destination) {
+                    return Err(ManifestError::UnsafeDestination(file.destination.clone()));
+                }
+            }
         }
         Ok(m)
     }
@@ -670,7 +657,10 @@ mod tests {
     }
 
     #[test]
-    fn files_spec_defaults_and_url_fields() {
+    fn file_spec_parses_inline_and_block_forms() {
+        // The inline-table array and the `[[models.files]]` block form are the
+        // same TOML structure; exercise both (on separate models — TOML forbids
+        // mixing the two for one key).
         let m = Manifest::parse(
             r#"
             [backend]
@@ -682,31 +672,70 @@ mod tests {
             contract = "v1"
 
             [[models]]
-            name = "m"
+            name = "m1"
+            provider = "local_whisper"
+            primary_language = "en"
+            supported_languages = ["en"]
+            supported_devices = ["cpu"]
+            files = [
+                { url = "https://example.com/config.json", destination = "models/m1/config.json" },
+            ]
+
+            [[models]]
+            name = "m2"
             provider = "local_whisper"
             primary_language = "en"
             supported_languages = ["en"]
             supported_devices = ["cpu"]
 
             [[models.files]]
-            repo = "openai/whisper-tiny"
-            files = ["model.safetensors"]
-            dest = "models/m"
-
-            [[models.files]]
-            source = "url"
-            url = "https://example.com/extra.bin"
-            sha256 = "ab"
-            dest = "models/m"
+            url = "https://huggingface.co/openai/whisper-tiny/resolve/main/model.safetensors"
+            destination = "models/m2/model.safetensors"
+            sha256 = "abc123"
             "#,
         )
         .unwrap();
-        let f = &m.models[0].files[0];
-        assert_eq!(f.source, FileSource::Huggingface);
-        assert_eq!(f.revision, "main");
-        let g = &m.models[0].files[1];
-        assert_eq!(g.source, FileSource::Url);
-        assert_eq!(g.url.as_deref(), Some("https://example.com/extra.bin"));
+        let inline = &m.models[0].files[0];
+        assert_eq!(inline.url, "https://example.com/config.json");
+        assert_eq!(inline.destination, "models/m1/config.json");
+        assert!(inline.sha256.is_none());
+        let block = &m.models[1].files[0];
+        assert_eq!(block.destination, "models/m2/model.safetensors");
+        assert_eq!(block.sha256.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn rejects_unsafe_destination() {
+        let manifest = |dest: &str| {
+            format!(
+                r#"
+                [backend]
+                source = "github.com/x/y"
+                name = "Y"
+                version = "1.0.0"
+                kind = "subprocess"
+                entrypoint = "y"
+                contract = "v1"
+
+                [[models]]
+                name = "m"
+                provider = "local_whisper"
+                primary_language = "en"
+                supported_languages = ["en"]
+                supported_devices = ["cpu"]
+                files = [{{ url = "https://example.com/x", destination = "{dest}" }}]
+                "#
+            )
+        };
+        for bad in ["../escape", "/abs/path", "a/../b", "models/"] {
+            let err = Manifest::parse(&manifest(bad)).unwrap_err();
+            assert!(
+                matches!(err, ManifestError::UnsafeDestination(_)),
+                "destination {bad:?} should be rejected, got {err}"
+            );
+        }
+        // A nested relative path is accepted.
+        Manifest::parse(&manifest("models/m/model.safetensors")).expect("safe nested path");
     }
 
     #[test]

--- a/super-stt-registry-types/src/schema.rs
+++ b/super-stt-registry-types/src/schema.rs
@@ -4,7 +4,7 @@
 //! Structure, field names, requiredness, enums, and descriptions are derived
 //! from the Rust types. Two things are injected here because no struct can
 //! express them: cross-field conditionals (kind→assets shape, accel→cuda
-//! fields, files.source→repo/url) and `additionalProperties: false` (the
+//! fields) and `additionalProperties: false` (the
 //! parsers stay lenient for forward compatibility; the editor schema is
 //! strict to catch typos). Draft-07 output for taplo compatibility.
 
@@ -138,20 +138,8 @@ pub fn backend_schema() -> Value {
             } }
         }),
     );
-    let files = defs.get_mut("FilesSpec").expect("FilesSpec def");
-    push_all_of(
-        files,
-        json!({
-            "if": {
-                "required": ["source"],
-                "properties": { "source": { "const": "url" } }
-            },
-            "then": { "required": ["url"] },
-            // source omitted defaults to huggingface, so the hf requirements
-            // can't hinge on the key's presence — they're the else branch.
-            "else": { "required": ["repo", "files"] }
-        }),
-    );
+    // `FileSpec` is flat — `url` and `destination` are required by serde and
+    // `sha256` is optional, so no cross-field conditional is needed here.
 
     // `supported_devices` must be non-empty (discovery rejects an empty
     // list); serde can't express minItems, so inject it here.

--- a/super-stt-registry-types/tests/schema_validation.rs
+++ b/super-stt-registry-types/tests/schema_validation.rs
@@ -126,12 +126,20 @@ fn rejects_contract_violations() {
                 "supported_devices": ["none"] }]);
             d
         }),
-        ("huggingface files without repo/files", {
+        ("file missing url", {
             let mut d = wasm_base();
             d["models"] = json!([{ "name": "m", "provider": "openai",
                 "primary_language": "en", "supported_languages": ["en"],
                 "supported_devices": ["none"],
-                "files": [{ "source": "huggingface", "dest": "models/m" }] }]);
+                "files": [{ "destination": "models/m/config.json" }] }]);
+            d
+        }),
+        ("file missing destination", {
+            let mut d = wasm_base();
+            d["models"] = json!([{ "name": "m", "provider": "openai",
+                "primary_language": "en", "supported_languages": ["en"],
+                "supported_devices": ["none"],
+                "files": [{ "url": "https://example.com/config.json" }] }]);
             d
         }),
         ("unknown top-level table", {
@@ -227,11 +235,11 @@ fn conditional_property_names_exist() {
             "SubprocessAsset missing `{key}`"
         );
     }
-    let files_props = defs["FilesSpec"]["properties"]
+    let files_props = defs["FileSpec"]["properties"]
         .as_object()
-        .expect("FilesSpec properties");
-    for key in ["source", "url", "repo", "files", "dest"] {
-        assert!(files_props.contains_key(key), "FilesSpec missing `{key}`");
+        .expect("FileSpec properties");
+    for key in ["url", "destination", "sha256"] {
+        assert!(files_props.contains_key(key), "FileSpec missing `{key}`");
     }
     let backend_props = defs["BackendMeta"]["properties"]
         .as_object()
@@ -291,4 +299,18 @@ fn allows_documented_optionals() {
         { "file": "y.tgz", "target": "t", "accel": "cuda", "cuda_major": 13 }
     ]);
     assert!(v.is_valid(&wildcard), "wildcard cuda_sm must validate");
+    // Model files: each entry is url + destination, with an optional sha256.
+    let mut with_files = sub_base();
+    with_files["models"] = json!([{ "name": "m", "provider": "local_whisper",
+        "primary_language": "en", "supported_languages": ["en"],
+        "supported_devices": ["cpu"],
+        "files": [
+            { "url": "https://example.com/config.json", "destination": "models/m/config.json" },
+            { "url": "https://example.com/model.safetensors",
+              "destination": "models/m/model.safetensors", "sha256": "abc123" }
+        ] }]);
+    assert!(
+        v.is_valid(&with_files),
+        "model files with url/destination/sha256 must validate"
+    );
 }


### PR DESCRIPTION
## What

`[[models.files]]` entries are now self-contained `{ url, destination, sha256 }`, fetched the same way regardless of host — Hugging Face is no longer special-cased. Replaces the old `source`/`repo`/`revision` shape.

- `destination` is the exact output path (including filename), validated as a safe relative path so it can't escape the backend dir.
- `sha256` (optional) is verified after download; an existing file is re-downloaded on mismatch.
- Migrates the in-repo `whisper` and `qwen3-asr` manifests; protocol docs updated (`docs/protocol/backend/config.md`).

The inline-table array (`files = [ { ... } ]`) and the `[[models.files]]` block form are equivalent TOML, so authors can use whichever reads better.

## Why

Removes Hugging Face's privileged default so backends can pull model files from any host. Clean break — no legacy `dest`/`source` parsing.

## Rollout

The indexer parses backends via the shared `registry-types`, so merging this lets it accept the new `destination` format — fixing the voxtral index failure where its already-migrated release hit the old `dest` parser. After this lands the indexer will reject any backend still publishing the old `dest` format; voxtral is already migrated and the other backends have no releases yet, so nothing breaks now.

## Verify

- clippy clean; tests pass: registry-types 30+6, daemon lib 182, indexer 41+1+4
- Confirmed the migrated voxtral manifest parses under the new parser (2 models, 17 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
