### PR TITLE
Fix GPU backend install: capability-based selection + multi-GB download timeout

### DIFF
--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -379,7 +379,13 @@ pub(super) fn spawn_install_pipeline(
             backends_dir,
             cache_dir,
             http: reqwest::Client::builder()
-                .timeout(Duration::from_mins(5))
+                // Bundles can be multi-GB (e.g. a CUDA backend's multi-part
+                // archive), so allow a generous total timeout like the model
+                // download client; the connect timeout still fails fast on an
+                // unreachable host. A 5-minute total previously aborted large
+                // GPU-bundle downloads as `DownloadFailed`.
+                .timeout(Duration::from_hours(1))
+                .connect_timeout(Duration::from_secs(30))
                 .redirect(reqwest::redirect::Policy::limited(10))
                 .build()
                 .unwrap_or_default(),

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -321,8 +321,7 @@ fn select_install_compat(
     }
 
     let host = host_detect::detect();
-    let prefs = compat::Prefs::default();
-    let sel = compat::select(&host, entry, &prefs);
+    let sel = compat::select(&host, entry);
     let Some(asset) = compat::to_selected_asset(entry, &sel) else {
         s.install_inflight.write().remove(source_key);
         return Err(Box::new(

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -150,7 +150,6 @@ pub(crate) async fn list_registry_backends(
     };
 
     let host = host_detect::detect();
-    let prefs = compat::Prefs::default();
     let bdir = backends_dir(&s).await;
 
     let mut result = Vec::new();
@@ -159,7 +158,7 @@ pub(crate) async fn list_registry_backends(
             continue;
         }
 
-        let sel = compat::select(&host, entry, &prefs);
+        let sel = compat::select(&host, entry);
         let compatible = !matches!(sel, compat::Selection::Incompatible { .. });
 
         if !compatible && !q.include_incompatible {

--- a/super-stt-daemon/src/daemon/http/v1/registry/update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/update.rs
@@ -139,8 +139,7 @@ fn select_update_compat(
     use crate::registry::{compat, host_detect};
 
     let host = host_detect::detect();
-    let prefs = compat::Prefs::default();
-    let sel = compat::select(&host, entry, &prefs);
+    let sel = compat::select(&host, entry);
 
     if compat::to_selected_asset(entry, &sel).is_none() {
         s.install_inflight.write().remove(source);

--- a/super-stt-daemon/src/registry/compat.rs
+++ b/super-stt-daemon/src/registry/compat.rs
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! `select(host, entry, prefs)` — pure: no I/O, no shared state.
+//! `select(host, entry)` — pure: no I/O, no shared state. Asset selection is
+//! driven solely by host capability (the most optimal asset the host can run);
+//! the runtime device preference is intentionally decoupled and never affects
+//! which asset is downloaded.
 
 use super_stt_shared::registry::SelectedAsset;
 
 use crate::registry::host_detect::Host;
 use crate::registry::index_schema::{IndexBackend, IndexSubprocessAsset};
-
-#[derive(Debug, Clone, Default)]
-pub struct Prefs {
-    /// User-asked to prefer GPU for this backend. Mirrors today's per-local-
-    /// model "Use GPU" checkbox.
-    pub prefer_gpu: bool,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Selection {
@@ -21,7 +17,7 @@ pub enum Selection {
 }
 
 #[must_use]
-pub fn select(host: &Host, entry: &IndexBackend, prefs: &Prefs) -> Selection {
+pub fn select(host: &Host, entry: &IndexBackend) -> Selection {
     if entry.kind == "wasm" {
         return if entry.assets.wasm.is_some() {
             Selection::Wasm
@@ -50,9 +46,10 @@ pub fn select(host: &Host, entry: &IndexBackend, prefs: &Prefs) -> Selection {
         };
     }
 
-    if prefs.prefer_gpu
-        && let Some(cuda) = &host.cuda
-    {
+    // Capability-driven: if the host has a usable CUDA GPU, install the best
+    // matching CUDA asset. Independent of the runtime device preference — a
+    // CUDA build still runs on CPU when the user selects that device.
+    if let Some(cuda) = &host.cuda {
         let cuda_matches: Vec<&(usize, &IndexSubprocessAsset)> = by_target
             .iter()
             .filter(|(_, a)| {
@@ -177,8 +174,36 @@ mod tests {
         }
     }
 
+    fn host_cpu() -> Host {
+        Host {
+            target_triple: "x86_64-unknown-linux-gnu".into(),
+            cuda: None,
+        }
+    }
+
     #[test]
-    fn picks_matching_cuda_when_gpu_preferred() {
+    fn cpu_host_without_gpu_picks_cpu() {
+        // Capability-driven: with no GPU on the host, the CPU asset is selected
+        // even though a matching CUDA asset exists.
+        let e = entry(
+            "subprocess",
+            vec![
+                sp("x86_64-unknown-linux-gnu", "cpu", None, None, false),
+                sp(
+                    "x86_64-unknown-linux-gnu",
+                    "cuda",
+                    Some(86),
+                    Some(13),
+                    false,
+                ),
+            ],
+        );
+        let sel = select(&host_cpu(), &e);
+        assert_eq!(sel, Selection::Subprocess { index: 0 });
+    }
+
+    #[test]
+    fn picks_matching_cuda_on_capable_host() {
         let e = entry(
             "subprocess",
             vec![
@@ -199,7 +224,7 @@ mod tests {
                 ),
             ],
         );
-        let sel = select(&host_cuda(86, 12, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 12, false), &e);
         assert_eq!(sel, Selection::Subprocess { index: 1 });
     }
 
@@ -218,7 +243,7 @@ mod tests {
                 ),
             ],
         );
-        let sel = select(&host_cuda(86, 12, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 12, false), &e);
         assert_eq!(sel, Selection::Subprocess { index: 0 });
     }
 
@@ -237,7 +262,7 @@ mod tests {
                 sp("x86_64-unknown-linux-gnu", "cuda", Some(86), Some(12), true),
             ],
         );
-        let sel = select(&host_cuda(86, 12, true), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 12, true), &e);
         assert_eq!(sel, Selection::Subprocess { index: 1 });
     }
 
@@ -263,7 +288,7 @@ mod tests {
             ],
         );
         // Host has CUDA 13 runtime
-        let sel = select(&host_cuda(86, 13, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 13, false), &e);
         assert_eq!(sel, Selection::Subprocess { index: 1 });
     }
 
@@ -289,7 +314,7 @@ mod tests {
             ],
         );
         // Host has CUDA 12 runtime — must not pick the cuda_major=13 build.
-        let sel = select(&host_cuda(86, 12, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 12, false), &e);
         assert_eq!(sel, Selection::Subprocess { index: 0 });
     }
 
@@ -304,7 +329,7 @@ mod tests {
             ],
         );
         // Host is sm_120 with a CUDA 13 runtime; the wildcard must match.
-        let sel = select(&host_cuda(120, 13, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(120, 13, false), &e);
         assert_eq!(sel, Selection::Subprocess { index: 1 });
     }
 
@@ -323,7 +348,7 @@ mod tests {
                 ),
             ],
         );
-        let sel = select(&host_cuda(90, 13, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(90, 13, false), &e);
         assert_eq!(
             sel,
             Selection::Subprocess { index: 1 },
@@ -341,7 +366,7 @@ mod tests {
                 sp("x86_64-unknown-linux-gnu", "cuda", None, Some(13), false),
             ],
         );
-        let sel = select(&host_cuda(86, 12, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 12, false), &e);
         assert_eq!(
             sel,
             Selection::Subprocess { index: 0 },
@@ -360,7 +385,7 @@ mod tests {
                 sp("x86_64-unknown-linux-gnu", "cuda", None, None, false),
             ],
         );
-        let sel = select(&host_cuda(86, 12, false), &e, &Prefs { prefer_gpu: true });
+        let sel = select(&host_cuda(86, 12, false), &e);
         assert_eq!(
             sel,
             Selection::Subprocess { index: 0 },
@@ -374,7 +399,7 @@ mod tests {
             "subprocess",
             vec![sp("aarch64-unknown-linux-gnu", "cpu", None, None, false)],
         );
-        let sel = select(&host_cuda(86, 12, false), &e, &Prefs { prefer_gpu: false });
+        let sel = select(&host_cuda(86, 12, false), &e);
         assert!(matches!(sel, Selection::Incompatible { .. }));
     }
 }

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -373,7 +373,18 @@ async fn stream_download<F>(
 where
     F: Fn(InstallPhase, Option<(u64, Option<u64>)>) + Send + Sync,
 {
-    let resp = http.get(url).send().await?.error_for_status()?;
+    let resp = http
+        .get(url)
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(|e| {
+            log::warn!(
+                "install: download request failed ({url}){}: {e}",
+                if e.is_timeout() { " [timeout]" } else { "" }
+            );
+            e
+        })?;
     let total = resp.content_length();
     let cap = download_cap(expected_size);
     let mut file = tokio::fs::File::create(dest).await?;
@@ -381,7 +392,13 @@ where
     let mut stream = resp.bytes_stream();
     let mut bytes_done: u64 = 0;
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
+        let chunk = chunk.map_err(|e| {
+            log::warn!(
+                "install: stream error ({url}) after {bytes_done} bytes{}: {e}",
+                if e.is_timeout() { " [timeout]" } else { "" }
+            );
+            e
+        })?;
         bytes_done += chunk.len() as u64;
         // Bound a server that streams past the index-declared size (or forever
         // when no size was declared) before it fills the disk.
@@ -436,13 +453,33 @@ where
     let mut out = tokio::fs::File::create(dest).await?;
     let mut overall: u64 = 0;
     for part in parts {
-        let resp = http.get(&part.url).send().await?.error_for_status()?;
+        let resp = http
+            .get(&part.url)
+            .send()
+            .await
+            .and_then(reqwest::Response::error_for_status)
+            .map_err(|e| {
+                log::warn!(
+                    "install: part request failed ({}){}: {e}",
+                    part.url,
+                    if e.is_timeout() { " [timeout]" } else { "" }
+                );
+                e
+            })?;
         let cap = download_cap(part.size);
         let mut hasher = Context::new(&SHA256);
         let mut stream = resp.bytes_stream();
         let mut part_done: u64 = 0;
         while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
+            let chunk = chunk.map_err(|e| {
+                log::warn!(
+                    "install: stream error on part {} after {part_done}/{} bytes{}: {e}",
+                    part.url,
+                    part.size,
+                    if e.is_timeout() { " [timeout]" } else { "" }
+                );
+                e
+            })?;
             part_done += chunk.len() as u64;
             if part_done > cap {
                 let _ = out.flush().await;
@@ -753,5 +790,93 @@ supported_devices = ["cpu"]
         let mut sidecar = final_path.as_os_str().to_owned();
         sidecar.push(".old");
         assert!(!Path::new(&sidecar).exists(), "sidecar must be cleaned up");
+    }
+
+    /// The multi-part path downloads each part in order, verifies its SHA-256,
+    /// and concatenates them byte-for-byte. Proves the multipart logic itself is
+    /// sound, so a real-world failure points elsewhere (network/timeout).
+    #[tokio::test]
+    async fn multipart_download_concatenates_and_verifies_parts() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let mut server = mockito::Server::new_async().await;
+        let p0 = vec![0xABu8; 4096];
+        let p1 = vec![0xCDu8; 2048];
+        let m0 = server
+            .mock("GET", "/p0")
+            .with_status(200)
+            .with_body(p0.as_slice())
+            .create_async()
+            .await;
+        let m1 = server
+            .mock("GET", "/p1")
+            .with_status(200)
+            .with_body(p1.as_slice())
+            .create_async()
+            .await;
+        let parts = vec![
+            IndexAsset {
+                url: format!("{}/p0", server.url()),
+                size: p0.len() as u64,
+                sha256: sha_hex(&p0),
+            },
+            IndexAsset {
+                url: format!("{}/p1", server.url()),
+                size: p1.len() as u64,
+                sha256: sha_hex(&p1),
+            },
+        ];
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.tar.gz");
+        let http = reqwest::Client::new();
+        download_verified_parts(&http, &parts, &dest, &Arc::new(|_, _| {}))
+            .await
+            .expect("multipart download must succeed");
+        m0.assert_async().await;
+        m1.assert_async().await;
+        let got = std::fs::read(&dest).unwrap();
+        let mut want = p0.clone();
+        want.extend_from_slice(&p1);
+        assert_eq!(got, want, "reassembled bytes must be part0 || part1");
+    }
+
+    /// A download that can't finish within the client's request timeout surfaces
+    /// as `PipelineError::Network`, which the install handler flattens to the
+    /// user-visible `DownloadFailed`. This is the exact failure a multi-GB CUDA
+    /// bundle hits when the client timeout is shorter than the transfer takes.
+    #[tokio::test]
+    async fn download_exceeding_client_timeout_is_a_download_failure() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        // A server that accepts the connection but never replies.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _hang = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                drop(stream);
+            }
+        });
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(300))
+            .build()
+            .unwrap();
+        let parts = vec![IndexAsset {
+            url: format!("http://{addr}/p0"),
+            size: 1024,
+            sha256: String::new(),
+        }];
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.tar.gz");
+        let err = download_verified_parts(&http, &parts, &dest, &Arc::new(|_, _| {}))
+            .await
+            .expect_err("a download that can't finish in time must fail");
+        assert!(
+            matches!(err, PipelineError::Network(_)),
+            "a timeout must surface as a network error, got {err:?}"
+        );
+        assert_eq!(
+            err.as_typed(InstallPhase::Downloading).1,
+            InstallError::DownloadFailed,
+            "network errors are the user-visible DownloadFailed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes that together let GPU-capable backends actually install and load on a GPU host (found while debugging qwen `device_unavailable`, then `DownloadFailed`).

- **Capability-based asset selection** (`794293f`): selection passed `Prefs::default()` (`prefer_gpu = false`) at every call site (install/update/list), so the daemon always installed the **CPU** asset regardless of host or preference — qwen then failed `device_unavailable` and voxtral silently ran on CPU. `select(host, entry)` is now driven purely by host capability (best matching CUDA build when a compatible GPU is present, else CPU), fully decoupled from the runtime device preference. The `Prefs`/`prefer_gpu` machinery is removed.

- **Multi-GB download timeout** (`8e7db2e`): once selection began picking GPU assets, the install client's **5-minute total timeout** aborted the ~2.8 GB CUDA multipart bundle as `DownloadFailed` — the bundle transfers in ~300 s, right at the cap. Raised to match the model-download client (1-hour total + 30-second connect), and surfaced the underlying reqwest error that `as_typed` previously discarded.

## Test plan

- `compat` unit tests updated for capability-driven selection (+ new no-GPU-host test).
- New install tests: multipart download concatenate/verify happy path, and timeout → `DownloadFailed` reproduction.
- Verified end-to-end against the live release: the real 2.8 GB qwen CUDA bundle downloads and SHA-256-verifies through the production path with the fix (300.61 s — the old 300 s cap was killing it ~0.6 s short).
- `cargo fmt --check` + pedantic clippy clean; full daemon `--lib` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)