### PR TITLE
CI: stable tests on PRs, beta/nightly on main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      # PRs gate on `stable` only (fast feedback). The `beta`/`nightly`
+      # toolchain checks run post-merge on `push` (main/develop) so a
+      # toolchain-specific break is still caught without slowing every PR.
       matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
+        rust: ${{ github.event_name == 'pull_request' && fromJSON('["stable"]') || fromJSON('["beta", "nightly"]') }}
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Splits the `test` job's toolchain matrix by event:

- **Pull requests** run `stable` only — fast feedback, the gate for merging.
- **Push to main/develop** runs `beta` and `nightly` — post-merge toolchain checks that no longer slow every PR.

Implemented with the standard dynamic-matrix idiom:

```yaml
matrix:
  rust: ${{ github.event_name == 'pull_request' && fromJSON('["stable"]') || fromJSON('["beta", "nightly"]') }}
```

The `clippy`, `fmt`, `check-features`, and `coverage` jobs are unchanged (they still run on both events).

Note: on this PR you'll see only `Test (stable)` — the beta/nightly jobs will appear on the main-branch run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)