### PR TITLE
Guarantee old configs survive upgrade + gate releases on it

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -37,8 +37,51 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  config-compat:
+    name: Old config compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libxkbcommon-x11-dev \
+            libegl1-mesa-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxss-dev \
+            libasound2-dev \
+            libdbus-1-dev \
+            pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-config-compat-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Load old config fixtures
+        run: just config-compat
+
   build-apps:
     name: Build App Binaries (Beta)
+    needs: config-compat
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,51 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  config-compat:
+    name: Old config compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libxkbcommon-x11-dev \
+            libegl1-mesa-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxss-dev \
+            libasound2-dev \
+            libdbus-1-dev \
+            pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-config-compat-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Load old config fixtures
+        run: just config-compat
+
   build-apps:
     name: Build App Binaries
+    needs: config-compat
     strategy:
       matrix:
         include:

--- a/fixtures/configs/README.md
+++ b/fixtures/configs/README.md
@@ -1,0 +1,10 @@
+# Old-config compatibility fixtures
+
+Each `vX.Y.Z/` directory holds the configuration file(s) that release persisted,
+hand-derived from that tag's source. They are loaded by the daemon and applet
+config tests (`just config-compat`) to prove the current code still loads configs
+written by older releases — it must load, migrate, or reset, never crash.
+
+**On every release, add a `vX.Y.Z/` directory** with the configs that version
+wrote (`daemon.toml`, `applet-full.toml`). Do not reformat existing files — they
+represent real on-disk user configs.

--- a/fixtures/configs/v0.1.0/applet-full.toml
+++ b/fixtures/configs/v0.1.0/applet-full.toml
@@ -1,0 +1,17 @@
+[visualization]
+theme = "CenteredEqualizer"
+side = "Full"
+
+[visualization.colors]
+light_colors = "SystemAccent"
+dark_colors = "SystemAccent"
+
+[audio]
+theme = "Classic"
+
+[ui]
+last_popup_state = "None"
+show_icon = true
+icon_alignment = "end"
+applet_width = 120
+show_visualization = true

--- a/fixtures/configs/v0.1.0/daemon.toml
+++ b/fixtures/configs/v0.1.0/daemon.toml
@@ -1,0 +1,10 @@
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "Classic"
+
+[transcription]
+preferred_model = "WhisperBase"
+write_mode = false
+preview_typing_enabled = false

--- a/fixtures/configs/v0.1.1/applet-full.toml
+++ b/fixtures/configs/v0.1.1/applet-full.toml
@@ -1,0 +1,17 @@
+[visualization]
+theme = "Pulse"
+side = "Full"
+
+[visualization.colors]
+light_colors = "Blue"
+dark_colors = "DarkBlue"
+
+[audio]
+theme = "Gentle"
+
+[ui]
+last_popup_state = "None"
+show_icon = true
+icon_alignment = "start"
+applet_width = 140
+show_visualization = true

--- a/fixtures/configs/v0.1.1/daemon.toml
+++ b/fixtures/configs/v0.1.1/daemon.toml
@@ -1,0 +1,10 @@
+[device]
+preferred_device = "cuda"
+
+[audio]
+theme = "Minimal"
+
+[transcription]
+preferred_model = "WhisperSmallEn"
+write_mode = true
+preview_typing_enabled = false

--- a/fixtures/configs/v0.1.2/applet-full.toml
+++ b/fixtures/configs/v0.1.2/applet-full.toml
@@ -1,0 +1,17 @@
+[visualization]
+theme = "BottomEqualizer"
+side = "Left"
+
+[visualization.colors]
+light_colors = "Green"
+dark_colors = "DarkGreen"
+
+[audio]
+theme = "Nature"
+
+[ui]
+last_popup_state = "None"
+show_icon = false
+icon_alignment = "end"
+applet_width = 160
+show_visualization = false

--- a/fixtures/configs/v0.1.2/daemon.toml
+++ b/fixtures/configs/v0.1.2/daemon.toml
@@ -1,0 +1,12 @@
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "SciFi"
+
+[transcription]
+preferred_model = "WhisperLargeV3"
+write_mode = false
+preview_typing_enabled = true
+recording_stop_mode = "SilenceOnly"
+write_method = "WaylandProtocol"

