### PR TITLE
Require a description in every backend.toml manifest

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -48,13 +48,14 @@ Backend identity and packaging.
 
 ```toml
 [backend]
-source     = "github.com/super-stt/whisper"
-name       = "Whisper (local)"
-version    = "0.1.0"
-kind       = "subprocess"
-entrypoint = "whisper-backend"
-contract   = "v1"
-license    = "Apache-2.0"
+source      = "github.com/super-stt/whisper"
+name        = "Whisper (local)"
+version     = "0.1.0"
+kind        = "subprocess"
+entrypoint  = "whisper-backend"
+contract    = "v1"
+license     = "Apache-2.0"
+description = "Local Whisper speech-to-text."
 ```
 
 | Field        | Type   | Required        | Notes                                                                 |
@@ -66,6 +67,7 @@ license    = "Apache-2.0"
 | `entrypoint` | string | yes             | Path, relative to the backend directory, to the executable (`subprocess`) or the `.wasm` component (`wasm`). |
 | `contract`   | string | yes             | The contract version the backend implements. Must be `v1`; unknown versions are rejected. |
 | `license`    | string | for publication | SPDX identifier of a current OSI-approved or FSF Free/Libre license (e.g. `Apache-2.0`, `MIT`, `GPL-3.0-only`), or the literal `other` for a license outside that set. Required for registry publication; optional for locally installed backends. |
+| `description`| string | yes             | One-line, human-readable summary shown in the registry/Browse listing. |
 
 `license` is checked against the SPDX license list embedded in the registry
 indexer — no network access — and must be a single, current (non-deprecated)
@@ -349,13 +351,14 @@ models ship `config.json`, `tokenizer.json`, and a single
 
 ```toml
 [backend]
-source     = "github.com/super-stt/whisper"
-name       = "Whisper (local)"
-version    = "0.1.0"
-kind       = "subprocess"
-entrypoint = "whisper-backend"
-contract   = "v1"
-license    = "Apache-2.0"
+source      = "github.com/super-stt/whisper"
+name        = "Whisper (local)"
+version     = "0.1.0"
+kind        = "subprocess"
+entrypoint  = "whisper-backend"
+contract    = "v1"
+license     = "Apache-2.0"
+description = "Local Whisper speech-to-text."
 
 [network]
 allowed_hosts = []
@@ -408,13 +411,14 @@ An OpenAI backend. No model files; one egress host; one secret and one option.
 
 ```toml
 [backend]
-source     = "github.com/super-stt/openai"
-name       = "OpenAI"
-version    = "0.1.0"
-kind       = "wasm"
-entrypoint = "openai.wasm"
-contract   = "v1"
-license    = "Apache-2.0"
+source      = "github.com/super-stt/openai"
+name        = "OpenAI"
+version     = "0.1.0"
+kind        = "wasm"
+entrypoint  = "openai.wasm"
+contract    = "v1"
+license     = "Apache-2.0"
+description = "OpenAI cloud transcription API."
 
 [network]
 allowed_hosts = ["api.openai.com"]
@@ -466,6 +470,9 @@ supported_devices   = ["none"]
   plaintext.
 - `[backend].source` must be unique across installed backends; a collision
   is a discovery error for the later backend.
+- `[backend].description` is required: a one-line, human-readable summary
+  shown in the registry/Browse listing. A manifest that omits it fails to
+  parse, and the backend is skipped during discovery.
 - `[backend].license` is required for registry publication: a current
   OSI-approved or FSF Free/Libre SPDX identifier, or the literal `other`. The
   indexer rejects a release whose manifest omits the field or declares an

