### PR TITLE
Drop unused system-dependency packages from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,6 @@ jobs:
             libwayland-dev \
             libxkbcommon-x11-dev \
             libegl1-mesa-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev \
-            libglib2.0-dev \
-            libgtk-4-dev \
-            libspeechd-dev \
             libxrandr-dev \
             libxinerama-dev \
             libxcursor-dev \
@@ -98,11 +93,6 @@ jobs:
             libwayland-dev \
             libxkbcommon-x11-dev \
             libegl1-mesa-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev \
-            libglib2.0-dev \
-            libgtk-4-dev \
-            libspeechd-dev \
             libxrandr-dev \
             libxinerama-dev \
             libxcursor-dev \


### PR DESCRIPTION
The CI `test` and `clippy` jobs apt-install a desktop dependency set, but five of those packages have **no matching FFI (`-sys`) crate** in `Cargo.lock` — they look like leftovers from a libcosmic/desktop template. This drops them from both jobs.

## Removed (no consumer in the lockfile)
| Package | Why it's unused |
|---|---|
| `libspeechd-dev` | nothing references speech-dispatcher anywhere |
| `libgtk-4-dev`, `libglib2.0-dev` | no `gtk*`/`glib`/`gdk`/`pango`/`cairo` `-sys` crates; `rfd` uses the `ashpd` (xdg-portal) backend, not GTK |
| `libfontconfig1-dev`, `libfreetype6-dev` | only the pure-Rust `fontconfig-parser` is present — no `freetype-sys`/`fontconfig-sys` |

## Kept (load-bearing)
- Windowing for the COSMIC/iced GUI crates: `libxkbcommon-dev`, `libxkbcommon-x11-dev`, `libwayland-dev`, `libegl1-mesa-dev`, `libxrandr/xinerama/xcursor/xi/xss-dev` (`xkbcommon` + `wayland-sys`).
- `libasound2-dev` (`alsa-sys`, cpal), `libdbus-1-dev` (`libdbus-sys`/`dbus`), `pkg-config`.

## Verification
The lockfile evidence above is strong but not absolute (a build script could probe a lib via pkg-config without a `-sys` crate), so **CI is the confirmation** — pkg-config failures are loud and immediate. If the `test`/`clippy` jobs stay green, the packages were unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
