### PR TITLE
Audit Tier 1 #16-#19: app message/nav/slider fixes

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -321,12 +321,16 @@ Three patterns account for the majority of findings:
   (only folding + capping to 200 chars when it is set) and unit-tested the
   empty-HOME regression, the fold, and the cap.
 
-### [ ] 17. 🟡 App: `handle_daemon_events` returns from inside the loop
+### [x] 17. 🟡 App: `handle_daemon_events` returns from inside the loop
 
 - **Where:** `handlers/daemon/events.rs:16-34`.
 - **Problem:** drops all events after the first that yields a task. Latent today
   (producers wrap singletons) but the API takes a `Vec`.
 - **Fix:** collect tasks across the whole batch and return them together.
+- **Resolved (branch `refactor/audit-app-tier1-16-19`):** the loop now pushes each
+  event's task into a `Vec`, processes the whole batch (so `last_event_timestamp`
+  advances past every event), appends the final `update_title()`, and returns
+  `Task::batch(tasks)`.
 
 ### [ ] 18. 🟡 App: reconnect force-navigates to Customization
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -310,12 +310,16 @@ Three patterns account for the majority of findings:
   leaves the control on its old, correct value (and the `PreviewTypingError` handler
   no longer abuses the transcription box). Uses the shared error slot from #13.
 
-### [ ] 16. 🟡 App: `$HOME` sanitization corrupts messages when HOME is unset
+### [x] 16. 🟡 App: `$HOME` sanitization corrupts messages when HOME is unset
 
 - **Where:** `err.replace(&std::env::var("HOME").unwrap_or_default(), "$HOME")`
   (`handlers/model.rs:120-124`).
 - **Problem:** an empty pattern inserts `$HOME` at every char boundary.
 - **Fix:** skip the replacement when the variable is missing or empty.
+- **Resolved (branch `refactor/audit-app-tier1-16-19`):** extracted a pure
+  `sanitize_home(err, home)` that returns the message unchanged when `home` is empty
+  (only folding + capping to 200 chars when it is set) and unit-tested the
+  empty-HOME regression, the fold, and the cap.
 
 ### [ ] 17. 🟡 App: `handle_daemon_events` returns from inside the loop
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -343,10 +343,14 @@ Three patterns account for the majority of findings:
   page stays Models (set in `init.rs`) and the user's current page is untouched
   across a daemon restart.
 
-### [ ] 19. 🟡 App: volume slider fires one POST per drag tick
+### [x] 19. 🟡 App: volume slider fires one POST per drag tick
 
 - **Where:** `ui/views/customization.rs:56`, `handlers/recording.rs:120-126`.
 - **Fix:** commit on `on_release` or debounce.
+- **Resolved (branch `refactor/audit-app-tier1-16-19`):** the slider's drag callback
+  (`VolumeChanged`) now only updates the local value; a new `VolumeCommit` wired to
+  the slider's `on_release` fires the single `set_volume` POST. A whole drag is one
+  request instead of hundreds.
 
 ### [ ] 20. 🟡 App: language client encodes `source` but interpolates `model` raw
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -332,12 +332,16 @@ Three patterns account for the majority of findings:
   advances past every event), appends the final `update_title()`, and returns
   `Task::batch(tasks)`.
 
-### [ ] 18. 🟡 App: reconnect force-navigates to Customization
+### [x] 18. 🟡 App: reconnect force-navigates to Customization
 
 - **Where:** `handlers/daemon/mod.rs:117-129`, contradicting the documented Models
   launch page (`core/app/init.rs:18-24`).
 - **Impact:** yanks mid-flow users to another page on every daemon restart.
 - **Fix:** don't navigate on reconnect.
+- **Resolved (branch `refactor/audit-app-tier1-16-19`):** deleted the
+  reconnect-time nav-activate block (and the now-unused `Page` import); the launch
+  page stays Models (set in `init.rs`) and the user's current page is untouched
+  across a daemon restart.
 
 ### [ ] 19. 🟡 App: volume slider fires one POST per drag tick
 

