### PR TITLE
Fix UTF-8 preview-slice panic and NaN audio-level panic

### DIFF
--- a/super-stt-daemon/src/audio/state.rs
+++ b/super-stt-daemon/src/audio/state.rs
@@ -75,6 +75,14 @@ impl RecordingState {
     }
 
     pub fn update_adaptive_levels(&mut self, rms: f32, is_currently_active: bool) {
+        // Drop non-finite samples before they reach the level buffers. An empty
+        // capture chunk computes `0.0/0.0 = NaN`, and a misbehaving device can
+        // deliver NaN samples; a NaN in the buffers would poison the percentile
+        // sorts in `update_level_estimates` and panic the capture thread.
+        if !rms.is_finite() {
+            return;
+        }
+
         if self.recent_levels.len() >= RECENT_LEVELS_BUFFER_SIZE {
             self.recent_levels.pop_front();
         }
@@ -98,7 +106,9 @@ impl RecordingState {
     fn update_level_estimates(&mut self) {
         if !self.quiet_levels.is_empty() {
             let mut sorted_quiet: Vec<f32> = self.quiet_levels.iter().copied().collect();
-            sorted_quiet.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            // `total_cmp` is a total order over f32 (NaN-safe), so the sort can
+            // never panic even if a non-finite value slips past the guard above.
+            sorted_quiet.sort_by(f32::total_cmp);
             // sorted_quiet.len() ≤ QUIET_LEVELS_BUFFER_SIZE = 100; fits u32 and f32 exactly.
             let len_f32 =
                 crate::num_cast::u32_to_f32(u32::try_from(sorted_quiet.len()).unwrap_or(u32::MAX));
@@ -112,7 +122,7 @@ impl RecordingState {
 
         if !self.active_levels.is_empty() {
             let mut sorted_active: Vec<f32> = self.active_levels.iter().copied().collect();
-            sorted_active.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            sorted_active.sort_by(f32::total_cmp);
             // sorted_active.len() ≤ ACTIVE_LEVELS_BUFFER_SIZE = 100; fits u32 and f32 exactly.
             let len_f32 =
                 crate::num_cast::u32_to_f32(u32::try_from(sorted_active.len()).unwrap_or(u32::MAX));
@@ -149,5 +159,32 @@ impl RecordingState {
             crate::num_cast::u32_to_f32(u32::try_from(speech_count).unwrap_or(u32::MAX));
         let total_f32 = crate::num_cast::u32_to_f32(u32::try_from(total_count).unwrap_or(u32::MAX));
         speech_f32 / total_f32 > SPEECH_DETECTION_THRESHOLD
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecordingState;
+
+    /// A non-finite RMS (an empty capture buffer computes `0.0/0.0 = NaN`, and a
+    /// misbehaving device can deliver NaN samples) must not reach the percentile
+    /// sort in `update_level_estimates`, whose `partial_cmp(...).unwrap()` would
+    /// panic on the cpal capture-callback thread. The level estimates must also
+    /// stay finite (a NaN must not poison the adaptive thresholds).
+    #[test]
+    fn non_finite_rms_does_not_panic_or_poison_levels() {
+        let mut state = RecordingState::new();
+        // Prime both buffers with finite levels so the sort has >1 element.
+        state.update_adaptive_levels(0.01, false);
+        state.update_adaptive_levels(0.02, true);
+        // These would panic under `partial_cmp(...).unwrap()`.
+        state.update_adaptive_levels(f32::NAN, false);
+        state.update_adaptive_levels(f32::NAN, true);
+        state.update_adaptive_levels(f32::INFINITY, false);
+        assert!(state.baseline_level.is_finite(), "baseline poisoned by NaN");
+        assert!(
+            state.active_level.is_finite(),
+            "active level poisoned by NaN"
+        );
     }
 }

--- a/super-stt-daemon/src/output/preview.rs
+++ b/super-stt-daemon/src/output/preview.rs
@@ -351,7 +351,12 @@ impl Typer {
         best_text.to_string()
     }
 
-    /// Find the position where the last 'n' characters of text1 match with a substring in text2.
+    /// Find where the last `length_of_match` characters of `text1` match a
+    /// substring of `text2`, returning the **byte offset** in `text2` just past
+    /// that match (so callers can `&text2[pos..]` safely), or `-1` if no match.
+    ///
+    /// The offset is a byte index — not a char index — so slicing `text2` with
+    /// it never lands inside a multibyte UTF-8 sequence.
     fn find_tail_match_in_text(text1: &str, text2: &str, length_of_match: usize) -> i32 {
         // Check if either text is too short
         if text1.chars().count() < length_of_match || text2.chars().count() < length_of_match {
@@ -373,7 +378,15 @@ impl Typer {
 
             // Compare substrings
             if current_substring == target_substring {
-                return i32::try_from(end_pos).unwrap_or_default();
+                // `end_pos` is a CHAR index into text2; map it to a byte offset
+                // so callers can byte-slice `&text2[pos..]` without splitting a
+                // multibyte char. `nth(end_pos) == None` means the match ends at
+                // the very end of text2, i.e. byte offset `text2.len()`.
+                let byte_off = text2
+                    .char_indices()
+                    .nth(end_pos)
+                    .map_or(text2.len(), |(b, _)| b);
+                return i32::try_from(byte_off).unwrap_or(i32::MAX);
             }
         }
 

--- a/super-stt-daemon/src/output/preview_tests.rs
+++ b/super-stt-daemon/src/output/preview_tests.rs
@@ -56,6 +56,22 @@ fn test_find_tail_match_in_text() {
 }
 
 #[test]
+fn find_tail_match_returns_utf8_safe_byte_offset() {
+    // "xyzáb" holds a 2-byte 'á' before the match boundary, so the matched-tail
+    // position as a CHAR index (4) differs from the BYTE offset (5). The result
+    // must be a byte offset: callers slice `&text2[pos..]`, and a char index
+    // would land inside the multibyte 'á' and panic ("not a char boundary").
+    let pos = Typer::find_tail_match_in_text("wyzá", "xyzáb", 3);
+    assert_eq!(
+        pos, 5,
+        "expected the byte offset (5), not the char index (4)"
+    );
+    // Must be usable as a &str byte slice without panicking.
+    let suffix = &"xyzáb"[usize::try_from(pos).unwrap()..];
+    assert_eq!(suffix, "b");
+}
+
+#[test]
 fn test_find_common_prefix() {
     assert_eq!(Typer::find_common_prefix("hello world", "hello there"), 6);
     assert_eq!(Typer::find_common_prefix("abc", "def"), 0);


### PR DESCRIPTION
Fixes two reachable panics found during an audit of the daemon's runtime paths. Both crash the recording task on routine input; both are covered by a regression test (written first, watched fail, then fixed).

## 1. UTF-8 panic in live preview typing (`output/preview.rs`)
`find_tail_match_in_text` returned a **character** index (a `Vec<char>` offset), but both call sites in `update_full_session_text` and `build_display_text` byte-slice `&text2[pos..]`. In Rust `&str[..]` indexes by **bytes**, so any multibyte transcription (accented Latin, CJK, curly quotes, em-dashes, emoji) sliced at a char offset panics with *"byte index N is not a char boundary"* — during ordinary streaming preview, where tail matches are common.

**Fix:** the function now maps the matched char index to a **byte offset** (`char_indices().nth(end_pos).map_or(text2.len(), |(b,_)| b)`) before returning, so callers slice safely. ASCII behavior is unchanged (byte == char), so existing tests are unaffected.

## 2. NaN panic on the audio capture-callback thread (`audio/state.rs`)
`update_level_estimates` sorted the RMS level buffers with `sort_by(|a, b| a.partial_cmp(b).unwrap())`, which panics when a `NaN` is present. An empty capture chunk computes `0.0/0.0 = NaN`, and a misbehaving device can deliver `NaN` samples; the NaN enters the level buffers and the next sort unwraps `None`, aborting audio capture across the cpal FFI boundary.

**Fix (defense in depth):** (1) `update_adaptive_levels` early-returns on `!rms.is_finite()`, so non-finite samples never enter the buffers *or* poison the adaptive thresholds; (2) both sorts now use `f32::total_cmp` (a NaN-safe total order).

## Tests
- `find_tail_match_returns_utf8_safe_byte_offset` — `"wyzá"`/`"xyzáb"` asserts byte offset 5 (not char index 4) and that `&text2[pos..]` is slice-safe.
- `non_finite_rms_does_not_panic_or_poison_levels` — NaN + INFINITY inputs: no panic, levels stay finite.

## Verification
A discovery sweep confirmed these are the **only** reachable instances of either footgun in the workspace; an adversarial verification pass (multibyte/combining-char/CJK/emoji inputs; all-NaN/inf buffers; sibling float-sort sites) found no residual defect. `partial_cmp().unwrap()` no longer appears anywhere in the tree.

Daemon lib tests: 220 pass. Workspace clippy `--pedantic -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
