### PR TITLE
Extract clear_loaded_model() helper for the current-model triple

### DIFF
--- a/super-stt-app/src/core/app/handlers/download.rs
+++ b/super-stt-app/src/core/app/handlers/download.rs
@@ -6,7 +6,6 @@ use crate::ui::messages::Message;
 use cosmic::prelude::*;
 use log::info;
 use log::warn;
-use super_stt_shared::models::provider::Provider;
 
 impl AppModel {
     /// Handle download progress messages
@@ -112,9 +111,7 @@ impl AppModel {
                 // resolve to "no installed backend serves  via
                 // local_whisper" and surface as a UI error.
                 self.model_operation_state = ModelOperationState::Ready;
-                self.current_model.clear();
-                self.current_provider = Provider::default();
-                self.current_source.clear();
+                self.clear_loaded_model();
                 Task::none()
             }
 
@@ -122,9 +119,7 @@ impl AppModel {
                 warn!("Download error for model {model}: {error}");
                 self.model_operation_state = ModelOperationState::Ready;
                 self.transcription_text = format!("Download Error: {error}");
-                self.current_model.clear();
-                self.current_provider = Provider::default();
-                self.current_source.clear();
+                self.clear_loaded_model();
                 Task::none()
             }
 

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -9,7 +9,6 @@ use crate::ui::messages::Message;
 use cosmic::prelude::*;
 use log::info;
 use log::warn;
-use super_stt_shared::models::provider::Provider;
 
 impl AppModel {
     /// Handle model management messages
@@ -125,9 +124,7 @@ impl AppModel {
                 self.model_operation_state = ModelOperationState::Error { message: sanitized };
                 // A failed switch leaves the daemon idle (no model) — the
                 // backend stays selected, but no model is loaded.
-                self.current_model = String::new();
-                self.current_provider = Provider::default();
-                self.current_source = String::new();
+                self.clear_loaded_model();
                 Task::none()
             }
 

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -12,7 +12,6 @@ use crate::state::{ContextPage, DaemonStatus, ModelsTab};
 use crate::ui::messages::Message;
 use cosmic::prelude::*;
 use log::debug;
-use super_stt_shared::models::provider::Provider;
 
 impl AppModel {
     /// Models-page UI: tab switch, per-backend dropdown / GPU / select, the
@@ -141,9 +140,7 @@ impl AppModel {
                 // Optimistic clear so the UI returns to the staged-pickers
                 // state immediately; the daemon's `ready` event with
                 // `model_loaded: false` is the source of truth.
-                self.current_model = String::new();
-                self.current_provider = Provider::default();
-                self.current_source = String::new();
+                self.clear_loaded_model();
                 self.staged_model = None;
                 self.staged_device = None;
                 self.model_operation_state = ModelOperationState::Ready;
@@ -278,9 +275,7 @@ impl AppModel {
                     return Task::none();
                 }
                 self.active_backend = Some(source.clone());
-                self.current_model = String::new();
-                self.current_provider = Provider::default();
-                self.current_source = String::new();
+                self.clear_loaded_model();
                 self.model_operation_state = ModelOperationState::Ready;
                 // Activation comes from the Models page's "Load a backend" sheet;
                 // dismiss it now that a choice was made.
@@ -296,9 +291,7 @@ impl AppModel {
                 // daemon goes idle. (Rejected only mid-recording — an edge case
                 // that self-heals on the next refresh.)
                 self.active_backend = None;
-                self.current_model = String::new();
-                self.current_provider = Provider::default();
-                self.current_source = String::new();
+                self.clear_loaded_model();
                 self.model_operation_state = ModelOperationState::Ready;
                 self.configure_backend = None;
                 // Close the configuration sheet if it was open for this backend.

--- a/super-stt-app/src/core/app/small_state.rs
+++ b/super-stt-app/src/core/app/small_state.rs
@@ -19,6 +19,17 @@ impl AppModel {
         matches!(self.model_operation_state, ModelOperationState::Ready)
     }
 
+    /// Clear the locally-tracked loaded model — its name, provider, and source.
+    /// Called wherever the daemon goes idle (unload, failed switch, download
+    /// error/cancel) or the selection is optimistically dropped. Adjacent state
+    /// (operation status, staged pickers, active backend) is each caller's
+    /// responsibility.
+    pub(in crate::core::app) fn clear_loaded_model(&mut self) {
+        self.current_model.clear();
+        self.current_provider = super_stt_shared::models::provider::Provider::default();
+        self.current_source.clear();
+    }
+
     /// Set model to downloading state
     pub(in crate::core::app) fn set_model_downloading(
         &mut self,
@@ -92,9 +103,7 @@ impl AppModel {
                 // A failed switch leaves the daemon idle — clear the selection
                 // so the UI doesn't show a model that isn't loaded (mirrors the
                 // `ModelError` handler).
-                self.current_model.clear();
-                self.current_provider = super_stt_shared::models::provider::Provider::default();
-                self.current_source.clear();
+                self.clear_loaded_model();
             }
             "completed" | "cancelled" => {
                 // State will be updated by subsequent daemon events


### PR DESCRIPTION
Addresses the `clear_loaded_model()` item from the super-stt-app section of `docs/audits/2026-07-code-quality.md`.

## What changed

The `current_model` / `current_provider` / `current_source` clear was copy-pasted at **7 sites**, each hand-picking its own adjacent resets. Replaced with a single `AppModel::clear_loaded_model()` helper in `small_state.rs` (`pub(in crate::core::app)`, matching that file's mutation-helper convention).

Sites collapsed:
- `small_state.rs` — failed-switch download progress
- `handlers/download.rs` ×2 — `DownloadCancelled`, `DownloadError`
- `handlers/model.rs` — `ModelError`
- `handlers/models_page/mod.rs` ×3 — `UnloadActiveModel`, `SelectBackend`, `DeselectBackend`

**Behavior preserved:** the helper does only the triple-clear; each caller keeps its own adjacent resets (`model_operation_state`, `staged_model`/`staged_device`, `active_backend`, `configure_backend`, `transcription_text`, context-sheet dismissal). Also drops three now-unused `Provider` imports.

`AppModel` has no `Default`/test constructor (45 fields), so a bespoke unit test for a 3-field reset would be disproportionate — this is a behavior-preserving mechanical extraction, verified by the compiler and the existing suite.

## Verification

clippy `--all-features --pedantic -D warnings`: clean. `just fmt`: clean. App tests: 43 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)