### PR TITLE
Unify backend.toml parsers and share the /backends DTO

### DIFF
--- a/super-stt-app/src/daemon/backends.rs
+++ b/super-stt-app/src/daemon/backends.rs
@@ -1,140 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-//! Deserialization types for the daemon's installed-backend catalog
-//! (`GET /backends`).
+//! The daemon's installed-backend catalog (`GET /backends`).
 //!
-//! A backend is an installed model provider discovered on disk. Each
-//! one declares the models it serves, the secrets it needs (stored in
-//! the system keyring), and the options it accepts (stored in the
-//! daemon config). The settings UI renders one section per backend.
+//! The response shape is shared with the daemon (which serializes it) via
+//! [`super_stt_shared::models::backends`], so the two sides cannot drift. This
+//! module re-exports it under the names the app's views already use.
 
-/// A single installed backend and everything the settings UI needs to
-/// render its section.
-#[derive(serde::Deserialize, Clone, Debug)]
-pub struct BackendInfo {
-    /// Repo id the backend was installed from, e.g.
-    /// `github.com/super-stt/openai`. Used as the daemon's keyring account
-    /// key and option key.
-    pub source: String,
-    /// Human-readable backend name, e.g. `OpenAI`.
-    pub name: String,
-    /// Hosts the backend is permitted to reach (`[network].allowed_hosts` from
-    /// its `backend.toml`). Empty for subprocess/local backends. Feeds the
-    /// "Online model" badge so the user sees where a cloud backend's audio goes.
-    #[serde(default)]
-    pub allowed_hosts: Vec<String>,
-    /// Models this backend serves.
-    pub models: Vec<BackendModel>,
-    /// Sensitive values (API keys, etc.) stored in the system keyring.
-    pub secrets: Vec<BackendSecret>,
-    /// Non-sensitive options stored in the daemon config.
-    pub options: Vec<BackendOption>,
-}
+pub use super_stt_shared::models::backends::{BackendInfo, BackendOption, BackendSecret};
 
