### PR TITLE
Revert coverage report to flat llvm-cov HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,20 +206,14 @@ jobs:
           name: coverage-lcov
           path: lcov.info
 
-      # Render the browsable report as a per-directory tree. cargo-llvm-cov's own
-      # --html index is a single flat list of every file; llvm-cov's
-      # -show-directory-coverage adds per-directory index pages, but cargo-llvm-cov
-      # (0.8) doesn't expose that flag. So capture the llvm-cov invocation it runs
-      # (-vv) and re-run it with the flag appended — no extra tooling beyond the
-      # llvm-tools already installed. Runs on PRs too, so the rendering is
-      # exercised before it ever reaches main.
+      # Render the browsable report. cargo-llvm-cov's --html index is a single flat
+      # list of every file; per-file pages show line-level coverage. (A directory
+      # tree would need lcov's genhtml or grcov; we intentionally keep to the
+      # llvm-cov toolchain and accept the flat index.) Runs on PRs too, so the
+      # rendering is exercised before it ever reaches main.
       - name: Render HTML coverage report
         run: |
-          set -euo pipefail
-          cargo llvm-cov report --html --ignore-filename-regex 'tests/' -vv 2> llvmcov-vv.log
-          cmd=$(sed -n 's/.*Running `\(.*llvm-cov show.*\)`.*/\1/p' llvmcov-vv.log | tail -1)
-          test -n "$cmd"
-          eval "$cmd -show-directory-coverage"
+          cargo llvm-cov report --html --ignore-filename-regex 'tests/'
           rm -rf coverage-html && cp -r target/llvm-cov/html coverage-html
 
       # Drop a shields.io "endpoint" JSON inside the report so the README badge

--- a/justfile
+++ b/justfile
@@ -126,22 +126,11 @@ coverage-lcov:
     cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --lcov --output-path lcov.info
     cargo llvm-cov report --summary-only --ignore-filename-regex 'tests/'
 
-# Render a browsable HTML report with a per-directory tree in target/llvm-cov/html/.
-# cargo-llvm-cov's own --html index is a single flat file list; llvm-cov's
-# -show-directory-coverage adds per-directory index pages. cargo-llvm-cov (0.8)
-# doesn't expose that flag, so capture the llvm-cov invocation it runs and re-run
-# it with the flag appended — no extra tooling beyond the llvm-tools-preview
-# component cargo-llvm-cov already uses. Usage: just coverage-html
+# Render a browsable HTML report to target/llvm-cov/html/. The index is a single
+# flat file list (cargo-llvm-cov's default); per-file pages show line-level
+# coverage. Usage: just coverage-html
 coverage-html *args:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    vvlog="$(mktemp)"
-    cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --html -vv {{ args }} 2> >(tee "$vvlog" >&2)
-    cmd="$(sed -n 's/.*Running `\(.*llvm-cov show.*\)`.*/\1/p' "$vvlog" | tail -1)"
-    [ -n "$cmd" ] || { echo 'could not capture llvm-cov show command' >&2; exit 1; }
-    eval "$cmd -show-directory-coverage"
-    rm -f "$vvlog"
-    echo 'Report: target/llvm-cov/html/index.html'
+    cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --html {{ args }}
 
 # Full local CI gate: format, lint, tests, doctests, schemas
 ci: fmt-check check test doctest schema-check


### PR DESCRIPTION
## Problem

The directory-tree render from #261 produces a **broken report (live 404 on gh-pages)**. `llvm-cov -show-directory-coverage` groups by *longest common string prefix*; since every crate is `super-stt-*`, it treats `super-stt-` as the root — emitting a root redirect to `coverage/super-stt-index.html` (nonexistent) and internal links to `app/`, `daemon/` (prefix stripped) while files stay in `super-stt-app/`, `super-stt-daemon/`. Every link breaks.

## Fix

Go back to cargo-llvm-cov's plain `--html` render (the working approach from #260). The index is a single flat file list, but per-file pages show line-level coverage and **all links resolve**. A real directory tree would require lcov's `genhtml` or `grcov`; per request we stay on the llvm-cov toolchain and accept the flat index.

The publish step's `rm -rf coverage` replaces the broken `coverage/` subtree on gh-pages with this correct flat output once merged + the main-push coverage job runs.

## Changes

- **`.github/workflows/ci.yml`** — render step back to `cargo llvm-cov report --html` (no `-show-directory-coverage`/`-vv` capture hack). Badge, artifact, and gh-pages publish unchanged.
- **`justfile`** — `coverage-html` recipe back to a one-line `cargo llvm-cov … --html`.

No new dependencies. Verified locally: the flat index's per-file links resolve (no 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)