### PR TITLE
Audit Tier 1 #12-#15: preview typer + app error surface, settings polling

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -298,6 +298,17 @@ Three patterns account for the majority of findings:
 - **Impact:** a failed API-key save shows nothing in the Configure sheet — the user
   believes the key is stored.
 - **Fix:** surface the failures and roll back optimistic state (Tier 3 #11).
+- **Resolved (branch `refactor/audit-app-error-surface`):** the four backend
+  secret/option save handlers now raise `SettingActionFailed { ConfigureBackend, .. }`
+  (rendered as an `error_banner` inside the Configure sheet) instead of the log-only
+  `BackendsError`, which is kept for catalog-load failures. `InstallFailedToStart`
+  records into a new `RegistryState::install_errors` map (mirroring `uninstall_errors`)
+  so the Browse card shows "Failed to start: …" and keeps the Install button for a
+  retry, rather than silently dropping the entry. The optimistic-state gap is closed
+  by making the preview-typing / recording-stop-mode / write-method handlers
+  confirm-then-apply: the local value is set only on the daemon ack, so a failed save
+  leaves the control on its old, correct value (and the `PreviewTypingError` handler
+  no longer abuses the transcription box). Uses the shared error slot from #13.
 
 ### [ ] 16. 🟡 App: `$HOME` sanitization corrupts messages when HOME is unset
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -262,8 +262,16 @@ Three patterns account for the majority of findings:
 - **Impact:** one trivial request failure hijacks the whole UI.
 - **Fix:** scope the error instead of escalating to connection state (the shared
   error surface, Tier 3 #11).
+- **Resolved (branch `refactor/audit-app-error-surface`):** built the shared
+  scope-tagged error slot the "one error surface" item calls for —
+  `AppModel::action_error: Option<ActionError>` with an `ErrorScope`
+  (`Customization` / `ConfigureBackend`) and an `action_error_for(scope)` accessor.
+  Volume/theme/feedback failures now raise `SettingActionFailed { Customization, .. }`
+  (rendered as an inline `error_banner` on the Customization page) instead of
+  `DaemonError`, so `daemon_status` no longer flips and the connection page is not
+  forced. The slot clears on retry, on reconnect, and on sheet open/close.
 
-### [ ] 14. 🟡 App: the app refetches all settings every 5 seconds forever
+### [x] 14. 🟡 App: the app refetches all settings every 5 seconds forever
 
 - **Where:** successful pings map to `Message::DaemonConnected`
   (`handlers/daemon/mod.rs:79-84`), whose handler unconditionally runs six settings
@@ -273,8 +281,15 @@ Three patterns account for the majority of findings:
 - **Fix:** introduce a dedicated `SettingSaved` ack and load settings only on the
   disconnected→connected transition (SSE `settings_changed` already covers
   cross-client sync).
+- **Resolved (branch `refactor/audit-app-error-surface`):** `handle_daemon_connected`
+  now runs the settings/model/language loads only on the disconnected→connected
+  transition; a periodic keep-alive ping (which also resolves to `DaemonConnected`)
+  returns `Task::none()`, so the six GETs no longer fire every tick or clobber
+  optimistic edits. The two audio save handlers stopped reusing `DaemonConnected` as
+  their success ack (they now resolve to `Action::None`), removing the per-toggle
+  refetch without needing a separate `SettingSaved` message.
 
-### [ ] 15. 🟠 App: failed secret/option saves are invisible
+### [x] 15. 🟠 App: failed secret/option saves are invisible
 
 - **Where:** all backend secret/option save failures route to log-only
   `BackendsError` (`handlers/backend.rs:103-211`); `InstallFailedToStart` is

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -233,7 +233,7 @@ Three patterns account for the majority of findings:
   canonical realtime path is `GET /v1/transcribe/realtime`. Nothing left to fix;
   `RealTimeSession` and `add_audio_chunk` no longer exist in the tree.
 
-### [ ] 12. 🟠 Daemon: preview typer accounting mixes bytes and chars
+### [x] 12. 🟠 Daemon: preview typer accounting mixes bytes and chars
 
 - **Where:** `apply_simple_diff` returns bytes (`output/typer.rs:200,231`) that
   `apply_text_update` adds to char counts (`typer.rs:313-350`).
@@ -244,8 +244,17 @@ Three patterns account for the majority of findings:
   O(n²) `Vec<char>` rebuilds.
 - **Fix:** count one unit consistently end-to-end; subtract deletions; return
   `Option<usize>` instead of the sentinel.
+- **Resolved (branch `refactor/audit-app-error-surface`):** `apply_simple_diff` now
+  returns the net **char** delta (chars typed minus chars deleted) instead of a byte
+  length; the byte-vs-char reconciliation in `apply_text_update` — whose two branches
+  were identical and whose only effect was a spurious non-ASCII warn — was deleted, so
+  `actually_typed` is set once to the display text. The misleading unconditional
+  "Failed to type" debug now logs the real `type_text` error. `find_tail_match_in_text`
+  returns `Option<usize>` (byte offset) and compares char slices in place instead of
+  allocating a `Vec<char>` per position; both call sites and the tests use the
+  `Option` form (added a rightmost-match case).
 
-### [ ] 13. 🟠 App: a single failed `set_volume`/theme POST flips the app to the full-screen connection-error page
+### [x] 13. 🟠 App: a single failed `set_volume`/theme POST flips the app to the full-screen connection-error page
 
 - **Where:** volume/theme failures map to `Message::DaemonError`
   (`handlers/recording.rs:100-124`), and `view.rs:140-145` forces the Connection

--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -5,9 +5,19 @@ use crate::daemon::client::{
     clear_backend_option, clear_backend_secret, list_backend_secrets, list_backends,
     set_backend_option, set_backend_secret,
 };
+use crate::state::ErrorScope;
 use crate::ui::messages::Message;
 use cosmic::prelude::*;
+use super_stt_shared::daemon::http_client::HttpError;
 use super_stt_shared::models::provider::Provider;
+
+/// Build a Configure-sheet-scoped banner message for a failed secret/option save.
+fn configure_backend_error(e: &HttpError) -> Message {
+    Message::SettingActionFailed {
+        scope: ErrorScope::ConfigureBackend,
+        message: e.to_string(),
+    }
+}
 
 impl AppModel {
     /// Backend catalog refresh + per-backend secret/option configuration
@@ -133,6 +143,8 @@ impl AppModel {
             // success via BackendSecretStored, so a transient failure leaves
             // the typed value intact for retry.
             Message::BackendSecretSaved { source, name } => {
+                // Clear any stale Configure-sheet banner as the user retries.
+                self.action_error = None;
                 let key = (source.clone(), name.clone());
                 let Some(value) = self.backend_secret_inputs.get(&key).cloned() else {
                     return Task::none();
@@ -147,7 +159,7 @@ impl AppModel {
                             source: source.clone(),
                             name: name.clone(),
                         }),
-                        Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                        Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                     },
                 )
             }
@@ -161,11 +173,12 @@ impl AppModel {
 
             // Clear secret via daemon; daemon reloads-if-active itself.
             Message::BackendSecretRemoved { source, name } => {
+                self.action_error = None;
                 self.backend_secret_inputs
                     .remove(&(source.clone(), name.clone()));
                 Task::perform(clear_backend_secret(source, name), move |res| match res {
                     Ok(()) => cosmic::Action::App(Message::BackendsReload),
-                    Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                    Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                 })
             }
 
@@ -181,6 +194,7 @@ impl AppModel {
             // Options go to the daemon config. If the input is empty, clear the
             // override; otherwise set the new value. The daemon reloads-if-active.
             Message::BackendOptionSaved { source, name } => {
+                self.action_error = None;
                 let value = self
                     .backend_option_inputs
                     .get(&(source.clone(), name.clone()))
@@ -189,14 +203,14 @@ impl AppModel {
                 if value.is_empty() {
                     Task::perform(clear_backend_option(source, name), |result| match result {
                         Ok(()) => cosmic::Action::App(Message::BackendsReload),
-                        Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                        Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                     })
                 } else {
                     Task::perform(
                         set_backend_option(source, name, value),
                         |result| match result {
                             Ok(()) => cosmic::Action::App(Message::BackendsReload),
-                            Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                            Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                         },
                     )
                 }
@@ -205,9 +219,10 @@ impl AppModel {
             // Explicit reset: clear the stored override and reload so the
             // option reverts to its daemon default.
             Message::BackendOptionReset { source, name } => {
+                self.action_error = None;
                 Task::perform(clear_backend_option(source, name), |result| match result {
                     Ok(()) => cosmic::Action::App(Message::BackendsReload),
-                    Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                    Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                 })
             }
 

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -131,17 +131,22 @@ impl AppModel {
             }
         }
 
-        let load_settings = build_load_settings_tasks();
-        let load_primary_language = self.load_primary_language();
-
+        // Load settings/models/languages ONLY on the disconnected→connected
+        // transition. Periodic keep-alive pings also resolve to `DaemonConnected`
+        // (daemon/mod.rs `PingTimeout`), so re-fetching here unconditionally re-ran
+        // six settings GETs + a language load every tick and clobbered optimistic
+        // local edits (Tier 1 #14). Cross-client settings sync rides the SSE
+        // `settings_changed` topic, not this poll.
         if was_disconnected {
+            // Fresh connection — drop any banner left over from before the drop.
+            self.action_error = None;
             Task::batch([
                 self.handle_model_messages(Message::LoadInitialData),
-                load_settings,
-                load_primary_language,
+                build_load_settings_tasks(),
+                self.load_primary_language(),
             ])
         } else {
-            Task::batch([load_settings, load_primary_language])
+            Task::none()
         }
     }
 

--- a/super-stt-app/src/core/app/handlers/models_page/install.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/install.rs
@@ -13,6 +13,8 @@ impl AppModel {
         match message {
             // Registry / Download-tab messages
             Message::InstallBackend(source) => {
+                // Clear a prior "failed to start" so the card reads "Installing…".
+                self.registry.install_errors.remove(&source);
                 let s = source.clone();
                 Task::perform(
                     async move { crate::daemon::registry::install_by_source(&s).await },
@@ -32,6 +34,7 @@ impl AppModel {
             }
 
             Message::InstallBackendFromRepoUrl(url) => {
+                self.registry.install_errors.remove(&url);
                 let u = url.clone();
                 Task::perform(
                     async move { crate::daemon::registry::install_by_repo_url(&u).await },
@@ -53,6 +56,8 @@ impl AppModel {
             Message::InstallAccepted { source, install_id } => {
                 use crate::state::registry::InstallStatus;
                 use super_stt_shared::registry::events::InstallPhase;
+                // The request was accepted — retire any prior start error.
+                self.registry.install_errors.remove(&source);
                 self.registry.installs.insert(
                     source,
                     InstallStatus {
@@ -68,11 +73,16 @@ impl AppModel {
 
             Message::InstallFailedToStart { source, error } => {
                 log::error!("install({source}) failed to start: {error}");
+                // Drop the pending marker (there is no background install) and
+                // record the reason so the Browse card shows "Failed" + a note
+                // instead of silently snapping back to the Install button.
                 self.registry.installs.remove(&source);
+                self.registry.install_errors.insert(source, error);
                 Task::none()
             }
 
             Message::UpdateBackend(source) => {
+                self.registry.install_errors.remove(&source);
                 let s = source.clone();
                 Task::perform(
                     async move { crate::daemon::registry::update(&s).await },
@@ -162,6 +172,7 @@ impl AppModel {
 
             Message::InstallCompleted { source } => {
                 self.registry.installs.remove(&source);
+                self.registry.install_errors.remove(&source);
                 // Refresh the installed-backends list so the new install
                 // shows up in the Installed tab.
                 Task::perform(list_backends(), |result| match result {

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -235,12 +235,15 @@ impl AppModel {
                 self.context_page = ContextPage::ConfigureBackend;
                 self.core.window.show_context = true;
                 self.installed_menu_open = None;
+                // Start the sheet without a stale save-error banner.
+                self.action_error = None;
                 Task::none()
             }
 
             Message::CloseBackendConfig => {
                 self.configure_backend = None;
                 self.core.window.show_context = false;
+                self.action_error = None;
                 Task::none()
             }
 

--- a/super-stt-app/src/core/app/handlers/recording.rs
+++ b/super-stt-app/src/core/app/handlers/recording.rs
@@ -5,10 +5,19 @@ use crate::daemon::client::{
     RecordEvent, record_command_stream, set_and_test_audio_theme, set_audio_theme, set_volume,
     stop_record_command,
 };
-use crate::state::{AudioTheme, RecordingStatus};
+use crate::state::{AudioTheme, ErrorScope, RecordingStatus};
 use crate::ui::messages::Message;
 use cosmic::prelude::*;
 use futures_util::StreamExt;
+use super_stt_shared::daemon::http_client::HttpError;
+
+/// Build a Customization-scoped banner message for a failed audio-settings save.
+fn customization_error(e: &HttpError) -> Message {
+    Message::SettingActionFailed {
+        scope: ErrorScope::Customization,
+        message: e.to_string(),
+    }
+}
 
 impl AppModel {
     /// Route recording/audio messages to the appropriate helper.
@@ -89,26 +98,34 @@ impl AppModel {
     fn handle_audio_messages(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
         match message {
             Message::AudioFeedbackToggled(enabled) => {
+                // Clear any stale Customization banner as the user retries.
+                self.action_error = None;
                 let theme = if enabled {
                     self.last_non_silent_theme
                 } else {
                     AudioTheme::Silent
                 };
                 self.selected_audio_theme = theme;
+                // Success is a no-op (the optimistic value already holds); a
+                // failure surfaces a scoped banner instead of flipping the whole
+                // app to the connection-error page (Tier 1 #13). Reusing
+                // `DaemonConnected` here also used to trigger a full settings
+                // refetch on every toggle (Tier 1 #14).
                 Task::perform(set_audio_theme(theme), |result| match result {
-                    Ok(_) => cosmic::Action::App(Message::DaemonConnected),
-                    Err(e) => cosmic::Action::App(Message::DaemonError(e)),
+                    Ok(_) => cosmic::Action::None,
+                    Err(e) => cosmic::Action::App(customization_error(&e)),
                 })
             }
 
             Message::AudioThemeSelected(theme) => {
+                self.action_error = None;
                 self.selected_audio_theme = theme;
                 if theme != AudioTheme::Silent {
                     self.last_non_silent_theme = theme;
                 }
                 Task::perform(set_and_test_audio_theme(theme), |result| match result {
-                    Ok(_) => cosmic::Action::App(Message::DaemonConnected),
-                    Err(e) => cosmic::Action::App(Message::DaemonError(e)),
+                    Ok(_) => cosmic::Action::None,
+                    Err(e) => cosmic::Action::App(customization_error(&e)),
                 })
             }
 
@@ -118,10 +135,11 @@ impl AppModel {
             }
 
             Message::VolumeChanged(vol) => {
+                self.action_error = None;
                 self.volume = vol;
                 Task::perform(set_volume(vol), |result| match result {
                     Ok(()) => cosmic::Action::None,
-                    Err(e) => cosmic::Action::App(Message::DaemonError(e)),
+                    Err(e) => cosmic::Action::App(customization_error(&e)),
                 })
             }
 

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -12,8 +12,11 @@ impl AppModel {
         message: Message,
     ) -> Task<cosmic::Action<Message>> {
         match message {
+            // Confirm-then-apply: the local value is set only when the daemon
+            // acks the save (via `PreviewTypingSettingLoaded`). A failed POST
+            // therefore leaves the toggle on its old, correct value instead of
+            // stranding an un-rolled-back optimistic one (Tier 1 #15).
             Message::PreviewTypingToggled(enabled) => {
-                self.preview_typing_enabled = enabled;
                 Task::perform(set_preview_typing(enabled), move |result| match result {
                     Ok(()) => cosmic::Action::App(Message::PreviewTypingSettingLoaded(enabled)),
                     Err(e) => cosmic::Action::App(Message::PreviewTypingError(e.to_string())),
@@ -26,9 +29,10 @@ impl AppModel {
             }
 
             Message::PreviewTypingError(err) => {
-                // Log error and show it to user in transcription text
+                // The toggle already reflects the daemon's last-known value (we
+                // never applied optimistically), so just log — no transcription
+                // box abuse.
                 log::warn!("Preview typing error: {err}");
-                self.transcription_text = format!("Preview Typing Error: {err}");
                 Task::none()
             }
 
@@ -42,8 +46,9 @@ impl AppModel {
         message: Message,
     ) -> Task<cosmic::Action<Message>> {
         match message {
+            // Confirm-then-apply (see `PreviewTypingToggled`): apply only on the
+            // daemon ack so a failed save doesn't strand an optimistic value.
             Message::RecordingStopModeChanged(mode) => {
-                self.recording_stop_mode = mode;
                 let mode_str = mode.to_string();
                 Task::perform(
                     set_recording_stop_mode(mode_str),
@@ -76,8 +81,9 @@ impl AppModel {
         message: Message,
     ) -> Task<cosmic::Action<Message>> {
         match message {
+            // Confirm-then-apply (see `PreviewTypingToggled`): apply only on the
+            // daemon ack so a failed save doesn't strand an optimistic value.
             Message::WriteMethodChanged(method) => {
-                self.write_method = method;
                 let method_str = method.to_string();
                 Task::perform(set_write_method(method_str), move |result| match result {
                     Ok(()) => cosmic::Action::App(Message::WriteMethodLoaded(method)),

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -177,6 +177,9 @@ impl AppModel {
 
             // Registry state
             registry: crate::state::registry::RegistryState::default(),
+
+            // No pending scoped action error at startup.
+            action_error: None,
         };
 
         // Create startup commands

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -192,6 +192,23 @@ pub struct AppModel {
 
     // Registry state (catalog + install progress for the Download tab).
     pub registry: crate::state::registry::RegistryState,
+
+    /// Scope-tagged banner for a failed settings/backend save. Rendered inline
+    /// on the owning page instead of hijacking the UI (Tier 1 #13) or being
+    /// dropped to the log (Tier 1 #15). `None` when there is no pending error.
+    pub action_error: Option<crate::state::ActionError>,
+}
+
+impl AppModel {
+    /// The pending [`action_error`](Self::action_error) message iff it is tagged
+    /// for `scope` — used by each page's view to render its own inline banner.
+    #[must_use]
+    pub fn action_error_for(&self, scope: crate::state::ErrorScope) -> Option<&str> {
+        self.action_error
+            .as_ref()
+            .filter(|e| e.scope == scope)
+            .map(|e| e.message.as_str())
+    }
 }
 
 /// Create a COSMIC application from the app model

--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -19,6 +19,12 @@ impl AppModel {
 
     /// Routes daemon, model, models-page, device, and download messages.
     fn dispatch_core(&mut self, message: Message) -> Option<Task<cosmic::Action<Message>>> {
+        // Scoped action failure: park it in the per-page banner slot.
+        if let Message::SettingActionFailed { scope, message } = message {
+            self.action_error = Some(crate::state::ActionError { scope, message });
+            return Some(Task::none());
+        }
+
         // Daemon-related messages
         if matches!(
             message,

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -156,6 +156,7 @@ impl AppModel {
                 &self.selected_audio_theme,
                 self.volume,
                 self.primary_language.as_deref(),
+                self.action_error_for(crate::state::ErrorScope::Customization),
             ),
             Page::Recording => views::recording::page(
                 self.recording_stop_mode,

--- a/super-stt-app/src/state/mod.rs
+++ b/super-stt-app/src/state/mod.rs
@@ -7,5 +7,6 @@ pub mod registry;
 
 // Re-export commonly used types
 pub use models::{
-    AudioTheme, ContextPage, DaemonStatus, MenuAction, ModelsTab, Page, RecordingStatus,
+    ActionError, AudioTheme, ContextPage, DaemonStatus, ErrorScope, MenuAction, ModelsTab, Page,
+    RecordingStatus,
 };

--- a/super-stt-app/src/state/models.rs
+++ b/super-stt-app/src/state/models.rs
@@ -69,6 +69,28 @@ pub enum ContextPage {
     LoadBackend,
 }
 
+/// Where a transient action error belongs, so a failed save surfaces as an
+/// inline banner on the owning surface instead of hijacking the whole UI
+/// (Tier 1 #13) or being dropped to the log (Tier 1 #15). One scope-tagged
+/// slot ([`ActionError`]) is held on `AppModel`; the audit's "one error
+/// surface" (App Tier 3 #11) generalizes this.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorScope {
+    /// The Customization page's Audio section: theme / volume / feedback saves.
+    Customization,
+    /// The per-backend Configure sheet: secret / option saves.
+    ConfigureBackend,
+}
+
+/// A scope-tagged, transient action failure rendered as an inline banner on the
+/// page named by [`ErrorScope`]. Set on a failed save, cleared when the user
+/// retries that action, reconnects, or closes the owning surface.
+#[derive(Clone, Debug)]
+pub struct ActionError {
+    pub scope: ErrorScope,
+    pub message: String,
+}
+
 /// Which tab of the Models page is active.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum ModelsTab {

--- a/super-stt-app/src/state/registry.rs
+++ b/super-stt-app/src/state/registry.rs
@@ -16,6 +16,11 @@ pub struct RegistryState {
     /// Cleared when the user retries that backend or it disappears from the
     /// reloaded catalog (i.e. the uninstall ultimately succeeded).
     pub uninstall_errors: HashMap<String, String>,
+    /// Install-request failures that never produced a background install
+    /// (`InstallFailedToStart`), keyed by `source`/repo-url. Surfaced on the
+    /// Browse card so a rejected request isn't silently dropped (Tier 1 #15).
+    /// Cleared when the user retries or the install ultimately succeeds.
+    pub install_errors: HashMap<String, String>,
     pub last_refresh: Option<RefreshOutcome>,
     /// In-progress URL text for the Custom-repo input in the Download tab.
     pub custom_repo_input: String,

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -230,6 +230,13 @@ pub enum Message {
     /// UI reflects the new effective values.
     BackendsReload,
     BackendsError(String),
+    /// A scoped settings/backend save failed. Stored in `AppModel::action_error`
+    /// and rendered as an inline banner on the page named by `scope`, instead of
+    /// hijacking the UI (Tier 1 #13) or being dropped to the log (Tier 1 #15).
+    SettingActionFailed {
+        scope: crate::state::ErrorScope,
+        message: String,
+    },
     /// Daemon-sourced configured flags for a backend's secrets, received after
     /// `BackendsLoaded`. Folds `(name, configured)` into `backend_secret_configured`.
     BackendSecretsConfigured {

--- a/super-stt-app/src/ui/views/common.rs
+++ b/super-stt-app/src/ui/views/common.rs
@@ -1,11 +1,27 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //! Common components and utilities shared across views.
 
-use cosmic::iced::Length;
+use cosmic::iced::{Alignment, Length};
+use cosmic::iced_widget::row;
 use cosmic::widget::{self, text};
 use cosmic::{Apply, Element};
 
+use crate::ui::icons;
 use crate::ui::messages::Message;
+
+/// A scope-tagged action-error banner: a destructive warning glyph plus the
+/// message. Shared by the pages that render `AppModel::action_error` (the
+/// Customization page and the Configure sheet) so a failed save surfaces
+/// inline instead of hijacking the UI. Mirrors the Models card's `card_error`.
+pub fn error_banner(message: &str) -> Element<'_, Message> {
+    row![
+        icons::phosphor_destructive(icons::WARNING, 18.0),
+        text::body(message.to_string()),
+    ]
+    .spacing(cosmic::theme::spacing().space_xs)
+    .align_y(Alignment::Center)
+    .into()
+}
 
 /// Create a page container following cosmic-settings patterns
 pub fn page_container<'a>(content: impl Into<Element<'a, Message>>) -> Element<'a, Message> {

--- a/super-stt-app/src/ui/views/customization.rs
+++ b/super-stt-app/src/ui/views/customization.rs
@@ -4,7 +4,7 @@ use cosmic::widget::{self, settings, space::horizontal as horizontal_space, text
 use cosmic::{Apply, Element};
 use super_stt_shared::theme::AudioTheme;
 
-use super::common::page_layout;
+use super::common::{error_banner, page_layout};
 use crate::ui::messages::Message;
 
 /// Customization page: audio feedback toggle, theme selection, volume, and language.
@@ -13,6 +13,7 @@ pub fn page<'a>(
     selected_audio_theme: &'a AudioTheme,
     volume: u8,
     app_primary_language: Option<&'a str>,
+    action_error: Option<&'a str>,
 ) -> Element<'a, Message> {
     let audio_enabled = *selected_audio_theme != AudioTheme::Silent;
 
@@ -94,6 +95,14 @@ pub fn page<'a>(
             ),
     );
 
-    let sections = settings::view_column(vec![section.into(), language_section.into()]);
-    page_layout("Customization", sections)
+    // Surface a failed audio-settings save inline (Tier 1 #13) instead of
+    // letting the failure flip the whole app to the connection-error page.
+    let mut blocks: Vec<Element<'a, Message>> = Vec::new();
+    if let Some(message) = action_error {
+        blocks.push(error_banner(message));
+    }
+    blocks.push(section.into());
+    blocks.push(language_section.into());
+
+    page_layout("Customization", settings::view_column(blocks))
 }

--- a/super-stt-app/src/ui/views/models/configure.rs
+++ b/super-stt-app/src/ui/views/models/configure.rs
@@ -19,6 +19,12 @@ pub fn configure_sheet<'a>(backend: &'a BackendInfo, app: &'a AppModel) -> Eleme
 
     let mut body: Vec<Element<'a, Message>> = Vec::new();
 
+    // Surface a failed secret/option save inline in the sheet (Tier 1 #15)
+    // instead of dropping it to the log.
+    if let Some(message) = app.action_error_for(crate::state::ErrorScope::ConfigureBackend) {
+        body.push(crate::ui::views::common::error_banner(message));
+    }
+
     if backend.secrets.is_empty() && backend.options.is_empty() {
         body.push(text::body("This backend has nothing to configure.").into());
     } else {

--- a/super-stt-app/src/ui/views/models/download.rs
+++ b/super-stt-app/src/ui/views/models/download.rs
@@ -236,6 +236,9 @@ pub(super) fn download_card<'a>(
     let spacing = cosmic::theme::spacing();
     let muted = muted_text_color();
     let in_flight = app.registry.installs.get(&entry.source);
+    // A request the daemon rejected before any background install started
+    // (Tier 1 #15). The Install button stays enabled for a retry.
+    let start_error = app.registry.install_errors.get(&entry.source);
 
     // Header carries no action — Install lives in the footer below.
     let mut card = widget::column::with_capacity(6)
@@ -290,6 +293,14 @@ pub(super) fn download_card<'a>(
             }
             _ => horizontal_space().into(),
         }
+    } else if let Some(err) = start_error {
+        row![
+            icons::phosphor_destructive(icons::WARNING, 14.0),
+            text::caption(format!("Failed to start: {err}")),
+        ]
+        .spacing(spacing.space_xxs)
+        .align_y(Alignment::Center)
+        .into()
     } else if !entry.compatibility.compatible {
         let reason = entry
             .compatibility

--- a/super-stt-daemon/src/output/preview.rs
+++ b/super-stt-daemon/src/output/preview.rs
@@ -64,44 +64,48 @@ pub(crate) fn find_common_prefix(text1: &str, text2: &str) -> usize {
 }
 
 /// Find where the last `length_of_match` characters of `text1` match a
-/// substring of `text2`, returning the **byte offset** in `text2` just past
-/// that match (so callers can `&text2[pos..]` safely), or `-1` if no match.
+/// substring of `text2`, returning `Some(byte_offset)` in `text2` just past the
+/// rightmost such match (so callers can `&text2[pos..]` safely), or `None` if
+/// there is no match.
 ///
-/// The offset is a byte index — not a char index — so slicing `text2` with
-/// it never lands inside a multibyte UTF-8 sequence.
-pub(crate) fn find_tail_match_in_text(text1: &str, text2: &str, length_of_match: usize) -> i32 {
-    // Check if either text is too short
-    if text1.chars().count() < length_of_match || text2.chars().count() < length_of_match {
-        return -1;
-    }
-
+/// The offset is a byte index — not a char index — so slicing `text2` with it
+/// never lands inside a multibyte UTF-8 sequence.
+pub(crate) fn find_tail_match_in_text(
+    text1: &str,
+    text2: &str,
+    length_of_match: usize,
+) -> Option<usize> {
     let text1_chars: Vec<char> = text1.chars().collect();
     let text2_chars: Vec<char> = text2.chars().collect();
 
-    // The end portion of text1 that we want to find in text2
-    let target_substring: Vec<char> = text1_chars[text1_chars.len() - length_of_match..].to_vec();
+    // Either side too short to hold a `length_of_match` window.
+    if text1_chars.len() < length_of_match || text2_chars.len() < length_of_match {
+        return None;
+    }
 
-    // Loop through text2 from right to left
+    // The trailing `length_of_match` chars of text1 we want to locate in text2.
+    let target = &text1_chars[text1_chars.len() - length_of_match..];
+
+    // Scan text2 right-to-left for the last occurrence of `target`. Compare the
+    // char slices directly rather than allocating a `Vec` per position.
     for i in 0..=(text2_chars.len() - length_of_match) {
-        let start_pos = text2_chars.len() - i - length_of_match;
-        let end_pos = text2_chars.len() - i;
-        let current_substring: Vec<char> = text2_chars[start_pos..end_pos].to_vec();
-
-        // Compare substrings
-        if current_substring == target_substring {
-            // `end_pos` is a CHAR index into text2; map it to a byte offset
-            // so callers can byte-slice `&text2[pos..]` without splitting a
-            // multibyte char. `nth(end_pos) == None` means the match ends at
-            // the very end of text2, i.e. byte offset `text2.len()`.
-            let byte_off = text2
-                .char_indices()
-                .nth(end_pos)
-                .map_or(text2.len(), |(b, _)| b);
-            return i32::try_from(byte_off).unwrap_or(i32::MAX);
+        let end_char = text2_chars.len() - i;
+        let start_char = end_char - length_of_match;
+        if text2_chars[start_char..end_char] == *target {
+            // `end_char` is a CHAR index into text2; map it to a byte offset so
+            // callers can byte-slice `&text2[pos..]` without splitting a
+            // multibyte char. No chars past the match => the byte offset is
+            // `text2.len()`.
+            return Some(
+                text2
+                    .char_indices()
+                    .nth(end_char)
+                    .map_or(text2.len(), |(b, _)| b),
+            );
         }
     }
 
-    -1
+    None
 }
 
 #[cfg(test)]

--- a/super-stt-daemon/src/output/preview_tests.rs
+++ b/super-stt-daemon/src/output/preview_tests.rs
@@ -30,23 +30,26 @@ fn test_find_tail_match_in_text() {
     // Test the key case: "engi" should match with "engineer"
     assert_eq!(
         find_tail_match_in_text("hello engi", "engineer is good", 4),
-        4
+        Some(4)
     );
 
     // Test basic tail matching
     assert_eq!(
         find_tail_match_in_text("hello world", "world is nice", 5),
-        5
+        Some(5)
     );
 
     // Test no match
-    assert_eq!(find_tail_match_in_text("hello", "goodbye", 3), -1);
+    assert_eq!(find_tail_match_in_text("hello", "goodbye", 3), None);
 
     // Test short strings
-    assert_eq!(find_tail_match_in_text("hi", "hello", 3), -1);
+    assert_eq!(find_tail_match_in_text("hi", "hello", 3), None);
 
     // Test exact match at end
-    assert_eq!(find_tail_match_in_text("abc", "xyzabc", 3), 6);
+    assert_eq!(find_tail_match_in_text("abc", "xyzabc", 3), Some(6));
+
+    // Rightmost occurrence wins: "abc" appears twice, match the later one.
+    assert_eq!(find_tail_match_in_text("abc", "abcxabc", 3), Some(7));
 }
 
 #[test]
@@ -57,11 +60,12 @@ fn find_tail_match_returns_utf8_safe_byte_offset() {
     // would land inside the multibyte 'á' and panic ("not a char boundary").
     let pos = find_tail_match_in_text("wyzá", "xyzáb", 3);
     assert_eq!(
-        pos, 5,
+        pos,
+        Some(5),
         "expected the byte offset (5), not the char index (4)"
     );
     // Must be usable as a &str byte slice without panicking.
-    let suffix = &"xyzáb"[usize::try_from(pos).unwrap()..];
+    let suffix = &"xyzáb"[pos.unwrap()..];
     assert_eq!(suffix, "b");
 }
 

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -109,13 +109,8 @@ impl State {
         }
 
         // Use tail matching to extend session with new content
-        let matching_pos = find_tail_match_in_text(&self.full_session_text, new_preview_text, 3);
-        if matching_pos >= 0 {
-            let extended = format!(
-                "{}{}",
-                self.full_session_text,
-                &new_preview_text[usize::try_from(matching_pos).unwrap_or(0)..]
-            );
+        if let Some(pos) = find_tail_match_in_text(&self.full_session_text, new_preview_text, 3) {
+            let extended = format!("{}{}", self.full_session_text, &new_preview_text[pos..]);
             if extended.len() > self.full_session_text.len() {
                 self.full_session_text = extended;
                 self.last_growth_time = std::time::Instant::now();
@@ -137,16 +132,9 @@ impl State {
         }
 
         // Try tail matching first
-        let matching_pos = find_tail_match_in_text(&self.stabilized_text, preview_text, 3);
-
-        if matching_pos >= 0 {
+        if let Some(pos) = find_tail_match_in_text(&self.stabilized_text, preview_text, 3) {
             // Found overlap - combine stabilized text with new part from preview
-            let combined = format!(
-                "{}{}",
-                self.stabilized_text,
-                &preview_text[usize::try_from(matching_pos).unwrap_or(0)..]
-            );
-            return combined;
+            return format!("{}{}", self.stabilized_text, &preview_text[pos..]);
         }
 
         // No tail match found - be conservative to avoid text loss
@@ -187,17 +175,22 @@ impl Typer {
         self.keyboard_simulator
     }
 
-    /// Apply a simple differential update by backspacing and retyping from first difference
-    pub fn apply_simple_diff(&mut self, old_text: &str, new_text: &str) -> usize {
+    /// Apply a simple differential update by backspacing to the first differing
+    /// character and retyping the rest. Returns the **net change in screen
+    /// characters** (chars typed minus chars deleted) so callers accounting in
+    /// chars stay consistent — mixing this with a byte length would drift on any
+    /// multibyte text.
+    pub fn apply_simple_diff(&mut self, old_text: &str, new_text: &str) -> isize {
         // Safety checks
         if old_text == new_text {
             return 0;
         }
 
         if old_text.is_empty() && !new_text.is_empty() {
-            let _ = self.keyboard_simulator.type_text(new_text);
-            debug!("Failed to type new text");
-            return new_text.len();
+            if let Err(e) = self.keyboard_simulator.type_text(new_text) {
+                debug!("Failed to type new text: {e}");
+            }
+            return isize::try_from(new_text.chars().count()).unwrap_or(isize::MAX);
         }
 
         if new_text.is_empty() {
@@ -214,6 +207,7 @@ impl Typer {
         // Calculate what to delete and what to type
         let chars_to_delete = old_chars.len() - common_prefix;
         let text_to_type: String = new_chars[common_prefix..].iter().collect();
+        let chars_to_type = new_chars.len() - common_prefix;
 
         debug!(
             "Simple diff: prefix={}, delete={}, type='{}'",
@@ -228,7 +222,9 @@ impl Typer {
         // Type the new part
         let _ = self.keyboard_simulator.type_text(&text_to_type);
 
-        text_to_type.len()
+        // Net screen delta in chars: what we added minus what we removed.
+        isize::try_from(chars_to_type).unwrap_or(isize::MAX)
+            - isize::try_from(chars_to_delete).unwrap_or(isize::MAX)
     }
 
     /// Update preview text using two-phase approach
@@ -311,74 +307,41 @@ impl Typer {
 
     /// Apply text update to screen (common logic)
     fn apply_text_update(&mut self, new_text: &str, actually_typed: &mut String) {
-        let old_char_count = actually_typed.chars().count();
-        let new_char_count = new_text.chars().count();
-
         info!(
-            "Typing logic: old_typed='{}', new_display='{}', old_count={}, new_count={}",
+            "Typing logic: old_typed='{}', new_display='{}'",
             actually_typed.chars().take(30).collect::<String>(),
             new_text.chars().take(30).collect::<String>(),
-            old_char_count,
-            new_char_count
         );
 
-        let actual_chars_on_screen;
-        // Screen is empty, just type the new text
-        if old_char_count == 0 {
+        if actually_typed.is_empty() {
+            // Screen is empty — type the whole thing.
             info!(
                 "Screen empty, typing new text: '{}'",
                 new_text.chars().take(30).collect::<String>()
             );
             let _ = self.keyboard_simulator.type_text(&format!("{new_text} "));
-            actual_chars_on_screen = new_char_count;
-        }
-        // Screen is not empty, check if new text starts with actually typed text
-        else if new_text.starts_with(actually_typed.as_str())
+        } else if new_text.starts_with(actually_typed.as_str())
             && new_text.len() > actually_typed.len()
         {
-            // Perfect extension - just add the suffix
+            // Perfect extension — append only the new suffix.
             let suffix = &new_text[actually_typed.len()..];
             info!("Perfect extension, adding suffix: '{suffix}'");
             let _ = self.keyboard_simulator.type_text(&format!("{suffix} "));
-            actual_chars_on_screen = new_char_count;
         } else {
-            // Need to replace - use differential update
-            info!("Need replacement, using diff update");
+            // Replacement — backspace to the first difference and retype.
             let net_change = self.apply_simple_diff(actually_typed, new_text);
-
-            // Calculate actual characters on screen based on the net change
-            actual_chars_on_screen = old_char_count + net_change;
-
-            info!(
-                "Replaced: {}{} chars (screen total: {})",
-                if net_change > 0 { "+" } else { "" },
-                net_change,
-                actual_chars_on_screen
-            );
+            info!("Diff replacement: net {net_change} char(s)");
         }
 
-        // Update state to match what we think is actually on screen
-        if actual_chars_on_screen == new_char_count {
-            // Typing succeeded completely
-            actually_typed.clear();
-            actually_typed.push_str(new_text);
-            info!(
-                "Updated actually_typed to: '{}'",
-                actually_typed.chars().take(30).collect::<String>()
-            );
-        } else {
-            // Typing failed or was partial - but for preview, we should still track what we attempted to type
-            // This ensures preview clearing works correctly even when there are typing discrepancies
-            warn!(
-                "Character count mismatch: expected {new_char_count}, actual {actual_chars_on_screen}, updating actually_typed anyway"
-            );
-            actually_typed.clear();
-            actually_typed.push_str(new_text);
-            info!(
-                "Force updated actually_typed to: '{}'",
-                actually_typed.chars().take(30).collect::<String>()
-            );
-        }
+        // `actually_typed` mirrors what we drove onto the screen so
+        // `clear_preview` backspaces the right count next time. Every branch
+        // above leaves the screen showing `new_text`. The keyboard results are
+        // best-effort and unchecked, so there is no measured count to reconcile
+        // against — the old byte-vs-char reconciliation was both wrong (it added
+        // `apply_simple_diff`'s byte length to a char count) and dead (both of
+        // its branches did exactly this assignment).
+        actually_typed.clear();
+        actually_typed.push_str(new_text);
     }
 
     /// Clear all typed text and reset state


### PR DESCRIPTION
Fixes Tier 1 #12, #13, #14, #15 from `docs/audits/2026-07-code-quality.md`.

## #12 — preview-typer byte/char accounting *(daemon)*
`apply_simple_diff` returned a byte length that `apply_text_update` added to a char count (drifting on any multibyte text). It now returns the net **char** delta (typed minus deleted); the identical byte-vs-char reconciliation branches — whose only effect was a spurious non-ASCII warn — are gone. `find_tail_match_in_text` returns `Option<usize>` (byte offset) and compares char slices in place instead of allocating a `Vec<char>` per position. The misleading unconditional "Failed to type" debug now logs the real error.

## #13 — one failed volume/theme POST no longer hijacks the UI *(app)*
Introduces the shared scope-tagged error slot the "one error surface" item calls for: `AppModel::action_error: Option<ActionError>` + `ErrorScope` (`Customization` / `ConfigureBackend`) + an `action_error_for(scope)` accessor and a shared `error_banner`. Volume/theme/feedback failures now raise a `Customization`-scoped inline banner instead of `Message::DaemonError`, so `daemon_status` no longer flips and the full-screen connection page is not forced.

## #14 — settings no longer refetched every 5 s *(app)*
`handle_daemon_connected` runs the six settings GETs + language load only on the disconnected→connected transition; a periodic keep-alive ping returns `Task::none()`. The two audio save handlers stopped reusing `DaemonConnected` as their success ack (now `Action::None`), removing the per-toggle refetch.

## #15 — failed secret/option saves are visible; optimistic state rolls back *(app)*
Backend secret/option save failures raise a `ConfigureBackend`-scoped banner in the Configure sheet (was log-only `BackendsError`). `InstallFailedToStart` records into a new `RegistryState::install_errors` map (mirroring `uninstall_errors`) so the Browse card shows "Failed to start: …" and keeps the Install button. Preview-typing / recording-stop-mode / write-method handlers now confirm-then-apply — the local value is set only on the daemon ack, so a failed save leaves the control on its old value (and `PreviewTypingError` no longer abuses the transcription box).

## Verification
Workspace clippy pedantic clean · 235 daemon lib tests + 43 app tests pass · doctests pass · `just fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)