--- a/super-stt-daemon/src/registry/custom_repo.rs
+++ b/super-stt-daemon/src/registry/custom_repo.rs
@@ -123,7 +123,7 @@ pub async fn resolve(
         version: manifest.backend.version.trim_start_matches('v').to_string(),
         tag: release.tag,
         name: manifest.backend.name,
-        description: manifest.backend.description,
+        description: Some(manifest.backend.description),
         license: manifest.backend.license.unwrap_or_default(),
         kind: manifest.backend.kind,
         contract: manifest.backend.contract,
@@ -333,8 +333,7 @@ struct BackendMeta {
     kind: String,
     entrypoint: String,
     contract: String,
-    #[serde(default)]
-    description: Option<String>,
+    description: String,
     #[serde(default)]
     license: Option<String>,
 }
@@ -471,6 +470,7 @@ mod tests {
             kind = "wasm"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
 
             [assets]
             wasm = "y.wasm"
@@ -498,6 +498,7 @@ mod tests {
             kind = "wasm"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
 
             [assets]
             wasm = "missing.wasm"
@@ -517,6 +518,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[assets.subprocess]]
             file = "y-cpu.tar.gz"
@@ -562,6 +564,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[assets.subprocess]]
             parts = ["y-cuda13.tar.gz.part00", "y-cuda13.tar.gz.part01"]

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -663,6 +663,7 @@ version = "1.0.0"
 kind = "subprocess"
 entrypoint = "x"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "m"

--- a/super-stt-daemon/src/registry/local_dir.rs
+++ b/super-stt-daemon/src/registry/local_dir.rs
@@ -75,7 +75,7 @@ pub fn resolve(local_path: &Path) -> Result<IndexBackend, ResolveError> {
         version,
         tag,
         name: m.backend.name.clone(),
-        description: None,
+        description: Some(m.backend.description.clone()),
         license: String::new(),
         kind: m.backend.kind.to_string(),
         contract: m.backend.contract.to_string(),
@@ -130,6 +130,7 @@ version = "1.2.3"
 kind = "wasm"
 entrypoint = "y.wasm"
 contract = "v1"
+description = "Test backend."
 "#;
 
     #[test]

--- a/super-stt-daemon/src/stt_models/backends/manifest.rs
+++ b/super-stt-daemon/src/stt_models/backends/manifest.rs
@@ -69,6 +69,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[secrets]]
 name = "openai_api_key"
@@ -96,6 +97,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[secrets]]
 name = "openai_api_key"
@@ -117,6 +119,7 @@ version = "0.2.0"
 kind = "wasm"
 entrypoint = "mistral.wasm"
 contract = "v1"
+description = "Test backend."
 
 [capabilities]
 websocket = true
@@ -135,6 +138,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 "#;
         let m = Manifest::parse(toml_src).expect("parse");
         assert!(!m.capabilities.websocket);
@@ -150,6 +154,7 @@ version = "0.2.0"
 kind = "wasm"
 entrypoint = "mistral.wasm"
 contract = "v1"
+description = "Test backend."
 
 [capabilities]
 websocket = true
@@ -177,6 +182,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "mistral.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "voxtral-mini-latest"
@@ -200,6 +206,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "super-stt-backend-whisper"
 contract = "v1"
+description = "Test backend."
 
 [capabilities]
 websocket = true
@@ -219,6 +226,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "whisper-backend"
 contract = "v1"
+description = "Test backend."
 
 [network]
 allowed_hosts = ["api.example.com"]
@@ -238,6 +246,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [network]
 allowed_hosts = ["api.openai.com"]
@@ -256,6 +265,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "whisper-backend"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-tiny"
@@ -281,6 +291,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "whisper-backend"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-en"
@@ -306,6 +317,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "whisper-backend"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-en"
@@ -330,6 +342,7 @@ version = "0.2.0"
 kind = "wasm"
 entrypoint = "mistral.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "voxtral-mini-transcribe-realtime-2602"
@@ -361,6 +374,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[options]]
 name = "base_url"
@@ -406,6 +420,7 @@ version = "1.0.0"
 kind = "subprocess"
 entrypoint = "/usr/bin/python3"
 contract = "v1"
+description = "Test backend."
 "#,
         )
         .unwrap();

--- a/super-stt-daemon/src/stt_models/backends/mod_tests.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod_tests.rs
@@ -29,6 +29,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [network]
 allowed_hosts = ["api.openai.com"]
@@ -67,6 +68,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "super-stt-backend-voxtral"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "voxtral-mini"
@@ -176,6 +178,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-1"
@@ -210,6 +213,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-1"
@@ -244,6 +248,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-1"
@@ -276,6 +281,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "whisper-1"
@@ -345,6 +351,7 @@ version = "0.1.0"
 kind = "wasm"
 entrypoint = "{dir}.wasm"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "{dir}-base"
@@ -448,6 +455,7 @@ version = "0.1.0"
 kind = "subprocess"
 entrypoint = "qwen3-asr"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "qwen3-asr-0.6b"

--- a/super-stt-daemon/tests/fixtures/dummy-backend.toml
+++ b/super-stt-daemon/tests/fixtures/dummy-backend.toml
@@ -9,6 +9,7 @@ version = "1.2.3"
 kind = "wasm"
 entrypoint = "dummy.wasm"
 contract = "v1"
