### PR TITLE
Split preview.rs into pure helpers and typer state machine

### DIFF
--- a/super-stt-daemon/src/daemon/core.rs
+++ b/super-stt-daemon/src/daemon/core.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{daemon::types::SuperSTTDaemon, output::keyboard::Simulator, output::preview::Typer};
+use crate::{daemon::types::SuperSTTDaemon, output::keyboard::Simulator, output::typer::Typer};
 use super_stt_shared::models::protocol::{Command, DaemonRequest, DaemonResponse};
 
 impl SuperSTTDaemon {

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -5,7 +5,7 @@ mod transcribe;
 
 use crate::daemon::types::SuperSTTDaemon;
 use crate::services::dbus::ListeningEvent;
-use crate::{audio::recorder::DaemonAudioRecorder, output::preview::Typer};
+use crate::{audio::recorder::DaemonAudioRecorder, output::typer::Typer};
 use anyhow::{Context, Result};
 use chrono::Utc;
 use log::{error, info, warn};

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -2,7 +2,7 @@
 
 use super::RecordingSession;
 use crate::daemon::types::SuperSTTDaemon;
-use crate::output::preview::Typer;
+use crate::output::typer::Typer;
 use anyhow::Result;
 use log::{debug, info, warn};
 use std::sync::Arc;
@@ -242,7 +242,7 @@ impl SuperSTTDaemon {
         if let Ok(text) = self.transcribe_audio_chunk(&resampled_audio).await
             && !text.trim().is_empty()
         {
-            let processed = crate::output::preview::Typer::preprocess_text(&text, true);
+            let processed = crate::output::preview::preprocess_text(&text, true);
 
             info!(
                 "Preview: '{}'",

--- a/super-stt-daemon/src/daemon/recording/transcribe.rs
+++ b/super-stt-daemon/src/daemon/recording/transcribe.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::daemon::types::SuperSTTDaemon;
-use crate::output::preview::Typer;
+use crate::output::typer::Typer;
 use crate::stt_models::dispatch::{DispatchError, dispatch_transcription};
 use anyhow::{Context, Result};
 use log::{debug, error, info, warn};

--- a/super-stt-daemon/src/output/mod.rs
+++ b/super-stt-daemon/src/output/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod keyboard;
 pub mod preview;
+pub mod typer;

--- a/super-stt-daemon/src/output/preview.rs
+++ b/super-stt-daemon/src/output/preview.rs
@@ -1,528 +1,107 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::output::keyboard::Simulator;
-use log::{debug, info, warn};
+//! Pure text-diff helpers for the preview typer.
+//!
+//! These are keyboard- and session-state-free string algorithms shared by the
+//! [`Typer`](crate::output::typer::Typer) state machine. Keeping them separate
+//! makes them exhaustively unit-testable without a keyboard `Simulator`.
 
-/// State for tracking preview updates
-pub struct State {
-    pub last_transcription: String,
-    pub prev_text: String,
-    /// Complete transcription built from all audio (for final output)
-    pub full_session_text: String,
-    /// When we last saw substantial text growth (to commit to full session)
-    pub last_growth_time: std::time::Instant,
-    /// History of transcriptions for stabilization
-    pub text_storage: Vec<String>,
-    /// Text confirmed by appearing in multiple transcriptions
-    pub stabilized_text: String,
+/// Preprocess text - normalize, remove ellipses, capitalize
+#[must_use]
+pub(crate) fn preprocess_text(text: &str, is_preview: bool) -> String {
+    // Remove leading whitespaces
+    let mut text = text.trim_start().to_string();
+
+    // Remove starting ellipses if present
+    if text.starts_with("...") {
+        text = text[3..].to_string();
+    }
+
+    // Remove any leading whitespaces again after ellipses removal
+    text = text.trim_start().to_string();
+
+    // Normalize whitespace
+    text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if text.is_empty() {
+        return text;
+    }
+
+    // Uppercase the first letter
+    let mut chars: Vec<char> = text.chars().collect();
+    if let Some(first_char) = chars.first_mut() {
+        *first_char = first_char.to_ascii_uppercase();
+    }
+    text = chars.iter().collect();
+
+    // Add period for final output if it ends with alphanumeric
+    if !is_preview && text.chars().last().is_some_and(char::is_alphanumeric) {
+        text.push('.');
+    }
+
+    text
 }
 
-impl Default for State {
-    fn default() -> Self {
-        Self {
-            last_transcription: String::new(),
-            prev_text: String::new(),
-            full_session_text: String::new(),
-            last_growth_time: std::time::Instant::now(),
-            text_storage: Vec::new(),
-            stabilized_text: String::new(),
-        }
+/// Simple extension check - much faster than complex word matching
+#[must_use]
+pub fn is_simple_extension(current: &str, new_text: &str) -> bool {
+    if current.is_empty() {
+        return !new_text.is_empty();
     }
+
+    // Check if new text starts with current text
+    new_text.starts_with(current) && new_text.len() > current.len()
 }
 
-/// Unified, simplified preview typer that combines the best of both approaches
-pub struct Typer {
-    keyboard_simulator: Simulator,
-    state: State,
+/// Find common prefix (in `char`s) between two strings
+#[must_use]
+pub(crate) fn find_common_prefix(text1: &str, text2: &str) -> usize {
+    text1
+        .chars()
+        .zip(text2.chars())
+        .take_while(|(c1, c2)| c1 == c2)
+        .count()
 }
 
-impl Typer {
-    #[must_use]
-    pub fn new(keyboard_simulator: Simulator) -> Self {
-        Self {
-            keyboard_simulator,
-            state: State::default(),
+/// Find where the last `length_of_match` characters of `text1` match a
+/// substring of `text2`, returning the **byte offset** in `text2` just past
+/// that match (so callers can `&text2[pos..]` safely), or `-1` if no match.
+///
+/// The offset is a byte index — not a char index — so slicing `text2` with
+/// it never lands inside a multibyte UTF-8 sequence.
+pub(crate) fn find_tail_match_in_text(text1: &str, text2: &str, length_of_match: usize) -> i32 {
+    // Check if either text is too short
+    if text1.chars().count() < length_of_match || text2.chars().count() < length_of_match {
+        return -1;
+    }
+
+    let text1_chars: Vec<char> = text1.chars().collect();
+    let text2_chars: Vec<char> = text2.chars().collect();
+
+    // The end portion of text1 that we want to find in text2
+    let target_substring: Vec<char> = text1_chars[text1_chars.len() - length_of_match..].to_vec();
+
+    // Loop through text2 from right to left
+    for i in 0..=(text2_chars.len() - length_of_match) {
+        let start_pos = text2_chars.len() - i - length_of_match;
+        let end_pos = text2_chars.len() - i;
+        let current_substring: Vec<char> = text2_chars[start_pos..end_pos].to_vec();
+
+        // Compare substrings
+        if current_substring == target_substring {
+            // `end_pos` is a CHAR index into text2; map it to a byte offset
+            // so callers can byte-slice `&text2[pos..]` without splitting a
+            // multibyte char. `nth(end_pos) == None` means the match ends at
+            // the very end of text2, i.e. byte offset `text2.len()`.
+            let byte_off = text2
+                .char_indices()
+                .nth(end_pos)
+                .map_or(text2.len(), |(b, _)| b);
+            return i32::try_from(byte_off).unwrap_or(i32::MAX);
         }
     }
 
-    #[must_use]
-    pub fn write_method_name(&self) -> &'static str {
-        self.keyboard_simulator.name()
-    }
-
-    /// Extract the simulator so it can be cached for reuse.
-    #[must_use]
-    pub fn take_simulator(self) -> Simulator {
-        self.keyboard_simulator
-    }
-}
-
-impl Typer {
-    /// Preprocess text - normalize, remove ellipses, capitalize
-    #[must_use]
-    pub fn preprocess_text(text: &str, is_preview: bool) -> String {
-        // Remove leading whitespaces
-        let mut text = text.trim_start().to_string();
-
-        // Remove starting ellipses if present
-        if text.starts_with("...") {
-            text = text[3..].to_string();
-        }
-
-        // Remove any leading whitespaces again after ellipses removal
-        text = text.trim_start().to_string();
-
-        // Normalize whitespace
-        text = text.split_whitespace().collect::<Vec<_>>().join(" ");
-
-        if text.is_empty() {
-            return text;
-        }
-
-        // Uppercase the first letter
-        let mut chars: Vec<char> = text.chars().collect();
-        if let Some(first_char) = chars.first_mut() {
-            *first_char = first_char.to_ascii_uppercase();
-        }
-        text = chars.iter().collect();
-
-        // Add period for final output if it ends with alphanumeric
-        if !is_preview && text.chars().last().is_some_and(char::is_alphanumeric) {
-            text.push('.');
-        }
-
-        text
-    }
-
-    /// Simple extension check - much faster than complex word matching
-    #[must_use]
-    pub fn is_simple_extension(current: &str, new_text: &str) -> bool {
-        if current.is_empty() {
-            return !new_text.is_empty();
-        }
-
-        // Check if new text starts with current text
-        new_text.starts_with(current) && new_text.len() > current.len()
-    }
-
-    /// Find common prefix between two strings
-    #[must_use]
-    fn find_common_prefix(text1: &str, text2: &str) -> usize {
-        text1
-            .chars()
-            .zip(text2.chars())
-            .take_while(|(c1, c2)| c1 == c2)
-            .count()
-    }
-
-    /// Apply a simple differential update by backspacing and retyping from first difference
-    pub fn apply_simple_diff(&mut self, old_text: &str, new_text: &str) -> usize {
-        // Safety checks
-        if old_text == new_text {
-            return 0;
-        }
-
-        if old_text.is_empty() && !new_text.is_empty() {
-            let _ = self.keyboard_simulator.type_text(new_text);
-            debug!("Failed to type new text");
-            return new_text.len();
-        }
-
-        if new_text.is_empty() {
-            // Skip
-            return 0;
-        }
-
-        let old_chars: Vec<char> = old_text.chars().collect();
-        let new_chars: Vec<char> = new_text.chars().collect();
-
-        // Find first different character position
-        let common_prefix = Self::find_common_prefix(old_text, new_text);
-
-        // Calculate what to delete and what to type
-        let chars_to_delete = old_chars.len() - common_prefix;
-        let text_to_type: String = new_chars[common_prefix..].iter().collect();
-
-        debug!(
-            "Simple diff: prefix={}, delete={}, type='{}'",
-            common_prefix,
-            chars_to_delete,
-            text_to_type.chars().take(20).collect::<String>()
-        );
-
-        // Backspace to the first different position
-        let _ = self.keyboard_simulator.backspace_n(chars_to_delete);
-
-        // Type the new part
-        let _ = self.keyboard_simulator.type_text(&text_to_type);
-
-        text_to_type.len()
-    }
-
-    /// Update preview text using two-phase approach
-    pub fn update_preview(&mut self, new_text: &str, actually_typed: &mut String) {
-        let processed_text = Self::preprocess_text(new_text, true);
-
-        info!(
-            "Preview update: new='{}', prev='{}', typed='{}'",
-            processed_text.chars().take(30).collect::<String>(),
-            self.state.prev_text.chars().take(30).collect::<String>(),
-            actually_typed.chars().take(30).collect::<String>()
-        );
-
-        // Skip if text hasn't changed
-        if processed_text == self.state.prev_text {
-            debug!("Text unchanged, skipping");
-            return;
-        }
-
-        // Skip empty text
-        if processed_text.is_empty() {
-            debug!("Empty text, skipping");
-            return;
-        }
-
-        // PHASE 1: Stabilization and session text update
-        self.update_with_stabilization(&processed_text);
-
-        // PHASE 2: Decide what to show on screen
-        let display_text = self.build_display_text(&processed_text);
-
-        info!(
-            "Display logic: display='{}', session='{}', stabilized='{}'",
-            display_text.chars().take(30).collect::<String>(),
-            self.state
-                .full_session_text
-                .chars()
-                .take(30)
-                .collect::<String>(),
-            self.state
-                .stabilized_text
-                .chars()
-                .take(30)
-                .collect::<String>()
-        );
-
-        // Apply the update to screen
-        self.apply_text_update(&display_text, actually_typed);
-        self.state.prev_text = processed_text;
-    }
-
-    /// Stabilization and session text update (Phase 1)
-    fn update_with_stabilization(&mut self, new_preview_text: &str) {
-        // Add current text to storage
-        self.state.text_storage.push(new_preview_text.to_string());
-
-        // Keep only recent texts for stabilization (prevent unbounded growth)
-        if self.state.text_storage.len() > 10 {
-            self.state.text_storage.remove(0);
-        }
-
-        // Find common prefix between last two texts
-        if self.state.text_storage.len() >= 2 {
-            let last_two = &self.state.text_storage[self.state.text_storage.len() - 2..];
-            let common_prefix = Self::find_common_prefix(&last_two[0], &last_two[1]);
-            let prefix_text = last_two[0].chars().take(common_prefix).collect::<String>();
-
-            // Only update stabilized text if we found a longer stable prefix
-            if prefix_text.len() > self.state.stabilized_text.len() {
-                self.state.stabilized_text = prefix_text;
-                debug!(
-                    "Updated stabilized text: '{}'",
-                    self.state
-                        .stabilized_text
-                        .chars()
-                        .take(30)
-                        .collect::<String>()
-                );
-            }
-        }
-
-        // Update full session text using stabilized text + tail matching
-        self.update_full_session_text(new_preview_text);
-    }
-
-    /// Update the full session text using stabilized text as base
-    fn update_full_session_text(&mut self, new_preview_text: &str) {
-        // If we have stabilized text, use it as our base
-        if !self.state.stabilized_text.is_empty()
-            && self.state.stabilized_text.len() > self.state.full_session_text.len()
-        {
-            self.state.full_session_text = self.state.stabilized_text.clone();
-            self.state.last_growth_time = std::time::Instant::now();
-            debug!(
-                "Updated session from stabilized: '{}'",
-                self.state
-                    .full_session_text
-                    .chars()
-                    .take(30)
-                    .collect::<String>()
-            );
-        }
-
-        // Only grow the session text, never shrink it
-        if self.state.full_session_text.is_empty() {
-            self.state.full_session_text = new_preview_text.to_string();
-            self.state.last_growth_time = std::time::Instant::now();
-            debug!(
-                "Started session text: '{}'",
-                self.state
-                    .full_session_text
-                    .chars()
-                    .take(30)
-                    .collect::<String>()
-            );
-            return;
-        }
-
-        // Check if preview text extends our session text
-        if new_preview_text.len() > self.state.full_session_text.len()
-            && new_preview_text.starts_with(&self.state.full_session_text)
-        {
-            // Perfect extension - just grow
-            self.state.full_session_text = new_preview_text.to_string();
-            self.state.last_growth_time = std::time::Instant::now();
-            debug!(
-                "Extended session text to: '{}'",
-                self.state
-                    .full_session_text
-                    .chars()
-                    .take(40)
-                    .collect::<String>()
-            );
-            return;
-        }
-
-        // Use tail matching to extend session with new content
-        let matching_pos =
-            Self::find_tail_match_in_text(&self.state.full_session_text, new_preview_text, 3);
-        if matching_pos >= 0 {
-            let extended = format!(
-                "{}{}",
-                self.state.full_session_text,
-                &new_preview_text[usize::try_from(matching_pos).unwrap_or(0)..]
-            );
-            if extended.len() > self.state.full_session_text.len() {
-                self.state.full_session_text = extended;
-                self.state.last_growth_time = std::time::Instant::now();
-                debug!(
-                    "Extended session via tail match: '{}'",
-                    self.state
-                        .full_session_text
-                        .chars()
-                        .take(40)
-                        .collect::<String>()
-                );
-            }
-        }
-    }
-
-    /// Build the display text (Phase 2) - what actually shows on screen
-    fn build_display_text(&mut self, preview_text: &str) -> String {
-        // Use stabilized text as base, but be smart about it
-
-        // If no stabilized text yet, show the preview
-        if self.state.stabilized_text.is_empty() {
-            return preview_text.to_string();
-        }
-
-        // Try tail matching first
-        let matching_pos =
-            Self::find_tail_match_in_text(&self.state.stabilized_text, preview_text, 3);
-
-        if matching_pos >= 0 {
-            // Found overlap - combine stabilized text with new part from preview
-            let combined = format!(
-                "{}{}",
-                self.state.stabilized_text,
-                &preview_text[usize::try_from(matching_pos).unwrap_or(0)..]
-            );
-            return combined;
-        }
-
-        // No tail match found - be conservative to avoid text loss
-        // Prefer the longer text (session text or preview) to avoid disappearing words
-        let best_text = if self.state.full_session_text.len() >= preview_text.len() {
-            &self.state.full_session_text
-        } else {
-            preview_text
-        };
-
-        best_text.to_string()
-    }
-
-    /// Find where the last `length_of_match` characters of `text1` match a
-    /// substring of `text2`, returning the **byte offset** in `text2` just past
-    /// that match (so callers can `&text2[pos..]` safely), or `-1` if no match.
-    ///
-    /// The offset is a byte index — not a char index — so slicing `text2` with
-    /// it never lands inside a multibyte UTF-8 sequence.
-    fn find_tail_match_in_text(text1: &str, text2: &str, length_of_match: usize) -> i32 {
-        // Check if either text is too short
-        if text1.chars().count() < length_of_match || text2.chars().count() < length_of_match {
-            return -1;
-        }
-
-        let text1_chars: Vec<char> = text1.chars().collect();
-        let text2_chars: Vec<char> = text2.chars().collect();
-
-        // The end portion of text1 that we want to find in text2
-        let target_substring: Vec<char> =
-            text1_chars[text1_chars.len() - length_of_match..].to_vec();
-
-        // Loop through text2 from right to left
-        for i in 0..=(text2_chars.len() - length_of_match) {
-            let start_pos = text2_chars.len() - i - length_of_match;
-            let end_pos = text2_chars.len() - i;
-            let current_substring: Vec<char> = text2_chars[start_pos..end_pos].to_vec();
-
-            // Compare substrings
-            if current_substring == target_substring {
-                // `end_pos` is a CHAR index into text2; map it to a byte offset
-                // so callers can byte-slice `&text2[pos..]` without splitting a
-                // multibyte char. `nth(end_pos) == None` means the match ends at
-                // the very end of text2, i.e. byte offset `text2.len()`.
-                let byte_off = text2
-                    .char_indices()
-                    .nth(end_pos)
-                    .map_or(text2.len(), |(b, _)| b);
-                return i32::try_from(byte_off).unwrap_or(i32::MAX);
-            }
-        }
-
-        -1
-    }
-
-    /// Process final text (completed sentence) - Uses full session audio
-    pub fn process_final_text(&mut self, transcription_result: &str) {
-        // No preview typing, type directly
-        let processed_text =
-            crate::output::preview::Typer::preprocess_text(transcription_result, false);
-        let final_text = format!("{processed_text} ");
-        if let Err(e) = self.keyboard_simulator.type_text(&final_text) {
-            warn!("Failed to type final transcription: {e}");
-        } else {
-            info!("Step 6 complete: Final transcription typed directly");
-        }
-
-        // Reset state for next sentence - but keep the full session text for user reference
-        self.state.prev_text.clear();
-        self.state.last_transcription = processed_text;
-        self.state.last_growth_time = std::time::Instant::now();
-
-        info!(
-            "Completed sentence. Session text: '{}'",
-            self.state
-                .full_session_text
-                .chars()
-                .take(50)
-                .collect::<String>()
-        );
-
-        // Clear session for next recording
-        self.state.full_session_text.clear();
-    }
-
-    /// Apply text update to screen (common logic)
-    fn apply_text_update(&mut self, new_text: &str, actually_typed: &mut String) {
-        let old_char_count = actually_typed.chars().count();
-        let new_char_count = new_text.chars().count();
-
-        info!(
-            "Typing logic: old_typed='{}', new_display='{}', old_count={}, new_count={}",
-            actually_typed.chars().take(30).collect::<String>(),
-            new_text.chars().take(30).collect::<String>(),
-            old_char_count,
-            new_char_count
-        );
-
-        let actual_chars_on_screen;
-        // Screen is empty, just type the new text
-        if old_char_count == 0 {
-            info!(
-                "Screen empty, typing new text: '{}'",
-                new_text.chars().take(30).collect::<String>()
-            );
-            let _ = self.keyboard_simulator.type_text(&format!("{new_text} "));
-            actual_chars_on_screen = new_char_count;
-        }
-        // Screen is not empty, check if new text starts with actually typed text
-        else if new_text.starts_with(actually_typed.as_str())
-            && new_text.len() > actually_typed.len()
-        {
-            // Perfect extension - just add the suffix
-            let suffix = &new_text[actually_typed.len()..];
-            info!("Perfect extension, adding suffix: '{suffix}'");
-            let _ = self.keyboard_simulator.type_text(&format!("{suffix} "));
-            actual_chars_on_screen = new_char_count;
-        } else {
-            // Need to replace - use differential update
-            info!("Need replacement, using diff update");
-            let net_change = self.apply_simple_diff(actually_typed, new_text);
-
-            // Calculate actual characters on screen based on the net change
-            actual_chars_on_screen = old_char_count + net_change;
-
-            info!(
-                "Replaced: {}{} chars (screen total: {})",
-                if net_change > 0 { "+" } else { "" },
-                net_change,
-                actual_chars_on_screen
-            );
-        }
-
-        // Update state to match what we think is actually on screen
-        if actual_chars_on_screen == new_char_count {
-            // Typing succeeded completely
-            actually_typed.clear();
-            actually_typed.push_str(new_text);
-            info!(
-                "Updated actually_typed to: '{}'",
-                actually_typed.chars().take(30).collect::<String>()
-            );
-        } else {
-            // Typing failed or was partial - but for preview, we should still track what we attempted to type
-            // This ensures preview clearing works correctly even when there are typing discrepancies
-            warn!(
-                "Character count mismatch: expected {new_char_count}, actual {actual_chars_on_screen}, updating actually_typed anyway"
-            );
-            actually_typed.clear();
-            actually_typed.push_str(new_text);
-            info!(
-                "Force updated actually_typed to: '{}'",
-                actually_typed.chars().take(30).collect::<String>()
-            );
-        }
-    }
-
-    /// Clear all typed text and reset state
-    pub fn clear_preview(&mut self, actually_typed: &mut String) {
-        info!("clear_preview called with actually_typed: '{actually_typed}'");
-
-        if actually_typed.is_empty() {
-            info!("actually_typed is empty, nothing to clear");
-            return;
-        }
-
-        let chars_to_delete = actually_typed.chars().count();
-        info!("Backspacing {chars_to_delete} characters");
-
-        if let Err(e) = self.keyboard_simulator.backspace_n(chars_to_delete) {
-            warn!("Failed to backspace preview text: {e}");
-        } else {
-            info!("Successfully backspaced {chars_to_delete} characters");
-        }
-
-        actually_typed.clear();
-
-        // Also clear state when explicitly clearing preview
-        self.state.prev_text.clear();
-        self.state.last_transcription.clear();
-        self.state.full_session_text.clear();
-        self.state.last_growth_time = std::time::Instant::now();
-
-        info!("Cleared all {chars_to_delete} characters and reset state");
-    }
+    -1
 }
 
 #[cfg(test)]

--- a/super-stt-daemon/src/output/preview_tests.rs
+++ b/super-stt-daemon/src/output/preview_tests.rs
@@ -4,55 +4,49 @@ use super::*;
 #[test]
 fn test_preprocess_text() {
     // Basic functionality
-    assert_eq!(Typer::preprocess_text("hello world", true), "Hello world");
-    assert_eq!(Typer::preprocess_text("hello world", false), "Hello world.");
-    assert_eq!(Typer::preprocess_text("", true), "");
+    assert_eq!(preprocess_text("hello world", true), "Hello world");
+    assert_eq!(preprocess_text("hello world", false), "Hello world.");
+    assert_eq!(preprocess_text("", true), "");
 
+    assert_eq!(preprocess_text("...hello world", true), "Hello world");
+    assert_eq!(preprocess_text("  ...  hello world  ", true), "Hello world");
     assert_eq!(
-        Typer::preprocess_text("...hello world", true),
-        "Hello world"
-    );
-    assert_eq!(
-        Typer::preprocess_text("  ...  hello world  ", true),
-        "Hello world"
-    );
-    assert_eq!(
-        Typer::preprocess_text("  multiple   spaces  ", true),
+        preprocess_text("  multiple   spaces  ", true),
         "Multiple spaces"
     );
 }
 
 #[test]
 fn test_is_simple_extension() {
-    assert!(Typer::is_simple_extension("hello", "hello world"));
-    assert!(Typer::is_simple_extension("", "hello"));
-    assert!(!Typer::is_simple_extension("hello", "hi world"));
-    assert!(!Typer::is_simple_extension("hello", "hello"));
-    assert!(!Typer::is_simple_extension("hello world", "hello"));
+    assert!(is_simple_extension("hello", "hello world"));
+    assert!(is_simple_extension("", "hello"));
+    assert!(!is_simple_extension("hello", "hi world"));
+    assert!(!is_simple_extension("hello", "hello"));
+    assert!(!is_simple_extension("hello world", "hello"));
 }
 
 #[test]
 fn test_find_tail_match_in_text() {
     // Test the key case: "engi" should match with "engineer"
     assert_eq!(
-        Typer::find_tail_match_in_text("hello engi", "engineer is good", 4),
+        find_tail_match_in_text("hello engi", "engineer is good", 4),
         4
     );
 
     // Test basic tail matching
     assert_eq!(
-        Typer::find_tail_match_in_text("hello world", "world is nice", 5),
+        find_tail_match_in_text("hello world", "world is nice", 5),
         5
     );
 
     // Test no match
-    assert_eq!(Typer::find_tail_match_in_text("hello", "goodbye", 3), -1);
+    assert_eq!(find_tail_match_in_text("hello", "goodbye", 3), -1);
 
     // Test short strings
-    assert_eq!(Typer::find_tail_match_in_text("hi", "hello", 3), -1);
+    assert_eq!(find_tail_match_in_text("hi", "hello", 3), -1);
 
     // Test exact match at end
-    assert_eq!(Typer::find_tail_match_in_text("abc", "xyzabc", 3), 6);
+    assert_eq!(find_tail_match_in_text("abc", "xyzabc", 3), 6);
 }
 
 #[test]
@@ -61,7 +55,7 @@ fn find_tail_match_returns_utf8_safe_byte_offset() {
     // position as a CHAR index (4) differs from the BYTE offset (5). The result
     // must be a byte offset: callers slice `&text2[pos..]`, and a char index
     // would land inside the multibyte 'á' and panic ("not a char boundary").
-    let pos = Typer::find_tail_match_in_text("wyzá", "xyzáb", 3);
+    let pos = find_tail_match_in_text("wyzá", "xyzáb", 3);
     assert_eq!(
         pos, 5,
         "expected the byte offset (5), not the char index (4)"
@@ -73,7 +67,7 @@ fn find_tail_match_returns_utf8_safe_byte_offset() {
 
 #[test]
 fn test_find_common_prefix() {
-    assert_eq!(Typer::find_common_prefix("hello world", "hello there"), 6);
-    assert_eq!(Typer::find_common_prefix("abc", "def"), 0);
-    assert_eq!(Typer::find_common_prefix("same text", "same text"), 9);
+    assert_eq!(find_common_prefix("hello world", "hello there"), 6);
+    assert_eq!(find_common_prefix("abc", "def"), 0);
+    assert_eq!(find_common_prefix("same text", "same text"), 9);
 }

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! The preview typer state machine: session/stabilization state plus the
+//! keyboard-driving update logic. The pure text-diff algorithms it builds on
+//! live in [`crate::output::preview`].
+
+use crate::output::keyboard::Simulator;
+use crate::output::preview::{find_common_prefix, find_tail_match_in_text, preprocess_text};
+use log::{debug, info, warn};
+
+/// State for tracking preview updates
+pub struct State {
+    pub last_transcription: String,
+    pub prev_text: String,
+    /// Complete transcription built from all audio (for final output)
+    pub full_session_text: String,
+    /// When we last saw substantial text growth (to commit to full session)
+    pub last_growth_time: std::time::Instant,
+    /// History of transcriptions for stabilization
+    pub text_storage: Vec<String>,
+    /// Text confirmed by appearing in multiple transcriptions
+    pub stabilized_text: String,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            last_transcription: String::new(),
+            prev_text: String::new(),
+            full_session_text: String::new(),
+            last_growth_time: std::time::Instant::now(),
+            text_storage: Vec::new(),
+            stabilized_text: String::new(),
+        }
+    }
+}
+
+impl State {
+    /// Stabilization and session text update (Phase 1).
+    ///
+    /// Keyboard-free: mutates only session/stabilization state, so it is
+    /// independently testable.
+    fn update_with_stabilization(&mut self, new_preview_text: &str) {
+        // Add current text to storage
+        self.text_storage.push(new_preview_text.to_string());
+
+        // Keep only recent texts for stabilization (prevent unbounded growth)
+        if self.text_storage.len() > 10 {
+            self.text_storage.remove(0);
+        }
+
+        // Find common prefix between last two texts
+        if self.text_storage.len() >= 2 {
+            let last_two = &self.text_storage[self.text_storage.len() - 2..];
+            let common_prefix = find_common_prefix(&last_two[0], &last_two[1]);
+            let prefix_text = last_two[0].chars().take(common_prefix).collect::<String>();
+
+            // Only update stabilized text if we found a longer stable prefix
+            if prefix_text.len() > self.stabilized_text.len() {
+                self.stabilized_text = prefix_text;
+                debug!(
+                    "Updated stabilized text: '{}'",
+                    self.stabilized_text.chars().take(30).collect::<String>()
+                );
+            }
+        }
+
+        // Update full session text using stabilized text + tail matching
+        self.update_full_session_text(new_preview_text);
+    }
+
+    /// Update the full session text using stabilized text as base.
+    fn update_full_session_text(&mut self, new_preview_text: &str) {
+        // If we have stabilized text, use it as our base
+        if !self.stabilized_text.is_empty()
+            && self.stabilized_text.len() > self.full_session_text.len()
+        {
+            self.full_session_text = self.stabilized_text.clone();
+            self.last_growth_time = std::time::Instant::now();
+            debug!(
+                "Updated session from stabilized: '{}'",
+                self.full_session_text.chars().take(30).collect::<String>()
+            );
+        }
+
+        // Only grow the session text, never shrink it
+        if self.full_session_text.is_empty() {
+            self.full_session_text = new_preview_text.to_string();
+            self.last_growth_time = std::time::Instant::now();
+            debug!(
+                "Started session text: '{}'",
+                self.full_session_text.chars().take(30).collect::<String>()
+            );
+            return;
+        }
+
+        // Check if preview text extends our session text
+        if new_preview_text.len() > self.full_session_text.len()
+            && new_preview_text.starts_with(&self.full_session_text)
+        {
+            // Perfect extension - just grow
+            self.full_session_text = new_preview_text.to_string();
+            self.last_growth_time = std::time::Instant::now();
+            debug!(
+                "Extended session text to: '{}'",
+                self.full_session_text.chars().take(40).collect::<String>()
+            );
+            return;
+        }
+
+        // Use tail matching to extend session with new content
+        let matching_pos = find_tail_match_in_text(&self.full_session_text, new_preview_text, 3);
+        if matching_pos >= 0 {
+            let extended = format!(
+                "{}{}",
+                self.full_session_text,
+                &new_preview_text[usize::try_from(matching_pos).unwrap_or(0)..]
+            );
+            if extended.len() > self.full_session_text.len() {
+                self.full_session_text = extended;
+                self.last_growth_time = std::time::Instant::now();
+                debug!(
+                    "Extended session via tail match: '{}'",
+                    self.full_session_text.chars().take(40).collect::<String>()
+                );
+            }
+        }
+    }
+
+    /// Build the display text (Phase 2) - what actually shows on screen.
+    fn build_display_text(&self, preview_text: &str) -> String {
+        // Use stabilized text as base, but be smart about it
+
+        // If no stabilized text yet, show the preview
+        if self.stabilized_text.is_empty() {
+            return preview_text.to_string();
+        }
+
+        // Try tail matching first
+        let matching_pos = find_tail_match_in_text(&self.stabilized_text, preview_text, 3);
+
+        if matching_pos >= 0 {
+            // Found overlap - combine stabilized text with new part from preview
+            let combined = format!(
+                "{}{}",
+                self.stabilized_text,
+                &preview_text[usize::try_from(matching_pos).unwrap_or(0)..]
+            );
+            return combined;
+        }
+
+        // No tail match found - be conservative to avoid text loss
+        // Prefer the longer text (session text or preview) to avoid disappearing words
+        let best_text = if self.full_session_text.len() >= preview_text.len() {
+            &self.full_session_text
+        } else {
+            preview_text
+        };
+
+        best_text.to_string()
+    }
+}
+
+/// Unified, simplified preview typer that combines the best of both approaches
+pub struct Typer {
+    keyboard_simulator: Simulator,
+    state: State,
+}
+
+impl Typer {
+    #[must_use]
+    pub fn new(keyboard_simulator: Simulator) -> Self {
+        Self {
+            keyboard_simulator,
+            state: State::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn write_method_name(&self) -> &'static str {
+        self.keyboard_simulator.name()
+    }
+
+    /// Extract the simulator so it can be cached for reuse.
+    #[must_use]
+    pub fn take_simulator(self) -> Simulator {
+        self.keyboard_simulator
+    }
+
+    /// Apply a simple differential update by backspacing and retyping from first difference
+    pub fn apply_simple_diff(&mut self, old_text: &str, new_text: &str) -> usize {
+        // Safety checks
+        if old_text == new_text {
+            return 0;
+        }
+
+        if old_text.is_empty() && !new_text.is_empty() {
+            let _ = self.keyboard_simulator.type_text(new_text);
+            debug!("Failed to type new text");
+            return new_text.len();
+        }
+
+        if new_text.is_empty() {
+            // Skip
+            return 0;
+        }
+
+        let old_chars: Vec<char> = old_text.chars().collect();
+        let new_chars: Vec<char> = new_text.chars().collect();
+
+        // Find first different character position
+        let common_prefix = find_common_prefix(old_text, new_text);
+
+        // Calculate what to delete and what to type
+        let chars_to_delete = old_chars.len() - common_prefix;
+        let text_to_type: String = new_chars[common_prefix..].iter().collect();
+
+        debug!(
+            "Simple diff: prefix={}, delete={}, type='{}'",
+            common_prefix,
+            chars_to_delete,
+            text_to_type.chars().take(20).collect::<String>()
+        );
+
+        // Backspace to the first different position
+        let _ = self.keyboard_simulator.backspace_n(chars_to_delete);
+
+        // Type the new part
+        let _ = self.keyboard_simulator.type_text(&text_to_type);
+
+        text_to_type.len()
+    }
+
+    /// Update preview text using two-phase approach
+    pub fn update_preview(&mut self, new_text: &str, actually_typed: &mut String) {
+        let processed_text = preprocess_text(new_text, true);
+
+        info!(
+            "Preview update: new='{}', prev='{}', typed='{}'",
+            processed_text.chars().take(30).collect::<String>(),
+            self.state.prev_text.chars().take(30).collect::<String>(),
+            actually_typed.chars().take(30).collect::<String>()
+        );
+
+        // Skip if text hasn't changed
+        if processed_text == self.state.prev_text {
+            debug!("Text unchanged, skipping");
+            return;
+        }
+
+        // Skip empty text
+        if processed_text.is_empty() {
+            debug!("Empty text, skipping");
+            return;
+        }
+
+        // PHASE 1: Stabilization and session text update
+        self.state.update_with_stabilization(&processed_text);
+
+        // PHASE 2: Decide what to show on screen
+        let display_text = self.state.build_display_text(&processed_text);
+
+        info!(
+            "Display logic: display='{}', session='{}', stabilized='{}'",
+            display_text.chars().take(30).collect::<String>(),
+            self.state
+                .full_session_text
+                .chars()
+                .take(30)
+                .collect::<String>(),
+            self.state
+                .stabilized_text
+                .chars()
+                .take(30)
+                .collect::<String>()
+        );
+
+        // Apply the update to screen
+        self.apply_text_update(&display_text, actually_typed);
+        self.state.prev_text = processed_text;
+    }
+
+    /// Process final text (completed sentence) - Uses full session audio
+    pub fn process_final_text(&mut self, transcription_result: &str) {
+        // No preview typing, type directly
+        let processed_text = preprocess_text(transcription_result, false);
+        let final_text = format!("{processed_text} ");
+        if let Err(e) = self.keyboard_simulator.type_text(&final_text) {
+            warn!("Failed to type final transcription: {e}");
+        } else {
+            info!("Step 6 complete: Final transcription typed directly");
+        }
+
+        // Reset state for next sentence - but keep the full session text for user reference
+        self.state.prev_text.clear();
+        self.state.last_transcription = processed_text;
+        self.state.last_growth_time = std::time::Instant::now();
+
+        info!(
+            "Completed sentence. Session text: '{}'",
+            self.state
+                .full_session_text
+                .chars()
+                .take(50)
+                .collect::<String>()
+        );
+
+        // Clear session for next recording
+        self.state.full_session_text.clear();
+    }
+
+    /// Apply text update to screen (common logic)
+    fn apply_text_update(&mut self, new_text: &str, actually_typed: &mut String) {
+        let old_char_count = actually_typed.chars().count();
+        let new_char_count = new_text.chars().count();
+
+        info!(
+            "Typing logic: old_typed='{}', new_display='{}', old_count={}, new_count={}",
+            actually_typed.chars().take(30).collect::<String>(),
+            new_text.chars().take(30).collect::<String>(),
+            old_char_count,
+            new_char_count
+        );
+
+        let actual_chars_on_screen;
+        // Screen is empty, just type the new text
+        if old_char_count == 0 {
+            info!(
+                "Screen empty, typing new text: '{}'",
+                new_text.chars().take(30).collect::<String>()
+            );
+            let _ = self.keyboard_simulator.type_text(&format!("{new_text} "));
+            actual_chars_on_screen = new_char_count;
+        }
+        // Screen is not empty, check if new text starts with actually typed text
+        else if new_text.starts_with(actually_typed.as_str())
+            && new_text.len() > actually_typed.len()
+        {
+            // Perfect extension - just add the suffix
+            let suffix = &new_text[actually_typed.len()..];
+            info!("Perfect extension, adding suffix: '{suffix}'");
+            let _ = self.keyboard_simulator.type_text(&format!("{suffix} "));
+            actual_chars_on_screen = new_char_count;
+        } else {
+            // Need to replace - use differential update
+            info!("Need replacement, using diff update");
+            let net_change = self.apply_simple_diff(actually_typed, new_text);
+
+            // Calculate actual characters on screen based on the net change
+            actual_chars_on_screen = old_char_count + net_change;
+
+            info!(
+                "Replaced: {}{} chars (screen total: {})",
+                if net_change > 0 { "+" } else { "" },
+                net_change,
+                actual_chars_on_screen
+            );
+        }
+
+        // Update state to match what we think is actually on screen
+        if actual_chars_on_screen == new_char_count {
+            // Typing succeeded completely
+            actually_typed.clear();
+            actually_typed.push_str(new_text);
+            info!(
+                "Updated actually_typed to: '{}'",
+                actually_typed.chars().take(30).collect::<String>()
+            );
+        } else {
+            // Typing failed or was partial - but for preview, we should still track what we attempted to type
+            // This ensures preview clearing works correctly even when there are typing discrepancies
+            warn!(
+                "Character count mismatch: expected {new_char_count}, actual {actual_chars_on_screen}, updating actually_typed anyway"
+            );
+            actually_typed.clear();
+            actually_typed.push_str(new_text);
+            info!(
+                "Force updated actually_typed to: '{}'",
+                actually_typed.chars().take(30).collect::<String>()
+            );
+        }
+    }
+
+    /// Clear all typed text and reset state
+    pub fn clear_preview(&mut self, actually_typed: &mut String) {
+        info!("clear_preview called with actually_typed: '{actually_typed}'");
+
+        if actually_typed.is_empty() {
+            info!("actually_typed is empty, nothing to clear");
+            return;
+        }
+
+        let chars_to_delete = actually_typed.chars().count();
+        info!("Backspacing {chars_to_delete} characters");
+
+        if let Err(e) = self.keyboard_simulator.backspace_n(chars_to_delete) {
+            warn!("Failed to backspace preview text: {e}");
+        } else {
+            info!("Successfully backspaced {chars_to_delete} characters");
+        }
+
+        actually_typed.clear();
+
+        // Also clear state when explicitly clearing preview
+        self.state.prev_text.clear();
+        self.state.last_transcription.clear();
+        self.state.full_session_text.clear();
+        self.state.last_growth_time = std::time::Instant::now();
+
+        info!("Cleared all {chars_to_delete} characters and reset state");
+    }
+}
+
+#[cfg(test)]
+#[path = "typer_tests.rs"]
+mod tests;

--- a/super-stt-daemon/src/output/typer_tests.rs
+++ b/super-stt-daemon/src/output/typer_tests.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use super::*;
+
+// ---------------------------------------------------------------------------
+// State machine characterization (keyboard-free transitions)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_display_text_returns_preview_when_no_stabilized_text() {
+    let s = State::default();
+    assert_eq!(s.build_display_text("Hello world"), "Hello world");
+}
+
+#[test]
+fn build_display_text_combines_stabilized_with_tail_matched_suffix() {
+    let mut s = State::default();
+    s.stabilized_text = "Hello engi".to_string();
+    // "engi"'s tail "ngi" overlaps "engineer…"; suffix "neer is good" is grafted on.
+    assert_eq!(
+        s.build_display_text("engineer is good"),
+        "Hello engineer is good"
+    );
+}
+
+#[test]
+fn build_display_text_prefers_session_when_no_tail_match_and_session_longer() {
+    let mut s = State::default();
+    s.stabilized_text = "abc".to_string();
+    s.full_session_text = "abcdefghij".to_string();
+    assert_eq!(s.build_display_text("wxyz"), "abcdefghij");
+}
+
+#[test]
+fn build_display_text_prefers_preview_when_no_tail_match_and_preview_longer() {
+    let mut s = State::default();
+    s.stabilized_text = "abc".to_string();
+    s.full_session_text = "ab".to_string();
+    assert_eq!(s.build_display_text("wxyz"), "wxyz");
+}
+
+#[test]
+fn update_full_session_text_adopts_first_preview() {
+    let mut s = State::default();
+    s.update_full_session_text("Hello");
+    assert_eq!(s.full_session_text, "Hello");
+}
+
+#[test]
+fn update_full_session_text_grows_on_perfect_extension() {
+    let mut s = State::default();
+    s.full_session_text = "Hello".to_string();
+    s.update_full_session_text("Hello world");
+    assert_eq!(s.full_session_text, "Hello world");
+}
+
+#[test]
+fn update_full_session_text_extends_via_tail_match() {
+    let mut s = State::default();
+    s.full_session_text = "Hello engi".to_string();
+    s.update_full_session_text("engineer here");
+    assert_eq!(s.full_session_text, "Hello engineer here");
+}
+
+#[test]
+fn update_with_stabilization_locks_common_prefix_across_two_texts() {
+    let mut s = State::default();
+    s.update_with_stabilization("Hello world");
+    s.update_with_stabilization("Hello there");
+    // The two texts share the char-prefix "Hello ", which stabilizes.
+    assert_eq!(s.stabilized_text, "Hello ");
+    // Session text was seeded by the first (longer) preview and not shrunk.
+    assert_eq!(s.full_session_text, "Hello world");
+}


### PR DESCRIPTION
Behavior-preserving split of the 530-line `output/preview.rs` god file into two cohesive modules, plus new characterization coverage for the previously-untested state machine.

## What changed

- **`preview.rs` (530 → 109)** — now holds only the pure text-diff helpers as free functions: `preprocess_text`, `is_simple_extension`, `find_common_prefix`, `find_tail_match_in_text`. Keyboard- and state-free, exhaustively unit-testable.
- **`typer.rs` (new)** — `State` + `Typer`: the session/stabilization state and the keyboard-driving update logic, building on the `preview` helpers.

## Why it unlocks testing

The `Simulator` enum wraps three real backends (Wayland/ydotool/portal) with no test/null variant, so a `Typer` can't be constructed headless — that's why `core_tests.rs` skips it. Moving the three **keyboard-free** state transitions (`update_with_stabilization`, `update_full_session_text`, `build_display_text`) onto `impl State` makes them testable without a `Simulator` for the first time. This adds **8 characterization tests** pinning the formerly-untested state machine (first-preview adopt, perfect-extension growth, tail-match extension, stabilized-prefix locking, display-text tail-merge vs. longest-fallback).

All logic was moved verbatim; the only call-path change is `Typer::preprocess_text` → `preview::preprocess_text` (helpers are now free functions), touching 4 import sites + 1 call.

## Verification

Build clean · clippy `--all-features` pedantic clean · `just fmt` clean · daemon lib **234** (226 + 8 new) · app 45 · `http_smoke_settings` 1 — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)