--- a/fixtures/configs/v0.1.3/applet-full.toml
+++ b/fixtures/configs/v0.1.3/applet-full.toml
@@ -1,0 +1,14 @@
+[visualization]
+theme = "Waveform"
+side = "Full"
+
+[visualization.colors]
+light_colors = "Blue"
+dark_colors = "PastelGreen"
+
+[ui]
+last_popup_state = "None"
+show_icon = true
+icon_alignment = "end"
+applet_width = 150
+show_visualization = true

--- a/fixtures/configs/v0.1.3/daemon.toml
+++ b/fixtures/configs/v0.1.3/daemon.toml
@@ -1,0 +1,17 @@
+[device]
+preferred_device = "cuda"
+
+[audio]
+theme = "Gentle"
+volume = 80
+
+[transcription]
+preferred_model = "WhisperLargeV3Turbo"
+write_mode = true
+preview_typing_enabled = false
+recording_stop_mode = "ManualOnly"
+write_method = "Ydotool"
+model_override_path = "/home/user/my-models"
+
+[online]
+allow_online_models = true

--- a/justfile
+++ b/justfile
@@ -104,6 +104,11 @@ fmt:
 test *args:
     cargo test {{ args }}
 
+# Load every committed old-config fixture against the current config types.
+config-compat *args:
+    cargo test -p super-stt-daemon --lib config {{ args }}
+    cargo test -p super-stt-cosmic-applet --lib config {{ args }}
+
 # Run doctests
 doctest *args:
     cargo test --doc {{ args }}

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -237,27 +237,18 @@ mod upgrade_compat_tests {
     use super::AppletConfig;
     use crate::models::theme::{VisualizationColor, VisualizationTheme, WorkingAnimationTheme};
 
-    /// A complete v0.1.3 `applet-full.toml` (no `working_animation` — added later).
-    const V0_1_3_APPLET_TOML: &str = r#"
-[visualization]
-theme = "Waveform"
-side = "Full"
-
-[visualization.colors]
-light_colors = "Blue"
-dark_colors = "PastelGreen"
-
-[ui]
-last_popup_state = "None"
-show_icon = true
-icon_alignment = "end"
-applet_width = 150
-show_visualization = true
-"#;
+    /// The committed v0.1.3 `applet-full.toml` fixture. The canonical copy lives
+    /// in the on-disk corpus so the release gate and these detailed assertions
+    /// test the same bytes.
+    fn v0_1_3_applet_fixture() -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../fixtures/configs/v0.1.3/applet-full.toml");
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    }
 
     #[test]
     fn v0_1_3_full_applet_config_loads() {
-        let (cfg, was_reset) = AppletConfig::parse_or_reset(V0_1_3_APPLET_TOML);
+        let (cfg, was_reset) = AppletConfig::parse_or_reset(&v0_1_3_applet_fixture());
         assert!(!was_reset, "a valid v0.1.3 applet config must load, not reset");
         assert_eq!(cfg.visualization.theme, VisualizationTheme::Waveform);
         assert_eq!(cfg.visualization.colors.light_colors, VisualizationColor::Blue);
@@ -267,6 +258,37 @@ show_visualization = true
         assert_eq!(
             cfg.visualization.working_animation,
             WorkingAnimationTheme::default()
+        );
+    }
+
+    #[test]
+    fn all_published_applet_configs_load_cleanly() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../fixtures/configs");
+        let mut checked = 0;
+        for entry in std::fs::read_dir(&dir).expect("fixtures/configs dir must exist") {
+            let version_dir = entry.expect("readable dir entry").path();
+            if !version_dir.is_dir() {
+                continue; // skip README.md and any other non-version files
+            }
+            for file in std::fs::read_dir(&version_dir).expect("readable version dir") {
+                let path = file.expect("readable file entry").path();
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if !(name.starts_with("applet-") && name.ends_with(".toml")) {
+                    continue;
+                }
+                let content = std::fs::read_to_string(&path).expect("read applet fixture");
+                let (_, was_reset) = AppletConfig::parse_or_reset(&content);
+                assert!(
+                    !was_reset,
+                    "applet fixture {} must load cleanly (no reset)",
+                    path.display()
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked >= 4,
+            "expected >= 4 applet fixtures (v0.1.0-v0.1.3), found {checked}"
         );
     }
 

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -249,9 +249,15 @@ mod upgrade_compat_tests {
     #[test]
     fn v0_1_3_full_applet_config_loads() {
         let (cfg, was_reset) = AppletConfig::parse_or_reset(&v0_1_3_applet_fixture());
-        assert!(!was_reset, "a valid v0.1.3 applet config must load, not reset");
+        assert!(
+            !was_reset,
+            "a valid v0.1.3 applet config must load, not reset"
+        );
         assert_eq!(cfg.visualization.theme, VisualizationTheme::Waveform);
-        assert_eq!(cfg.visualization.colors.light_colors, VisualizationColor::Blue);
+        assert_eq!(
+            cfg.visualization.colors.light_colors,
+            VisualizationColor::Blue
+        );
         assert_eq!(cfg.ui.applet_width, 150);
         assert_eq!(cfg.ui.icon_alignment, "end");
         // New field materializes at its default.
@@ -319,7 +325,10 @@ show_visualization = true
 "#;
         let cfg: AppletConfig = toml::from_str(toml_str).expect("must parse, not error");
         assert_eq!(cfg.visualization.theme, VisualizationTheme::default()); // reset
-        assert_eq!(cfg.visualization.colors.light_colors, VisualizationColor::Blue); // preserved
+        assert_eq!(
+            cfg.visualization.colors.light_colors,
+            VisualizationColor::Blue
+        ); // preserved
         assert_eq!(cfg.ui.applet_width, 150); // preserved
         assert!(cfg.ui.show_icon);
     }

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -13,11 +13,23 @@ pub struct AppletConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisualizationConfig {
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub theme: VisualizationTheme,
-    pub side: VisualizationSide, // This will be fixed per binary but stored for completeness
+    // This will be fixed per binary but stored for completeness.
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
+    pub side: VisualizationSide,
     pub colors: VisualizationColorConfig,
     /// Animation shown while the daemon transcribes (`Processing` state).
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub working_animation: WorkingAnimationTheme,
 }
 
@@ -63,32 +75,30 @@ impl AppletConfig {
         config_dir.join(format!("applet-{variant}.toml"))
     }
 
+    /// Parse applet config `content`, falling back to defaults on a parse
+    /// error. Pure (no I/O) so the load/reset decision is unit-testable.
+    /// Returns the config and whether a reset occurred.
+    fn parse_or_reset(content: &str) -> (Self, bool) {
+        match toml::from_str::<AppletConfig>(content) {
+            Ok(config) => (config, false),
+            Err(e) => {
+                warn!("Failed to parse applet config: {e}. Using defaults.");
+                (Self::default(), true)
+            }
+        }
+    }
+
     /// Load configuration from disk for a specific variant
     pub fn load(variant: &str, vis_side: VisualizationSide) -> Self {
         let config_path = Self::get_config_path(variant);
 
-        if let Ok(content) = fs::read_to_string(&config_path) {
-            match toml::from_str::<AppletConfig>(&content) {
-                Ok(mut config) => {
-                    // Always override the vis_side with the binary-specific value
-                    config.visualization.side = vis_side;
-                    config
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to parse config file {}: {e}. Using defaults.",
-                        config_path.display()
-                    );
-                    let mut config = Self::default();
-                    config.visualization.side = vis_side;
-                    config
-                }
-            }
-        } else {
-            let mut config = Self::default();
-            config.visualization.side = vis_side;
-            config
-        }
+        let mut config = match fs::read_to_string(&config_path) {
+            Ok(content) => Self::parse_or_reset(&content).0,
+            Err(_) => Self::default(),
+        };
+        // Always override the vis_side with the binary-specific value.
+        config.visualization.side = vis_side;
+        config
     }
 
     /// Save configuration to disk for a specific variant
@@ -219,5 +229,76 @@ mod working_animation_config_tests {
             cfg.visualization.working_animation,
             WorkingAnimationTheme::Droplet
         );
+    }
+}
+
+#[cfg(test)]
+mod upgrade_compat_tests {
+    use super::AppletConfig;
+    use crate::models::theme::{VisualizationColor, VisualizationTheme, WorkingAnimationTheme};
+
+    /// A complete v0.1.3 `applet-full.toml` (no `working_animation` — added later).
+    const V0_1_3_APPLET_TOML: &str = r#"
+[visualization]
+theme = "Waveform"
+side = "Full"
+
+[visualization.colors]
+light_colors = "Blue"
+dark_colors = "PastelGreen"
+
+[ui]
+last_popup_state = "None"
+show_icon = true
+icon_alignment = "end"
+applet_width = 150
+show_visualization = true
+"#;
+
+    #[test]
+    fn v0_1_3_full_applet_config_loads() {
+        let (cfg, was_reset) = AppletConfig::parse_or_reset(V0_1_3_APPLET_TOML);
+        assert!(!was_reset, "a valid v0.1.3 applet config must load, not reset");
+        assert_eq!(cfg.visualization.theme, VisualizationTheme::Waveform);
+        assert_eq!(cfg.visualization.colors.light_colors, VisualizationColor::Blue);
+        assert_eq!(cfg.ui.applet_width, 150);
+        assert_eq!(cfg.ui.icon_alignment, "end");
+        // New field materializes at its default.
+        assert_eq!(
+            cfg.visualization.working_animation,
+            WorkingAnimationTheme::default()
+        );
+    }
+
+    #[test]
+    fn corrupt_applet_config_resets_to_default() {
+        let (cfg, was_reset) = AppletConfig::parse_or_reset("not ::: valid toml [");
+        assert!(was_reset, "garbage input must trigger a reset");
+        assert_eq!(cfg.visualization.theme, VisualizationTheme::default());
+    }
+
+    #[test]
+    fn applet_bad_theme_falls_back_preserving_rest() {
+        let toml_str = r#"
+[visualization]
+theme = "Nonexistent"
+side = "Full"
+
+[visualization.colors]
+light_colors = "Blue"
+dark_colors = "PastelGreen"
+
+[ui]
+last_popup_state = "None"
+show_icon = true
+icon_alignment = "end"
+applet_width = 150
+show_visualization = true
+"#;
+        let cfg: AppletConfig = toml::from_str(toml_str).expect("must parse, not error");
+        assert_eq!(cfg.visualization.theme, VisualizationTheme::default()); // reset
+        assert_eq!(cfg.visualization.colors.light_colors, VisualizationColor::Blue); // preserved
+        assert_eq!(cfg.ui.applet_width, 150); // preserved
+        assert!(cfg.ui.show_icon);
     }
 }

