### PR TITLE
Render coverage HTML as a directory tree (no lcov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,7 @@ jobs:
 
       # `cargo llvm-cov` builds the whole workspace, including the COSMIC/iced
       # GUI crates, so it needs the same Wayland/xkbcommon/GTK/dbus/alsa libs
-      # the test and clippy jobs install. `lcov` provides genhtml, used to render
-      # the directory-tree HTML report.
+      # the test and clippy jobs install.
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -168,7 +167,6 @@ jobs:
             libxss-dev \
             libasound2-dev \
             libdbus-1-dev \
-            lcov \
             pkg-config
 
       - name: Install Rust
@@ -208,15 +206,21 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
-      # Render the browsable report with genhtml (from lcov). Unlike llvm-cov's
-      # own --html — a single flat list of every file — genhtml groups by
-      # crate/directory with drill-down, which the workspace needs. Runs on PRs
-      # too so this rendering is exercised before it ever reaches main.
+      # Render the browsable report as a per-directory tree. cargo-llvm-cov's own
+      # --html index is a single flat list of every file; llvm-cov's
+      # -show-directory-coverage adds per-directory index pages, but cargo-llvm-cov
+      # (0.8) doesn't expose that flag. So capture the llvm-cov invocation it runs
+      # (-vv) and re-run it with the flag appended — no extra tooling beyond the
+      # llvm-tools already installed. Runs on PRs too, so the rendering is
+      # exercised before it ever reaches main.
       - name: Render HTML coverage report
         run: |
-          genhtml lcov.info --output-directory coverage-html \
-            --title "Super STT coverage" --legend \
-            --ignore-errors source,inconsistent,corrupt
+          set -euo pipefail
+          cargo llvm-cov report --html --ignore-filename-regex 'tests/' -vv 2> llvmcov-vv.log
+          cmd=$(sed -n 's/.*Running `\(.*llvm-cov show.*\)`.*/\1/p' llvmcov-vv.log | tail -1)
+          test -n "$cmd"
+          eval "$cmd -show-directory-coverage"
+          rm -rf coverage-html && cp -r target/llvm-cov/html coverage-html
 
       # Drop a shields.io "endpoint" JSON inside the report so the README badge
       # reads the latest line-% straight from Pages — no Gist or PAT. jq ships on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,8 @@ jobs:
 
       # `cargo llvm-cov` builds the whole workspace, including the COSMIC/iced
       # GUI crates, so it needs the same Wayland/xkbcommon/GTK/dbus/alsa libs
-      # the test and clippy jobs install.
+      # the test and clippy jobs install. `lcov` provides genhtml, used to render
+      # the directory-tree HTML report.
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -167,6 +168,7 @@ jobs:
             libxss-dev \
             libasound2-dev \
             libdbus-1-dev \
+            lcov \
             pkg-config
 
       - name: Install Rust
@@ -206,22 +208,20 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
-      # --- main only: publish the browsable HTML report to GitHub Pages ---
-      # This repo serves Pages from the `gh-pages` branch (the model registry
-      # index.json + schemas live there), so we can't use actions/deploy-pages —
-      # that requires Pages Source = "GitHub Actions", which would break the
-      # registry deploy. Instead we push the report into a `coverage/` subtree of
-      # the same branch, leaving the registry files untouched.
-      # Served at https://jorge-menjivar.github.io/super-stt/coverage/.
-      - name: Generate HTML coverage report
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: cargo llvm-cov report --html --ignore-filename-regex 'tests/'
+      # Render the browsable report with genhtml (from lcov). Unlike llvm-cov's
+      # own --html — a single flat list of every file — genhtml groups by
+      # crate/directory with drill-down, which the workspace needs. Runs on PRs
+      # too so this rendering is exercised before it ever reaches main.
+      - name: Render HTML coverage report
+        run: |
+          genhtml lcov.info --output-directory coverage-html \
+            --title "Super STT coverage" --legend \
+            --ignore-errors source,inconsistent,corrupt
 
-      # Drop a shields.io "endpoint" JSON beside the HTML so the README badge
+      # Drop a shields.io "endpoint" JSON inside the report so the README badge
       # reads the latest line-% straight from Pages — no Gist or PAT. jq ships on
       # the runner.
       - name: Write coverage badge JSON
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
           pct=$(cargo llvm-cov report --json --summary-only --ignore-filename-regex 'tests/' \
@@ -233,9 +233,22 @@ jobs:
           else color=red
           fi
           printf '{"schemaVersion":1,"label":"coverage","message":"%.1f%%","color":"%s"}\n' \
-            "$pct" "$color" > target/llvm-cov/html/coverage.json
-          cat target/llvm-cov/html/coverage.json
+            "$pct" "$color" > coverage-html/coverage.json
+          cat coverage-html/coverage.json
 
+      # Preview artifact so the rendered tree can be eyeballed from a PR before merge.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage-html
+          path: coverage-html
+
+      # --- main only: publish the browsable HTML report to GitHub Pages ---
+      # This repo serves Pages from the `gh-pages` branch (the model registry
+      # index.json + schemas live there), so we can't use actions/deploy-pages —
+      # that requires Pages Source = "GitHub Actions", which would break the
+      # registry deploy. Instead we push the report into a `coverage/` subtree of
+      # the same branch, leaving the registry files untouched.
+      # Served at https://jorge-menjivar.github.io/super-stt/coverage/.
       - name: Publish coverage to gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
@@ -258,7 +271,7 @@ jobs:
             # report's underscore-prefixed assets; .nojekyll disables that.
             touch .nojekyll
             rm -rf coverage
-            cp -r ../target/llvm-cov/html coverage
+            cp -r ../coverage-html coverage
             git add -A
             if git diff --cached --quiet; then
               echo "coverage report unchanged; nothing to publish"

--- a/justfile
+++ b/justfile
@@ -126,6 +126,13 @@ coverage-lcov:
     cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --lcov --output-path lcov.info
     cargo llvm-cov report --summary-only --ignore-filename-regex 'tests/'
 
+# Render a browsable HTML report (directory tree) from lcov.info via genhtml.
+# llvm-cov's own --html index is a single flat file list; genhtml groups by
+# crate/dir with drill-down. Regenerates lcov.info first; output in
+# target/coverage-html/. Requires: lcov (provides genhtml).
+coverage-html: coverage-lcov
+    genhtml lcov.info --output-directory target/coverage-html --title 'Super STT coverage' --legend --ignore-errors source,inconsistent,corrupt
+
 # Full local CI gate: format, lint, tests, doctests, schemas
 ci: fmt-check check test doctest schema-check
 

--- a/justfile
+++ b/justfile
@@ -126,12 +126,22 @@ coverage-lcov:
     cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --lcov --output-path lcov.info
     cargo llvm-cov report --summary-only --ignore-filename-regex 'tests/'
 
-# Render a browsable HTML report (directory tree) from lcov.info via genhtml.
-# llvm-cov's own --html index is a single flat file list; genhtml groups by
-# crate/dir with drill-down. Regenerates lcov.info first; output in
-# target/coverage-html/. Requires: lcov (provides genhtml).
-coverage-html: coverage-lcov
-    genhtml lcov.info --output-directory target/coverage-html --title 'Super STT coverage' --legend --ignore-errors source,inconsistent,corrupt
+# Render a browsable HTML report with a per-directory tree in target/llvm-cov/html/.
+# cargo-llvm-cov's own --html index is a single flat file list; llvm-cov's
+# -show-directory-coverage adds per-directory index pages. cargo-llvm-cov (0.8)
+# doesn't expose that flag, so capture the llvm-cov invocation it runs and re-run
+# it with the flag appended — no extra tooling beyond the llvm-tools-preview
+# component cargo-llvm-cov already uses. Usage: just coverage-html
+coverage-html *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    vvlog="$(mktemp)"
+    cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --html -vv {{ args }} 2> >(tee "$vvlog" >&2)
+    cmd="$(sed -n 's/.*Running `\(.*llvm-cov show.*\)`.*/\1/p' "$vvlog" | tail -1)"
+    [ -n "$cmd" ] || { echo 'could not capture llvm-cov show command' >&2; exit 1; }
+    eval "$cmd -show-directory-coverage"
+    rm -f "$vvlog"
+    echo 'Report: target/llvm-cov/html/index.html'
 
 # Full local CI gate: format, lint, tests, doctests, schemas
 ci: fmt-check check test doctest schema-check


### PR DESCRIPTION
## Problem

The coverage report published by #260 renders with `llvm-cov`'s own `--html`, whose `index.html` is a single **flat list of every file** — no directory grouping. Fine for a single-crate repo like `super-stt-voxtral`, but unwieldy for this ~240-file workspace.

## Fix (no new dependencies)

`llvm-cov` — already provided by the `llvm-tools-preview` component `cargo-llvm-cov` uses — has a `-show-directory-coverage` flag that renders a navigable **per-directory tree** (per-directory `index.html` pages). `cargo-llvm-cov` 0.8 doesn't expose that flag, so we capture the `llvm-cov show` invocation it runs (via `-vv`) and re-run it with the flag appended. **No `lcov`/`genhtml`, no extra tooling.**

Verified end-to-end: with the flag, llvm-cov emits per-directory index pages; without it, a single flat index.

## Changes

- **`.github/workflows/ci.yml`** — replace the HTML render step: capture cargo-llvm-cov's `llvm-cov show` command and re-run with `-show-directory-coverage`. (No `lcov` apt package.) Render + badge run on **PRs too** and upload a `coverage-html` **preview artifact**; only the gh-pages push stays main-only.
- **`justfile`** — `coverage-html` recipe does the same capture-and-rerun for local use (`cargo install cargo-llvm-cov`; no lcov).

No Rust changes; `lcov.info` (the artifact, produced natively by cargo-llvm-cov) and the gh-pages publish mechanism are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)