### PR TITLE
Audit Tier 1 #20-#23: path encoding, bar-renderer guard, applet child reaping

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -374,20 +374,30 @@ Three patterns account for the majority of findings:
   was checked and is safe — its `bands_to_show - 1` sits inside the
   `0..bands_to_show` loop, never reached at zero.
 
-### [ ] 22. 🟡 Applet: `launch_app`/`open_github` never reap children
+### [x] 22. 🟡 Applet: `launch_app`/`open_github` never reap children
 
 - **Where:** `app/update.rs:348-389`.
 - **Problem:** zombies accumulate for the session-long applet; `launch_app` also
   probes hardcoded `./target/{debug,release}/` dev paths relative to the panel
   process CWD.
 - **Fix:** reap spawned children (or detach properly); drop the dev-path probing.
+- **Resolved (branch `refactor/audit-tier1-20-23`):** added a `spawn_detached`
+  helper that reaps each child in a detached thread, and routed both `open_github`
+  and `launch_app` through it. The two `./target/{debug,release}` dev paths (and the
+  redundant `which` probe — `Command::new("super-stt-app")` already searches `PATH`)
+  are gone; `launch_app` now tries PATH, `/usr/local/bin`, `/usr/bin`.
 
-### [ ] 23. 🟡 Applet: the "connection health watchdog" doesn't exist
+### [x] 23. 🟡 Applet: the "connection health watchdog" doesn't exist
 
 - **Where:** `last_udp_data` is written four times, read nowhere (`app/mod.rs:45`,
   `update.rs:47,57,229-231,256`).
 - **Problem:** the comments advertise a safety net that was removed.
 - **Fix:** implement the watchdog or delete the field and comments.
+- **Resolved (branch `refactor/audit-tier1-20-23`):** deleted the write-only
+  `last_udp_data` field, its initializer, the four writes, and the "connection health
+  watchdog" comment (plus the now-unused `Instant` import in `init.rs`). The
+  self-healing event subscription is the real reconnection path; there is no separate
+  watchdog to advertise.
 
 ### [x] 24. 🟠 Shared: `GET /audio_themes` violates the documented wire form
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -361,13 +361,18 @@ Three patterns account for the majority of findings:
   `/backends/{source}/models/{model}/language` builders now `enc(&model)` as well as
   `enc(&source)`, so a `/` (or any reserved char) in a model name yields a valid path.
 
-### [ ] 21. 🟠 Applet: empty `frequency_bands` panics/degenerates the bar renderers
+### [x] 21. 🟠 Applet: empty `frequency_bands` panics/degenerates the bar renderers
 
 - **Where:** `equalizer.rs:60` / `centered_bars.rs:59`.
 - **Problem:** `b64_to_f32_vec` degrades malformed input to an empty vec, then
   `bars_to_show - 1` underflows a usize (debug panic; ~1.8e19 spacing in release).
   Same class as the #268 fix.
 - **Fix:** guard `bands_to_show == 0` and use `saturating_sub`.
+- **Resolved (branch `refactor/audit-tier1-20-23`):** both renderers now
+  early-return when `bars_to_show == 0` (which also avoids the `width / 0.0`
+  degeneration) and use `saturating_sub(1)` for the centering width. `waveform.rs`
+  was checked and is safe — its `bands_to_show - 1` sits inside the
+  `0..bands_to_show` loop, never reached at zero.
 
 ### [ ] 22. 🟡 Applet: `launch_app`/`open_github` never reap children
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -352,11 +352,14 @@ Three patterns account for the majority of findings:
   the slider's `on_release` fires the single `set_volume` POST. A whole drag is one
   request instead of hundreds.
 
-### [ ] 20. 🟡 App: language client encodes `source` but interpolates `model` raw
+### [x] 20. 🟡 App: language client encodes `source` but interpolates `model` raw
 
 - **Where:** `daemon/client/v1/settings/language.rs:67,89,116`.
 - **Impact:** a model name containing `/` produces a malformed path.
 - **Fix:** percent-encode both path segments.
+- **Resolved (branch `refactor/audit-tier1-20-23`):** all three
+  `/backends/{source}/models/{model}/language` builders now `enc(&model)` as well as
+  `enc(&source)`, so a `/` (or any reserved char) in a model name yields a valid path.
 
 ### [ ] 21. 🟠 Applet: empty `frequency_bands` panics/degenerates the bar renderers
 