+description = "Test backend."
 license = "Apache-2.0"
 
 [network]

--- a/super-stt-daemon/tests/http_smoke_backend_options.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_options.rs
@@ -69,6 +69,7 @@ version = "1.0.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 license = "Apache-2.0"
 
 [network]

--- a/super-stt-daemon/tests/http_smoke_backend_secrets.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_secrets.rs
@@ -72,6 +72,7 @@ version = "1.0.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 license = "Apache-2.0"
 
 [network]

--- a/super-stt-daemon/tests/http_smoke_language.rs
+++ b/super-stt-daemon/tests/http_smoke_language.rs
@@ -69,6 +69,7 @@ version = "1.0.0"
 kind = "wasm"
 entrypoint = "openai.wasm"
 contract = "v1"
+description = "Test backend."
 license = "Apache-2.0"
 
 [network]

--- a/super-stt-daemon/tests/subprocess_mock.rs
+++ b/super-stt-daemon/tests/subprocess_mock.rs
@@ -29,6 +29,7 @@ version = "0.0.0"
 kind = "subprocess"
 entrypoint = "mock-backend"
 contract = "v1"
+description = "Test backend."
 
 [[models]]
 name = "mock"

--- a/super-stt-indexer/src/local.rs
+++ b/super-stt-indexer/src/local.rs
@@ -251,6 +251,7 @@ mod tests {
             kind = "wasm"
             entrypoint = "dummy.wasm"
             contract = "v1"
+            description = "Test backend."
 
             [assets]
             wasm = "dummy.wasm"

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -297,7 +297,7 @@ pub(crate) fn into_index_backend(
         version,
         tag,
         name: m.backend.name,
-        description: m.backend.description,
+        description: Some(m.backend.description),
         license: m.backend.license.unwrap_or_default(),
         kind: m.backend.kind.to_string(),
         contract: m.backend.contract.to_string(),

--- a/super-stt-indexer/src/manifest.rs
+++ b/super-stt-indexer/src/manifest.rs
@@ -107,6 +107,7 @@ mod tests {
         kind = "wasm"
         entrypoint = "y.wasm"
         contract = "v1"
+        description = "Test backend."
         license = "Apache-2.0"
 
         [assets]
@@ -161,6 +162,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "../escape"
             contract = "v1"
+            description = "Test backend."
         "#;
         let err: ManifestError = Manifest::parse(t).unwrap_err().into();
         assert!(matches!(
@@ -179,6 +181,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
             license = "Apache-2.0"
 
             [[assets.subprocess]]
@@ -201,6 +204,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
             license = "Apache-2.0"
 
             [[assets.subprocess]]

--- a/super-stt-indexer/tests/integration.rs
+++ b/super-stt-indexer/tests/integration.rs
@@ -16,6 +16,7 @@ version = "1.0.0"
 kind = "wasm"
 entrypoint = "y.wasm"
 contract = "v1"
+description = "Test backend."
 license = "Apache-2.0"
 
 [assets]

--- a/super-stt-indexer/tests/local.rs
+++ b/super-stt-indexer/tests/local.rs
@@ -32,6 +32,7 @@ version = "{version}"
 kind = "wasm"
 entrypoint = "{wasm_file}"
 contract = "v1"
+description = "Test backend."
 license = "Apache-2.0"
 
 [assets]

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -74,9 +74,9 @@ pub struct BackendMeta {
     /// a manifest that omits the field or declares an unrecognized value.
     #[serde(default)]
     pub license: Option<String>,
-    /// One-line summary shown in the registry/Browse listing.
-    #[serde(default)]
-    pub description: Option<String>,
+    /// One-line, human-readable summary shown in the registry/Browse listing.
+    /// Required for every backend.
+    pub description: String,
 }
 
 /// Transport a backend uses: a wasm32 component or a native executable.
@@ -568,6 +568,7 @@ mod tests {
             kind = "wasm"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
 
             [assets]
             wasm = "y.wasm"
@@ -614,9 +615,28 @@ mod tests {
             kind = "wasm"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
 
             [[secrets]]
             name = "y_api_key"
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("description"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_backend_without_description() {
+        let err = Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
             "#,
         )
         .unwrap_err()
@@ -635,6 +655,7 @@ mod tests {
             kind = "container"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
             "#,
         )
         .unwrap_err()
@@ -654,6 +675,7 @@ mod tests {
                 kind = "wasm"
                 entrypoint = "y.wasm"
                 contract = "v1"
+                description = "Test backend."
 
                 [[models]]
                 name = "m"
@@ -691,6 +713,7 @@ mod tests {
                 kind = "subprocess"
                 entrypoint = "{bad}"
                 contract = "v1"
+                description = "Test backend."
                 "#
             );
             let err = Manifest::parse(&text).unwrap_err();
@@ -715,6 +738,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[models]]
             name = "m1"
@@ -761,6 +785,7 @@ mod tests {
                 kind = "subprocess"
                 entrypoint = "y"
                 contract = "v1"
+                description = "Test backend."
 
                 [[models]]
                 name = "m"
@@ -812,6 +837,7 @@ mod tests {
             kind = "wasm"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
 
             [[options]]
             name = "a"
@@ -845,6 +871,7 @@ mod tests {
             kind = "wasm"
             entrypoint = "y.wasm"
             contract = "v1"
+            description = "Test backend."
             future_field = "ignored"
 
             [future_table]
@@ -866,6 +893,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[assets.subprocess]]
             file = "y-cuda13.tar.gz"
@@ -893,6 +921,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[assets.subprocess]]
             parts = ["y-cuda13.tar.gz.part00", "y-cuda13.tar.gz.part01"]
@@ -922,6 +951,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[assets.subprocess]]
             file = "y.tar.gz"
@@ -945,6 +975,7 @@ mod tests {
             kind = "subprocess"
             entrypoint = "y"
             contract = "v1"
+            description = "Test backend."
 
             [[assets.subprocess]]
             target = "x86_64-unknown-linux-gnu"

--- a/super-stt-registry-types/tests/schema_validation.rs
+++ b/super-stt-registry-types/tests/schema_validation.rs
@@ -62,7 +62,7 @@ fn wasm_base() -> Value {
     json!({
         "backend": { "source": "github.com/x/y", "name": "Y", "version": "1.0.0",
                       "kind": "wasm", "entrypoint": "y.wasm", "contract": "v1",
-                      "license": "Apache-2.0" },
+                      "license": "Apache-2.0", "description": "Y backend." },
         "assets": { "wasm": "y.wasm" }
     })
 }
@@ -71,7 +71,7 @@ fn sub_base() -> Value {
     json!({
         "backend": { "source": "github.com/x/y", "name": "Y", "version": "1.0.0",
                       "kind": "subprocess", "entrypoint": "y", "contract": "v1",
-                      "license": "Apache-2.0" },
+                      "license": "Apache-2.0", "description": "Y backend." },
         "assets": { "subprocess": [
             { "file": "y.tgz", "target": "x86_64-unknown-linux-gnu", "accel": "cpu" }
         ] }


### PR DESCRIPTION
## What

Make `[backend].description` a **required** field in `backend.toml` (it was optional). Mirrors how the existing `[[secrets]]`/`[[options]]` descriptions are already required.

## Why

Every backend should carry a one-line summary for the registry/Browse listing; making it optional meant a backend could ship without one.

## How

- **Canonical parser** (`super-stt-registry-types/src/manifest.rs`): `BackendMeta.description` is now `String` (was `Option<String>` + `#[serde(default)]`). Serde rejects any manifest omitting it — daemon discovery, indexer publication, and local installs alike. The generated JSON Schema marks it `required` automatically.
- **Custom-repo loose parser** (`daemon/registry/custom_repo.rs`): its own private `BackendMeta` also made required, so the Custom-repo install path enforces it too.
- **Producers** wrap the now-required field into the `Option` wire types; `local_dir` now surfaces the description for locally-installed backends (was dropped).
- **Wire/index types stay `Option<String>`** (`index.json`, daemon `IndexBackend`, shared catalog) to keep deserializing pre-existing index entries.
- Updated the contract doc (`docs/protocol/backend/config.md`: table row, examples, validation bullet) and every test/fixture manifest.

## Verification

- `registry-types`: 34 manifest + 6 schema tests pass (incl. new `rejects_backend_without_description`).
- `indexer`: 42 lib + 1 integration + 4 local pass. `daemon --lib`: 196 pass.
- Full workspace compiles (`cargo test --no-run`); standard clippy clean.
- Schema confirmed: `BackendMeta.required` includes `description` (`license` stays optional).
- Daemon HTTP integration tests not run locally (they hang on a locked keyring); they compile and their fixtures carry a description. The install path writes the pinned `backend.toml` verbatim, so installed backends always have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)