-/// One model served by a backend.
-#[derive(serde::Deserialize, Clone, Debug)]
-pub struct BackendModel {
-    pub name: String,
-    /// Provider string, e.g. `local_whisper` / `openai`. Parsed into a
-    /// [`super_stt_shared::models::provider::Provider`] for selection.
-    pub provider: String,
-    /// Devices the model can be loaded onto. Non-empty `snake_case` values
-    /// from `["cpu", "cuda", "metal", "none"]`. The settings UI surfaces
-    /// these as the device choice in the active-backend card; `"none"`
-    /// (the only-entry sentinel for online models) means no device picker
-    /// is shown.
-    #[serde(default)]
-    pub supported_devices: Vec<String>,
-    /// Conservative GPU memory estimate (weights + KV cache + overhead) in
-    /// bytes; `0` when unknown or not GPU-resident. Drives the "may not fit"
-    /// warning when a CUDA load is staged against the detected GPU memory.
-    #[serde(default)]
-    pub estimated_vram_bytes: u64,
-    /// Whether this model supports multiple transcription languages (as
-    /// opposed to a mono-lingual model baked for a single language).
-    #[serde(default)]
-    pub multilingual: bool,
-    /// BCP-47 tags the model can transcribe, e.g. `["en", "es", "fr"]`.
-    /// Empty for mono-lingual models. Deserialized from the daemon for
-    /// forward use; the picker currently reads languages from the live
-    /// resolution block, so this is not read yet.
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub supported_languages: Vec<String>,
-    /// The model's built-in default language (BCP-47 tag). Deserialized from
-    /// the daemon for forward use; not read yet.
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub primary_language: String,
-}
-
-/// A sensitive value the backend requires, stored in the system keyring.
-#[derive(serde::Deserialize, Clone, Debug)]
-pub struct BackendSecret {
-    /// `snake_case` identifier (the keyring account suffix; the backend reads
-    /// it as `x-stt-secret-<name>`).
-    pub name: String,
-    /// Human-readable label for the UI. Falls back to `name` when absent.
-    #[serde(default)]
-    pub label: Option<String>,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub required: bool,
-}
-
-/// A non-sensitive option the backend accepts, stored in the daemon config.
-#[derive(serde::Deserialize, Clone, Debug)]
-pub struct BackendOption {
-    /// `snake_case` identifier (the daemon config key; the backend reads it as
-    /// `x-stt-option-<name>`).
-    pub name: String,
-    /// Human-readable label for the UI. Falls back to `name` when absent.
-    #[serde(default)]
-    pub label: Option<String>,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub default: Option<String>,
-    #[serde(default)]
-    pub required: bool,
-    /// Current effective value (override or default) reported by the daemon.
-    #[serde(default)]
-    pub value: Option<String>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::BackendInfo;
-
-    /// `GET /backends` reports each backend's `[network].allowed_hosts`; the
-    /// "Online model" badge reads them straight off `BackendInfo`.
-    #[test]
-    fn parses_allowed_hosts() {
-        let json = serde_json::json!({
-            "source": "github.com/super-stt/openai",
-            "name": "OpenAI",
-            "models": [],
-            "secrets": [],
-            "options": [],
-            "allowed_hosts": ["api.openai.com"],
-        });
-        let info: BackendInfo = serde_json::from_value(json).unwrap();
-        assert_eq!(info.allowed_hosts, vec!["api.openai.com".to_string()]);
-    }
-
-    /// A backend that declares no hosts (or an older daemon that omits the
-    /// field) yields an empty list, not a parse error.
-    #[test]
-    fn allowed_hosts_defaults_empty_when_absent() {
-        let json = serde_json::json!({
-            "source": "s",
-            "name": "n",
-            "models": [],
-            "secrets": [],
-            "options": [],
-        });
-        let info: BackendInfo = serde_json::from_value(json).unwrap();
-        assert!(info.allowed_hosts.is_empty());
-    }
-}
+// `BackendModel` is named only by the models-view test fixtures, never by
+// non-test code (views iterate `BackendInfo::models` without naming the type),
+// so the re-export reads as unused in a normal build of this binary crate.
+#[allow(unused_imports)]
+pub use super_stt_shared::models::backends::BackendModel;

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -358,6 +358,7 @@ mod capability_tests {
         BackendInfo {
             source: "github.com/super-stt/test".to_string(),
             name: "Test".to_string(),
+            kind: "subprocess".to_string(),
             allowed_hosts: Vec::new(),
             models: per_model
                 .iter()
@@ -370,6 +371,7 @@ mod capability_tests {
                     multilingual: false,
                     supported_languages: Vec::new(),
                     primary_language: String::new(),
+                    realtime: false,
                 })
                 .collect(),
             secrets: Vec::new(),

--- a/super-stt-app/src/ui/views/models/status.rs
+++ b/super-stt-app/src/ui/views/models/status.rs
@@ -52,6 +52,7 @@ mod unmet_requirements_tests {
         BackendInfo {
             source: "github.com/super-stt/openai".to_string(),
             name: "OpenAI".to_string(),
+            kind: "wasm".to_string(),
             allowed_hosts: Vec::new(),
             models: vec![BackendModel {
                 name: "whisper-1".to_string(),
@@ -61,6 +62,7 @@ mod unmet_requirements_tests {
                 multilingual: false,
                 supported_languages: Vec::new(),
                 primary_language: String::new(),
+                realtime: false,
             }],
             secrets,
             options,
@@ -86,6 +88,7 @@ mod unmet_requirements_tests {
             name: name.to_string(),
             label: label.map(str::to_string),
             description: String::new(),
+            r#type: None,
             default: None,
             required,
             value: value.map(str::to_string),
@@ -277,6 +280,7 @@ mod model_status_tests {
         BackendInfo {
             source: "github.com/super-stt/openai".to_string(),
             name: "OpenAI".to_string(),
+            kind: "wasm".to_string(),
             allowed_hosts: Vec::new(),
             models: vec![BackendModel {
                 name: "whisper-1".to_string(),
@@ -286,6 +290,7 @@ mod model_status_tests {
                 multilingual: false,
                 supported_languages: Vec::new(),
                 primary_language: String::new(),
+                realtime: false,
             }],
             secrets: vec![BackendSecret {
                 name: "openai_api_key".to_string(),

--- a/super-stt-daemon/src/daemon/backend_config_handlers.rs
+++ b/super-stt-daemon/src/daemon/backend_config_handlers.rs
@@ -2,6 +2,7 @@
 
 use crate::daemon::types::SuperSTTDaemon;
 use log::info;
+use super_stt_shared::models::backends::{BackendInfo, BackendModel, BackendOption, BackendSecret};
 use super_stt_shared::models::protocol::DaemonResponse;
 
 /// Fold an optional reload-failure warning into a success message, so a failed
@@ -21,38 +22,34 @@ impl SuperSTTDaemon {
         let config = self.config.read().await;
         let backends = self.backends.read().await;
 
-        let catalog: Vec<serde_json::Value> = backends
+        let catalog: Vec<BackendInfo> = backends
             .iter()
             .map(|b| {
-                let models: Vec<serde_json::Value> = b
+                let models = b
                     .models
                     .iter()
-                    .map(|m| {
-                        serde_json::json!({
-                            "name": m.name,
-                            "provider": m.provider.to_string(),
-                            "multilingual": m.is_multilingual,
-                            "primary_language": m.primary_language,
-                            "supported_languages": m.supported_languages,
-                            "supported_devices": m.supported_devices,
-                            "estimated_vram_bytes": m.estimated_vram_bytes,
-                            "realtime": m.realtime,
-                        })
+                    .map(|m| BackendModel {
+                        name: m.name.clone(),
+                        provider: m.provider.to_string(),
+                        supported_devices: m.supported_devices.clone(),
+                        estimated_vram_bytes: m.estimated_vram_bytes,
+                        multilingual: m.is_multilingual,
+                        supported_languages: m.supported_languages.clone(),
+                        primary_language: m.primary_language.clone(),
+                        realtime: m.realtime,
                     })
                     .collect();
-                let secrets: Vec<serde_json::Value> = b
+                let secrets = b
                     .secrets
                     .iter()
-                    .map(|s| {
-                        serde_json::json!({
-                            "name": s.name,
-                            "label": s.label,
-                            "description": s.description,
-                            "required": s.required,
-                        })
+                    .map(|s| BackendSecret {
+                        name: s.name.clone(),
+                        label: s.label.clone(),
+                        description: s.description.clone(),
+                        required: s.required,
                     })
                     .collect();
-                let options: Vec<serde_json::Value> = b
+                let options = b
                     .options
                     .iter()
                     .map(|o| {
@@ -61,32 +58,33 @@ impl SuperSTTDaemon {
                             .backend_option(&b.source, &o.name)
                             .map(str::to_string)
                             .or_else(|| default.clone());
-                        serde_json::json!({
-                            "name": o.name,
-                            "label": o.label,
-                            "description": o.description,
-                            "type": o.r#type,
-                            "default": default,
-                            "required": o.required,
-                            "value": value,
-                        })
+                        BackendOption {
+                            name: o.name.clone(),
+                            label: o.label.clone(),
+                            description: o.description.clone(),
+                            r#type: o.r#type.map(|t| t.as_str().to_string()),
+                            default,
+                            required: o.required,
+                            value,
+                        }
                     })
                     .collect();
-                serde_json::json!({
-                    "source": b.source,
-                    "name": b.name,
-                    "kind": b.kind,
-                    "allowed_hosts": b.allowed_hosts,
-                    "models": models,
-                    "secrets": secrets,
-                    "options": options,
-                })
+                BackendInfo {
+                    source: b.source.clone(),
+                    name: b.name.clone(),
+                    kind: b.kind.clone(),
+                    allowed_hosts: b.allowed_hosts.clone(),
+                    models,
+                    secrets,
+                    options,
+                }
             })
             .collect();
 
         info!("Backends catalog requested: {} backend(s)", catalog.len());
+        let backends_json = serde_json::to_value(&catalog).unwrap_or_default();
         DaemonResponse::success()
-            .with_backends(serde_json::json!(catalog))
+            .with_backends(backends_json)
             .with_message("Backends listed successfully".to_string())
     }
 

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -29,10 +29,9 @@ fn custom_repo_error_response(
         ResolveError::BadRepoUrl(_) => (StatusCode::BAD_REQUEST, "bad_repo_url"),
         ResolveError::ManifestTooLarge => (StatusCode::UNPROCESSABLE_ENTITY, "manifest_too_large"),
         ResolveError::NotUtf8(_)
-        | ResolveError::Toml(_)
+        | ResolveError::Manifest(_)
         | ResolveError::MissingWasmAsset
         | ResolveError::MissingSubprocessAssets
-        | ResolveError::UnknownKind(_)
         | ResolveError::UnsafeComponent { .. } => {
             (StatusCode::UNPROCESSABLE_ENTITY, "manifest_invalid")
         }

--- a/super-stt-daemon/src/registry/custom_repo.rs
+++ b/super-stt-daemon/src/registry/custom_repo.rs
@@ -11,10 +11,7 @@
 //! it verbatim — the `unverified_source` warning surfaced to clients (see
 //! `docs/protocol/endpoints/v1/registry/install.md`) reflects this.
 
-use std::str::FromStr;
-
-use serde::Deserialize;
-use super_stt_registry_types::manifest::Device;
+use super_stt_registry_types::manifest::{Device, Kind, Manifest, ManifestError, ModelEntry};
 use thiserror::Error;
 
 use crate::registry::index_schema::{
@@ -35,14 +32,12 @@ pub enum ResolveError {
     ManifestTooLarge,
     #[error("backend.toml is not valid UTF-8: {0}")]
     NotUtf8(#[from] std::string::FromUtf8Error),
-    #[error("backend.toml parse: {0}")]
-    Toml(#[from] toml::de::Error),
+    #[error("backend.toml invalid: {0}")]
+    Manifest(#[from] ManifestError),
     #[error("backend.toml declares kind = `wasm` but no `[assets].wasm` entry")]
     MissingWasmAsset,
     #[error("backend.toml declares kind = `subprocess` but no `[[assets.subprocess]]` entries")]
     MissingSubprocessAssets,
-    #[error("backend.toml declares unknown kind `{0}` (expected `wasm` or `subprocess`)")]
-    UnknownKind(String),
     #[error("release has no asset named `{0}`")]
     AssetMissing(String),
     #[error(
@@ -86,20 +81,17 @@ pub async fn resolve(
         return Err(ResolveError::ManifestTooLarge);
     }
     let manifest_text = String::from_utf8(manifest_bytes)?;
-    let manifest: Manifest = toml::from_str(&manifest_text)?;
+    // Parse through the canonical manifest so a custom-repo install is validated
+    // exactly as the daemon's own discovery will validate it: typed
+    // kind/provider/device/accel, required descriptions, and the safe-entrypoint
+    // / safe-destination guards all come from the single shared parser.
+    let manifest = Manifest::parse(&manifest_text)?;
 
     // Unlike the registry path, a custom repo's manifest is never run through
     // the indexer's source-vs-repo check. Enforce it here (see
-    // `ensure_source_matches_repo`).
+    // `ensure_source_matches_repo`). The entrypoint safety guard is already
+    // applied by `Manifest::parse`.
     ensure_source_matches_repo(&manifest.backend.source, &repo)?;
-    // `entrypoint` is joined onto the install dir (it may be nested, e.g.
-    // `bin/launcher`), and `id` becomes that dir's name (a single component).
-    if !super_stt_shared::registry::is_safe_relative_path(&manifest.backend.entrypoint) {
-        return Err(ResolveError::UnsafeComponent {
-            field: "entrypoint",
-            value: manifest.backend.entrypoint,
-        });
-    }
 
     let assets = synthesize_assets(&manifest, &release.assets)?;
 
@@ -125,8 +117,8 @@ pub async fn resolve(
         name: manifest.backend.name,
         description: Some(manifest.backend.description),
         license: manifest.backend.license.unwrap_or_default(),
-        kind: manifest.backend.kind,
-        contract: manifest.backend.contract,
+        kind: manifest.backend.kind.to_string(),
+        contract: manifest.backend.contract.to_string(),
         entrypoint: manifest.backend.entrypoint,
         allowed_hosts: manifest.network.allowed_hosts,
         online,
@@ -134,11 +126,15 @@ pub async fn resolve(
         supports_cpu,
         models: manifest
             .models
-            .into_iter()
+            .iter()
             .map(|m| IndexModel {
-                name: m.name,
-                provider: m.provider,
-                supported_devices: m.supported_devices,
+                name: m.name.clone(),
+                provider: m.provider.as_str().to_string(),
+                supported_devices: m
+                    .supported_devices
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
             })
             .collect(),
         secrets: manifest
@@ -146,7 +142,7 @@ pub async fn resolve(
             .into_iter()
             .map(|s| IndexSecret {
                 name: s.name,
-                label: s.label,
+                label: s.label.unwrap_or_default(),
                 required: s.required,
             })
             .collect(),
@@ -155,9 +151,12 @@ pub async fn resolve(
             .into_iter()
             .map(|o| IndexOption {
                 name: o.name,
-                label: o.label,
-                r#type: o.r#type,
-                default: o.default,
+                label: o.label.unwrap_or_default(),
+                r#type: o.r#type.map(|t| t.as_str().to_string()).unwrap_or_default(),
+                default: o
+                    .default
+                    .as_ref()
+                    .and_then(|d| serde_json::to_value(d).ok()),
             })
             .collect(),
         assets,
@@ -184,25 +183,16 @@ struct ModelSupport {
     supports_cpu: bool,
 }
 
-/// Classify a manifest's models through the canonical [`Device`] type (and the
-/// `none` device sentinel for online/remote models) so the custom-repo path
-/// agrees with the registry indexer on what counts as online / GPU / CPU.
-/// Device strings that aren't canonical simply don't match — the lenient parser
-/// still records them in the index, and the canonical layer rejects them
-/// downstream.
-fn classify_models(models: &[Model]) -> ModelSupport {
-    let online = models
-        .iter()
-        .any(|m| m.supported_devices.iter().any(|d| d == "none"));
-    let any_device = |pred: fn(Device) -> bool| {
-        models.iter().any(|m| {
-            m.supported_devices
-                .iter()
-                .any(|d| Device::from_str(d).is_ok_and(pred))
-        })
-    };
+/// Classify a manifest's models by their [`Device`]s — the `none` sentinel
+/// marks online/remote models, `cuda`/`metal` mark GPU, `cpu` marks CPU — so
+/// the custom-repo path's index card agrees with the registry indexer. Devices
+/// are already validated by [`Manifest::parse`], so there is no string matching
+/// to get wrong here.
+fn classify_models(models: &[ModelEntry]) -> ModelSupport {
+    let any_device =
+        |pred: fn(&Device) -> bool| models.iter().any(|m| m.supported_devices.iter().any(pred));
     ModelSupport {
-        online,
+        online: any_device(|d| matches!(d, Device::None)),
         supports_gpu: any_device(|d| matches!(d, Device::Cuda | Device::Metal)),
         supports_cpu: any_device(|d| matches!(d, Device::Cpu)),
     }
@@ -238,8 +228,8 @@ fn synthesize_assets(
     };
 
     let mut out = IndexAssets::default();
-    match manifest.backend.kind.as_str() {
-        "wasm" => {
+    match manifest.backend.kind {
+        Kind::Wasm => {
             let file = manifest
                 .assets
                 .wasm
@@ -252,18 +242,16 @@ fn synthesize_assets(
                 sha256: String::new(),
             });
         }
-        "subprocess" => {
+        Kind::Subprocess => {
             if manifest.assets.subprocess.is_empty() {
                 return Err(ResolveError::MissingSubprocessAssets);
             }
             for sa in &manifest.assets.subprocess {
-                // A variant is one `file` or several concatenated `parts`. The
-                // custom-repo path has no pinned hash (TLS is the guarantee), so
-                // each synthesized pin carries an empty sha256.
-                let names: Vec<&str> = match &sa.file {
-                    Some(f) => vec![f.as_str()],
-                    None => sa.parts.iter().map(String::as_str).collect(),
-                };
+                // A variant is one `file` or several concatenated `parts` (the
+                // file-xor-parts invariant is guaranteed by `Manifest::parse`).
+                // The custom-repo path has no pinned hash (TLS is the
+                // guarantee), so each synthesized pin carries an empty sha256.
+                let names = sa.release_files();
                 if names.is_empty() {
                     return Err(ResolveError::MissingSubprocessAssets);
                 }
@@ -276,7 +264,7 @@ fn synthesize_assets(
                         sha256: String::new(),
                     });
                 }
-                let (url, size, sha256, parts) = if sa.file.is_none() {
+                let (url, size, sha256, parts) = if sa.is_multipart() {
                     (None, None, None, pins)
                 } else {
                     let p = pins.remove(0);
@@ -284,7 +272,7 @@ fn synthesize_assets(
                 };
                 out.subprocess.push(IndexSubprocessAsset {
                     target: sa.target.clone(),
-                    accel: sa.accel.clone(),
+                    accel: sa.accel.to_string(),
                     cuda_major: sa.cuda_major,
                     cuda_sm: sa.cuda_sm,
                     cudnn: sa.cudnn,
@@ -295,150 +283,67 @@ fn synthesize_assets(
                 });
             }
         }
-        other => return Err(ResolveError::UnknownKind(other.into())),
     }
     Ok(out)
 }
 
-// ---------- Manifest types (local to this module) ----------
-//
-// custom_repo vets a remote repository's manifest before install; it needs
-// only the asset-selection subset of the full manifest schema.  A minimal,
-// lenient local parser is kept here deliberately rather than parsing the whole
-// thing through the canonical super-stt-registry-types, which owns the
-// installed-backend shape.  The provider/device fields stay `String` here, but
-// their *classification* (online / GPU / CPU) runs through the canonical
-// `Provider`/`Device` types — see `classify_models` — so this path agrees with
-// the registry indexer instead of using ad-hoc string lists.
-
-#[derive(Debug, Deserialize)]
-struct Manifest {
-    backend: BackendMeta,
-    #[serde(default)]
-    network: Network,
-    #[serde(default)]
-    models: Vec<Model>,
-    #[serde(default)]
-    secrets: Vec<Secret>,
-    #[serde(default)]
-    options: Vec<Opt>,
-    assets: Assets,
-}
-
-#[derive(Debug, Deserialize)]
-struct BackendMeta {
-    source: String,
-    name: String,
-    version: String,
-    kind: String,
-    entrypoint: String,
-    contract: String,
-    description: String,
-    #[serde(default)]
-    license: Option<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct Network {
-    #[serde(default)]
-    allowed_hosts: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Model {
-    name: String,
-    provider: String,
-    #[serde(default)]
-    supported_devices: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Secret {
-    name: String,
-    #[serde(default)]
-    label: String,
-    #[serde(default)]
-    required: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct Opt {
-    name: String,
-    #[serde(default)]
-    label: String,
-    #[serde(rename = "type", default)]
-    r#type: String,
-    #[serde(default)]
-    default: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Assets {
-    #[serde(default)]
-    wasm: Option<String>,
-    #[serde(default)]
-    subprocess: Vec<SubprocessAsset>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SubprocessAsset {
-    #[serde(default)]
-    file: Option<String>,
-    #[serde(default)]
-    parts: Vec<String>,
-    target: String,
-    accel: String,
-    #[serde(default)]
-    cuda_major: Option<u32>,
-    #[serde(default)]
-    cuda_sm: Option<u32>,
-    #[serde(default)]
-    cudnn: bool,
-}
+// The manifest types are the canonical `super_stt_registry_types::manifest`
+// set (see the imports): custom_repo parses a remote repo's `backend.toml`
+// through the same strict parser the daemon's discovery uses, then projects the
+// asset-selection subset onto the loose registry-index shape (`IndexBackend`).
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use super_stt_forge::RepoRef;
+    use super_stt_registry_types::provider::Provider;
 
-    fn model(name: &str, provider: &str, devices: &[&str]) -> Model {
-        Model {
-            name: name.into(),
-            provider: provider.into(),
-            supported_devices: devices.iter().map(|s| (*s).to_string()).collect(),
+    /// Build a `ModelEntry` with the given provider and devices; the other
+    /// fields are irrelevant to `classify_models` (which reads only devices).
+    fn model(provider: &str, devices: &[Device]) -> ModelEntry {
+        ModelEntry {
+            name: "m".into(),
+            provider: Provider::from(provider),
+            multilingual: true,
+            primary_language: "en".into(),
+            supported_languages: vec!["en".into()],
+            supported_devices: devices.to_vec(),
+            estimated_vram_bytes: 0,
+            processing_interval_ms: None,
+            realtime: false,
+            files: vec![],
         }
     }
 
     #[test]
     fn classify_marks_online_from_none_device_not_provider() {
         // Online-ness is derived from the `none` device sentinel, not the
-        // (now free-form) provider string.
-        assert!(classify_models(&[model("m", "openai", &["none"])]).online);
-        assert!(classify_models(&[model("m", "mistral", &["none"])]).online);
-        assert!(classify_models(&[model("m", "deepgram", &["none"])]).online);
+        // (free-form) provider string.
+        assert!(classify_models(&[model("openai", &[Device::None])]).online);
+        assert!(classify_models(&[model("mistral", &[Device::None])]).online);
         // A made-up provider is still online if it declares the `none` device.
-        assert!(classify_models(&[model("m", "anthropic", &["none"])]).online);
-        assert!(classify_models(&[model("m", "totally_bogus", &["none"])]).online);
+        assert!(classify_models(&[model("totally_bogus", &[Device::None])]).online);
         // No `none` device → not online, regardless of provider.
-        assert!(!classify_models(&[model("m", "openai", &["cpu"])]).online);
-        assert!(!classify_models(&[model("m", "local_whisper", &["cpu"])]).online);
-        assert!(!classify_models(&[model("m", "openai", &[])]).online);
+        assert!(!classify_models(&[model("openai", &[Device::Cpu])]).online);
+        assert!(!classify_models(&[model("local_whisper", &[Device::Cpu])]).online);
+        assert!(!classify_models(&[model("openai", &[])]).online);
     }
 
     #[test]
-    fn classify_marks_gpu_for_cuda_or_metal_not_rocm() {
-        assert!(classify_models(&[model("m", "local_whisper", &["cuda"])]).supports_gpu);
-        assert!(classify_models(&[model("m", "local_whisper", &["metal"])]).supports_gpu);
-        // `rocm` is an Accel build axis, never a model Device — not GPU here.
-        assert!(!classify_models(&[model("m", "local_whisper", &["rocm"])]).supports_gpu);
-        assert!(!classify_models(&[model("m", "local_whisper", &["cpu"])]).supports_gpu);
+    fn classify_marks_gpu_for_cuda_or_metal() {
+        // `rocm` is an `Accel` build axis, never a model `Device` — the typed
+        // `Device` enum makes it unrepresentable here, so there is nothing to
+        // mis-classify.
+        assert!(classify_models(&[model("local_whisper", &[Device::Cuda])]).supports_gpu);
+        assert!(classify_models(&[model("local_whisper", &[Device::Metal])]).supports_gpu);
+        assert!(!classify_models(&[model("local_whisper", &[Device::Cpu])]).supports_gpu);
     }
 
     #[test]
     fn classify_marks_cpu_only_for_cpu_device() {
-        assert!(classify_models(&[model("m", "local_whisper", &["cpu"])]).supports_cpu);
-        assert!(!classify_models(&[model("m", "openai", &["none"])]).supports_cpu);
-        assert!(!classify_models(&[model("m", "local_whisper", &["cuda"])]).supports_cpu);
+        assert!(classify_models(&[model("local_whisper", &[Device::Cpu])]).supports_cpu);
+        assert!(!classify_models(&[model("openai", &[Device::None])]).supports_cpu);
+        assert!(!classify_models(&[model("local_whisper", &[Device::Cuda])]).supports_cpu);
     }
 
     #[test]
@@ -475,7 +380,7 @@ mod tests {
             [assets]
             wasm = "y.wasm"
         "#;
-        let m: Manifest = toml::from_str(manifest_text).unwrap();
+        let m = Manifest::parse(manifest_text).unwrap();
         let release_assets = vec![ReleaseAsset {
             name: "y.wasm".into(),
             download_url: "https://example/y.wasm".into(),
@@ -503,7 +408,7 @@ mod tests {
             [assets]
             wasm = "missing.wasm"
         "#;
-        let m: Manifest = toml::from_str(manifest_text).unwrap();
+        let m = Manifest::parse(manifest_text).unwrap();
         let err = synthesize_assets(&m, &[]).unwrap_err();
         assert!(matches!(err, ResolveError::AssetMissing(_)));
     }
@@ -532,7 +437,7 @@ mod tests {
             cuda_major = 12
             cuda_sm = 86
         "#;
-        let m: Manifest = toml::from_str(manifest_text).unwrap();
+        let m = Manifest::parse(manifest_text).unwrap();
         let release_assets = vec![
             ReleaseAsset {
                 name: "y-cpu.tar.gz".into(),
@@ -572,7 +477,7 @@ mod tests {
             accel = "cuda"
             cuda_major = 13
         "#;
-        let m: Manifest = toml::from_str(manifest_text).unwrap();
+        let m = Manifest::parse(manifest_text).unwrap();
         let release_assets = vec![
             ReleaseAsset {
                 name: "y-cuda13.tar.gz.part00".into(),

--- a/super-stt-shared/src/models/backends.rs
+++ b/super-stt-shared/src/models/backends.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! The `GET /backends` installed-backend catalog response.
+//!
+//! A backend is an installed model provider discovered on disk. Each one
+//! declares the models it serves, the secrets it needs (stored in the system
+//! keyring), and the options it accepts (stored in the daemon config). The
+//! daemon serializes this catalog from its discovered backends; the settings UI
+//! deserializes it and renders one section per backend. Keeping the shape here,
+//! shared by both sides, is what keeps the wire contract from drifting.
+//!
+//! `#[serde(default)]` on the non-identity fields lets an older daemon that
+//! omits a newer field still deserialize (the value simply defaults).
+
+use serde::{Deserialize, Serialize};
+
+/// A single installed backend and everything the settings UI needs to render
+/// its section.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BackendInfo {
+    /// Repo id the backend was installed from, e.g.
+    /// `github.com/super-stt/openai`. Used as the daemon's keyring account
+    /// key and option key.
+    pub source: String,
+    /// Human-readable backend name, e.g. `OpenAI`.
+    pub name: String,
+    /// `"wasm"` or `"subprocess"` — the backend's transport.
+    #[serde(default)]
+    pub kind: String,
+    /// Hosts the backend is permitted to reach (`[network].allowed_hosts` from
+    /// its `backend.toml`). Empty for subprocess/local backends. Feeds the
+    /// "Online model" badge so the user sees where a cloud backend's audio goes.
+    #[serde(default)]
+    pub allowed_hosts: Vec<String>,
+    /// Models this backend serves.
+    pub models: Vec<BackendModel>,
+    /// Sensitive values (API keys, etc.) stored in the system keyring.
+    pub secrets: Vec<BackendSecret>,
+    /// Non-sensitive options stored in the daemon config.
+    pub options: Vec<BackendOption>,
+}
+
+/// One model served by a backend.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BackendModel {
+    pub name: String,
+    /// Provider string, e.g. `local_whisper` / `openai`. Parsed into a
+    /// [`crate::models::provider::Provider`] for selection.
+    pub provider: String,
+    /// Devices the model can be loaded onto. Non-empty `snake_case` values
+    /// from `["cpu", "cuda", "metal", "none"]`. The settings UI surfaces
+    /// these as the device choice in the active-backend card; `"none"`
+    /// (the only-entry sentinel for online models) means no device picker
+    /// is shown.
+    #[serde(default)]
+    pub supported_devices: Vec<String>,
+    /// Conservative GPU memory estimate (weights + KV cache + overhead) in
+    /// bytes; `0` when unknown or not GPU-resident. Drives the "may not fit"
+    /// warning when a CUDA load is staged against the detected GPU memory.
+    #[serde(default)]
+    pub estimated_vram_bytes: u64,
+    /// Whether this model supports multiple transcription languages (as
+    /// opposed to a mono-lingual model baked for a single language).
+    #[serde(default)]
+    pub multilingual: bool,
+    /// BCP-47 tags the model can transcribe, e.g. `["en", "es", "fr"]`.
+    /// Empty for mono-lingual models.
+    #[serde(default)]
+    pub supported_languages: Vec<String>,
+    /// The model's built-in default language (BCP-47 tag).
+    #[serde(default)]
+    pub primary_language: String,
+    /// Whether the model is driven over the realtime WebSocket path rather than
+    /// batch `POST /v1/transcribe`.
+    #[serde(default)]
+    pub realtime: bool,
+}
+
+/// A sensitive value the backend requires, stored in the system keyring.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BackendSecret {
+    /// `snake_case` identifier (the keyring account suffix; the backend reads
+    /// it as `x-stt-secret-<name>`).
+    pub name: String,
+    /// Human-readable label for the UI. Falls back to `name` when absent.
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// A non-sensitive option the backend accepts, stored in the daemon config.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BackendOption {
+    /// `snake_case` identifier (the daemon config key; the backend reads it as
+    /// `x-stt-option-<name>`).
+    pub name: String,
+    /// Human-readable label for the UI. Falls back to `name` when absent.
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub description: String,
+    /// The option's input type (`string` / `integer` / `bool`); absent when the
+    /// backend declared none.
+    #[serde(default, rename = "type")]
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub default: Option<String>,
+    #[serde(default)]
+    pub required: bool,
+    /// Current effective value (override or default) reported by the daemon.
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BackendInfo;
+
+    /// `GET /backends` reports each backend's `[network].allowed_hosts`; the
+    /// "Online model" badge reads them straight off `BackendInfo`.
+    #[test]
+    fn parses_allowed_hosts() {
+        let json = serde_json::json!({
+            "source": "github.com/super-stt/openai",
+            "name": "OpenAI",
+            "models": [],
+            "secrets": [],
+            "options": [],
+            "allowed_hosts": ["api.openai.com"],
+        });
+        let info: BackendInfo = serde_json::from_value(json).unwrap();
+        assert_eq!(info.allowed_hosts, vec!["api.openai.com".to_string()]);
+    }
+
+    /// A backend that declares no hosts (or an older daemon that omits the
+    /// field) yields an empty list, not a parse error.
+    #[test]
+    fn allowed_hosts_defaults_empty_when_absent() {
+        let json = serde_json::json!({
+            "source": "s",
+            "name": "n",
+            "models": [],
+            "secrets": [],
+            "options": [],
+        });
+        let info: BackendInfo = serde_json::from_value(json).unwrap();
+        assert!(info.allowed_hosts.is_empty());
+    }
+}

--- a/super-stt-shared/src/models/mod.rs
+++ b/super-stt-shared/src/models/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pub mod audio;
+pub mod backends;
 pub mod protocol;
 pub mod provider;
 pub mod recording_stop_mode;


### PR DESCRIPTION
Reduces the drift across the places that model backend metadata. Two independent, self-contained commits.

## The picture

Backend metadata was modeled in three places that had to be kept in sync by hand:
1. **Canonical** `super_stt_registry_types::manifest::Manifest` — strict, typed `backend.toml` parser (the source of truth; used by daemon discovery + the indexer).
2. **custom_repo loose** — a ~80-line duplicate `backend.toml` parser (all-`String`) for vetting remote repos.
3. **app `BackendInfo`** — a hand-mirror of the daemon's `GET /backends` **JSON** response (a different serialization contract, not a TOML parser).

## Commit 1 — Unify the two TOML parsers

`custom_repo` now parses through the canonical `Manifest` instead of its own structs, so a custom-repo install is validated exactly as the daemon's own discovery validates it (typed `kind`/`provider`/`device`/`accel`, required descriptions, safe entrypoint/destinations). `classify_models` works on typed `Device`s; `synthesize_assets` is an exhaustive `Kind` match reusing `SubprocessAsset::release_files`/`is_multipart`.

- **Behavior:** a canonically-invalid manifest is now rejected at install (**same `422 manifest_invalid`**) rather than installing and failing later at load — strictly fail-faster.
- The `SourceSpoof` identity check and source-id safety guard are preserved. The now-unrepresentable `rocm`-as-a-device test is dropped (the type system enforces it).

## Commit 2 — Share the `/backends` DTO

The `GET /backends` response shape moves into `super_stt_shared::models::backends` (`BackendInfo`/`BackendModel`/`BackendSecret`/`BackendOption`). The daemon builds and serializes the typed DTO instead of hand-rolling `serde_json::json!`; the app re-exports it instead of maintaining a parallel struct set — so the two sides can no longer drift. **Same wire shape** (`kind`/`realtime`/`type` still emitted). The app's two forward-compat fields become real shared-lib API instead of `#[allow(dead_code)]`.

## Net

−215 lines (145 added, 360 removed).

## Verification

Workspace clippy `--all-features --pedantic -D warnings`: clean. `just fmt`: clean.
Tests: shared 83, daemon lib 226, app 43, `http_smoke_backend_options` 5, `http_smoke_backend_secrets` 3 — all pass.

Merge with **"Rebase and merge"** to keep the two commits distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)