### PR TITLE
Polish language pickers with readable BCP-47 names

### DIFF
--- a/super-stt-app/src/ui/languages.rs
+++ b/super-stt-app/src/ui/languages.rs
@@ -1,42 +1,350 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! Curated, region-qualified language tags for the global Primary Language
-//! picker, plus human-friendly names. Wire form is the BCP-47 tag; names are
-//! display-only. Per-model pickers reuse `friendly_name` for the model's own
-//! `supported_languages` (which may include base tags).
+//! Language tags for the pickers plus human-friendly names. The wire form is
+//! always the BCP-47 tag; names are display-only and composed at render time
+//! from a base-language table and a region table, so there is a single source
+//! of truth. The global Primary Language picker offers the curated,
+//! region-qualified [`GLOBAL_LANGUAGES`]; per-model pickers reuse
+//! [`friendly_name`] for each model's own `supported_languages`, which are
+//! usually base ISO 639-1 codes (e.g. `es`).
 
-/// `(bcp47_tag, friendly_name)` — region-qualified only. Country codes for
-/// single countries; UN M.49 (`es-419`) for multi-country regions.
-pub const GLOBAL_LANGUAGES: &[(&str, &str)] = &[
-    ("en-US", "English (United States)"),
-    ("en-GB", "English (United Kingdom)"),
-    ("es-419", "Spanish (Latin America)"),
-    ("es-MX", "Spanish (Mexico)"),
-    ("es-US", "Spanish (United States)"),
-    ("es-ES", "Spanish (Spain)"),
-    ("pt-BR", "Portuguese (Brazil)"),
-    ("pt-PT", "Portuguese (Portugal)"),
-    ("fr-FR", "French (France)"),
-    ("fr-CA", "French (Canada)"),
-    ("de-DE", "German (Germany)"),
-    ("it-IT", "Italian (Italy)"),
-    ("ja-JP", "Japanese (Japan)"),
-    ("ko-KR", "Korean (South Korea)"),
-    ("zh-CN", "Chinese (Simplified)"),
-    ("zh-TW", "Chinese (Traditional)"),
-    ("hi-IN", "Hindi (India)"),
-    ("ar-SA", "Arabic (Saudi Arabia)"),
-    ("ru-RU", "Russian (Russia)"),
-    ("nl-NL", "Dutch (Netherlands)"),
+/// Tags offered by the global Primary Language picker. Region-qualified, with
+/// one exception: Chinese uses the ISO 15924 script subtags `zh-Hans` /
+/// `zh-Hant`, since script — not region — is what distinguishes Simplified from
+/// Traditional. A region is a country code, or UN M.49 for a multi-country
+/// region (`es-419`). Display order is alphabetical by name and is applied by
+/// the picker; every subtag here resolves through the tables below.
+pub const GLOBAL_LANGUAGES: &[&str] = &[
+    "af-ZA", "ar-EG", "ar-SA", "bn-BD", "bg-BG", "ca-ES", "zh-Hans", "zh-Hant", "hr-HR", "cs-CZ",
+    "da-DK", "nl-NL", "en-AU", "en-CA", "en-IN", "en-GB", "en-US", "et-EE", "fi-FI", "fr-BE",
+    "fr-CA", "fr-FR", "de-AT", "de-DE", "de-CH", "el-GR", "he-IL", "hi-IN", "hu-HU", "id-ID",
+    "it-IT", "ja-JP", "ko-KR", "ms-MY", "no-NO", "fa-IR", "pl-PL", "pt-BR", "pt-PT", "ro-RO",
+    "ru-RU", "sk-SK", "es-419", "es-MX", "es-ES", "es-US", "sw-KE", "sv-SE", "tl-PH", "ta-IN",
+    "te-IN", "th-TH", "tr-TR", "uk-UA", "ur-PK", "vi-VN", "cy-GB",
 ];
 
-/// Friendly display name for any tag. Falls back to the raw tag.
+/// Script subtag (ISO 15924) → display name. Names the `Hans` / `Hant` Chinese
+/// distinction (a script, not a region) and the Latin / Cyrillic / Arabic
+/// variants some languages carry. Unrecognized scripts keep their raw subtag.
+const SCRIPTS: &[(&str, &str)] = &[
+    ("Hans", "Simplified"),
+    ("Hant", "Traditional"),
+    ("Latn", "Latin"),
+    ("Cyrl", "Cyrillic"),
+    ("Arab", "Arabic"),
+    ("Deva", "Devanagari"),
+    ("Mong", "Mongolian"),
+];
+
+/// Base language subtag (ISO 639-1, plus a few ISO 639-3) → English name.
+const BASE_LANGUAGES: &[(&str, &str)] = &[
+    ("af", "Afrikaans"),
+    ("am", "Amharic"),
+    ("ar", "Arabic"),
+    ("as", "Assamese"),
+    ("az", "Azerbaijani"),
+    ("ba", "Bashkir"),
+    ("be", "Belarusian"),
+    ("bg", "Bulgarian"),
+    ("bn", "Bengali"),
+    ("bo", "Tibetan"),
+    ("br", "Breton"),
+    ("bs", "Bosnian"),
+    ("ca", "Catalan"),
+    ("cs", "Czech"),
+    ("cy", "Welsh"),
+    ("da", "Danish"),
+    ("de", "German"),
+    ("el", "Greek"),
+    ("en", "English"),
+    ("es", "Spanish"),
+    ("et", "Estonian"),
+    ("eu", "Basque"),
+    ("fa", "Persian"),
+    ("fi", "Finnish"),
+    ("fo", "Faroese"),
+    ("fr", "French"),
+    ("gl", "Galician"),
+    ("gu", "Gujarati"),
+    ("ha", "Hausa"),
+    ("haw", "Hawaiian"),
+    ("he", "Hebrew"),
+    ("hi", "Hindi"),
+    ("hr", "Croatian"),
+    ("ht", "Haitian Creole"),
+    ("hu", "Hungarian"),
+    ("hy", "Armenian"),
+    ("id", "Indonesian"),
+    ("is", "Icelandic"),
+    ("it", "Italian"),
+    ("ja", "Japanese"),
+    ("jw", "Javanese"),
+    ("ka", "Georgian"),
+    ("kk", "Kazakh"),
+    ("km", "Khmer"),
+    ("kn", "Kannada"),
+    ("ko", "Korean"),
+    ("la", "Latin"),
+    ("lb", "Luxembourgish"),
+    ("ln", "Lingala"),
+    ("lo", "Lao"),
+    ("lt", "Lithuanian"),
+    ("lv", "Latvian"),
+    ("mg", "Malagasy"),
+    ("mi", "Maori"),
+    ("mk", "Macedonian"),
+    ("ml", "Malayalam"),
+    ("mn", "Mongolian"),
+    ("mr", "Marathi"),
+    ("ms", "Malay"),
+    ("mt", "Maltese"),
+    ("my", "Burmese"),
+    ("ne", "Nepali"),
+    ("nl", "Dutch"),
+    ("nn", "Norwegian Nynorsk"),
+    ("no", "Norwegian"),
+    ("oc", "Occitan"),
+    ("pa", "Punjabi"),
+    ("pl", "Polish"),
+    ("ps", "Pashto"),
+    ("pt", "Portuguese"),
+    ("ro", "Romanian"),
+    ("ru", "Russian"),
+    ("sa", "Sanskrit"),
+    ("sd", "Sindhi"),
+    ("si", "Sinhala"),
+    ("sk", "Slovak"),
+    ("sl", "Slovenian"),
+    ("sn", "Shona"),
+    ("so", "Somali"),
+    ("sq", "Albanian"),
+    ("sr", "Serbian"),
+    ("su", "Sundanese"),
+    ("sv", "Swedish"),
+    ("sw", "Swahili"),
+    ("ta", "Tamil"),
+    ("te", "Telugu"),
+    ("tg", "Tajik"),
+    ("th", "Thai"),
+    ("tk", "Turkmen"),
+    ("tl", "Tagalog"),
+    ("tr", "Turkish"),
+    ("tt", "Tatar"),
+    ("uk", "Ukrainian"),
+    ("ur", "Urdu"),
+    ("uz", "Uzbek"),
+    ("vi", "Vietnamese"),
+    ("yi", "Yiddish"),
+    ("yo", "Yoruba"),
+    ("yue", "Cantonese"),
+    ("zh", "Chinese"),
+];
+
+/// Region subtag → English name: ISO 3166-1 alpha-2 country codes and UN M.49
+/// area codes (`419` = Latin America).
+const REGIONS: &[(&str, &str)] = &[
+    ("AE", "United Arab Emirates"),
+    ("AR", "Argentina"),
+    ("AT", "Austria"),
+    ("AU", "Australia"),
+    ("BD", "Bangladesh"),
+    ("BE", "Belgium"),
+    ("BG", "Bulgaria"),
+    ("BO", "Bolivia"),
+    ("BR", "Brazil"),
+    ("BY", "Belarus"),
+    ("CA", "Canada"),
+    ("CH", "Switzerland"),
+    ("CL", "Chile"),
+    ("CN", "China"),
+    ("CO", "Colombia"),
+    ("CR", "Costa Rica"),
+    ("CU", "Cuba"),
+    ("CY", "Cyprus"),
+    ("CZ", "Czechia"),
+    ("DE", "Germany"),
+    ("DK", "Denmark"),
+    ("DO", "Dominican Republic"),
+    ("EC", "Ecuador"),
+    ("EE", "Estonia"),
+    ("EG", "Egypt"),
+    ("ES", "Spain"),
+    ("FI", "Finland"),
+    ("FR", "France"),
+    ("GB", "United Kingdom"),
+    ("GE", "Georgia"),
+    ("GR", "Greece"),
+    ("GT", "Guatemala"),
+    ("HK", "Hong Kong"),
+    ("HR", "Croatia"),
+    ("HU", "Hungary"),
+    ("ID", "Indonesia"),
+    ("IE", "Ireland"),
+    ("IL", "Israel"),
+    ("IN", "India"),
+    ("IQ", "Iraq"),
+    ("IR", "Iran"),
+    ("IS", "Iceland"),
+    ("IT", "Italy"),
+    ("JP", "Japan"),
+    ("KE", "Kenya"),
+    ("KR", "South Korea"),
+    ("KZ", "Kazakhstan"),
+    ("LK", "Sri Lanka"),
+    ("LT", "Lithuania"),
+    ("LU", "Luxembourg"),
+    ("LV", "Latvia"),
+    ("MA", "Morocco"),
+    ("MX", "Mexico"),
+    ("MY", "Malaysia"),
+    ("NG", "Nigeria"),
+    ("NL", "Netherlands"),
+    ("NO", "Norway"),
+    ("NP", "Nepal"),
+    ("NZ", "New Zealand"),
+    ("PA", "Panama"),
+    ("PE", "Peru"),
+    ("PH", "Philippines"),
+    ("PK", "Pakistan"),
+    ("PL", "Poland"),
+    ("PT", "Portugal"),
+    ("PY", "Paraguay"),
+    ("RO", "Romania"),
+    ("RS", "Serbia"),
+    ("RU", "Russia"),
+    ("SA", "Saudi Arabia"),
+    ("SE", "Sweden"),
+    ("SG", "Singapore"),
+    ("SI", "Slovenia"),
+    ("SK", "Slovakia"),
+    ("SV", "El Salvador"),
+    ("TH", "Thailand"),
+    ("TR", "Turkey"),
+    ("TW", "Taiwan"),
+    ("UA", "Ukraine"),
+    ("US", "United States"),
+    ("UY", "Uruguay"),
+    ("VE", "Venezuela"),
+    ("VN", "Vietnam"),
+    ("ZA", "South Africa"),
+    ("419", "Latin America"),
+];
+
+/// Case-insensitive lookup in a `(code, name)` table.
+fn lookup(table: &[(&'static str, &'static str)], key: &str) -> Option<&'static str> {
+    table
+        .iter()
+        .find(|&&(code, _)| code.eq_ignore_ascii_case(key))
+        .map(|&(_, name)| name)
+}
+
+/// Whether a BCP-47 subtag has script shape: 4 ASCII letters (e.g. `Hans`).
+fn is_script(sub: &str) -> bool {
+    sub.len() == 4 && sub.chars().all(|c| c.is_ascii_alphabetic())
+}
+
+/// Whether a BCP-47 subtag has region shape: a 2-letter country code or a
+/// 3-digit UN M.49 area code (e.g. `US`, `419`).
+fn is_region(sub: &str) -> bool {
+    (sub.len() == 2 && sub.chars().all(|c| c.is_ascii_alphabetic()))
+        || (sub.len() == 3 && sub.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Friendly display name for any BCP-47 tag.
+///
+/// `auto` becomes "Auto-detect". Otherwise the tag is split into subtags, each
+/// classified by shape: the first is the language, a 4-letter subtag is a
+/// script, and a 2-letter or 3-digit subtag is a region. Recognized subtags
+/// render via their table; unrecognized ones keep their raw code (regions
+/// upper-cased). The result is "Language (qualifier, …)" — so `en-US` renders
+/// "English (United States)", `zh-Hans` renders "Chinese (Simplified)",
+/// `zh-Hans-CN` renders "Chinese (Simplified, China)", `en-XYZ` renders
+/// "English (XYZ)", and a bare unknown `xx` renders "xx".
 #[must_use]
 pub fn friendly_name(tag: &str) -> String {
-    if tag == "auto" {
+    if tag.eq_ignore_ascii_case("auto") {
         return "Auto-detect".to_string();
     }
-    GLOBAL_LANGUAGES
-        .iter()
-        .find(|(t, _)| *t == tag)
-        .map_or_else(|| tag.to_string(), |(_, name)| (*name).to_string())
+    let mut subtags = tag.split('-');
+    let lang = subtags.next().unwrap_or(tag);
+    let name = match lookup(BASE_LANGUAGES, lang) {
+        Some(n) => n.to_string(),
+        None => lang.to_string(),
+    };
+    let mut qualifiers: Vec<String> = Vec::new();
+    for sub in subtags {
+        if sub.is_empty() {
+            continue; // tolerate a trailing/double hyphen without empty parens
+        }
+        if is_script(sub) {
+            qualifiers.push(match lookup(SCRIPTS, sub) {
+                Some(n) => n.to_string(),
+                None => sub.to_string(),
+            });
+        } else if is_region(sub) {
+            qualifiers.push(match lookup(REGIONS, sub) {
+                Some(n) => n.to_string(),
+                None => sub.to_uppercase(),
+            });
+        } else {
+            qualifiers.push(sub.to_string());
+        }
+    }
+    if qualifiers.is_empty() {
+        name
+    } else {
+        format!("{name} ({})", qualifiers.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::friendly_name;
+
+    #[test]
+    fn auto_and_bare_language() {
+        assert_eq!(friendly_name("auto"), "Auto-detect");
+        assert_eq!(friendly_name("en"), "English");
+        assert_eq!(friendly_name("zh"), "Chinese");
+    }
+
+    #[test]
+    fn language_region() {
+        assert_eq!(friendly_name("en-US"), "English (United States)");
+        assert_eq!(friendly_name("es-419"), "Spanish (Latin America)");
+        assert_eq!(friendly_name("zh-CN"), "Chinese (China)");
+        assert_eq!(friendly_name("zh-TW"), "Chinese (Taiwan)");
+    }
+
+    #[test]
+    fn language_script() {
+        assert_eq!(friendly_name("zh-Hans"), "Chinese (Simplified)");
+        assert_eq!(friendly_name("zh-Hant"), "Chinese (Traditional)");
+        assert_eq!(friendly_name("sr-Latn"), "Serbian (Latin)");
+    }
+
+    #[test]
+    fn language_script_region() {
+        // Three subtags (two hyphens) — the script must not be mistaken for the
+        // region, and both qualifiers appear.
+        assert_eq!(friendly_name("zh-Hans-CN"), "Chinese (Simplified, China)");
+        assert_eq!(friendly_name("zh-Hant-TW"), "Chinese (Traditional, Taiwan)");
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(friendly_name("EN-us"), "English (United States)");
+        assert_eq!(friendly_name("zh-hans"), "Chinese (Simplified)");
+    }
+
+    #[test]
+    fn unknown_subtags_kept_raw() {
+        assert_eq!(friendly_name("en-XYZ"), "English (XYZ)");
+        assert_eq!(friendly_name("xx"), "xx");
+    }
+
+    #[test]
+    fn empty_subtags_dropped() {
+        assert_eq!(friendly_name("en-"), "English");
+        assert_eq!(friendly_name("en--US"), "English (United States)");
+    }
 }

--- a/super-stt-app/src/ui/views/language_picker.rs
+++ b/super-stt-app/src/ui/views/language_picker.rs
@@ -11,12 +11,15 @@ pub fn sheet(app: &AppModel) -> Element<'_, Message> {
     let spacing = cosmic::theme::spacing();
     let q = app.language_picker_query.to_lowercase();
 
-    // Build the candidate (tag, label) list for the active mode.
-    let mut rows: Vec<(Option<String>, String)> = Vec::new();
+    // Build the candidate (tag, label) list for the active mode. Special
+    // entries stay pinned at the top; the language entries are sorted
+    // alphabetically by display name.
+    let mut pinned: Vec<(Option<String>, String)> = Vec::new();
+    let mut langs: Vec<(Option<String>, String)> = Vec::new();
     if let Some((ref src, ref mdl)) = app.language_picker_target {
         // Per-model sheet.
-        rows.push((None, "Follow global".to_string())); // clear → DELETE
-        rows.push((Some("auto".to_string()), friendly_name("auto"))); // "Auto-detect"
+        pinned.push((None, "Follow global".to_string())); // clear → DELETE
+        pinned.push((Some("auto".to_string()), friendly_name("auto"))); // "Auto-detect"
         // Supported languages from the resolution block — but only when the
         // block belongs to this exact (source, model) pair (stale-block guard).
         if app.model_language_for.as_ref() == Some(&(src.clone(), mdl.clone()))
@@ -24,17 +27,34 @@ pub fn sheet(app: &AppModel) -> Element<'_, Message> {
             && let Some(arr) = block.get("supported").and_then(|v| v.as_array())
         {
             for tag in arr.iter().filter_map(|v| v.as_str()) {
-                rows.push((Some(tag.to_string()), friendly_name(tag)));
+                if tag.eq_ignore_ascii_case("auto") {
+                    continue; // already pinned as "Auto-detect"
+                }
+                langs.push((Some(tag.to_string()), friendly_name(tag)));
             }
         }
     } else {
-        // Global sheet.
-        rows.push((None, "No preference".to_string())); // clear → DELETE
-        rows.push((Some("auto".to_string()), friendly_name("auto"))); // "Auto-detect"
-        for (tag, name) in GLOBAL_LANGUAGES {
-            rows.push((Some((*tag).to_string()), (*name).to_string()));
+        // Global sheet — "Auto-detect" only; the unset state is reached by not
+        // choosing anything, so there is no explicit "No preference" entry.
+        pinned.push((Some("auto".to_string()), friendly_name("auto"))); // "Auto-detect"
+        for tag in GLOBAL_LANGUAGES {
+            langs.push((Some((*tag).to_string()), friendly_name(tag)));
         }
     }
+    langs.sort_by(|a, b| a.1.cmp(&b.1));
+    // The pinned controls always show; only the language list is narrowed by the
+    // search query, so the user can never filter away "Auto-detect" / "Follow
+    // global".
+    let rows: Vec<(Option<String>, String)> = pinned
+        .into_iter()
+        .chain(langs.into_iter().filter(|(tag, label)| {
+            if q.is_empty() {
+                return true;
+            }
+            let hay = format!("{label} {}", tag.as_deref().unwrap_or("")).to_lowercase();
+            hay.contains(&q)
+        }))
+        .collect();
 
     // Search field pinned at the top.
     let search = text_input("Search languages…", &app.language_picker_query)
@@ -43,18 +63,14 @@ pub fn sheet(app: &AppModel) -> Element<'_, Message> {
 
     let mut list = column::with_capacity(rows.len()).spacing(spacing.space_xxs);
     for (tag, label) in rows {
-        let hay = format!("{label} {}", tag.as_deref().unwrap_or("")).to_lowercase();
-        if !q.is_empty() && !hay.contains(&q) {
-            continue;
-        }
         let msg = if let Some((ref src, ref mdl)) = app.language_picker_target {
             Message::ModelLanguageSelected {
                 source: src.clone(),
                 model: mdl.clone(),
-                choice: tag.clone(),
+                choice: tag,
             }
         } else {
-            Message::PrimaryLanguageSelected(tag.clone())
+            Message::PrimaryLanguageSelected(tag)
         };
         list = list.push(button::text(label).width(Length::Fill).on_press(msg));
     }


### PR DESCRIPTION
Follow-up to #255 polishing the language pickers in the settings app. All app-internal (`super-stt-app/src/ui`), no daemon/protocol changes.

## Display names

`friendly_name` now parses a BCP-47 tag into all its subtags and classifies each by shape — first = language, 4 letters = script, 2 letters / 3 digits = region — composing `Language (qualifier, …)`:

| tag | renders |
|---|---|
| `en` / `es` / `zh` | English / Spanish / Chinese |
| `en-US` | English (United States) |
| `es-419` | Spanish (Latin America) |
| `zh-Hans` / `zh-Hant` | Chinese (Simplified) / (Traditional) |
| `zh-CN` / `zh-HK` | Chinese (China) / (Hong Kong) |
| `zh-Hans-CN` | Chinese (Simplified, China) |
| `sr-Latn` | Serbian (Latin) |
| `en-XYZ` / `en-` | English (XYZ) / English (unknown & empty subtags handled) |

Display names are now derived from one source (base-language / script / region / M.49 tables), so the picker, model card, and global card can't drift.

## Picker behavior

- Global picker dropped the redundant **"No preference"** entry (Auto-detect covers it); the unset state is the initial default.
- Entries sorted **alphabetically** by display name; **"Auto-detect" / "Follow global"** stay pinned on top and are **never filtered away** by the search box.
- Global list broadened (~20 → ~57 region-qualified options across many language families).
- Chinese uses the script subtags `zh-Hans`/`zh-Hant` rather than region proxies, so Simplified/Traditional is honest and doesn't collide with `zh-CN`/`zh-TW` for backends (Deepgram) that list both forms.

## Tests / review

Added a `#[cfg(test)]` module covering the parser (incl. multi-hyphen, case-insensitivity, empty subtags). Ran an xhigh code review: fixed the pinned-controls-get-filtered UX bug and the empty-subtag label defect; verified against the real backend manifests that script-form Chinese tags resolve correctly daemon-side (Deepgram exact-matches `zh-Hans`; Whisper strips to `zh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
