### PR TITLE
Strip region tags to base language before defaulting

### DIFF
--- a/super-stt-daemon/src/daemon/language.rs
+++ b/super-stt-daemon/src/daemon/language.rs
@@ -48,13 +48,12 @@ fn adapt(tag: &str, supported: &[String]) -> Option<String> {
     if supported.iter().any(|s| s == tag) {
         return Some(tag.to_string()); // exact (base or region)
     }
+    // No exact match: a region tag falls back to the base language when the
+    // model lists it (e.g. es-MX → es), even if the model also carries region
+    // variants for that language (e.g. Deepgram's `es` + `es-419`). Only when
+    // the base isn't supported either is the language unsupported → omit.
     if has_region(tag) {
         let b = base(tag);
-        // Region-aware for `b` but missing this region → fall through.
-        if supported.iter().any(|s| base(s) == b && has_region(s)) {
-            return None;
-        }
-        // Region-agnostic: model lists the base code → strip the region.
         if supported.iter().any(|s| s == b) {
             return Some(b.to_string());
         }
@@ -151,8 +150,18 @@ mod tests {
     }
 
     #[test]
-    fn global_region_falls_back_when_region_aware_misses() {
-        // Model is region-aware for `es` (es-419, es-ES) but lacks es-MX → default.
+    fn global_region_strips_to_base_even_with_region_siblings() {
+        // Model lists base `es` AND a region variant (`es-419`), like Deepgram.
+        // A picked es-MX strips to base `es` rather than falling back to default.
+        let r = resolve_language(true, None, Some("es-MX"), &s(&["en", "es", "es-419"]));
+        assert_eq!(r.wire.as_deref(), Some("es"));
+        assert_eq!(r.source, LanguageSource::Global);
+    }
+
+    #[test]
+    fn global_region_falls_back_when_base_unsupported() {
+        // Model carries only region variants for `es` (`es-419`, `es-ES`) and no
+        // base `es`, and lacks es-MX → the language is unsupported → default.
         let r = resolve_language(true, None, Some("es-MX"), &s(&["en-US", "es-419", "es-ES"]));
         assert_eq!(r.wire, None);
         assert_eq!(r.source, LanguageSource::Default);


### PR DESCRIPTION
Follow-up to #252 (transcription language selection). The `adapt` step that maps a chosen language tag onto a model's `supported_languages` checked for a region sibling *before* trying the base code, so a global preference like `es-MX` resolved to **omit → model default** on any model that lists both a base tag and a region variant for that language.

In practice this bit Deepgram, whose `nova-3` manifest declares both base `es` and `es-419`: a user whose global language is `es-MX` got **English** instead of Spanish.

## Fix

Try the base code first. A region tag with no exact match now:
- strips to the base language when the model lists it (`es-MX` → `es`), and
- falls back to the model default only when neither the exact region nor the base is supported.

That makes the previously-special "region-aware → default" branch redundant, so it's removed. The existing fallback case (a model with only region variants, no base) still returns the model default — now because the base genuinely isn't supported.

## Tests

- `global_region_strips_to_base_even_with_region_siblings` — new; the Deepgram shape (`["en","es","es-419"]` + `es-MX` → `es`).
- `global_region_falls_back_when_base_unsupported` — renamed from `…_when_region_aware_misses`; the fallback now hinges on the base being absent.

All 10 `daemon::language` unit tests pass; `cargo fmt --all -- --check` and workspace clippy (`-W clippy::pedantic -D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
