### PR TITLE
Fix backend-secret config UI state; secret-endpoint follow-ups

### DIFF
--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -175,6 +175,8 @@ impl AppModel {
                 | Message::BackendSecretInputChanged { .. }
                 | Message::BackendSecretSaved { .. }
                 | Message::BackendSecretRemoved { .. }
+                | Message::BackendSecretStored { .. }
+                | Message::BackendSecretsConfigured { .. }
                 | Message::BackendOptionInputChanged { .. }
                 | Message::BackendOptionSaved { .. }
         ) {

--- a/super-stt-daemon/src/daemon/http/v1/backends/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/mod.rs
@@ -32,3 +32,13 @@ pub(crate) fn json_error(code: StatusCode, message: &str) -> Response {
     )
         .into_response()
 }
+
+/// House-style JSON success response with status 200.
+pub(crate) fn ok(v: &serde_json::Value) -> Response {
+    (
+        StatusCode::OK,
+        [("content-type", "application/json")],
+        v.to_string(),
+    )
+        .into_response()
+}

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use super::{decode_source, find_backend, json_error};
+use super::{decode_source, find_backend, json_error, ok};
 use crate::daemon::http::internal::helpers::dispatch::dispatch_command;
 use crate::daemon::http::state::AppState;
 use crate::stt_models::backends::DiscoveredBackend;
@@ -143,13 +143,4 @@ async fn guard_missing(s: &AppState, source: &str, name: &str) -> Option<Respons
         Some(b) if b.options.iter().any(|o| o.name == name) => None,
         Some(_) => Some(json_error(StatusCode::NOT_FOUND, "unknown_option")),
     }
-}
-
-fn ok(v: &serde_json::Value) -> Response {
-    (
-        StatusCode::OK,
-        [("content-type", "application/json")],
-        v.to_string(),
-    )
-        .into_response()
 }

--- a/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use super::{decode_source, find_backend, json_error};
+use super::{decode_source, find_backend, json_error, ok};
 use crate::daemon::http::state::AppState;
 use axum::Router;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use axum::routing::get;
 use serde::Deserialize;
 
@@ -128,13 +128,4 @@ fn secret_result(
             resp.message.as_deref().unwrap_or("keyring_unavailable"),
         )
     }
-}
-
-fn ok(v: &serde_json::Value) -> Response {
-    (
-        StatusCode::OK,
-        [("content-type", "application/json")],
-        v.to_string(),
-    )
-        .into_response()
 }

--- a/super-stt-daemon/tests/http_smoke_backend_secrets.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_secrets.rs
@@ -265,13 +265,46 @@ async fn secret_endpoints_require_the_secrets_scope() {
     // Only `settings` scope — no `secrets`.
     let (_guard, sock, token) = start_daemon(&["settings"]).await;
 
-    let path = format!("/backends/{FIXTURE_SOURCE_ENC}/secrets/openai_api_key");
+    let secret_path = format!("/backends/{FIXTURE_SOURCE_ENC}/secrets/openai_api_key");
+    let list_path = format!("/backends/{FIXTURE_SOURCE_ENC}/secrets/list");
 
-    let (s, body) = post(&sock, &path, &token, serde_json::json!({ "value": "x" })).await;
+    let (s, body) = post(
+        &sock,
+        &secret_path,
+        &token,
+        serde_json::json!({ "value": "x" }),
+    )
+    .await;
     assert_eq!(
         s,
         StatusCode::FORBIDDEN,
         "settings-only token must be 403 on secret POST: {body}"
+    );
+    assert_eq!(body["message"], "scope_denied", "error code: {body}");
+
+    // The scope guard is a router-layer middleware — it must fire on GET too.
+    let (s, body) = get(&sock, &secret_path, &token).await;
+    assert_eq!(
+        s,
+        StatusCode::FORBIDDEN,
+        "settings-only token must be 403 on secret GET: {body}"
+    );
+    assert_eq!(body["message"], "scope_denied", "error code: {body}");
+
+    let (s, body) = get(&sock, &list_path, &token).await;
+    assert_eq!(
+        s,
+        StatusCode::FORBIDDEN,
+        "settings-only token must be 403 on secrets/list GET: {body}"
+    );
+    assert_eq!(body["message"], "scope_denied", "error code: {body}");
+
+    // And on DELETE.
+    let (s, body) = delete_req(&sock, &secret_path, &token).await;
+    assert_eq!(
+        s,
+        StatusCode::FORBIDDEN,
+        "settings-only token must be 403 on secret DELETE: {body}"
     );
     assert_eq!(body["message"], "scope_denied", "error code: {body}");
 }


### PR DESCRIPTION
Follow-ups to #244 (daemon-owned backend secrets). The headline is a real bug fix found while auditing the settings UI for completeness.

## Bug fix — backend-secret config UI never reflected saved state

#244 added two app message variants — `BackendSecretsConfigured` (populates the per-secret "configured" map from the daemon on catalog load) and `BackendSecretStored` (clears the input and refreshes after a successful save) — and handled them in `handle_backend_messages`. But the outer dispatcher in `core/app/update.rs` routes backend messages through an explicit `matches!` gate that was never updated, so **both variants silently no-op'd**.

Impact: a user could set a backend API key — it saved to the daemon correctly — but the configure UI kept showing it as *not configured*, and `unmet_requirements` would wrongly gate model selection on required secrets. Fixed by adding the two variants to the routing gate.

Caveat: cosmic's two-layer message dispatch isn't practically unit-testable (no live app model in tests), so this fix is verified by build + reasoning, not a regression test. The duplicated variant list across the `update.rs` gate and `handle_backend_messages` remains a latent fragility worth a future refactor.

## Polish

- The secret scope-denial smoke test now asserts `403 scope_denied` on GET and DELETE, not just POST (the guard is router-layer middleware; this proves it for all methods).
- Deduped the identical `ok()` JSON-response helper from `backends/secrets.rs` + `options.rs` into the shared `backends/mod.rs`.

## Not in this PR (tracked as follow-up)

Two UI gaps surfaced in the audit, deferred as design choices: a dedicated "Reset to default" affordance for options (clear-and-save already works), and "required" markers on secret/option rows in the configure sub-view.

## Testing

`cargo fmt --all -- --check` clean; clippy `--all-features --workspace` clean; secret smoke tests pass (incl. the new GET/DELETE 403 assertions); app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
