### PR TITLE
Route realtime-only models through a realtime session

### DIFF
--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -69,6 +69,7 @@ impl SuperSTTDaemon {
             info,
             headers,
             websocket_capability,
+            def.realtime,
         )?;
         Ok(Box::new(inst))
     }

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -49,6 +49,10 @@ pub struct WasmBackend {
     allow_loopback: bool,
     transcribe_headers: Vec<(String, String)>,
     model_id: String,
+    /// Whether the active model is realtime-only (`[[models]] realtime = true`).
+    /// When set, the batch `transcribe_audio` path is served by an internal
+    /// one-shot realtime session — the model's batch endpoint rejects it.
+    realtime: bool,
     info: ModelInfoData,
 }
 
@@ -64,6 +68,7 @@ impl WasmBackend {
         info: ModelInfoData,
         transcribe_headers: Vec<(String, String)>,
         websocket_capability: bool,
+        realtime: bool,
     ) -> Result<Self> {
         let mut config = Config::new();
         config.wasm_component_model(true);
@@ -100,6 +105,7 @@ impl WasmBackend {
             allow_loopback: false,
             transcribe_headers,
             model_id,
+            realtime,
             info,
         })
     }
@@ -114,6 +120,15 @@ impl WasmBackend {
     #[must_use]
     pub fn permit_loopback_egress(mut self) -> Self {
         self.allow_loopback = true;
+        self
+    }
+
+    /// Mark this backend's active model as realtime-only, so batch
+    /// `transcribe_audio` is served via an internal realtime session. Test-only
+    /// opt-in; production sets this through [`Self::with_info`].
+    #[must_use]
+    pub fn with_realtime(mut self) -> Self {
+        self.realtime = true;
         self
     }
 
@@ -141,6 +156,7 @@ impl WasmBackend {
             allowed_hosts,
             info,
             transcribe_headers,
+            false,
             false,
         )
     }
@@ -171,6 +187,7 @@ impl WasmBackend {
             info,
             transcribe_headers,
             true,
+            false,
         )
     }
 
@@ -288,6 +305,81 @@ impl WasmBackend {
         let (_, body) = self.invoke("GET", "/v1/ping", &[], Vec::new()).await?;
         Ok(serde_json::from_slice(&body)?)
     }
