### PR TITLE
Support multi-part subprocess assets for >2 GiB bundles

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -176,6 +176,8 @@ wasm = "openai.wasm"   # filename on the release; must be a `wasm32` component
 
 Subprocess backends declare one entry per built variant. Selection axes are
 `target`, `accel`, and (when `accel = "cuda"`) `cuda_major`, `cuda_sm`, `cudnn`.
+Each variant names its archive with `file`, or with `parts` when the `.tar.gz`
+exceeds the 2 GiB release-asset limit (see [Multi-part assets](#multi-part-assets)).
 
 ```toml
 [[assets.subprocess]]
@@ -201,16 +203,47 @@ cudnn      = true
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `file` | string | yes | Filename on the GitHub release. Subprocess: `.tar.gz`; wasm: `.wasm`. |
+| `file` | string | one of `file`/`parts` | Filename on the GitHub release. Subprocess: `.tar.gz`; wasm: `.wasm`. |
+| `parts` | array of strings | one of `file`/`parts` | **Subprocess only.** Ordered release filenames whose byte-for-byte concatenation is the variant's `.tar.gz`. Use instead of `file` when the archive would exceed the 2 GiB release-asset limit. See [Multi-part assets](#multi-part-assets). |
 | `target` | string | yes | Rust target triple. Tier-1/2 only; indexer rejects unknown. |
 | `accel` | string | yes | One of `"cpu"`, `"cuda"`, `"metal"`, `"rocm"`, `"vulkan"`. |
 | `cuda_major` | integer | for `accel = "cuda"` | CUDA major version this build targets. |
 | `cuda_sm` | integer | no | Compute capability (e.g. `75`, `86`, `90`). Omit to match **any** compute capability — use this for framework builds (e.g. a PyTorch wheel) whose kernels are multi-architecture. When both an exact-SM and a wildcard asset match a host, the exact-SM asset is preferred. |
 | `cudnn` | bool | no | Defaults `false`. Allowed only when `accel = "cuda"`. |
 
+A variant gives `file` **or** `parts`, never both (and `wasm` always uses a
+single `file`).
+
+### Multi-part assets
+
+A single GitHub release asset may not exceed **2 GiB**. A build whose `.tar.gz`
+is larger — typically a CUDA framework bundle (PyTorch ships ~2.5 GiB of CUDA
+libraries) — is split into ordered parts, each a separate release asset under
+the limit, and listed in `parts` instead of `file`:
+
+```toml
+[[assets.subprocess]]
+parts      = [
+    "qwen3-asr-x86_64-unknown-linux-gnu-cuda13.tar.gz.part00",
+    "qwen3-asr-x86_64-unknown-linux-gnu-cuda13.tar.gz.part01",
+]
+target     = "x86_64-unknown-linux-gnu"
+accel      = "cuda"
+cuda_major = 13
+```
+
+The parts' **byte-for-byte concatenation, in the order listed**, reconstitutes
+the original `.tar.gz`. The daemon downloads each part, verifies it, concatenates
+them in order, then extracts the result. The registry indexer pins every part
+independently (`{url, size, sha256}`), so every delivered byte is hash-verified —
+there is no separate whole-archive digest. Splitting is purely a delivery
+detail: the reassembled archive obeys the same archive-contents rules below, and
+host selection (`target`/`accel`/`cuda_*`) is unaffected.
+
 ### Subprocess archive contents
 
-A subprocess `.tar.gz` MUST contain `bin/<entrypoint>` (the path that the
+A subprocess `.tar.gz` (the reassembled archive, when delivered as
+[parts](#multi-part-assets)) MUST contain `bin/<entrypoint>` (the path that the
 backend's `[backend].entrypoint` resolves to after extraction). Tarballs
 containing path-traversal entries (`..`, absolute paths) or symlinks that
 escape the archive root are rejected by the registry indexer and by the
@@ -437,6 +470,11 @@ supported_devices   = ["none"]
   OSI-approved or FSF Free/Libre SPDX identifier, or the literal `other`. The
   indexer rejects a release whose manifest omits the field or declares an
   unrecognized value. Locally installed backends may omit it.
+- Each `[[assets.subprocess]]` variant declares exactly one of `file` or
+  `parts`; `parts`, when used, must be non-empty and its filenames are
+  concatenated in the listed order. The indexer rejects any single release
+  asset — a `file` or an individual part — larger than 2 GiB (the GitHub
+  release-asset limit).
 - A `subprocess` backend with a non-empty `allowed_hosts` is rejected — the
   transport provides no network.
 - `primary_language` must appear in `supported_languages`. When

--- a/super-stt-daemon/src/registry/compat.rs
+++ b/super-stt-daemon/src/registry/compat.rs
@@ -159,9 +159,10 @@ mod tests {
             cuda_major: cm,
             cuda_sm: sm,
             cudnn,
-            url: "x".into(),
-            size: 1,
-            sha256: "x".into(),
+            url: Some("x".into()),
+            size: Some(1),
+            sha256: Some("x".into()),
+            parts: Vec::new(),
         }
     }
 

--- a/super-stt-daemon/src/registry/custom_repo.rs
+++ b/super-stt-daemon/src/registry/custom_repo.rs
@@ -257,16 +257,41 @@ fn synthesize_assets(
                 return Err(ResolveError::MissingSubprocessAssets);
             }
             for sa in &manifest.assets.subprocess {
-                let a = find(&sa.file)?;
+                // A variant is one `file` or several concatenated `parts`. The
+                // custom-repo path has no pinned hash (TLS is the guarantee), so
+                // each synthesized pin carries an empty sha256.
+                let names: Vec<&str> = match &sa.file {
+                    Some(f) => vec![f.as_str()],
+                    None => sa.parts.iter().map(String::as_str).collect(),
+                };
+                if names.is_empty() {
+                    return Err(ResolveError::MissingSubprocessAssets);
+                }
+                let mut pins: Vec<IndexAsset> = Vec::with_capacity(names.len());
+                for n in &names {
+                    let a = find(n)?;
+                    pins.push(IndexAsset {
+                        url: a.download_url.clone(),
+                        size: a.size,
+                        sha256: String::new(),
+                    });
+                }
+                let (url, size, sha256, parts) = if sa.file.is_none() {
+                    (None, None, None, pins)
+                } else {
+                    let p = pins.remove(0);
+                    (Some(p.url), Some(p.size), Some(p.sha256), Vec::new())
+                };
                 out.subprocess.push(IndexSubprocessAsset {
                     target: sa.target.clone(),
                     accel: sa.accel.clone(),
                     cuda_major: sa.cuda_major,
                     cuda_sm: sa.cuda_sm,
                     cudnn: sa.cudnn,
-                    url: a.download_url.clone(),
-                    size: a.size,
-                    sha256: String::new(),
+                    url,
+                    size,
+                    sha256,
+                    parts,
                 });
             }
         }
@@ -358,7 +383,10 @@ struct Assets {
 
 #[derive(Debug, Deserialize)]
 struct SubprocessAsset {
-    file: String,
+    #[serde(default)]
+    file: Option<String>,
+    #[serde(default)]
+    parts: Vec<String>,
     target: String,
     accel: String,
     #[serde(default)]
@@ -519,6 +547,50 @@ mod tests {
         assert!(assets.wasm.is_none());
         assert_eq!(assets.subprocess.len(), 2);
         assert_eq!(assets.subprocess[1].cuda_sm, Some(86));
-        assert!(assets.subprocess[1].sha256.is_empty());
+        // Single-file custom-repo synth carries an empty (unverified) pin.
+        assert_eq!(assets.subprocess[1].sha256.as_deref(), Some(""));
+        assert!(assets.subprocess[1].parts.is_empty());
+    }
+
+    #[test]
+    fn synthesize_subprocess_maps_parts_to_a_multipart_entry() {
+        let manifest_text = r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "subprocess"
+            entrypoint = "y"
+            contract = "v1"
+
+            [[assets.subprocess]]
+            parts = ["y-cuda13.tar.gz.part00", "y-cuda13.tar.gz.part01"]
+            target = "x86_64-unknown-linux-gnu"
+            accel = "cuda"
+            cuda_major = 13
+        "#;
+        let m: Manifest = toml::from_str(manifest_text).unwrap();
+        let release_assets = vec![
+            ReleaseAsset {
+                name: "y-cuda13.tar.gz.part00".into(),
+                download_url: "https://example/p0".into(),
+                size: 10,
+            },
+            ReleaseAsset {
+                name: "y-cuda13.tar.gz.part01".into(),
+                download_url: "https://example/p1".into(),
+                size: 20,
+            },
+        ];
+        let assets = synthesize_assets(&m, &release_assets).unwrap();
+        assert_eq!(assets.subprocess.len(), 1);
+        let a = &assets.subprocess[0];
+        // Multi-part: no single-file pin, the parts carry the URLs in order.
+        assert!(a.url.is_none());
+        assert_eq!(a.parts.len(), 2);
+        assert_eq!(a.parts[0].url, "https://example/p0");
+        assert_eq!(a.parts[1].size, 20);
+        // Unverified custom-repo source → empty per-part pins.
+        assert!(a.parts.iter().all(|p| p.sha256.is_empty()));
     }
 }

--- a/super-stt-daemon/src/registry/index_schema.rs
+++ b/super-stt-daemon/src/registry/index_schema.rs
@@ -171,9 +171,19 @@ pub struct IndexSubprocessAsset {
     pub cuda_sm: Option<u32>,
     #[serde(default)]
     pub cudnn: bool,
-    pub url: String,
-    pub size: u64,
-    pub sha256: String,
+    /// Single-file archive pin: present for a single-file variant, absent for
+    /// multi-part.
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub size: Option<u64>,
+    #[serde(default)]
+    pub sha256: Option<String>,
+    /// Multi-part archive: ordered part pins whose byte-for-byte concatenation
+    /// is the `.tar.gz`. Present for a multi-part variant, absent for
+    /// single-file. Each part is hash-verified independently on download.
+    #[serde(default)]
+    pub parts: Vec<IndexAsset>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -13,7 +13,7 @@ use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
 use crate::registry::compat::Selection;
-use crate::registry::index_schema::{IndexAsset, IndexBackend, IndexSubprocessAsset};
+use crate::registry::index_schema::{IndexAsset, IndexBackend};
 
 /// Absolute ceiling on a single downloaded asset when its size is not declared
 /// in the index. Declared sizes are honored directly (plus a small margin).
@@ -23,10 +23,17 @@ const MAX_DOWNLOAD_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 const MAX_MANIFEST_BYTES: u64 = 256 * 1024;
 /// Slack allowed over a declared asset size before a download is rejected.
 const DOWNLOAD_SIZE_MARGIN: u64 = 1024 * 1024;
-/// Per-file ceiling when unpacking a subprocess tarball.
-const MAX_TARBALL_ENTRY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
-/// Total uncompressed-output ceiling for a subprocess tarball.
-const MAX_TARBALL_TOTAL_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+/// Per-file ceiling when unpacking a subprocess tarball. A single bundled
+/// library (e.g. a CUDA `.so`) can be large, so this is generous.
+const MAX_TARBALL_ENTRY_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+/// Floor for the total uncompressed-output ceiling. The actual cap scales with
+/// the compressed archive (see [`unpack_cap`]) so a large but legitimate bundle
+/// (a CUDA `PyTorch` tarball unpacks to several GiB) is allowed while a zip-bomb —
+/// a tiny archive with huge output — is still rejected.
+const MAX_TARBALL_TOTAL_FLOOR: u64 = 4 * 1024 * 1024 * 1024;
+/// Maximum unpacked-output-to-compressed-archive ratio. gzip over already-packed
+/// ML libraries stays far below this; a zip-bomb is far above it.
+const MAX_DECOMP_RATIO: u64 = 5;
 
 /// The byte ceiling for a download given the index-declared `expected_size`
 /// (0 when unknown).
@@ -36,6 +43,14 @@ fn download_cap(expected_size: u64) -> u64 {
     } else {
         expected_size.saturating_add(DOWNLOAD_SIZE_MARGIN)
     }
+}
+
+/// The uncompressed-output ceiling for an archive of `archive_size` compressed
+/// bytes: scales with the input but never drops below the floor.
+fn unpack_cap(archive_size: u64) -> u64 {
+    archive_size
+        .saturating_mul(MAX_DECOMP_RATIO)
+        .max(MAX_TARBALL_TOTAL_FLOOR)
 }
 
 #[derive(Debug, Error)]
@@ -94,23 +109,9 @@ where
 
     (p.on_progress)(P::Resolving, None);
 
-    let (url, expected_sha, expected_size, kind_subdir) = match selection {
-        Selection::Wasm => {
-            let a = entry
-                .assets
-                .wasm
-                .as_ref()
-                .ok_or((P::Resolving, InstallError::Incompatible))?;
-            (a.url.clone(), a.sha256.clone(), a.size, false)
-        }
-        Selection::Subprocess { index } => {
-            let a: &IndexSubprocessAsset = entry
-                .assets
-                .subprocess
-                .get(*index)
-                .ok_or((P::Resolving, InstallError::Incompatible))?;
-            (a.url.clone(), a.sha256.clone(), a.size, true)
-        }
+    let kind_subdir = match selection {
+        Selection::Wasm => false,
+        Selection::Subprocess { .. } => true,
         Selection::Incompatible { reason: _ } => {
             return Err((P::Resolving, InstallError::Incompatible));
         }
@@ -127,25 +128,10 @@ where
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Downloading))?;
 
-    (p.on_progress)(P::Downloading, Some((0, None)));
-    let actual_sha = stream_download(&p.http, &url, expected_size, &partial_path, &p.on_progress)
-        .await
-        .map_err(|e| e.as_typed(P::Downloading))?;
-
-    (p.on_progress)(P::Verifying, None);
-    if expected_sha.is_empty() {
-        // Custom-repo install path: the synthesized entry has no registry
-        // checksum (see `custom_repo::resolve`). TLS to the source is the
-        // only integrity guarantee — clients see `warning: "unverified_source"`.
-        log::warn!(
-            "install({}): no expected sha256; skipping asset verification (actual=`{}`)",
-            entry.source,
-            actual_sha
-        );
-    } else if actual_sha != expected_sha {
-        let _ = fs::remove_file(&partial_path).await;
-        return Err((P::Verifying, InstallError::AssetHashMismatch));
-    }
+    // Fetch the verified artifact into `partial_path`: a single download for a
+    // wasm or single-file subprocess asset, or a per-part download +
+    // concatenation for a multi-part subprocess archive.
+    download_and_verify(p, entry, selection, &partial_path).await?;
 
     (p.on_progress)(P::Extracting, None);
     let staging = p
@@ -189,6 +175,75 @@ where
 
     (p.on_progress)(P::Rescanning, None);
     Ok(entry.version.clone())
+}
+
+/// Download the artifact `selection` names into `partial_path` and verify its
+/// integrity: a single hashed download for a wasm or single-file subprocess
+/// asset, or a per-part download + concatenation for a multi-part archive.
+async fn download_and_verify<F>(
+    p: &Pipeline<F>,
+    entry: &IndexBackend,
+    selection: &Selection,
+    partial_path: &Path,
+) -> Result<(), (InstallPhase, InstallError)>
+where
+    F: Fn(InstallPhase, Option<(u64, Option<u64>)>) + Send + Sync,
+{
+    use InstallPhase as P;
+    (p.on_progress)(P::Downloading, Some((0, None)));
+    match selection {
+        Selection::Wasm => {
+            let a = entry
+                .assets
+                .wasm
+                .as_ref()
+                .ok_or((P::Resolving, InstallError::Incompatible))?;
+            let actual = stream_download(&p.http, &a.url, a.size, partial_path, &p.on_progress)
+                .await
+                .map_err(|e| e.as_typed(P::Downloading))?;
+            (p.on_progress)(P::Verifying, None);
+            verify_asset_sha(&actual, &a.sha256, &entry.source, partial_path).await
+        }
+        Selection::Subprocess { index } => {
+            let a = entry
+                .assets
+                .subprocess
+                .get(*index)
+                .ok_or((P::Resolving, InstallError::Incompatible))?;
+            if a.parts.is_empty() {
+                let url = a
+                    .url
+                    .as_deref()
+                    .ok_or((P::Resolving, InstallError::Incompatible))?;
+                let actual = stream_download(
+                    &p.http,
+                    url,
+                    a.size.unwrap_or(0),
+                    partial_path,
+                    &p.on_progress,
+                )
+                .await
+                .map_err(|e| e.as_typed(P::Downloading))?;
+                (p.on_progress)(P::Verifying, None);
+                verify_asset_sha(
+                    &actual,
+                    a.sha256.as_deref().unwrap_or(""),
+                    &entry.source,
+                    partial_path,
+                )
+                .await
+            } else {
+                // Multi-part: download each part, verify its SHA-256, and append
+                // it to the partial `.tar.gz` (verification is inline, per part).
+                download_verified_parts(&p.http, &a.parts, partial_path, &p.on_progress)
+                    .await
+                    .map_err(|e| e.as_typed(P::Downloading))?;
+                (p.on_progress)(P::Verifying, None);
+                Ok(())
+            }
+        }
+        Selection::Incompatible { reason: _ } => Err((P::Resolving, InstallError::Incompatible)),
+    }
 }
 
 /// Import-from-dir variant: the operator provided `src_dir`, so the
@@ -343,7 +398,85 @@ where
     Ok(hex::encode(hasher.finish().as_ref()))
 }
 
+/// Verify a downloaded asset's SHA-256 against the index pin. An empty pin is
+/// the custom-repo "unverified source" case (no index pre-computed a hash) —
+/// TLS to the origin is then the only integrity guarantee.
+async fn verify_asset_sha(
+    actual: &str,
+    expected: &str,
+    source: &str,
+    partial: &Path,
+) -> Result<(), (InstallPhase, InstallError)> {
+    if expected.is_empty() {
+        log::warn!(
+            "install({source}): no expected sha256; skipping asset verification (actual=`{actual}`)"
+        );
+        Ok(())
+    } else if actual == expected {
+        Ok(())
+    } else {
+        let _ = fs::remove_file(partial).await;
+        Err((InstallPhase::Verifying, InstallError::AssetHashMismatch))
+    }
+}
+
+/// Download each part in listed order, verifying its SHA-256, and append it to
+/// `dest` — reconstituting the multi-part `.tar.gz` byte-for-byte. A bad part
+/// removes the partial file and aborts. Progress spans the whole set.
+async fn download_verified_parts<F>(
+    http: &reqwest::Client,
+    parts: &[IndexAsset],
+    dest: &Path,
+    on_progress: &Arc<F>,
+) -> Result<(), PipelineError>
+where
+    F: Fn(InstallPhase, Option<(u64, Option<u64>)>) + Send + Sync,
+{
+    let total_expected: u64 = parts.iter().map(|p| p.size).sum();
+    let mut out = tokio::fs::File::create(dest).await?;
+    let mut overall: u64 = 0;
+    for part in parts {
+        let resp = http.get(&part.url).send().await?.error_for_status()?;
+        let cap = download_cap(part.size);
+        let mut hasher = Context::new(&SHA256);
+        let mut stream = resp.bytes_stream();
+        let mut part_done: u64 = 0;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            part_done += chunk.len() as u64;
+            if part_done > cap {
+                let _ = out.flush().await;
+                drop(out);
+                let _ = tokio::fs::remove_file(dest).await;
+                return Err(PipelineError::TooLarge { limit: cap });
+            }
+            out.write_all(&chunk).await?;
+            hasher.update(&chunk);
+            overall += chunk.len() as u64;
+            on_progress(
+                InstallPhase::Downloading,
+                Some((overall, Some(total_expected))),
+            );
+        }
+        let actual = hex::encode(hasher.finish().as_ref());
+        if !part.sha256.is_empty() && actual != part.sha256 {
+            let _ = out.flush().await;
+            drop(out);
+            let _ = tokio::fs::remove_file(dest).await;
+            return Err(PipelineError::HashMismatch {
+                expected: part.sha256.clone(),
+                actual,
+            });
+        }
+    }
+    out.flush().await?;
+    Ok(())
+}
+
 fn extract_tarball(src: &Path, dest_dir: &Path) -> Result<(), PipelineError> {
+    // Cap the uncompressed output relative to the (verified) compressed size so
+    // a legitimate multi-GB bundle is allowed but a zip-bomb is not.
+    let total_cap = unpack_cap(std::fs::metadata(src)?.len());
     // First pass: validate the archive (no unsafe entries) without unpacking.
     {
         let f = std::fs::File::open(src)?;
@@ -378,9 +511,9 @@ fn extract_tarball(src: &Path, dest_dir: &Path) -> Result<(), PipelineError> {
             )));
         }
         total = total.saturating_add(size);
-        if total > MAX_TARBALL_TOTAL_BYTES {
+        if total > total_cap {
             return Err(PipelineError::TarUnsafe(format!(
-                "archive output exceeds {MAX_TARBALL_TOTAL_BYTES} bytes"
+                "archive output exceeds {total_cap} bytes"
             )));
         }
         entry.unpack_in(dest_dir)?;

--- a/super-stt-indexer/src/assets.rs
+++ b/super-stt-indexer/src/assets.rs
@@ -1,10 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //! Per-asset validation + SHA-256 over streamed downloads.
+//!
+//! A subprocess variant's archive is one release asset (`file`) or several
+//! (`parts`, concatenated in order). Each release asset is capped at 2 GiB (the
+//! GitHub limit) and pinned independently; the reassembled tar is validated by
+//! streaming the parts in order, so a multi-GB archive is never held in memory.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use ring::digest::{Context, SHA256};
 use thiserror::Error;
 
-pub const MAX_ASSET_BYTES: u64 = 200 * 1024 * 1024;
+/// Ceiling for a single release asset — a `file` or one part of a multi-part
+/// archive. Matches GitHub's 2 GiB per-asset release limit; a larger archive
+/// must be split into `parts`.
+pub const MAX_ASSET_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 /// Ceiling for a `backend.toml` manifest asset — manifests are tiny; this only
 /// bounds a hostile or mistaken upload.
 pub const MAX_MANIFEST_BYTES: u64 = 256 * 1024;
@@ -28,7 +39,8 @@ pub enum AssetError {
     Io(#[from] std::io::Error),
 }
 
-/// Resolve a declared asset's URL via the release manifest, refusing if missing.
+/// Resolve a declared asset's URL via the release manifest, refusing if missing
+/// or larger than [`MAX_ASSET_BYTES`].
 pub fn resolve_url(
     file: &str,
     release_assets: &[super_stt_forge::ReleaseAsset],
@@ -46,11 +58,12 @@ pub fn resolve_url(
     Ok((a.download_url.clone(), a.size))
 }
 
-/// Stream the asset, compute SHA-256, and dispatch validation based on kind.
-pub async fn fetch_and_validate(
+/// Stream a wasm component, verify the `wasm32` magic header, and return its
+/// SHA-256. Components are small, so this does not touch disk.
+pub async fn fetch_wasm_and_hash(
     http: &reqwest::Client,
     url: &str,
-    expected: AssetExpect<'_>,
+    file: &str,
 ) -> Result<String, AssetError> {
     use futures::StreamExt;
     let mut resp = http
@@ -62,16 +75,15 @@ pub async fn fetch_and_validate(
         .map_err(|e| AssetError::Http(e.into()))?
         .bytes_stream();
     let mut ctx = Context::new(&SHA256);
-    let mut buf: Vec<u8> = Vec::new();
     let mut first_chunk: Vec<u8> = Vec::new();
-    let mut total_streamed: u64 = 0;
+    let mut total: u64 = 0;
     while let Some(chunk) = resp.next().await {
         let chunk = chunk.map_err(|e| AssetError::Http(e.into()))?;
-        total_streamed += chunk.len() as u64;
-        if total_streamed > MAX_ASSET_BYTES {
+        total += chunk.len() as u64;
+        if total > MAX_ASSET_BYTES {
             return Err(AssetError::TooLarge {
-                file: expected.file().into(),
-                size: total_streamed,
+                file: file.into(),
+                size: total,
             });
         }
         ctx.update(&chunk);
@@ -79,21 +91,50 @@ pub async fn fetch_and_validate(
             let need = 4 - first_chunk.len();
             first_chunk.extend_from_slice(&chunk[..need.min(chunk.len())]);
         }
-        if matches!(expected, AssetExpect::Subprocess { .. }) {
-            buf.extend_from_slice(&chunk);
-        }
     }
-    match expected {
-        AssetExpect::Wasm { file } => {
-            if first_chunk != WASM_MAGIC {
-                return Err(AssetError::NotWasm(file.into()));
-            }
-        }
-        AssetExpect::Subprocess { file, entrypoint } => {
-            validate_tarball(file, entrypoint, &buf)?;
-        }
+    if first_chunk != WASM_MAGIC {
+        return Err(AssetError::NotWasm(file.into()));
     }
     Ok(hex::encode(ctx.finish().as_ref()))
+}
+
+/// Stream a release asset (a `file`, or one part of a multi-part archive) to
+/// `dest`, computing its size and SHA-256 and enforcing [`MAX_ASSET_BYTES`].
+/// Writing to disk keeps a multi-GB part out of memory; the caller validates
+/// the reassembled archive with [`validate_subprocess_parts`].
+pub async fn download_to_file(
+    http: &reqwest::Client,
+    url: &str,
+    file: &str,
+    dest: &Path,
+) -> Result<(u64, String), AssetError> {
+    use futures::StreamExt;
+    use tokio::io::AsyncWriteExt;
+    let mut resp = http
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| AssetError::Http(e.into()))?
+        .error_for_status()
+        .map_err(|e| AssetError::Http(e.into()))?
+        .bytes_stream();
+    let mut out = tokio::fs::File::create(dest).await?;
+    let mut ctx = Context::new(&SHA256);
+    let mut total: u64 = 0;
+    while let Some(chunk) = resp.next().await {
+        let chunk = chunk.map_err(|e| AssetError::Http(e.into()))?;
+        total += chunk.len() as u64;
+        if total > MAX_ASSET_BYTES {
+            return Err(AssetError::TooLarge {
+                file: file.into(),
+                size: total,
+            });
+        }
+        ctx.update(&chunk);
+        out.write_all(&chunk).await?;
+    }
+    out.flush().await?;
+    Ok((total, hex::encode(ctx.finish().as_ref())))
 }
 
 /// Download the `backend.toml` manifest asset, returning its raw bytes and
@@ -129,21 +170,28 @@ pub async fn fetch_manifest_asset(
     Ok((buf, hex::encode(ctx.finish().as_ref())))
 }
 
-pub enum AssetExpect<'a> {
-    Wasm { file: &'a str },
-    Subprocess { file: &'a str, entrypoint: &'a str },
-}
-
-impl AssetExpect<'_> {
-    fn file(&self) -> &str {
-        match self {
-            AssetExpect::Wasm { file } | AssetExpect::Subprocess { file, .. } => file,
-        }
+/// Validate that the reassembled subprocess archive — the in-order
+/// concatenation of `parts` (one entry for a single-file asset) — is a
+/// `.tar.gz` containing `bin/<entrypoint>` with no path-escaping or symlink
+/// entries. Streams the parts through the decoder so a multi-GB archive is
+/// never held in memory.
+pub fn validate_subprocess_parts(
+    parts: &[PathBuf],
+    file: &str,
+    entrypoint: &str,
+) -> Result<(), AssetError> {
+    let mut chained: Box<dyn Read> = Box::new(std::io::empty());
+    for p in parts {
+        let f = std::fs::File::open(p)?;
+        chained = Box::new(chained.chain(f));
     }
+    validate_tarball_read(file, entrypoint, chained)
 }
 
-fn validate_tarball(file: &str, entrypoint: &str, bytes: &[u8]) -> Result<(), AssetError> {
-    let gz = flate2::read::GzDecoder::new(bytes);
+/// The tar-content checks, over any reader: rejects path-traversal and symlink
+/// entries and requires `bin/<entrypoint>` (or the bare entrypoint path).
+fn validate_tarball_read<R: Read>(file: &str, entrypoint: &str, r: R) -> Result<(), AssetError> {
+    let gz = flate2::read::GzDecoder::new(r);
     let mut archive = tar::Archive::new(gz);
     let mut found_entrypoint = false;
     for entry in archive.entries()? {
@@ -176,6 +224,11 @@ fn validate_tarball(file: &str, entrypoint: &str, bytes: &[u8]) -> Result<(), As
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+fn validate_tarball(file: &str, entrypoint: &str, bytes: &[u8]) -> Result<(), AssetError> {
+    validate_tarball_read(file, entrypoint, bytes)
 }
 
 #[cfg(test)]
@@ -273,5 +326,47 @@ mod tests {
         let bytes = make_raw_tar_gz_with_path("../escape");
         let err = validate_tarball("v.tar.gz", "voxtral", &bytes).unwrap_err();
         assert!(matches!(err, AssetError::TarEscape { .. }));
+    }
+
+    /// A tarball split into parts validates when the parts are concatenated in
+    /// order — the multi-part reassembly path.
+    #[test]
+    fn validates_tarball_reassembled_from_parts() {
+        let bytes = make_tarball(|tb| {
+            let mut h = tar::Header::new_gnu();
+            h.set_size(3);
+            h.set_mode(0o755);
+            h.set_cksum();
+            tb.append_data(&mut h, "bin/qwen3-asr", &b"abc"[..])
+                .unwrap();
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let mid = bytes.len() / 2;
+        let p0 = dir.path().join("a.part00");
+        let p1 = dir.path().join("a.part01");
+        std::fs::write(&p0, &bytes[..mid]).unwrap();
+        std::fs::write(&p1, &bytes[mid..]).unwrap();
+        validate_subprocess_parts(&[p0, p1], "q.tar.gz", "bin/qwen3-asr").unwrap();
+    }
+
+    /// Parts concatenated out of order do not reassemble into a valid archive.
+    #[test]
+    fn rejects_parts_in_wrong_order() {
+        let bytes = make_tarball(|tb| {
+            let mut h = tar::Header::new_gnu();
+            h.set_size(3);
+            h.set_mode(0o755);
+            h.set_cksum();
+            tb.append_data(&mut h, "bin/qwen3-asr", &b"abc"[..])
+                .unwrap();
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let mid = bytes.len() / 2;
+        let p0 = dir.path().join("a.part00");
+        let p1 = dir.path().join("a.part01");
+        std::fs::write(&p0, &bytes[..mid]).unwrap();
+        std::fs::write(&p1, &bytes[mid..]).unwrap();
+        // Swapped order → corrupt gzip → an error (not a clean archive).
+        assert!(validate_subprocess_parts(&[p1, p0], "q.tar.gz", "bin/qwen3-asr").is_err());
     }
 }

--- a/super-stt-indexer/src/index_json.rs
+++ b/super-stt-indexer/src/index_json.rs
@@ -101,9 +101,19 @@ pub struct IndexSubprocessAsset {
     pub cuda_sm: Option<u32>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cudnn: bool,
-    pub url: String,
-    pub size: u64,
-    pub sha256: String,
+    /// Single-file archive pin. Present for a single-file variant; omitted when
+    /// the archive is delivered as `parts`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Multi-part archive: ordered part pins whose byte-for-byte concatenation
+    /// is the `.tar.gz`. Present for a multi-part variant; omitted for
+    /// single-file. Each part is hash-verified independently.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<IndexAsset>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/super-stt-indexer/src/local.rs
+++ b/super-stt-indexer/src/local.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, bail};
 use clap::Args;
 use log::info;
 
-use crate::index_json::{self, Index, IndexAsset, IndexAssets, IndexBackend, IndexSubprocessAsset};
+use crate::index_json::{self, Index, IndexAsset, IndexAssets, IndexBackend};
 use crate::manifest::{Kind, Manifest};
 
 /// All-zero SHA-256, emitted for assets not staged on disk under
@@ -155,21 +155,28 @@ fn resolve_assets(
         }
         Kind::Subprocess => {
             for a in &m.assets.subprocess {
-                // A test box rarely has every CUDA build staged; skip variants
-                // whose artifact isn't present (unless placeholdering).
-                let Some((size, sha256)) = hash_staged(out_dir, &a.file, allow_missing)? else {
+                // A test box rarely has every CUDA build staged; skip a variant
+                // any of whose parts isn't present (unless placeholdering).
+                let files = a.release_files();
+                let mut pins: Vec<IndexAsset> = Vec::with_capacity(files.len());
+                let mut missing = false;
+                for f in &files {
+                    let Some((size, sha256)) = hash_staged(out_dir, f, allow_missing)? else {
+                        missing = true;
+                        break;
+                    };
+                    pins.push(IndexAsset {
+                        url: format!("{base}/{f}"),
+                        size,
+                        sha256,
+                    });
+                }
+                if missing {
                     continue;
-                };
-                assets.subprocess.push(IndexSubprocessAsset {
-                    target: a.target.clone(),
-                    accel: a.accel.to_string(),
-                    cuda_major: a.cuda_major,
-                    cuda_sm: a.cuda_sm,
-                    cudnn: a.cudnn,
-                    url: format!("{base}/{}", a.file),
-                    size,
-                    sha256,
-                });
+                }
+                assets
+                    .subprocess
+                    .push(crate::subprocess_index_entry(a, pins));
             }
             if assets.subprocess.is_empty() {
                 bail!(
@@ -203,9 +210,20 @@ fn hash_staged(
 }
 
 fn sha256_and_size(path: &Path) -> anyhow::Result<(u64, String)> {
-    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
-    let sha = hex::encode(ring::digest::digest(&ring::digest::SHA256, &bytes));
-    Ok((bytes.len() as u64, sha))
+    use std::io::Read;
+    let mut f = std::fs::File::open(path).with_context(|| format!("reading {}", path.display()))?;
+    let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut size: u64 = 0;
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        size += n as u64;
+        ctx.update(&buf[..n]);
+    }
+    Ok((size, hex::encode(ctx.finish().as_ref())))
 }
 
 #[cfg(test)]

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -191,6 +191,39 @@ async fn build_entry(
     ))
 }
 
+/// A unique temp path for staging one downloaded asset part during validation.
+fn temp_part_path() -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("stt-idx-{}-{n}.part", std::process::id()))
+}
+
+/// Build the index entry for one subprocess variant from its downloaded part
+/// pins: a single-file pin (`url`/`size`/`sha256`) or a multi-part pin.
+fn subprocess_index_entry(
+    sa: &manifest::SubprocessAsset,
+    mut pins: Vec<index_json::IndexAsset>,
+) -> index_json::IndexSubprocessAsset {
+    let (url, size, sha256, parts) = if sa.is_multipart() {
+        (None, None, None, pins)
+    } else {
+        let p = pins.remove(0);
+        (Some(p.url), Some(p.size), Some(p.sha256), Vec::new())
+    };
+    index_json::IndexSubprocessAsset {
+        target: sa.target.clone(),
+        accel: sa.accel.to_string(),
+        cuda_major: sa.cuda_major,
+        cuda_sm: sa.cuda_sm,
+        cudnn: sa.cudnn,
+        url,
+        size,
+        sha256,
+        parts,
+    }
+}
+
 /// Resolve and hash the binary artifacts a release declares — the wasm
 /// component or each subprocess variant — into the index's asset block.
 async fn resolve_index_assets(
@@ -201,8 +234,7 @@ async fn resolve_index_assets(
     let mut idx_assets = index_json::IndexAssets::default();
     if let Some(wasm) = &m.assets.wasm {
         let (url, size) = assets::resolve_url(wasm, release_assets)?;
-        let sha = assets::fetch_and_validate(http, &url, assets::AssetExpect::Wasm { file: wasm })
-            .await?;
+        let sha = assets::fetch_wasm_and_hash(http, &url, wasm).await?;
         idx_assets.wasm = Some(index_json::IndexAsset {
             url,
             size,
@@ -210,28 +242,25 @@ async fn resolve_index_assets(
         });
     }
     for sa in &m.assets.subprocess {
-        let (url, size) = assets::resolve_url(&sa.file, release_assets)?;
-        let sha = assets::fetch_and_validate(
-            http,
-            &url,
-            assets::AssetExpect::Subprocess {
-                file: &sa.file,
-                entrypoint: &m.backend.entrypoint,
-            },
-        )
-        .await?;
-        idx_assets
-            .subprocess
-            .push(index_json::IndexSubprocessAsset {
-                target: sa.target.clone(),
-                accel: sa.accel.to_string(),
-                cuda_major: sa.cuda_major,
-                cuda_sm: sa.cuda_sm,
-                cudnn: sa.cudnn,
-                url,
-                size,
-                sha256: sha,
-            });
+        // Download each part (a single-file variant has one) to a temp file,
+        // hashing it, then validate the reassembled archive before pinning.
+        let files = sa.release_files();
+        let mut tmp_paths: Vec<std::path::PathBuf> = Vec::with_capacity(files.len());
+        let mut pins: Vec<index_json::IndexAsset> = Vec::with_capacity(files.len());
+        for f in &files {
+            let (url, _) = assets::resolve_url(f, release_assets)?;
+            let dest = temp_part_path();
+            let (size, sha256) = assets::download_to_file(http, &url, f, &dest).await?;
+            tmp_paths.push(dest);
+            pins.push(index_json::IndexAsset { url, size, sha256 });
+        }
+        let validated =
+            assets::validate_subprocess_parts(&tmp_paths, &sa.label(), &m.backend.entrypoint);
+        for p in &tmp_paths {
+            let _ = std::fs::remove_file(p);
+        }
+        validated?;
+        idx_assets.subprocess.push(subprocess_index_entry(sa, pins));
     }
     Ok(idx_assets)
 }

--- a/super-stt-indexer/src/manifest.rs
+++ b/super-stt-indexer/src/manifest.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use thiserror::Error;
 
 pub use super_stt_registry_types::manifest::{
-    Accel, Device, Kind, Manifest, ManifestError as ParseError,
+    Accel, Device, Kind, Manifest, ManifestError as ParseError, SubprocessAsset,
 };
 
 #[derive(Debug, Error)]
@@ -80,20 +80,14 @@ pub fn validate(
             // `cuda_sm` stays optional: omitted means the build matches any
             // compute capability (multi-architecture framework builds).
             if a.cuda_major.is_none() {
-                return Err(ManifestError::CudaMissingMajor {
-                    file: a.file.clone(),
-                });
+                return Err(ManifestError::CudaMissingMajor { file: a.label() });
             }
         } else {
             if a.cuda_major.is_some() || a.cuda_sm.is_some() {
-                return Err(ManifestError::CudaForbiddenFields {
-                    file: a.file.clone(),
-                });
+                return Err(ManifestError::CudaForbiddenFields { file: a.label() });
             }
             if a.cudnn {
-                return Err(ManifestError::CudnnRequiresCuda {
-                    file: a.file.clone(),
-                });
+                return Err(ManifestError::CudnnRequiresCuda { file: a.label() });
             }
         }
     }

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -154,12 +154,25 @@ pub struct Assets {
 }
 
 /// One `[[assets.subprocess]]` build variant.
+///
+/// The variant's `.tar.gz` is named by `file`, or — when it would exceed the
+/// 2 GiB GitHub release-asset limit — by `parts`, whose byte-for-byte
+/// concatenation in order is the archive. Exactly one of the two is set
+/// (enforced by [`Manifest::parse`]).
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct SubprocessAsset {
-    /// Filename on the GitHub release (`.tar.gz`). The archive must contain
+    /// Single-file archive: the filename on the GitHub release (`.tar.gz`).
+    /// Mutually exclusive with `parts`. The archive must contain
     /// `bin/<entrypoint>`.
-    pub file: String,
+    #[serde(default)]
+    pub file: Option<String>,
+    /// Multi-part archive: ordered release filenames whose byte-for-byte
+    /// concatenation is the `.tar.gz`. Mutually exclusive with `file`; use when
+    /// the archive exceeds the 2 GiB release-asset limit. The indexer pins each
+    /// part independently.
+    #[serde(default)]
+    pub parts: Vec<String>,
     /// Rust target triple, e.g. `x86_64-unknown-linux-gnu`. Tier-1/2 only;
     /// the indexer rejects unknown triples.
     pub target: String,
@@ -179,6 +192,34 @@ pub struct SubprocessAsset {
     /// Default `false`.
     #[serde(default)]
     pub cudnn: bool,
+}
+
+impl SubprocessAsset {
+    /// The release filenames composing this variant's archive: the single
+    /// `file`, or the ordered `parts`. Exactly one source is populated once the
+    /// manifest has passed [`Manifest::parse`].
+    #[must_use]
+    pub fn release_files(&self) -> Vec<&str> {
+        match &self.file {
+            Some(f) => vec![f.as_str()],
+            None => self.parts.iter().map(String::as_str).collect(),
+        }
+    }
+
+    /// Whether the archive is delivered as multiple concatenated parts.
+    #[must_use]
+    pub fn is_multipart(&self) -> bool {
+        self.file.is_none()
+    }
+
+    /// A short label for diagnostics (the `file`, else the first part).
+    #[must_use]
+    pub fn label(&self) -> String {
+        self.file
+            .clone()
+            .or_else(|| self.parts.first().cloned())
+            .unwrap_or_else(|| "<unnamed subprocess asset>".into())
+    }
 }
 
 /// Acceleration backend of a subprocess build.
@@ -440,6 +481,12 @@ pub enum ManifestError {
     /// A `[[models.files]]` `destination` is not a safe relative path.
     #[error("backend.toml file destination {0:?} is not a safe relative path")]
     UnsafeDestination(String),
+    /// A `[[assets.subprocess]]` entry set neither or both of `file`/`parts`.
+    #[error(
+        "backend.toml subprocess asset for target {0:?} must set exactly one of \
+         `file` or `parts`"
+    )]
+    AssetFileXorParts(String),
 }
 
 impl Manifest {
@@ -464,6 +511,17 @@ impl Manifest {
                 if !crate::is_safe_relative_path(&file.destination) {
                     return Err(ManifestError::UnsafeDestination(file.destination.clone()));
                 }
+            }
+        }
+        // A subprocess build variant names its archive with exactly one of
+        // `file` (single) or `parts` (split across release assets, concatenated
+        // in order). The guard lives in the canonical parser so the daemon and
+        // the indexer agree on the contract.
+        for a in &m.assets.subprocess {
+            let has_file = a.file.as_deref().is_some_and(|f| !f.is_empty());
+            let has_parts = !a.parts.is_empty() && a.parts.iter().all(|p| !p.is_empty());
+            if has_file == has_parts {
+                return Err(ManifestError::AssetFileXorParts(a.target.clone()));
             }
         }
         Ok(m)
@@ -835,6 +893,79 @@ mod tests {
         assert_eq!(a.cuda_major, Some(13));
         assert_eq!(a.cuda_sm, None);
         assert!(!a.cudnn);
+    }
+
+    #[test]
+    fn parses_multipart_subprocess_asset() {
+        let m = Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "subprocess"
+            entrypoint = "y"
+            contract = "v1"
+
+            [[assets.subprocess]]
+            parts = ["y-cuda13.tar.gz.part00", "y-cuda13.tar.gz.part01"]
+            target = "x86_64-unknown-linux-gnu"
+            accel = "cuda"
+            cuda_major = 13
+            "#,
+        )
+        .unwrap();
+        let a = &m.assets.subprocess[0];
+        assert!(a.is_multipart());
+        assert_eq!(a.file, None);
+        assert_eq!(
+            a.release_files(),
+            vec!["y-cuda13.tar.gz.part00", "y-cuda13.tar.gz.part01"]
+        );
+    }
+
+    #[test]
+    fn rejects_subprocess_asset_with_both_file_and_parts() {
+        let err = Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "subprocess"
+            entrypoint = "y"
+            contract = "v1"
+
+            [[assets.subprocess]]
+            file = "y.tar.gz"
+            parts = ["y.tar.gz.part00"]
+            target = "x86_64-unknown-linux-gnu"
+            accel = "cpu"
+            "#,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ManifestError::AssetFileXorParts(_)));
+    }
+
+    #[test]
+    fn rejects_subprocess_asset_with_neither_file_nor_parts() {
+        let err = Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "subprocess"
+            entrypoint = "y"
+            contract = "v1"
+
+            [[assets.subprocess]]
+            target = "x86_64-unknown-linux-gnu"
+            accel = "cpu"
+            "#,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ManifestError::AssetFileXorParts(_)));
     }
 
     #[test]

--- a/super-stt-registry-types/src/schema.rs
+++ b/super-stt-registry-types/src/schema.rs
@@ -138,6 +138,23 @@ pub fn backend_schema() -> Value {
             } }
         }),
     );
+    // Exactly one of `file` (single archive) or `parts` (multi-part). `oneOf`
+    // passes only when one branch matches: file-only or parts-only is valid;
+    // both or neither fails — the schema mirror of the parser's xor guard.
+    push_all_of(
+        asset,
+        json!({
+            "oneOf": [
+                { "required": ["file"] },
+                { "required": ["parts"] }
+            ]
+        }),
+    );
+    // A multi-part `parts` list must be non-empty (serde can't express minItems).
+    asset["properties"]["parts"]
+        .as_object_mut()
+        .expect("parts property")
+        .insert("minItems".into(), json!(1));
     // `FileSpec` is flat — `url` and `destination` are required by serde and
     // `sha256` is optional, so no cross-field conditional is needed here.
 


### PR DESCRIPTION
## Summary
- A subprocess variant's archive may now ship as ordered `parts` (each a sub-2 GiB release asset) instead of a single `file`, for bundles past GitHub's 2 GiB per-asset release limit (e.g. the qwen3-asr CUDA PyTorch bundle). The parts' in-order byte concatenation is the `.tar.gz`.
- The canonical `backend.toml` parser enforces `file` xor `parts`; the indexer pins each part and validates the reassembled archive; the daemon downloads, verifies, and concatenates the parts before extracting. The daemon's unpack ceiling becomes a decompression-ratio bound so multi-GB bundles extract. Contract: `docs/protocol/backend/config.md`.
- Resolves the indexer skipping `qwen3_asr` with "missing field `file`" — its published `v0.1.0` ships cuda13 as `…part00`/`…part01`.

## Notes
- Rebased onto `main` after #235 (pluggable forge): the multi-part logic is re-applied on top of the forge-rerouted indexer/daemon code (`custom_repo.rs` conflict + `download_url` rename reconciled).

## Test Plan
- [x] `cargo build --workspace`
- [x] registry-types / super-stt-forge / indexer test suites
- [x] `cargo test -p super-stt-daemon --lib` (178 passed)
- [x] `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)