--- a/super-stt-app/src/daemon/client/v1/settings/language.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/language.rs
@@ -62,7 +62,7 @@ pub async fn get_model_language(source: String, model: String) -> HttpResult<ser
     with_settings_token(move |socket, token| {
         let (source, model) = (source.clone(), model.clone());
         async move {
-            let path = format!("/backends/{}/models/{}/language", enc(&source), model);
+            let path = format!("/backends/{}/models/{}/language", enc(&source), enc(&model));
             let resp = require_success(
                 transport::settings_get(socket, &token, &path).await?,
                 "get_model_language",
@@ -84,7 +84,7 @@ pub async fn set_model_language(
     with_settings_token(move |socket, token| {
         let (source, model, language) = (source.clone(), model.clone(), language.clone());
         async move {
-            let path = format!("/backends/{}/models/{}/language", enc(&source), model);
+            let path = format!("/backends/{}/models/{}/language", enc(&source), enc(&model));
             let resp = require_success(
                 transport::settings_post(
                     socket,
@@ -108,7 +108,7 @@ pub async fn clear_model_language(source: String, model: String) -> HttpResult<s
     with_settings_token(move |socket, token| {
         let (source, model) = (source.clone(), model.clone());
         async move {
-            let path = format!("/backends/{}/models/{}/language", enc(&source), model);
+            let path = format!("/backends/{}/models/{}/language", enc(&source), enc(&model));
             let resp = require_success(
                 transport::settings_delete(socket, &token, &path).await?,
                 "clear_model_language",

--- a/super-stt-cosmic-applet/src/app/init.rs
+++ b/super-stt-cosmic-applet/src/app/init.rs
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::time::Instant;
-
 use cosmic::{
     app as cosmic_app,
     widget::segmented_button::{Entity, SingleSelectModel},
@@ -94,7 +92,6 @@ impl SuperSttApplet {
             visualization,
             working_animation,
             working_anim_start: None,
-            last_udp_data: Instant::now(),
             config,
             variant_name,
             icon_alignment_model,

--- a/super-stt-cosmic-applet/src/app/mod.rs
+++ b/super-stt-cosmic-applet/src/app/mod.rs
@@ -42,7 +42,6 @@ pub struct SuperSttApplet {
     /// Wall-clock start of the current Processing phase; `Some` only while
     /// transcribing, used to derive the animation's elapsed time.
     working_anim_start: Option<Instant>,
-    last_udp_data: Instant,
     config: AppletConfig,
     variant_name: String,
     icon_alignment_model: SingleSelectModel,

--- a/super-stt-cosmic-applet/src/app/update.rs
+++ b/super-stt-cosmic-applet/src/app/update.rs
@@ -44,7 +44,6 @@ impl SuperSttApplet {
                 ..
             } => self.widget_frequency_bands(&bands, total_energy),
             Message::WidgetTranscribingStarted => {
-                self.last_udp_data = Instant::now();
                 // Guard against out-of-order delivery: only enter Processing
                 // mid-cycle, never resurrect it after transcribing_stopped
                 // already returned us to Idle.
@@ -54,7 +53,6 @@ impl SuperSttApplet {
                 cosmic_app::Task::none()
             }
             Message::WidgetTranscribingStopped => {
-                self.last_udp_data = Instant::now();
                 self.set_recording_state(RecordingState::Idle);
                 self.visualization.clear();
                 cosmic_app::Task::none()
@@ -226,10 +224,6 @@ impl SuperSttApplet {
     }
 
     fn widget_recording_state(&mut self, is_recording: bool) -> cosmic_app::Task<Message> {
-        // Update the last-event timestamp used by the connection health
-        // watchdog.
-        self.last_udp_data = Instant::now();
-
         let was_recording = matches!(self.recording_state, RecordingState::Recording);
         let new_state = if is_recording {
             RecordingState::Recording
@@ -253,7 +247,6 @@ impl SuperSttApplet {
         bands: &[f32],
         total_energy: f32,
     ) -> cosmic_app::Task<Message> {
-        self.last_udp_data = Instant::now();
         self.visualization
             .update_frequency_bands(bands, total_energy);
         self.audio_level = total_energy;
@@ -345,10 +338,21 @@ impl SuperSttApplet {
         cosmic_app::Task::none()
     }
 
+    /// Spawn a fire-and-forget child and reap it in a detached thread, so a
+    /// launched helper never lingers as a zombie in the session-long applet
+    /// (Tier 1 #22). We don't care about the exit status — the `wait` only
+    /// prevents the zombie.
+    fn spawn_detached(cmd: &mut std::process::Command) -> std::io::Result<()> {
+        let mut child = cmd.spawn()?;
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+        Ok(())
+    }
+
     fn open_github() -> cosmic_app::Task<Message> {
-        if let Err(e) = std::process::Command::new("xdg-open")
-            .arg(crate::REPOSITORY)
-            .spawn()
+        if let Err(e) =
+            Self::spawn_detached(std::process::Command::new("xdg-open").arg(crate::REPOSITORY))
         {
             warn!("Failed to open GitHub URL: {e}");
         }
@@ -356,29 +360,18 @@ impl SuperSttApplet {
     }
 
     fn launch_app() -> cosmic_app::Task<Message> {
+        // `Command::new("super-stt-app")` already searches `PATH`, then fall
+        // back to the standard install prefixes. The old `./target/{debug,
+        // release}` dev paths (resolved against the panel process' CWD) never
+        // matched for an installed applet and were dropped (Tier 1 #22).
         let launch_attempts = [
-            "super-stt-app",                  // System PATH
-            "./target/debug/super-stt-app",   // Local debug build
-            "./target/release/super-stt-app", // Local release build
-            "/usr/local/bin/super-stt-app",   // Local install
-            "/usr/bin/super-stt-app",         // System install
+            "super-stt-app",                // System PATH
+            "/usr/local/bin/super-stt-app", // Local install
+            "/usr/bin/super-stt-app",       // System install
         ];
 
-        if let Ok(output) = std::process::Command::new("which")
-            .arg("super-stt-app")
-            .output()
-            && output.status.success()
-            && let Ok(path) = std::str::from_utf8(&output.stdout)
-        {
-            let path = path.trim();
-            if std::process::Command::new(path).spawn().is_ok() {
-                info!("Successfully launched Super STT app from PATH: {path}");
-                return cosmic_app::Task::none();
-            }
-        }
-
-        for command in &launch_attempts {
-            if std::process::Command::new(command).spawn().is_ok() {
+        for command in launch_attempts {
+            if Self::spawn_detached(&mut std::process::Command::new(command)).is_ok() {
                 info!("Successfully launched Super STT app with command: {command}");
                 return cosmic_app::Task::none();
             }

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/centered_bars.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/centered_bars.rs
@@ -51,12 +51,21 @@ impl VisualizationRenderer for CenteredBarsVisualization {
             VisualizationSide::Full => (total_bars, 0),
         };
 
+        // Nothing to draw (e.g. malformed/empty frequency data decoded to zero
+        // bands). Bail before dividing `bar_width`/`spacing` by zero and before
+        // `bars_to_show - 1` underflows the usize below (Tier 1 #21, same class
+        // as #268).
+        if bars_to_show == 0 {
+            return;
+        }
+
         let bars_f32 = usize_to_f32(bars_to_show);
         let bar_width = effective_bounds.width / bars_f32 * 0.8;
         let spacing = effective_bounds.width / bars_f32 * 0.2;
 
         // Center the bars in the available width.
-        let total_bars_width = (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show - 1));
+        let total_bars_width =
+            (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show.saturating_sub(1)));
         let start_x = effective_bounds.x + (effective_bounds.width - total_bars_width) / 2.0;
 
         let normalization_factor = 1.0 / FREQUENCY_NORMALIZATION_MAX;

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/equalizer.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/equalizer.rs
@@ -52,12 +52,21 @@ impl VisualizationRenderer for EqualizerVisualization {
             VisualizationSide::Full => (total_bars, 0),
         };
 
+        // Nothing to draw (e.g. malformed/empty frequency data decoded to zero
+        // bands). Bail before dividing `bar_width`/`spacing` by zero and before
+        // `bars_to_show - 1` underflows the usize below (Tier 1 #21, same class
+        // as #268).
+        if bars_to_show == 0 {
+            return;
+        }
+
         let bars_f32 = usize_to_f32(bars_to_show);
         let bar_width = effective_bounds.width / bars_f32 * 0.8;
         let spacing = effective_bounds.width / bars_f32 * 0.2;
 
         // Center the bars in the available width.
-        let total_bars_width = (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show - 1));
+        let total_bars_width =
+            (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show.saturating_sub(1)));
         let start_x = effective_bounds.x + (effective_bounds.width - total_bars_width) / 2.0;
 
         let normalization_factor = 1.0 / FREQUENCY_NORMALIZATION_MAX;


### PR DESCRIPTION
Fixes Tier 1 #20, #21, #22, #23 from `docs/audits/2026-07-code-quality.md`. #20 is app-side; #21–#23 are applet.

## #20 — language client interpolated `model` raw *(app)*
All three `/backends/{source}/models/{model}/language` builders encoded `source` but interpolated `model` raw, so a model name containing `/` produced a malformed path. Both segments are now percent-encoded.

## #21 — empty `frequency_bands` panicked/degenerated the bar renderers *(applet)*
With zero decoded bands, `bars_to_show - 1` underflowed the usize (debug panic; ~1.8e19 spacing in release) and `width / 0.0` degenerated. Both `equalizer.rs` and `centered_bars.rs` now early-return at zero and use `saturating_sub` for the centering width. (`waveform.rs` was checked and is safe — its `- 1` is inside the `0..bands_to_show` loop.)

## #22 — `launch_app`/`open_github` never reaped children *(applet)*
Spawned children were never reaped, so zombies accumulated in the session-long applet, and `launch_app` probed `./target/{debug,release}` paths relative to the panel CWD. Added a `spawn_detached` reaper thread and trimmed the launch list to PATH + install prefixes (the `which` probe was redundant with PATH search).

## #23 — phantom "connection health watchdog" *(applet)*
`last_udp_data` was written four times and read nowhere; its comments advertised a watchdog that was removed. Deleted the field, initializer, writes, and comment (plus the now-unused `Instant` import). The self-healing event subscription is the real reconnect path.

#22 and #23 share `app/update.rs`, so they land in one commit; #20 and #21 are one commit each.

## Verification
Workspace clippy pedantic clean · `just fmt-check` clean · 18 applet + 46 app + 235 daemon lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)