+
+    /// Serve a one-shot transcription for a realtime-only model by driving an
+    /// internal realtime session over the buffered audio. The consumer channel
+    /// is unbounded and the guest reads all audio, commits, then drains the
+    /// upstream — so we pre-load `start` + PCM16 frames + `stop` *before*
+    /// invoking the session and collect only the final `done` transcript
+    /// *after* it returns. No concurrent feeder, so this is safe even from the
+    /// synchronous (`block_on`) `transcribe_audio` call sites.
+    #[cfg(feature = "wasm-backends")]
+    #[allow(clippy::cast_possible_truncation)] // intentional f32 -> i16 PCM clamp
+    async fn transcribe_via_realtime(&self, audio: &[f32], sample_rate: u32) -> Result<String> {
+        use ws_host::{ConsumerStreamTransport, WsFrame};
+
+        // 16-bit PCM, mono, LE. Mistral's `input_audio_buffer.append` caps a
+        // single message at 262144 raw bytes; 16384 samples (32768 bytes) per
+        // frame stays well under it.
+        const FRAME_SAMPLES: usize = 16384;
+
+        let (incoming_tx, incoming_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
+        let (outgoing_tx, mut outgoing_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
+
+        // Pre-load the consumer side: start, the audio as PCM16 binary chunks,
+        // then stop. The guest breaks on `stop`, so no further consumer recv.
+        let send = |frame| {
+            incoming_tx
+                .send(frame)
+                .map_err(|_| anyhow!("realtime channel closed"))
+        };
+        send(WsFrame::Text(format!(
+            "{{\"type\":\"start\",\"sample_rate\":{sample_rate}}}"
+        )))?;
+        for chunk in audio.chunks(FRAME_SAMPLES) {
+            let mut pcm = Vec::with_capacity(chunk.len() * 2);
+            for &s in chunk {
+                let v = (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+                pcm.extend_from_slice(&v.to_le_bytes());
+            }
+            send(WsFrame::Binary(pcm))?;
+        }
+        send(WsFrame::Text("{\"type\":\"stop\"}".to_string()))?;
+
+        let transport = ConsumerStreamTransport {
+            incoming: incoming_rx,
+            outgoing: outgoing_tx,
+        };
+        self.realtime_session(transport).await?;
+
+        // The session has returned, so every frame the guest emitted (previews
+        // plus the terminal `done`/`error`) is buffered. Return only the final
+        // transcription.
+        let mut done: Option<String> = None;
+        while let Ok(frame) = outgoing_rx.try_recv() {
+            let WsFrame::Text(s) = frame else { continue };
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(&s) else {
+                continue;
+            };
+            match v.get("type").and_then(serde_json::Value::as_str) {
+                Some("done") => {
+                    done = v
+                        .get("transcription")
+                        .and_then(serde_json::Value::as_str)
+                        .map(String::from);
+                }
+                Some("error") => {
+                    let msg = v
+                        .get("message")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("realtime transcription failed");
+                    bail!("{msg}");
+                }
+                _ => {} // ignore previews / unknown frames
+            }
+        }
+        done.ok_or_else(|| anyhow!("realtime session produced no final transcription"))
+    }
 }
 
 impl ModelInfo for WasmBackend {
@@ -306,6 +398,12 @@ impl ModelState for WasmBackend {
 #[async_trait]
 impl Transcribe for WasmBackend {
     async fn transcribe_audio(&mut self, audio: &[f32], sample_rate: u32) -> Result<String> {
+        // A realtime-only model is rejected by the batch endpoint, so serve the
+        // regular `/v1/transcribe` request through an internal one-shot realtime
+        // session and return only the final transcript.
+        if self.realtime {
+            return self.transcribe_via_realtime(audio, sample_rate).await;
+        }
         let body = serde_json::to_vec(&serde_json::json!({
             "audio_data": audio,
             "sample_rate": sample_rate,

--- a/super-stt-daemon/tests/wasm_mock_realtime.rs
+++ b/super-stt-daemon/tests/wasm_mock_realtime.rs
@@ -100,3 +100,28 @@ async fn realtime_orchestration_against_mock() {
         "done frame should carry the canned transcript; got {done}"
     );
 }
+
+/// A realtime model's batch `transcribe_audio` must route through an internal
+/// realtime session (the model's batch endpoint would reject it) and return
+/// only the final transcript. Loading the mock with `with_realtime()` flips the
+/// instance into that mode; the canned session emits a preview + done, and we
+/// assert `transcribe_audio` hands back just the `done` transcript.
+#[tokio::test]
+async fn realtime_model_transcribe_audio_returns_final_transcript() {
+    let Some(path) = mock_component() else {
+        eprintln!(
+            "skipping: mock realtime component not built (run `just build-mock-wasm-realtime-backend`)"
+        );
+        return;
+    };
+
+    let mut backend = WasmBackend::new_realtime(&path, Vec::new(), "mock".to_string(), Vec::new())
+        .expect("load mock realtime backend")
+        .with_realtime();
+
+    let text = backend
+        .transcribe_audio(&[0.0_f32; 1600], 16000)
+        .await
+        .expect("realtime-routed transcribe should succeed");
+    assert_eq!(text, "mock realtime transcription");
+}


### PR DESCRIPTION
Fixes realtime-only models (e.g. Mistral's `voxtral-mini-transcribe-realtime-2602`) failing on the normal recording flow — they were sent to the batch transcription endpoint, which the model rejects (`status 400 … "only supports realtime transcription"`).

## Problem

The daemon's batch record flow (`POST /v1/transcribe`) calls `transcribe_audio` regardless of the model's `realtime` flag. A realtime WebSocket path (`GET /v1/transcribe/realtime` → `realtime_session`) exists but **no client connects to it**, so a realtime-only model is only ever reachable via the batch path — which the upstream rejects.

## Fix

When the active model is `realtime`, `WasmBackend::transcribe_audio` routes the request through an internal one-shot realtime session: it pre-loads the recorded audio as PCM16 frames into the existing `ws-server` path, drives `realtime_session`, and returns **only the final transcript**. The flag is plumbed from `def.realtime` at the load site (`model_management/instantiate.rs`).

The consumer channel is unbounded and the half-duplex backend reads all audio → commits → drains, so the frames are pre-loaded *before* the session runs — no concurrent feeder task, which keeps it safe from the synchronous (`block_on`) `transcribe_audio` call sites. Every existing call site benefits unchanged.

## Verification

- New `wasm_mock_realtime` case: a realtime model's `transcribe_audio` returns the canned final transcript — runs in hosted CI (no network/systemd).
- `cargo build`, `cargo clippy --all-features --workspace` (pedantic, `-D warnings`), `cargo fmt --check`, and `cargo test -p super-stt-daemon --lib` + `wasm_mock` + `wasm_mock_realtime` — all green.
- Verified **live** against the real Mistral realtime API (paired with the matching `super-stt-mistral` upstream-protocol fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