--- a/super-stt-cosmic-applet/src/models/theme.rs
+++ b/super-stt-cosmic-applet/src/models/theme.rs
@@ -125,8 +125,9 @@ impl VisualizationSide {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub enum VisualizationColor {
+    #[default]
     SystemAccent, // COSMIC system accent color
     White,
     Black,
@@ -293,7 +294,15 @@ impl VisualizationColor {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisualizationColorConfig {
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub light_colors: VisualizationColor,
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub dark_colors: VisualizationColor,
 }
 

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use log::{debug, error, warn};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -8,27 +8,6 @@ use super_stt_shared::models::provider::Provider;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::models::write_method::WriteMethod;
 use super_stt_shared::theme::AudioTheme;
-
-/// Deserialize a value via its serde impl, falling back to `Default` if the
-/// stored representation is no longer recognized (e.g. a TOML field saved by
-/// an older build using a stale format). Logs a warning so the migration is
-/// observable. The model loader has its own fallback for invalid (model,
-/// provider) combinations, so a single bad field shouldn't fail the whole
-/// config.
-fn deserialize_or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-where
-    T: Default + serde::de::DeserializeOwned,
-    D: Deserializer<'de>,
-{
-    let raw = serde_json::Value::deserialize(deserializer)?;
-    match serde_json::from_value::<T>(raw.clone()) {
-        Ok(value) => Ok(value),
-        Err(e) => {
-            warn!("config field {raw} unrecognized ({e}); using default");
-            Ok(T::default())
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonConfig {
@@ -71,6 +50,10 @@ pub struct DeviceConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AudioConfig {
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub theme: AudioTheme,
     #[serde(default = "default_volume")]
     pub volume: u8,
@@ -92,7 +75,10 @@ pub struct OnlineConfig {
 pub struct TranscriptionConfig {
     #[serde(default)]
     pub preferred_model: String,
-    #[serde(default, deserialize_with = "deserialize_or_default")]
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub preferred_provider: Provider,
     /// Repo id of the backend that serves the preferred model. Empty means the
     /// daemon picks the first installed backend serving `(model, provider)`.
@@ -102,9 +88,15 @@ pub struct TranscriptionConfig {
     pub write_mode: bool, // Auto-type transcriptions
     #[serde(default)] // For backwards compatibility with existing configs
     pub preview_typing_enabled: bool, // Beta feature: show preview while typing
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub recording_stop_mode: RecordingStopMode,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
     pub write_method: WriteMethod,
     /// Vestigial: retained for config compatibility. Custom models are now
     /// provided as backends discovered under [`backends_dir`].
@@ -170,42 +162,49 @@ impl DaemonConfig {
         config_dir.join("daemon.toml")
     }
 
+    /// Parse config file `content` into a [`DaemonConfig`], falling back to
+    /// defaults on a parse error. Pure (no I/O) so the load/reset decision is
+    /// unit-testable without touching the real config path. Returns the config
+    /// and whether a reset occurred (so the caller knows to persist defaults).
+    fn parse_or_reset(content: &str) -> (Self, bool) {
+        match toml::from_str::<DaemonConfig>(content) {
+            Ok(config) => (config, false),
+            Err(e) => {
+                warn!("Failed to parse config: {e}. Resetting to defaults.");
+                (Self::default(), true)
+            }
+        }
+    }
+
     /// Load configuration from disk.
     ///
     /// Falls back to defaults when the file is missing or cannot be parsed
     /// (e.g. after a format change). When falling back, the default config is
-    /// saved to disk so subsequent loads succeed cleanly. If individual
-    /// fields fell back via [`deserialize_or_default`], the canonical form
-    /// is rewritten so the warning doesn't repeat next startup.
+    /// saved to disk so subsequent loads succeed cleanly. If individual fields
+    /// fell back to their defaults (a stale enum value via the shared
+    /// `deserialize_or_default` helper), the canonical form is rewritten so the
+    /// warning doesn't repeat next startup.
     #[must_use]
     pub fn load() -> Self {
         let config_path = Self::get_config_path();
 
-        match fs::read_to_string(&config_path) {
-            Ok(content) => match toml::from_str::<DaemonConfig>(&content) {
-                Ok(config) => {
-                    if let Ok(canonical) = toml::to_string_pretty(&config)
-                        && canonical != content
-                        && let Err(e) = config.save()
-                    {
-                        error!("Failed to rewrite config in canonical form: {e}");
-                    }
-                    config
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to parse config file {}: {e}. Resetting to defaults.",
-                        config_path.display()
-                    );
-                    let config = Self::default();
-                    if let Err(save_err) = config.save() {
-                        error!("Failed to save default config after parse error: {save_err}");
-                    }
-                    config
-                }
-            },
-            Err(_) => Self::default(),
+        let Ok(content) = fs::read_to_string(&config_path) else {
+            return Self::default();
+        };
+
+        let (config, was_reset) = Self::parse_or_reset(&content);
+        if was_reset {
+            // Persist the regenerated defaults so subsequent loads are clean.
+            if let Err(e) = config.save() {
+                error!("Failed to save default config after parse error: {e}");
+            }
+        } else if let Ok(canonical) = toml::to_string_pretty(&config)
+            && canonical != content
+            && let Err(e) = config.save()
+        {
+            error!("Failed to rewrite config in canonical form: {e}");
         }
+        config
     }
 
     /// Save configuration to disk

--- a/super-stt-daemon/src/config_tests.rs
+++ b/super-stt-daemon/src/config_tests.rs
@@ -369,30 +369,18 @@ fn corrupt_daemon_config_resets_to_default() {
     assert_eq!(cfg.device.preferred_device, "cpu");
 }
 
-/// A complete, realistic v0.1.3 `daemon.toml` (customized, not defaults).
-const V0_1_3_DAEMON_TOML: &str = r#"
-[device]
-preferred_device = "cuda"
-
-[audio]
-theme = "Gentle"
-volume = 80
-
-[transcription]
-preferred_model = "WhisperLargeV3Turbo"
-write_mode = true
-preview_typing_enabled = false
-recording_stop_mode = "ManualOnly"
-write_method = "Ydotool"
-model_override_path = "/home/user/my-models"
-
-[online]
-allow_online_models = true
-"#;
+/// The committed v0.1.3 `daemon.toml` fixture (customized, not defaults). The
+/// canonical copy lives in the on-disk corpus so the release gate and these
+/// detailed assertions test the same bytes.
+fn v0_1_3_daemon_fixture() -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fixtures/configs/v0.1.3/daemon.toml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
 
 #[test]
 fn v0_1_3_full_daemon_config_loads_and_migrates() {
-    let (cfg, was_reset) = DaemonConfig::parse_or_reset(V0_1_3_DAEMON_TOML);
+    let (cfg, was_reset) = DaemonConfig::parse_or_reset(&v0_1_3_daemon_fixture());
     assert!(!was_reset, "a valid v0.1.3 config must load, not reset");
 
     // Preserved fields.
@@ -469,10 +457,38 @@ fn v0_1_3_config_reserializes_to_stable_canonical() {
     // load() rewrites a migrated config in canonical form; that rewrite must
     // itself be a valid, stable current config (backends empty → no HashMap
     // ordering nondeterminism).
-    let (cfg, _) = DaemonConfig::parse_or_reset(V0_1_3_DAEMON_TOML);
+    let (cfg, _) = DaemonConfig::parse_or_reset(&v0_1_3_daemon_fixture());
     let s1 = toml::to_string_pretty(&cfg).expect("serialize migrated config");
     let (cfg2, was_reset) = DaemonConfig::parse_or_reset(&s1);
     assert!(!was_reset, "canonical rewrite must re-parse cleanly");
     let s2 = toml::to_string_pretty(&cfg2).expect("serialize round-trip");
     assert_eq!(s1, s2, "canonical form must be idempotent");
+}
+
+#[test]
+fn all_published_daemon_configs_load_cleanly() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../fixtures/configs");
+    let mut checked = 0;
+    for entry in std::fs::read_dir(&dir).expect("fixtures/configs dir must exist") {
+        let version_dir = entry.expect("readable dir entry").path();
+        if !version_dir.is_dir() {
+            continue; // skip README.md and any other non-version files
+        }
+        let fixture = version_dir.join("daemon.toml");
+        if !fixture.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(&fixture).expect("read daemon.toml fixture");
+        let (_, was_reset) = DaemonConfig::parse_or_reset(&content);
+        assert!(
+            !was_reset,
+            "daemon fixture {} must load cleanly (no reset)",
+            fixture.display()
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 4,
+        "expected >= 4 daemon fixtures (v0.1.0-v0.1.3), found {checked}"
+    );
 }

--- a/super-stt-daemon/src/config_tests.rs
+++ b/super-stt-daemon/src/config_tests.rs
@@ -305,3 +305,174 @@ write_mode = false
     let config: DaemonConfig = toml::from_str(toml_str).expect("should deserialize");
     assert!(config.transcription.active_backend.is_none());
 }
+
+#[test]
+fn daemon_bad_theme_falls_back_preserving_rest() {
+    // A single unrecognized enum value must NOT wipe the whole config.
+    let toml_str = r#"
+[device]
+preferred_device = "cuda"
+
+[audio]
+theme = "Nonexistent"
+volume = 80
+
+[transcription]
+preferred_model = "WhisperTiny"
+write_mode = true
+recording_stop_mode = "ManualOnly"
+write_method = "Ydotool"
+"#;
+    let cfg: DaemonConfig = toml::from_str(toml_str).expect("must parse, not error");
+    assert_eq!(cfg.audio.theme, AudioTheme::default()); // bad field reset
+    assert_eq!(cfg.audio.volume, 80); // everything else preserved
+    assert_eq!(cfg.device.preferred_device, "cuda");
+    assert!(cfg.transcription.write_mode);
+    assert_eq!(
+        cfg.transcription.recording_stop_mode,
+        RecordingStopMode::ManualOnly
+    );
+    assert_eq!(cfg.transcription.write_method, WriteMethod::Ydotool);
+}
+
+#[test]
+fn daemon_bad_stop_mode_and_write_method_fall_back_preserving_rest() {
+    let toml_str = r#"
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "Gentle"
+volume = 100
+
+[transcription]
+preferred_model = "WhisperTiny"
+write_mode = false
+recording_stop_mode = "BogusMode"
+write_method = "BogusMethod"
+"#;
+    let cfg: DaemonConfig = toml::from_str(toml_str).expect("must parse, not error");
+    assert_eq!(cfg.audio.theme, AudioTheme::Gentle); // preserved
+    assert_eq!(
+        cfg.transcription.recording_stop_mode,
+        RecordingStopMode::default()
+    );
+    assert_eq!(cfg.transcription.write_method, WriteMethod::default());
+}
+
+#[test]
+fn corrupt_daemon_config_resets_to_default() {
+    let (cfg, was_reset) = DaemonConfig::parse_or_reset("this is not ::: valid toml [");
+    assert!(was_reset, "garbage input must trigger a reset");
+    // The reset config is a valid default (proves no panic, app can start).
+    assert_eq!(cfg.audio.theme, AudioTheme::default());
+    assert_eq!(cfg.device.preferred_device, "cpu");
+}
+
+/// A complete, realistic v0.1.3 `daemon.toml` (customized, not defaults).
+const V0_1_3_DAEMON_TOML: &str = r#"
+[device]
+preferred_device = "cuda"
+
+[audio]
+theme = "Gentle"
+volume = 80
+
+[transcription]
+preferred_model = "WhisperLargeV3Turbo"
+write_mode = true
+preview_typing_enabled = false
+recording_stop_mode = "ManualOnly"
+write_method = "Ydotool"
+model_override_path = "/home/user/my-models"
+
+[online]
+allow_online_models = true
+"#;
+
+#[test]
+fn v0_1_3_full_daemon_config_loads_and_migrates() {
+    let (cfg, was_reset) = DaemonConfig::parse_or_reset(V0_1_3_DAEMON_TOML);
+    assert!(!was_reset, "a valid v0.1.3 config must load, not reset");
+
+    // Preserved fields.
+    assert_eq!(cfg.device.preferred_device, "cuda");
+    assert_eq!(cfg.audio.theme, AudioTheme::Gentle);
+    assert_eq!(cfg.audio.volume, 80);
+    assert!(cfg.transcription.write_mode);
+    assert!(!cfg.transcription.preview_typing_enabled);
+    assert_eq!(
+        cfg.transcription.recording_stop_mode,
+        RecordingStopMode::ManualOnly
+    );
+    assert_eq!(cfg.transcription.write_method, WriteMethod::Ydotool);
+    assert!(cfg.online.allow_online_models);
+
+    // `preferred_model` widened from STTModel enum to String: the old value is
+    // retained verbatim (daemon model loader has its own fallback downstream).
+    assert_eq!(cfg.transcription.preferred_model, "WhisperLargeV3Turbo");
+
+    // Removed field dropped (no `deny_unknown_fields`); the replacement is None.
+    assert_eq!(cfg.transcription.custom_models_dir, None);
+
+    // New fields materialize at their defaults.
+    assert_eq!(cfg.transcription.preferred_provider, Provider::default());
+    assert_eq!(cfg.transcription.preferred_source, "");
+    assert_eq!(cfg.transcription.backends_dir, None);
+    assert_eq!(cfg.transcription.active_backend, None);
+    assert_eq!(cfg.transcription.primary_language, None);
+    assert!(cfg.backends.options.is_empty());
+    assert!(cfg.backends.models.is_empty());
+}
+
+#[test]
+fn v0_1_3_every_preferred_model_variant_loads() {
+    // Every STTModel serde name v0.1.3 could have written to `preferred_model`.
+    const V0_1_3_MODELS: &[&str] = &[
+        "WhisperTiny",
+        "WhisperTinyEn",
+        "WhisperBase",
+        "WhisperBaseEn",
+        "WhisperSmall",
+        "WhisperSmallEn",
+        "WhisperMedium",
+        "WhisperMediumEn",
+        "WhisperLarge",
+        "WhisperLargeV2",
+        "WhisperLargeV3",
+        "WhisperLargeV3Turbo",
+        "WhisperDistilMediumEn",
+        "WhisperDistilLargeV2",
+        "WhisperDistilLargeV3",
+        "VoxtralSmall",
+        "VoxtralMini",
+        "OpenAIWhisper1",
+        "OpenAIGpt4oTranscribe",
+        "OpenAIGpt4oMiniTranscribe",
+        "MistralVoxtralMiniTranscribeV2",
+        "DeepgramNova3",
+    ];
+    for model in V0_1_3_MODELS {
+        let toml_str = format!(
+            "[device]\npreferred_device = \"cpu\"\n\
+             [audio]\ntheme = \"Classic\"\nvolume = 100\n\
+             [transcription]\npreferred_model = \"{model}\"\nwrite_mode = false\n"
+        );
+        let (cfg, was_reset) = DaemonConfig::parse_or_reset(&toml_str);
+        assert!(!was_reset, "v0.1.3 model {model} must load, not reset");
+        assert_eq!(cfg.transcription.preferred_model, *model);
+    }
+}
+
+#[test]
+fn v0_1_3_config_reserializes_to_stable_canonical() {
+    // load() rewrites a migrated config in canonical form; that rewrite must
+    // itself be a valid, stable current config (backends empty → no HashMap
+    // ordering nondeterminism).
+    let (cfg, _) = DaemonConfig::parse_or_reset(V0_1_3_DAEMON_TOML);
+    let s1 = toml::to_string_pretty(&cfg).expect("serialize migrated config");
+    let (cfg2, was_reset) = DaemonConfig::parse_or_reset(&s1);
+    assert!(!was_reset, "canonical rewrite must re-parse cleanly");
+    let s2 = toml::to_string_pretty(&cfg2).expect("serialize round-trip");
+    assert_eq!(s1, s2, "canonical form must be idempotent");
+}

--- a/super-stt-shared/src/utils/mod.rs
+++ b/super-stt-shared/src/utils/mod.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
 #[cfg(feature = "audio")]
 pub mod audio;
+pub mod serde_helpers;

--- a/super-stt-shared/src/utils/serde_helpers.rs
+++ b/super-stt-shared/src/utils/serde_helpers.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use log::warn;
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a value via its serde impl, falling back to `Default` if the
+/// stored representation is no longer recognized (e.g. a config field written
+/// by an older build using a stale format). Logs a warning so the migration is
+/// observable. Used on individual enum/struct fields so a single unrecognized
+/// value degrades that field to its default instead of failing the whole
+/// config parse.
+///
+/// # Errors
+///
+/// Returns an error only if the underlying value cannot be captured at all
+/// (malformed input); an unrecognized-but-well-formed value yields the default.
+pub fn deserialize_or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + serde::de::DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    match serde_json::from_value::<T>(raw.clone()) {
+        Ok(value) => Ok(value),
+        Err(e) => {
+            warn!("config field {raw} unrecognized ({e}); using default");
+            Ok(T::default())
+        }
+    }
+}


### PR DESCRIPTION
## Why

Preparing a release, we need assurance that users upgrading from any published release won't be broken by their existing on-disk configuration. The hard requirement: **the app crashing or not starting is unacceptable.** An old config must load, migrate, or reset to a fresh compatible config — never crash.

Two persisted configs are in scope: `daemon.toml` (daemon) and `applet-{full,left,right}.toml` (cosmic applet). Nothing else persists upgrade-relevant state.

## What

**1. Make current code resilient (per-field hardening)**
- Moved a shared `deserialize_or_default` fallback into `super-stt-shared`.
- Applied it per-field to `audio.theme`, `recording_stop_mode`, `write_method` (daemon) and the visualization theme/side/working-animation/color fields (applet). A stale enum now degrades that one field to its default instead of wiping the whole file.
- Extracted a pure, unit-testable `parse_or_reset(content) -> (config, was_reset)` from each `load()`. No behavior change.

**2. Test the upgrade path for every published release**
- Committed an on-disk fixture corpus at `fixtures/configs/<version>/` covering **v0.1.0, v0.1.1, v0.1.2, v0.1.3** (`daemon.toml` + `applet-full.toml`), hand-derived from each tag's real structs. Older fixtures carry since-removed fields/tables (daemon `model_override_path`, applet `[audio]`) so they test real migration, not just defaults.
- Auto-discovery `--lib` tests in both crates load every fixture via `parse_or_reset` and assert a clean load (`was_reset == false`), with a minimum-count guard so a wrong path can't vacuously pass.

**3. Gate releases on it**
- New `just config-compat` recipe runs the daemon + applet config tests.
- A `config-compat` job in `release.yml` and `release-beta.yml` that the `build-apps` job `needs:`, so **no release builds or publishes unless every old config loads.**

## Verification

- `just config-compat` passes locally, loading all v0.1.0–v0.1.3 fixtures.
- `cargo test -p super-stt-daemon --lib` — 203 passed; `cargo test -p super-stt-cosmic-applet --lib` — 22 passed.
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` — clean.
- No behavior change for valid configs (all pre-existing config tests still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)