### PR TITLE
Audit Tier 1 #8-#11: feature-combo builds, 304 panic, egress convergence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
       - name: Run clippy
         run: just check
 
+      # The clippy/test gates use --all-features (both backend transports on),
+      # so a #[cfg] slip that only breaks a single-transport or no-backend build
+      # is invisible to them (audit Tier 1 #8). Compile every combination here.
+      - name: Check backend-feature combinations
+        run: just check-features
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -161,7 +161,7 @@ Three patterns account for the majority of findings:
   clears it only when the id is still its own, so a losing racer can neither clobber
   nor null the winner's sender.
 
-### [ ] 8. 🟠 Daemon: `--no-default-features --features wasm-backends` does not compile
+### [x] 8. 🟠 Daemon: `--no-default-features --features wasm-backends` does not compile
 
 - **Where:** the subprocess stub is missing `&self`
   (`daemon/model_management/instantiate.rs:159-169`), and
@@ -170,8 +170,18 @@ Three patterns account for the majority of findings:
 - **Problem/Impact:** the feature combination is broken and neither combination is
   exercised by CI, so it can't stay fixed.
 - **Fix:** repair the stub and variant references; add the feature matrix to CI.
+- **Resolved (branch `refactor/audit-daemon-robustness`):** the empirical breakage
+  (the `install.rs` variant references had already been de-gated since the audit)
+  was: the `#[cfg(not(subprocess-backends))]` `instantiate_subprocess` stub lacked
+  `&self`; `daemon_main.rs` called `stt_models::subprocess::cleanup_orphan_units()`
+  unconditionally; and `transcribe.rs`'s `SuperSTTDaemon`/`Response` imports plus
+  `instantiate.rs`'s `log::warn` import went unused when a transport was off. Added
+  `&self`, gated the orphan-sweep call and the wasm-only imports, and fully-qualified
+  the one `warn` call. New `just check-features` compiles all three reduced combos
+  (subprocess-only, wasm-only, no-backends) under `RUSTFLAGS=-D warnings`, wired into
+  `just ci` and the CI clippy job so the drift can't return.
 
-### [ ] 9. 🟠 Daemon: unsolicited `304` panics the registry client
+### [x] 9. 🟠 Daemon: unsolicited `304` panics the registry client
 
 - **Where:** `refresh()` does `self.state.read().as_ref().unwrap()` on 304
   (`registry/client.rs:147-152`); `Client::new` also unwraps the builder
@@ -179,8 +189,18 @@ Three patterns account for the majority of findings:
 - **Impact:** a misbehaving proxy can panic the daemon.
 - **Fix:** treat an unsolicited 304 with no cached state as a refetch/error;
   propagate builder failure instead of unwrapping.
+- **Resolved (branch `refactor/audit-daemon-robustness`):** the 304 branch now takes
+  a single write lock and, if the in-memory cache is empty (an unsolicited 304 when
+  we sent no `If-None-Match`), returns `ClientError::Unavailable` instead of
+  unwrapping `None`. `get()` already degrades that to the disk cache or `Unavailable`,
+  so a misbehaving proxy can no longer panic the daemon. Added a mockito test. The
+  builder-unwrap sub-point was superseded by the Tier 2 #4 forge consolidation: the
+  `reqwest` client is now built once in `super_stt_forge::http::{short,download}_client`
+  with a single documented `.expect()` on a path that can't fail for these settings
+  (rustls-no-provider does no eager TLS init) — threading `Result` through a dozen
+  infallible call sites for an unreachable branch was not worth it.
 
-### [ ] 10. 🔴 Daemon: HTTP vs WS egress allowlists diverge in the wasm host *(security)*
+### [x] 10. 🔴 Daemon: HTTP vs WS egress allowlists diverge in the wasm host *(security)*
 
 - **Where:** `send_request` matches the authority as written
   (`stt_models/wasm/host.rs:67-69`) while `check_host_allowed` matches synthesized
@@ -190,14 +210,28 @@ Three patterns account for the majority of findings:
   on the runtime and is check-then-connect (TOCTOU, acknowledged at
   `host.rs:84-85`).
 - **Fix:** route `send_request` through `check_host_allowed`.
+- **Resolved (branch `refactor/audit-daemon-robustness`):** the HTTP hook's inline
+  allowlist match (authority-as-written) is gone; `send_request` now derives
+  `host` + scheme-default `port` and calls `check_host_allowed`, the exact function
+  the `ws` host uses — so `["h:443"]` behaves identically for `https://h/` and
+  `wss://h/`. A no-host authority-form request is rejected outright. Added a
+  regression test at the shared `check_host_allowed` for the default-port `host:port`
+  match. The synchronous-DNS / check-then-connect TOCTOU is unchanged and stays noted
+  in the code (a follow-up; not the divergence this item is about).
 
