### PR TITLE
Drop redundant active_device GPU-memory path in favor of /gpu_info

### DIFF
--- a/docs/protocol/endpoints/v1/active_device.md
+++ b/docs/protocol/endpoints/v1/active_device.md
@@ -89,9 +89,7 @@ Content-Type: application/json
 {
   "status":            "success",
   "device":            "cuda",
-  "available_devices": ["cpu", "cuda"],
-  "gpu_free_memory":   8123456789,
-  "gpu_total_memory":  25395560448
+  "available_devices": ["cpu", "cuda"]
 }
 ```
 
@@ -99,8 +97,9 @@ Content-Type: application/json
 |---------------------|----------|----------------------------------------------------------------------------------|
 | `device`            | string   | The active device                                                                 |
 | `available_devices` | string[] | Devices reachable on this host                                                    |
-| `gpu_free_memory`   | u64?     | Free GPU memory in bytes (omitted on hosts with no GPU)                           |
-| `gpu_total_memory`  | u64?     | Total GPU memory in bytes (omitted on hosts with no GPU)                          |
+
+GPU memory (free / total / used per device) is reported by
+[`GET /gpu_info`](./gpu_info.md), not this endpoint.
 
 **Errors:**
 

--- a/super-stt-app/src/core/app/handlers/device.rs
+++ b/super-stt-app/src/core/app/handlers/device.rs
@@ -60,11 +60,10 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::DeviceInfoLoaded(device, available_devices, gpu_memory) => {
+            Message::DeviceInfoLoaded(device, available_devices) => {
                 info!("DeviceInfoLoaded: device={device}, available_devices={available_devices:?}");
                 self.current_device.clone_from(&device);
                 self.available_devices.clone_from(&available_devices);
-                self.gpu_memory = gpu_memory;
 
                 if matches!(self.device_state, DeviceState::Switching { .. }) {
                     info!("Device switch completed to: {device}");

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -54,14 +54,13 @@ impl AppModel {
                         Err(e) => cosmic::Action::App(Message::ModelError(e)),
                     }),
                     Task::perform(get_current_device(), |result| match result {
-                        Ok((device, available_devices, gpu_memory)) => {
+                        Ok((device, available_devices)) => {
                             info!(
                                 "Initial device load successful: device={device}, available_devices={available_devices:?}"
                             );
                             cosmic::Action::App(Message::DeviceInfoLoaded(
                                 device,
                                 available_devices,
-                                gpu_memory,
                             ))
                         }
                         Err(e) => {

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -128,7 +128,6 @@ impl AppModel {
             // Initialize device state
             current_device: String::new(), // Empty until loaded from daemon
             available_devices: vec!["cpu".to_string()], // Default until loaded from daemon
-            gpu_memory: None,
             gpu_info: Vec::new(),
             device_state: DeviceState::Ready,
             last_device_switch: None,

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -103,8 +103,6 @@ pub struct AppModel {
     pub current_device: String,
     /// Available devices from daemon
     pub available_devices: Vec<String>,
-    /// GPU memory info: (free, total) in bytes. None if CUDA unavailable.
-    pub gpu_memory: crate::daemon::client::GpuMemoryInfo,
     /// GPU inventory + memory from the daemon's `GET /gpu_info` (gpu-probe).
     pub gpu_info: Vec<super_stt_shared::models::protocol::GpuInfo>,
     /// Device switching state

--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -100,7 +100,7 @@ impl AppModel {
             message,
             Message::DeviceSelected(_)
                 | Message::DeviceLoaded(_)
-                | Message::DeviceInfoLoaded(_, _, _)
+                | Message::DeviceInfoLoaded(_, _)
                 | Message::DeviceError(_)
         ) {
             return Some(self.handle_device_messages(message));

--- a/super-stt-app/src/daemon/client/mod.rs
+++ b/super-stt-app/src/daemon/client/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod v1;
 pub use v1::health::{ping_daemon, test_daemon_connection};
 pub use v1::transcribe::{RecordEvent, record_command_stream, stop_record_command};
 
-pub use v1::settings::active_device::{GpuMemoryInfo, get_current_device, set_device};
+pub use v1::settings::active_device::{get_current_device, set_device};
 pub use v1::settings::active_model::{
     cancel_download, get_current_model, get_download_status, list_available_models,
     reload_active_model, set_model, unload_active_model,

--- a/super-stt-app/src/daemon/client/v1/settings/active_device.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/active_device.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! `/active_device` — compute device (CPU/CUDA) + GPU memory.
+//! `/active_device` — compute device (CPU/CUDA). GPU memory is served
+//! separately by `GET /gpu_info` (gpu-probe).
 
 use crate::daemon::client::internal::response::{require_success, require_unit};
 use crate::daemon::client::internal::session::with_settings_token;
 use super_stt_shared::daemon::http_client::transport;
 
-/// `(free_bytes, total_bytes)` for a CUDA device; `None` on CPU or when the
-/// driver couldn't be queried.
-pub type GpuMemoryInfo = Option<(u64, u64)>;
-
-/// Read current device + available devices + GPU memory (HTTP `GET /active_device`).
-pub async fn get_current_device() -> Result<(String, Vec<String>, GpuMemoryInfo), String> {
+/// Read current device + available devices (HTTP `GET /active_device`).
+pub async fn get_current_device() -> Result<(String, Vec<String>), String> {
     with_settings_token(|socket, token| async move {
         let resp = require_success(
             transport::settings_get(socket, &token, "/active_device").await?,
@@ -20,11 +17,7 @@ pub async fn get_current_device() -> Result<(String, Vec<String>, GpuMemoryInfo)
         let available_devices = resp
             .available_devices
             .unwrap_or_else(|| vec!["cpu".to_string()]);
-        let gpu_memory = match (resp.gpu_free_memory, resp.gpu_total_memory) {
-            (Some(free), Some(total)) => Some((free, total)),
-            _ => None,
-        };
-        Ok((device, available_devices, gpu_memory))
+        Ok((device, available_devices))
     })
     .await
 }

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -199,10 +199,10 @@ pub enum Message {
     ModelError(String),
 
     // Device management messages
-    DeviceSelected(String), // "cpu" or "cuda"
-    DeviceLoaded(String),   // Current device from daemon
-    DeviceInfoLoaded(String, Vec<String>, crate::daemon::client::GpuMemoryInfo), // Current device, available devices, GPU memory (free, total)
-    DeviceError(String), // Device switching error
+    DeviceSelected(String),                // "cpu" or "cuda"
+    DeviceLoaded(String),                  // Current device from daemon
+    DeviceInfoLoaded(String, Vec<String>), // Current device, available devices
+    DeviceError(String),                   // Device switching error
 
     // Download progress messages
     DownloadProgressUpdate(super_stt_shared::models::protocol::DownloadProgress),

--- a/super-stt-daemon/src/daemon/device_management.rs
+++ b/super-stt-daemon/src/daemon/device_management.rs
@@ -422,32 +422,10 @@ impl SuperSTTDaemon {
             format!("Device: {actual_device} (preferred and actual match)")
         };
 
-        let mut response = DaemonResponse::success()
+        DaemonResponse::success()
             .with_device(actual_device)
             .with_available_devices(available_devices)
-            .with_message(message);
-
-        // Include GPU memory info when CUDA is available
-        match Self::get_gpu_memory_info() {
-            Ok((free, total)) => {
-                response = response
-                    .with_gpu_free_memory(free)
-                    .with_gpu_total_memory(total);
-            }
-            Err(e) => {
-                info!("GPU memory query unavailable: {e}");
-            }
-        }
-
-        response
-    }
-
-    /// GPU memory reporting now lives in the GPU-resident backends, not the
-    /// daemon (which no longer links a CUDA runtime). Always unavailable here.
-    fn get_gpu_memory_info() -> Result<(u64, u64), anyhow::Error> {
-        Err(anyhow::anyhow!(
-            "GPU memory info is reported by the backend, not the daemon"
-        ))
+            .with_message(message)
     }
 
     /// Read-only GPU inventory for `GET /gpu_info`. Hardware detection runs on a

--- a/super-stt-shared/src/models/protocol/response.rs
+++ b/super-stt-shared/src/models/protocol/response.rs
@@ -26,14 +26,6 @@ pub struct DaemonResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_devices: Option<Vec<String>>,
 
-    /// Free GPU memory in bytes (only set when CUDA is available)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gpu_free_memory: Option<u64>,
-
-    /// Total GPU memory in bytes (only set when CUDA is available)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gpu_total_memory: Option<u64>,
-
     // Notification system fields
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscribed_to: Option<Vec<String>>,
@@ -284,18 +276,6 @@ impl DaemonResponse {
     #[must_use]
     pub fn with_available_devices(mut self, devices: Vec<String>) -> Self {
         self.available_devices = Some(devices);
-        self
-    }
-
-    #[must_use]
-    pub fn with_gpu_free_memory(mut self, bytes: u64) -> Self {
-        self.gpu_free_memory = Some(bytes);
-        self
-    }
-
-    #[must_use]
-    pub fn with_gpu_total_memory(mut self, bytes: u64) -> Self {
-        self.gpu_total_memory = Some(bytes);
         self
     }
 


### PR DESCRIPTION
## What

The `active_device` response carried `gpu_free_memory` / `gpu_total_memory` fields that were dead end-to-end:

- They were only ever populated by a daemon stub (`get_gpu_memory_info`) that **always** returned an error — logging `GPU memory query unavailable: GPU memory info is reported by the backend, not the daemon` at `info!` on every device-status poll.
- The app stored the value in `app.gpu_memory` but **never rendered it** — the UI sources GPU memory from `app.gpu_info`, fed by the gpu-probe-backed `GET /gpu_info` endpoint.

This removes the redundant path entirely, leaving `/gpu_info` (gpu-probe) as the single source of GPU memory. No GPU-memory capability is lost or reimplemented.

## Changes

- **Daemon:** delete the always-erroring `get_gpu_memory_info` stub + its log line; `handle_get_device` no longer touches GPU memory.
- **Shared protocol:** remove the `gpu_free_memory` / `gpu_total_memory` response fields and their `with_*` builders.
- **App:** drop the `GpuMemoryInfo` type, the `app.gpu_memory` field, the `DeviceInfoLoaded` payload, and all plumbing.
- **Docs:** update `active_device.md` to drop the fields and point at `GET /gpu_info`.

## Verification

`cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)