--- a/super-stt-app/src/core/app/handlers/daemon/events.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/events.rs
@@ -15,22 +15,28 @@ impl AppModel {
         match message {
             Message::DaemonEventsReceived(events) => {
                 debug!("Received {} daemon events", events.len());
+                // Process EVERY event and collect their tasks. Returning on the
+                // first event that yields a task dropped the rest of the batch
+                // (and left `last_event_timestamp` stuck before them) — latent
+                // only because producers currently wrap singletons (Tier 1 #17).
+                let mut tasks = Vec::new();
                 for event in events {
                     // Update timestamp for next polling
                     self.last_event_timestamp = Some(event.timestamp.clone());
 
                     if event.event_type == "daemon_status_changed" {
                         if let Some(task) = self.process_daemon_status_event(&event) {
-                            return task;
+                            tasks.push(task);
                         }
                     } else if event.event_type == "download_progress"
                         && let Some(task) = self.process_download_progress_event(&event)
                     {
-                        return task;
+                        tasks.push(task);
                     }
                 }
                 // Force UI update after processing events that may change state
-                self.update_title()
+                tasks.push(self.update_title());
+                Task::batch(tasks)
             }
 
             _ => Task::none(),

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -9,7 +9,7 @@ use crate::daemon::client::{
     get_current_audio_theme, get_custom_models_dir, get_preview_typing, get_recording_stop_mode,
     get_volume, get_write_method, ping_daemon, test_daemon_connection,
 };
-use crate::state::{AudioTheme, DaemonStatus, Page};
+use crate::state::{AudioTheme, DaemonStatus};
 use crate::ui::messages::Message;
 use cosmic::prelude::*;
 use log::{info, warn};
@@ -117,19 +117,10 @@ impl AppModel {
             info!("Daemon reconnected; events subscription is self-healing, no iced restart");
         }
 
-        // Only switch to first page on initial connection, not on periodic pings
-        if was_disconnected {
-            let mut first_entity = None;
-            for entity in self.nav.iter() {
-                if matches!(self.nav.data::<Page>(entity), Some(Page::Customization)) {
-                    first_entity = Some(entity);
-                    break;
-                }
-            }
-            if let Some(entity) = first_entity {
-                self.nav.activate(entity);
-            }
-        }
+        // Do NOT navigate on (re)connect: the launch page is Models (set in
+        // `init.rs`), and yanking a mid-flow user to another page on every
+        // daemon restart was both surprising and contradicted that default
+        // (Tier 1 #18). Whatever page the user is on stays active.
 
         // Load settings/models/languages ONLY on the disconnected→connected
         // transition. Periodic keep-alive pings also resolve to `DaemonConnected`

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -116,11 +116,8 @@ impl AppModel {
 
             Message::ModelError(err) => {
                 warn!("Model operation failed: {err}");
-                let sanitized = err
-                    .replace(&std::env::var("HOME").unwrap_or_default(), "$HOME")
-                    .chars()
-                    .take(200)
-                    .collect::<String>();
+                let home = std::env::var("HOME").unwrap_or_default();
+                let sanitized = sanitize_home(&err, &home);
                 self.model_operation_state = ModelOperationState::Error { message: sanitized };
                 // A failed switch leaves the daemon idle (no model) — the
                 // backend stays selected, but no model is loaded.
@@ -149,5 +146,45 @@ impl AppModel {
             }),
             Err(e) => cosmic::Action::App(Message::ModelError(e.to_string())),
         })
+    }
+}
+
+/// Collapse the user's home directory back to `$HOME` in an error message and
+/// cap it at 200 chars for display. Skips the substitution when `home` is empty
+/// — an empty `from` makes `str::replace` insert the replacement at every char
+/// boundary, shredding the message (Tier 1 #16).
+fn sanitize_home(err: &str, home: &str) -> String {
+    if home.is_empty() {
+        err.chars().take(200).collect()
+    } else {
+        err.replace(home, "$HOME").chars().take(200).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_home;
+
+    #[test]
+    fn empty_home_leaves_message_intact() {
+        // The regression: an empty HOME must NOT insert "$HOME" everywhere.
+        assert_eq!(
+            sanitize_home("load failed at /a/b", ""),
+            "load failed at /a/b"
+        );
+    }
+
+    #[test]
+    fn set_home_is_folded_back() {
+        assert_eq!(
+            sanitize_home("no file /home/jo/models/x", "/home/jo"),
+            "no file $HOME/models/x"
+        );
+    }
+
+    #[test]
+    fn output_is_capped_at_200_chars() {
+        let long = "e".repeat(500);
+        assert_eq!(sanitize_home(&long, "").chars().count(), 200);
     }
 }

--- a/super-stt-app/src/core/app/handlers/recording.rs
+++ b/super-stt-app/src/core/app/handlers/recording.rs
@@ -35,6 +35,7 @@ impl AppModel {
             | Message::AudioThemeSelected(_)
             | Message::AudioThemesLoaded(_)
             | Message::VolumeChanged(_)
+            | Message::VolumeCommit
             | Message::WidgetAudioLevel { .. }
             | Message::WidgetRecordingState(_) => self.handle_audio_messages(message),
 
@@ -135,9 +136,16 @@ impl AppModel {
             }
 
             Message::VolumeChanged(vol) => {
-                self.action_error = None;
+                // Drag tick: update the slider locally only. The daemon POST is
+                // deferred to VolumeCommit (on release) so a drag doesn't fire
+                // one set_volume per tick (Tier 1 #19).
                 self.volume = vol;
-                Task::perform(set_volume(vol), |result| match result {
+                Task::none()
+            }
+
+            Message::VolumeCommit => {
+                self.action_error = None;
+                Task::perform(set_volume(self.volume), |result| match result {
                     Ok(()) => cosmic::Action::None,
                     Err(e) => cosmic::Action::App(customization_error(&e)),
                 })

--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -207,6 +207,7 @@ impl AppModel {
                 | Message::AudioThemeSelected(_)
                 | Message::AudioThemesLoaded(_)
                 | Message::VolumeChanged(_)
+                | Message::VolumeCommit
                 | Message::WidgetAudioLevel { .. }
                 | Message::WidgetRecordingState(_)
         ) {

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -220,7 +220,11 @@ pub enum Message {
     WriteMethodError(String),
 
     // Volume messages
+    /// A drag tick: updates the local slider value only (no daemon POST).
     VolumeChanged(u8),
+    /// The slider was released: commit the current value to the daemon once,
+    /// rather than one POST per drag tick (Tier 1 #19).
+    VolumeCommit,
 
     // Backend catalog + per-backend secret/option configuration.
     // Secrets are managed via the daemon's secrets endpoints.

--- a/super-stt-app/src/ui/views/customization.rs
+++ b/super-stt-app/src/ui/views/customization.rs
@@ -54,7 +54,11 @@ pub fn page<'a>(
             .into()
         };
 
+        // Drag ticks update the local value; the daemon POST fires once on
+        // release (Tier 1 #19), so a single drag isn't hundreds of set_volume
+        // requests.
         let slider = widget::slider(0..=100, volume, Message::VolumeChanged)
+            .on_release(Message::VolumeCommit)
             .width(Length::Fill)
             .apply(widget::container)
             .max_width(250.);


### PR DESCRIPTION
Fixes Tier 1 #16, #17, #18, #19 from `docs/audits/2026-07-code-quality.md`. All app-side, one commit each.

## #16 — `$HOME` sanitization corrupted messages when HOME is unset
An empty pattern makes `str::replace` insert `$HOME` at every char boundary, shredding the message. Extracted a pure `sanitize_home(err, home)` that returns the message unchanged when `home` is empty (only folding + capping to 200 chars when set). Unit-tested the empty-HOME regression, the fold, and the cap.

## #17 — `handle_daemon_events` returned from inside the loop
It returned on the first event that yielded a task, dropping the rest of the batch and stalling `last_event_timestamp` before them. Now collects every event's task, processes the whole batch, and returns `Task::batch`.

## #18 — reconnect force-navigated to Customization
Deleted the reconnect-time nav-activate block (and the now-unused `Page` import). The launch page stays Models (set in `init.rs`) and the user's current page is untouched across a daemon restart.

## #19 — volume slider fired one POST per drag tick
`VolumeChanged` now updates only the local slider value; a new `VolumeCommit` wired to the slider's `on_release` fires the single `set_volume` POST. A whole drag is one request instead of hundreds.

## Verification
Workspace clippy pedantic clean · 46 app tests pass (3 new for `sanitize_home`) · 235 daemon lib tests pass · `just fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)