-### [ ] 11. 🟠 Daemon: duplicate adaptive-VAD in `RealTimeSession::add_audio_chunk` reintroduces the NaN hazard fixed in #268
+### [x] 11. 🟠 Daemon: duplicate adaptive-VAD in `RealTimeSession::add_audio_chunk` reintroduces the NaN hazard fixed in #268
 
 - **Where:** `services/transcription.rs:90-132`.
 - **Problem:** RMS computes 0/0 = NaN on an empty chunk (the guard exists only in
   `audio/state.rs:78-81`); `recent_levels`/`silence_start`/votes feed write-only
   state that is never read.
 - **Fix:** delete the block or reuse `RecordingState`.
+- **Resolved (subsumed by Tier 1 #2, PR #275):** the entire `services/transcription.rs`
+  file — `RealTimeSession`, its `add_audio_chunk`, the duplicate adaptive-VAD block,
+  and the `recent_levels`/`silence_start`/vote fields — was deleted when the
+  vestigial `RealTimeTranscriptionManager` was removed (commit `caaff4d`). The
+  canonical realtime path is `GET /v1/transcribe/realtime`. Nothing left to fix;
+  `RealTimeSession` and `add_audio_chunk` no longer exist in the tree.
 
 ### [ ] 12. 🟠 Daemon: preview typer accounting mixes bytes and chars
 

--- a/justfile
+++ b/justfile
@@ -92,6 +92,16 @@ check *args:
 # Runs a clippy check with JSON message format
 check-json: (check '--message-format=json')
 
+# Verify the daemon compiles under every backend-transport feature combination.
+# The `check`/`test` gates use `--all-features` (both transports on), so a `#[cfg]`
+# slip that only breaks a single-transport or no-backend build slips through
+# otherwise (see audit Tier 1 #8). `-D warnings` also catches feature-conditional
+# unused imports.
+check-features:
+    RUSTFLAGS="-D warnings" cargo check -p super-stt-daemon --no-default-features --features subprocess-backends
+    RUSTFLAGS="-D warnings" cargo check -p super-stt-daemon --no-default-features --features wasm-backends
+    RUSTFLAGS="-D warnings" cargo check -p super-stt-daemon --no-default-features
+
 # Check formatting without modifying files
 fmt-check:
     cargo fmt --all -- --check
@@ -137,8 +147,8 @@ coverage-lcov:
 coverage-html *args:
     cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --html {{ args }}
 
-# Full local CI gate: format, lint, tests, doctests, schemas
-ci: fmt-check check test doctest schema-check
+# Full local CI gate: format, lint, feature-combo compile, tests, doctests, schemas
+ci: fmt-check check check-features test doctest schema-check
 
 # Run the app for testing purposes
 run-app *args:

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -2,10 +2,15 @@
 use crate::daemon::http::internal::helpers::dispatch::{build_request, dispatch, json_response};
 use crate::daemon::http::internal::helpers::responses::recording_in_progress_response;
 use crate::daemon::http::state::AppState;
+// Only the wasm-backends realtime handler references the daemon type / bare
+// `Response`; gated so the subprocess-only and no-backend builds stay warning-clean.
+#[cfg(feature = "wasm-backends")]
 use crate::daemon::types::SuperSTTDaemon;
 use axum::extract::State;
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
+#[cfg(feature = "wasm-backends")]
+use axum::response::Response;
 use std::sync::Arc;
 use super_stt_shared::models::protocol::DaemonResponse;
 

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -3,7 +3,6 @@ use crate::daemon::types::SuperSTTDaemon;
 use crate::stt_models::backends::{self, DiscoveredBackend};
 use crate::stt_models::transcribe::Transcribe;
 use anyhow::{Result, anyhow, bail};
-use log::warn;
 use super_stt_shared::models::provider::Provider;
 use super_stt_shared::models::registry::ModelDefinition;
 
@@ -125,7 +124,7 @@ impl SuperSTTDaemon {
                 .download_manager
                 .start_download(std::sync::Arc::clone(&t))
             {
-                warn!("could not register download tracker: {e}");
+                log::warn!("could not register download tracker: {e}");
             }
             // Emit the initial state immediately so the UI shows "0%" rather
             // than nothing while the first chunk lands.
@@ -158,6 +157,7 @@ impl SuperSTTDaemon {
 
     #[cfg(not(feature = "subprocess-backends"))]
     async fn instantiate_subprocess(
+        &self,
         backend: &DiscoveredBackend,
         _name: &str,
         _device_pref: &str,

--- a/super-stt-daemon/src/daemon_main.rs
+++ b/super-stt-daemon/src/daemon_main.rs
@@ -130,7 +130,8 @@ pub async fn run() -> Result<()> {
     // skipped `Drop`). The transient unit's name embeds the spawning
     // daemon's PID, so a restarted daemon can't reach it via the regular
     // unload path — sweeping at startup is the only deterministic way to
-    // recover from that.
+    // recover from that. Only meaningful with the subprocess transport.
+    #[cfg(feature = "subprocess-backends")]
     crate::stt_models::subprocess::cleanup_orphan_units().await;
 
     // Set up Ctrl+C handler

--- a/super-stt-daemon/src/registry/client.rs
+++ b/super-stt-daemon/src/registry/client.rs
@@ -110,10 +110,8 @@ impl Client {
     ///
     /// # Errors
     /// Returns a `ClientError` on network failure, I/O error, or JSON parse error.
-    ///
-    /// # Panics
-    /// Panics only if the in-memory cache is unexpectedly empty after a 304 Not-Modified
-    /// response (should never happen in practice).
+    /// Returns `ClientError::Unavailable` if the server answers with an unsolicited
+    /// `304 Not Modified` and there is no cached index to fall back on.
     pub async fn refresh(&self) -> Result<Index, ClientError> {
         // Load from disk if memory is empty.
         let etag = {
@@ -141,10 +139,16 @@ impl Client {
         let resp = req.send().await?;
 
         if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
-            if let Some(c) = self.state.write().as_mut() {
-                c.fetched_at = SystemTime::now();
-            }
-            return Ok(self.state.read().as_ref().unwrap().index.clone());
+            // A 304 is only valid as the answer to our conditional request, so a
+            // cached index should exist to refresh. If it doesn't — a misbehaving
+            // proxy replying 304 when we sent no `If-None-Match` — treat it as
+            // unavailable rather than unwrapping `None` and panicking the daemon.
+            let mut guard = self.state.write();
+            let Some(c) = guard.as_mut() else {
+                return Err(ClientError::Unavailable);
+            };
+            c.fetched_at = SystemTime::now();
+            return Ok(c.index.clone());
         }
 
         let resp = resp.error_for_status()?;
@@ -222,6 +226,26 @@ mod tests {
         let idx = c.refresh().await.unwrap();
         assert_eq!(idx.schema_version, 1);
         assert!(dir.path().join("c.json").exists());
+    }
+
+    #[tokio::test]
+    async fn unsolicited_304_without_cache_is_unavailable_not_panic() {
+        // A misbehaving proxy can answer 304 even though we sent no
+        // If-None-Match (fresh client, no disk cache). Must surface as
+        // Unavailable, not panic on an empty in-memory cache.
+        crate::install_crypto_provider();
+        let mut s = mockito::Server::new_async().await;
+        s.mock("GET", "/idx.json")
+            .with_status(304)
+            .create_async()
+            .await;
+        let dir = tempdir().unwrap();
+        let c = Client::new(
+            format!("{}/idx.json", s.url()),
+            dir.path().join("c.json"),
+            DEFAULT_TTL,
+        );
+        assert!(matches!(c.refresh().await, Err(ClientError::Unavailable)));
     }
 
     #[tokio::test]

--- a/super-stt-daemon/src/stt_models/wasm/host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/host.rs
@@ -62,40 +62,34 @@ impl WasiHttpHooks for AllowlistHooks {
         request: hyper::Request<HyperOutgoingBody>,
         config: OutgoingRequestConfig,
     ) -> HttpResult<HostFutureIncomingResponse> {
-        let authority = request.uri().authority().map(|a| a.as_str().to_string());
-        let host = request.uri().host().map(str::to_string);
-        let allowed = self.allowed_hosts.iter().any(|a| {
-            Some(a.as_str()) == authority.as_deref() || Some(a.as_str()) == host.as_deref()
-        });
-        if !allowed {
-            return Err(ErrorCode::InternalError(Some(format!(
-                "outbound host not allowed: {}",
-                authority.or(host).unwrap_or_default()
-            )))
-            .into());
-        }
-
-        // SSRF guard: a backend must not reach a private/loopback/link-local
-        // address or the cloud metadata endpoint (169.254.169.254), whether it
-        // names a hostname (which could DNS-rebind) or an IP literal. The
-        // allowlist is backend-declared, so an IP literal is *not* a trusted
-        // operator opt-in — check it against the disallow-list too.
+        // Enforce egress through the shared allowlist+SSRF check so HTTP and the
+        // `ws` host apply byte-for-byte identical rules. This hook used to match
+        // the authority string exactly as written, which diverged from
+        // `check_host_allowed`'s synthesized `host:port` match: an allowlist
+        // entry of `api.example.com:443` passed for `wss://` but not `https://`
+        // (whose port is the scheme default and so absent from the authority).
         //
-        // NOTE: this resolves synchronously; production should use async DNS
-        // and pin the resolved address through to connect.
-        if let Some(h) = host.as_deref() {
-            let port =
-                request
-                    .uri()
-                    .port_u16()
-                    .unwrap_or(if request.uri().scheme_str() == Some("http") {
-                        80
-                    } else {
-                        443
-                    });
-            if let Err(msg) = guard_egress_host(h, port, self.allow_loopback) {
-                return Err(ErrorCode::InternalError(Some(msg)).into());
-            }
+        // NOTE: `check_host_allowed` resolves DNS synchronously and is
+        // check-then-connect (TOCTOU); production should use async DNS and pin
+        // the resolved address through to connect. The bare-host early return
+        // rejects an authority-form request with no host outright.
+        let Some(host) = request.uri().host().map(str::to_string) else {
+            return Err(
+                ErrorCode::InternalError(Some("outbound request has no host".to_string())).into(),
+            );
+        };
+        let port =
+            request
+                .uri()
+                .port_u16()
+                .unwrap_or(if request.uri().scheme_str() == Some("http") {
+                    80
+                } else {
+                    443
+                });
+        if let Err(msg) = check_host_allowed(&self.allowed_hosts, &host, port, self.allow_loopback)
+        {
+            return Err(ErrorCode::InternalError(Some(msg)).into());
         }
 
         Ok(default_send_request(request, config))
@@ -241,6 +235,17 @@ mod tests {
     fn host_not_on_allowlist_is_rejected() {
         let allow = vec!["api.example.com".to_string()];
         assert!(check_host_allowed(&allow, "169.254.169.254", 80, false).is_err());
+    }
+
+    #[test]
+    fn host_port_authority_matches_when_port_is_scheme_default() {
+        // Divergence regression (Tier 1 #10): a `host:port` allowlist entry must
+        // match a request whose port is the scheme default and therefore absent
+        // from the written authority. Both the HTTP hook (`send_request`) and the
+        // `ws` host now route through `check_host_allowed`, so `["h:443"]` behaves
+        // identically for `https://h/` and `wss://h/`. Loopback avoids real DNS.
+        let allow = vec!["127.0.0.1:443".to_string()];
+        assert!(check_host_allowed(&allow, "127.0.0.1", 443, true).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Fixes Tier 1 #8, #9, #10 from `docs/audits/2026-07-code-quality.md`, and ticks #11 (already resolved).

## #8 — daemon single-transport builds now compile
`--no-default-features --features {wasm,subprocess}-backends` and the no-backend build were broken. Added `&self` to the subprocess-off `instantiate_subprocess` stub, gated the unconditional orphan-unit sweep and the wasm-only `transcribe.rs` imports, and fully-qualified the one `warn` call. New `just check-features` compiles all three reduced combos under `RUSTFLAGS=-D warnings`, wired into `just ci` **and** the CI clippy job so the drift can't return.

## #9 — unsolicited 304 no longer panics the registry client
`refresh()` unwrapped the in-memory cache on a 304, so a proxy answering 304 when we sent no `If-None-Match` panicked the daemon. It now returns `ClientError::Unavailable` when the cache is empty (`get()` already degrades that to the disk cache). Mockito regression test added. The builder-unwrap sub-point was superseded by the Tier 2 #4 forge consolidation (single documented `.expect()` on an unreachable path).

## #10 — HTTP/WS egress allowlists converged *(security)*
The HTTP hook matched the authority as written while `check_host_allowed` matched a synthesized `host:port`, so `["h:443"]` passed for `wss://` but not `https://`. `send_request` now derives host + scheme-default port and calls `check_host_allowed` — the same function the `ws` host uses. Regression test added. The synchronous-DNS/TOCTOU note is unchanged (separate follow-up).

## #11 — subsumed by #275
`RealTimeSession::add_audio_chunk` and its duplicate NaN-hazard VAD block lived in `services/transcription.rs`, deleted when `RealTimeTranscriptionManager` was removed (`caaff4d`). Doc-ticked only.

## Verification
All 4 feature combos compile clean · workspace clippy pedantic clean · 235 daemon lib tests pass · doctests pass · `just fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)