### PR TITLE
Audit Tier 2 #6-#8: shared logging, XDG paths, smaller-item dedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6605,7 +6605,6 @@ version = "0.1.4-beta.2"
 dependencies = [
  "anyhow",
  "dirs",
- "env_logger",
  "futures-util",
  "i18n-embed",
  "i18n-embed-fl",
@@ -6649,10 +6648,10 @@ dependencies = [
 name = "super-stt-consent"
 version = "0.1.4-beta.2"
 dependencies = [
- "env_logger",
  "libc",
  "libcosmic",
  "log",
+ "super-stt-shared",
 ]
 
 [[package]]
@@ -6661,8 +6660,6 @@ version = "0.1.4-beta.2"
 dependencies = [
  "base64",
  "clap",
- "dirs",
- "env_logger",
  "futures-util",
  "libc",
  "libcosmic",
@@ -6689,7 +6686,6 @@ dependencies = [
  "dashmap",
  "dirs",
  "enigo",
- "env_logger",
  "flate2",
  "futures",
  "futures-util",
@@ -6766,7 +6762,6 @@ dependencies = [
  "mockito",
  "reqwest",
  "ring",
- "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -6804,6 +6799,8 @@ dependencies = [
  "clap",
  "cpal",
  "dashmap",
+ "dirs",
+ "env_logger",
  "futures-util",
  "hound",
  "http-body-util",

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -659,7 +659,7 @@ Ranked by drift risk. These answer "what should be standardized or reused."
   adapters (config + update→message mapping), which is by design — per the fix's
   "per-app topics/scopes/messages stay per-crate".
 
-### [ ] 6. 🟡 Logging init
+### [x] 6. 🟡 Logging init
 
 - **Where:** five variants — byte-identical RUST_LOG-else-Info blocks in
   `app/main.rs:9-17` and `consent/main.rs:341-347`, parameterized in
@@ -670,8 +670,16 @@ Ranked by drift risk. These answer "what should be standardized or reused."
   config *before* initializing logging (`daemon_main.rs:93` vs `:114`), so the
   "config invalid, reset to defaults" warning (`config.rs:173`) is silently
   dropped — init logging first.
+- **Resolved (branch `refactor/audit-tier2-6-7-8`):** added
+  `super_stt_shared::logging::{init, init_with}` (RUST_LOG wins, else the given
+  default). Wired the app, CLI (previously none), applet (was silent — now `Info`
+  like its siblings), consent, and daemon; the daemon now inits logging **before**
+  `DaemonConfig::load()`, so the config-invalid warning is captured. `env_logger`
+  moved out of four crates (now only shared + the standalone indexer). The indexer
+  is deliberately left on its own one-liner rather than coupling a build tool to the
+  daemon-protocol crate for a logging call.
 
-### [ ] 7. 🟡 XDG path helpers
+### [x] 7. 🟡 XDG path helpers
 
 - **Where:** `get_config_path` is byte-identical daemon↔applet
   (`daemon/config.rs:154-163` vs `applet/config/settings.rs:67-76`); three
@@ -682,8 +690,17 @@ Ranked by drift risk. These answer "what should be standardized or reused."
   (`shared/validation/paths.rs:29-61`).
 - **Fix:** one `shared::paths` module; route the subprocess socket through the
   validated helper.
+- **Resolved (branch `refactor/audit-tier2-6-7-8`):** added
+  `super_stt_shared::paths::{config_dir, data_dir, cache_dir}` (each keeping its
+  call sites' existing fallback, so no behavior change) and routed all five
+  production dir sites through it — the daemon+applet `get_config_path`, the
+  backends `data_dir`, and the registry-client/pipeline `cache_dir`. The private
+  socket validator was generalized to `pub fn secure_runtime_path(relative)`; the
+  subprocess socket now goes through it (`backends/<name>.sock`) instead of a raw
+  `$XDG_RUNTIME_DIR` join, so it inherits the traversal/prefix/length guards. Dropped
+  the applet's now-unused `dirs` dep.
 
-### [ ] 8. 🟡 Smaller shared items
+### [x] 8. 🟡 Smaller shared items
 
 - `accept_base_url` duplicated verbatim (`forge/lib.rs:139-147` vs
   `daemon/registry/mod.rs:17-22`) — keep forge's, import it.
@@ -700,6 +717,20 @@ Ranked by drift risk. These answer "what should be standardized or reused."
   `sse::block_stream`; also fix the stale NDJSON doc comments in transcribe.rs.
 - Hand-rolled `unsafe` pin projection (`http_client/internal/transport.rs:17-42`)
   re-implements `http_body_util::Either` — the crate's only `unsafe`, deletable.
+- **Resolved (branch `refactor/audit-tier2-6-7-8`):** all six:
+  `accept_base_url` is now `pub` in forge (tests moved there); the daemon re-exports
+  it. `install_crypto_provider` lives in `forge::http` beside the client factory
+  (forge `rustls` promoted from dev-dep); the daemon re-exports it, the redundant
+  `download.rs` call is gone, and the indexer's inline install is dropped (its unused
+  `rustls` removed). `KNOWN_SCOPES`/`is_known_scope` moved to
+  `super_stt_shared::daemon::scopes`; the daemon re-exports, consent gained a
+  conformance test that every known scope has a specific description (no
+  "deny is safe" fall-through). The CLI's `stop-mode` values come from the shared
+  `RecordingStopMode::WIRE_VARIANTS` (added to `wire_enum_strings!`). The two SSE
+  loops collapse into `sse::block_stream(body, parse_block, on_error)`; the stale
+  "NDJSON" docs now say SSE. `RequestBody` is now
+  `http_body_util::Either<Empty, Full>`, deleting the hand-rolled `unsafe` pin
+  projection.
 
 ---
 

--- a/super-stt-app/Cargo.toml
+++ b/super-stt-app/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
     anyhow.workspace = true
     dirs.workspace = true
-    env_logger.workspace = true
     futures-util.workspace = true
     i18n-embed.workspace = true
     i18n-embed-fl.workspace = true

--- a/super-stt-app/src/main.rs
+++ b/super-stt-app/src/main.rs
@@ -6,15 +6,7 @@ mod state;
 mod ui;
 
 fn main() -> cosmic::iced::Result {
-    // Initialize logging - respect RUST_LOG env var, fallback to verbose flag
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    } else {
-        let log_level = log::LevelFilter::Info;
-        env_logger::Builder::from_default_env()
-            .filter_level(log_level)
-            .init();
-    }
+    super_stt_shared::logging::init();
 
     // Get the system's preferred languages.
     let requested_languages = i18n_embed::DesktopLanguageRequester::requested_languages();

--- a/super-stt-cli/src/main.rs
+++ b/super-stt-cli/src/main.rs
@@ -28,6 +28,10 @@ const SCOPES: &[&str] = &["transcribe", "status"];
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // The CLI previously had no logging at all; initialize it like the other
+    // binaries (RUST_LOG wins, else Info) (Tier 2 #6).
+    super_stt_shared::logging::init();
+
     // Honor SUPER_STT_KEYRING_MOCK before any session-token access so
     // automated shells / CI (and our own integration tests) don't block on
     // the system secret service. No-op when the env var is unset.
@@ -65,7 +69,13 @@ async fn main() -> Result<()> {
                     Arg::new("stop-mode")
                         .long("stop-mode")
                         .help("Override the configured stop mode")
-                        .value_parser(["silence_only", "silence_and_manual", "manual_only"]),
+                        // Drive the accepted values from the shared wire-enum
+                        // table so they can't drift from the daemon (Tier 2 #8).
+                        .value_parser(clap::builder::PossibleValuesParser::new(
+                            super_stt_shared::models::recording_stop_mode::RecordingStopMode::WIRE_VARIANTS
+                                .iter()
+                                .copied(),
+                        )),
                 ),
         )
         .subcommand(Command::new("stop").about("Stop an in-flight daemon-mic recording"))

--- a/super-stt-consent/Cargo.toml
+++ b/super-stt-consent/Cargo.toml
@@ -22,9 +22,9 @@ workspace = true
         "wayland",
         "winit",
     ] }
-env_logger.workspace = true
 libc.workspace = true
 log.workspace = true
+super-stt-shared = { version = "0.1.4-beta.2", path = "../super-stt-shared" }
 
 [dev-dependencies]
 libc.workspace = true

--- a/super-stt-consent/src/main.rs
+++ b/super-stt-consent/src/main.rs
@@ -211,6 +211,28 @@ fn permissions_for_scope(scope: &str) -> &'static [&'static str] {
     }
 }
 
+#[cfg(test)]
+mod scope_conformance {
+    use super::{constants, permissions_for_scope};
+
+    /// Every scope the daemon accepts must have a specific consent description.
+    /// A daemon scope that falls through to `UNKNOWN_SCOPE_PERMISSIONS` would
+    /// render the "unknown scope — deny is safe" warning on a legitimate prompt,
+    /// so this pins the two lists together (Tier 2 #8).
+    #[test]
+    fn every_known_scope_has_specific_permissions() {
+        for scope in super_stt_shared::daemon::scopes::KNOWN_SCOPES {
+            assert!(
+                !std::ptr::eq(
+                    permissions_for_scope(scope),
+                    constants::UNKNOWN_SCOPE_PERMISSIONS
+                ),
+                "scope `{scope}` has no specific consent description; add an arm to permissions_for_scope"
+            );
+        }
+    }
+}
+
 /// Union of the per-scope bullet lists for every scope the app asked
 /// for, de-duplicated and order-preserving. Falls back to the unknown
 /// bullet if the set is empty.
@@ -346,13 +368,7 @@ fn read_env() -> AuthRequestPayload {
 }
 
 fn main() -> cosmic::iced::Result {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    } else {
-        env_logger::Builder::from_default_env()
-            .filter_level(log::LevelFilter::Info)
-            .init();
-    }
+    super_stt_shared::logging::init();
 
     install_termination_handlers();
     maybe_spawn_auto_approve_timer();

--- a/super-stt-cosmic-applet/Cargo.toml
+++ b/super-stt-cosmic-applet/Cargo.toml
@@ -22,8 +22,6 @@ base64 = "0.22.1"
         "applet",
         "tokio",
     ] }
-    dirs.workspace = true
-    env_logger.workspace = true
     futures-util.workspace = true
     libc.workspace = true
     log.workspace = true

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -65,14 +65,7 @@ impl Default for AppletConfig {
 impl AppletConfig {
     /// Get the config file path for a specific applet variant
     fn get_config_path(variant: &str) -> PathBuf {
-        let config_dir = dirs::config_dir()
-            .unwrap_or_else(|| {
-                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-                PathBuf::from(home).join(".config")
-            })
-            .join("super-stt");
-
-        config_dir.join(format!("applet-{variant}.toml"))
+        super_stt_shared::paths::config_dir().join(format!("applet-{variant}.toml"))
     }
 
     /// Parse applet config `content`, falling back to defaults on a parse

--- a/super-stt-cosmic-applet/src/main.rs
+++ b/super-stt-cosmic-applet/src/main.rs
@@ -20,7 +20,9 @@ impl From<Side> for VisualizationSide {
 }
 
 fn main() -> cosmic::iced::Result {
-    env_logger::init();
+    // `Info` default (the bare `env_logger::init()` here defaulted to `error`,
+    // making the applet effectively silent vs its siblings) (Tier 2 #6).
+    super_stt_shared::logging::init();
     log::info!("Starting Super STT applet with version {VERSION}");
 
     let matches = Command::new("super-stt-cosmic-applet")

--- a/super-stt-daemon/Cargo.toml
+++ b/super-stt-daemon/Cargo.toml
@@ -21,7 +21,6 @@ chrono.workspace = true
     dirs.workspace = true
     # Input simulation
     enigo.workspace = true
-    env_logger.workspace = true
     futures = "0.3"
     keyring.workspace = true
     libc.workspace = true

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -152,14 +152,7 @@ impl Default for DaemonConfig {
 impl DaemonConfig {
     /// Get the config file path
     fn get_config_path() -> PathBuf {
-        let config_dir = dirs::config_dir()
-            .unwrap_or_else(|| {
-                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-                PathBuf::from(home).join(".config")
-            })
-            .join("super-stt");
-
-        config_dir.join("daemon.toml")
+        super_stt_shared::paths::config_dir().join("daemon.toml")
     }
 
     /// Parse config file `content` into a [`DaemonConfig`], falling back to

--- a/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
+++ b/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
@@ -89,49 +89,8 @@ pub(crate) fn auth_err(status: StatusCode, message: &str, reason: &str) -> Respo
     error_response(status, message, reason)
 }
 
-/// The complete set of scope tokens this daemon understands, in wire
-/// (`snake_case`) form. A token may be granted any non-empty subset.
-/// Source of truth for `/auth/request` validation; mirrors the scope
-/// catalog in `docs/protocol/auth.md`.
-pub(crate) const KNOWN_SCOPES: &[&str] = &[
-    "transcribe",
-    "settings",
-    "secrets",
-    "status",
-    "recording_events",
-    "audio_visualization",
-    "global_transcriptions",
-    "daemon_status",
-];
-
-/// True if `s` is a recognized scope token.
-pub(crate) fn is_known_scope(s: &str) -> bool {
-    KNOWN_SCOPES.contains(&s)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn known_scopes_are_recognized() {
-        for s in KNOWN_SCOPES {
-            assert!(is_known_scope(s), "{s} should be a known scope");
-        }
-    }
-
-    #[test]
-    fn old_personas_and_garbage_are_rejected() {
-        for s in ["client", "widget", "", "Settings", "transcribe ", "global"] {
-            assert!(!is_known_scope(s), "{s:?} must not be a known scope");
-        }
-    }
-
-    #[test]
-    fn secrets_is_a_known_scope() {
-        assert!(
-            is_known_scope("secrets"),
-            "secrets must be an accepted scope"
-        );
-    }
-}
+/// The auth scope catalog now lives in `super-stt-shared` so the daemon and the
+/// consent dialog share one list (Tier 2 #8). Re-exported for the existing
+/// `/auth/request` validation call site; the catalog's own tests live in
+/// `super_stt_shared::daemon::scopes`.
+pub(crate) use super_stt_shared::daemon::scopes::is_known_scope;

--- a/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
@@ -98,9 +98,7 @@ pub(super) fn spawn_install_pipeline(
                 PathBuf::from,
             )
         };
-        let cache_dir = dirs::cache_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("super-stt/install");
+        let cache_dir = super_stt_shared::paths::cache_dir().join("install");
 
         let events = Arc::clone(&daemon.events);
         let install_id_ev = install_id.clone();

--- a/super-stt-daemon/src/daemon_main.rs
+++ b/super-stt-daemon/src/daemon_main.rs
@@ -15,23 +15,6 @@ use log::{error, info, warn};
 use std::path::PathBuf;
 use super_stt_shared::theme::AudioTheme;
 
-/// Initialize the `env_logger`. Respects `RUST_LOG`; otherwise sets the
-/// level from the `--verbose` flag.
-fn init_logging(verbose: bool) {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    } else {
-        let log_level = if verbose {
-            log::LevelFilter::Debug
-        } else {
-            log::LevelFilter::Info
-        };
-        env_logger::Builder::from_default_env()
-            .filter_level(log_level)
-            .init();
-    }
-}
-
 /// Resolve the per-session overrides set on the command line. An override
 /// is `Some` only when the user passed the flag explicitly — when not
 /// set, the daemon falls back to whatever is in the config file.
@@ -88,8 +71,18 @@ async fn spawn_http_listener(daemon: &SuperSTTDaemon) -> Result<tokio::task::Joi
 /// Panics if the daemon fails to initialize.
 pub async fn run() -> Result<()> {
     let matches = cli::build().get_matches();
+    let verbose = matches.get_flag("verbose");
 
-    // Load saved configuration first
+    // Init logging BEFORE loading config so a "config invalid, reset to
+    // defaults" warning emitted during the load is actually captured, instead
+    // of being dropped before any logger exists (Tier 2 #6).
+    super_stt_shared::logging::init_with(if verbose {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    });
+
+    // Load saved configuration
     let config = DaemonConfig::load();
 
     // CLI flag overrides the saved preferred model for this session;
@@ -101,7 +94,6 @@ pub async fn run() -> Result<()> {
 
     let device = matches.get_one::<String>("device").unwrap();
     let force_cpu = device == "cpu";
-    let verbose = matches.get_flag("verbose");
 
     let audio_theme =
         if matches.value_source("audio-theme") == Some(clap::parser::ValueSource::CommandLine) {
@@ -110,8 +102,6 @@ pub async fn run() -> Result<()> {
         } else {
             config.audio.theme
         };
-
-    init_logging(verbose);
 
     info!("Starting Super STT Daemon");
     info!("Model: {model}");

--- a/super-stt-daemon/src/lib.rs
+++ b/super-stt-daemon/src/lib.rs
@@ -19,8 +19,7 @@ pub use daemon_main::run;
 mod daemon_main;
 mod num_cast;
 
-/// Install the ring crypto provider for rustls.
-/// Safe to call multiple times — returns Ok on first call, Err on subsequent (which we ignore).
-pub fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
+/// Re-export the shared rustls provider installer from `super-stt-forge`, so
+/// `main` and the tests install the provider through one implementation that
+/// lives beside the reqwest client factory.
+pub use super_stt_forge::install_crypto_provider;

--- a/super-stt-daemon/src/registry/client.rs
+++ b/super-stt-daemon/src/registry/client.rs
@@ -62,6 +62,7 @@ impl Client {
         }
     }
 
+    #[must_use]
     pub fn from_env() -> Self {
         let url = match std::env::var("SUPER_STT_REGISTRY_URL") {
             Ok(v) if crate::registry::accept_base_url(&v) => v,
@@ -71,9 +72,7 @@ impl Client {
             }
             Err(_) => DEFAULT_URL.into(),
         };
-        let cache_dir = dirs::cache_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("super-stt");
+        let cache_dir = super_stt_shared::paths::cache_dir();
         let _ = std::fs::create_dir_all(&cache_dir);
         Self::new(url, cache_dir.join("registry-index.json"), DEFAULT_TTL)
     }

--- a/super-stt-daemon/src/registry/mod.rs
+++ b/super-stt-daemon/src/registry/mod.rs
@@ -9,32 +9,6 @@ pub mod index_schema;
 pub mod install;
 pub mod local_dir;
 
-/// Whether an operator-provided base URL (`GITHUB_API_BASE`,
-/// `SUPER_STT_REGISTRY_URL`) may be used. Requires `https://`, except a
-/// loopback `http://` URL which is permitted for local testing. Anything else
-/// is rejected so callers fall back to their secure default.
-#[must_use]
-pub(crate) fn accept_base_url(url: &str) -> bool {
-    if let Some(rest) = url.strip_prefix("https://") {
-        !rest.is_empty()
-    } else if let Some(rest) = url.strip_prefix("http://") {
-        rest.starts_with("localhost") || rest.starts_with("127.0.0.1") || rest.starts_with("[::1]")
-    } else {
-        false
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::accept_base_url;
-
-    #[test]
-    fn accepts_https_and_loopback_http_only() {
-        assert!(accept_base_url("https://api.github.com"));
-        assert!(accept_base_url("http://localhost:8787"));
-        assert!(accept_base_url("http://127.0.0.1:9000"));
-        assert!(!accept_base_url("http://evil.example.com"));
-        assert!(!accept_base_url("ftp://x"));
-        assert!(!accept_base_url("https://"));
-    }
-}
+/// Re-export the shared operator-base-URL gate from `super-stt-forge` so the
+/// registry client and the forge adapters apply one identical rule.
+pub(crate) use super_stt_forge::accept_base_url;

--- a/super-stt-daemon/src/stt_models/backends/mod.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod.rs
@@ -233,13 +233,7 @@ pub fn list_models(backends: &[DiscoveredBackend]) -> Vec<(String, Provider, Str
 /// The default backends search directory: `<data_dir>/super-stt/backends`.
 #[must_use]
 pub fn default_backends_dir() -> PathBuf {
-    dirs::data_dir()
-        .unwrap_or_else(|| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-            PathBuf::from(home).join(".local/share")
-        })
-        .join("super-stt")
-        .join("backends")
+    super_stt_shared::paths::data_dir().join("backends")
 }
 
 #[cfg(test)]

--- a/super-stt-daemon/src/stt_models/download.rs
+++ b/super-stt-daemon/src/stt_models/download.rs
@@ -221,7 +221,8 @@ pub async fn download_files(
     tracker: Option<&Arc<DownloadProgressTracker>>,
     starting_file_index: usize,
 ) -> Result<()> {
-    crate::install_crypto_provider();
+    // The provider is installed once in `main` before any download runs, so no
+    // redundant install here (Tier 2 #8).
     let client = super_stt_forge::http::download_client();
 
     for (offset, item) in items.iter().enumerate() {

--- a/super-stt-daemon/src/stt_models/subprocess/mod.rs
+++ b/super-stt-daemon/src/stt_models/subprocess/mod.rs
@@ -100,10 +100,18 @@ impl SubprocessBackend {
         }
 
         // Socket under the runtime dir (pathname socket — survives PrivateNetwork).
-        let runtime = std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/tmp".to_string());
-        let socket_dir = PathBuf::from(&runtime).join("stt/backends");
+        // Route through the shared validated helper so it gets the same
+        // traversal/prefix/length guards as the daemon's own sockets, instead
+        // of a raw `$XDG_RUNTIME_DIR` join (Tier 2 #7).
+        let socket = super_stt_shared::validation::secure_runtime_path(&format!(
+            "backends/{}.sock",
+            sanitize(model_name)
+        ));
+        let socket_dir = socket.parent().map_or_else(
+            || PathBuf::from("/tmp/stt/backends"),
+            std::path::Path::to_path_buf,
+        );
         std::fs::create_dir_all(&socket_dir)?;
-        let socket = socket_dir.join(format!("{}.sock", sanitize(model_name)));
         let _ = std::fs::remove_file(&socket);
 
         let binary = backend_dir.join(&manifest.backend.entrypoint);

--- a/super-stt-forge/Cargo.toml
+++ b/super-stt-forge/Cargo.toml
@@ -14,11 +14,11 @@ workspace = true
 async-trait = "0.1.89"
 log.workspace = true
 reqwest.workspace = true
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 serde.workspace = true
 super-stt-registry-types = { version = "0.1.4-beta.2", path = "../super-stt-registry-types" }
 thiserror.workspace = true
 
 [dev-dependencies]
 mockito = "1"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/super-stt-forge/src/http.rs
+++ b/super-stt-forge/src/http.rs
@@ -18,6 +18,14 @@ use std::time::Duration;
 /// logs and rate-limiters can attribute traffic.
 pub const USER_AGENT: &str = concat!("super-stt/", env!("CARGO_PKG_VERSION"));
 
+/// Install the `ring` rustls crypto provider — the workspace uses
+/// `reqwest`/`rustls` with no bundled provider, so every binary must install one
+/// once before its first request (these client builders deliberately don't).
+/// Idempotent: the first call wins, later ones are ignored.
+pub fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 /// Client for small, quick requests (release metadata, `index.json`, manifest
 /// assets): a 20 s overall timeout and a bounded redirect chain.
 ///

--- a/super-stt-forge/src/lib.rs
+++ b/super-stt-forge/src/lib.rs
@@ -4,6 +4,7 @@
 mod github;
 pub mod http;
 pub use github::Github;
+pub use http::install_crypto_provider;
 
 use async_trait::async_trait;
 use super_stt_registry_types::forge::Forge;
@@ -131,25 +132,33 @@ pub fn client(forge: Forge) -> Box<dyn ForgeClient> {
     }
 }
 
-/// Install the ring crypto provider for rustls.
-/// Safe to call multiple times — returns `Ok` on first call, `Err` on
-/// subsequent (which we ignore).
-#[cfg(test)]
-pub(crate) fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
 /// Whether an operator-provided API base URL may be used: `https://`, or a
 /// loopback `http://` for local testing. Anything else is rejected so adapters
-/// fall back to their secure default.
+/// fall back to their secure default. Shared with the daemon's registry client
+/// (`SUPER_STT_REGISTRY_URL` / `GITHUB_API_BASE` gating).
 #[must_use]
-pub(crate) fn accept_base_url(url: &str) -> bool {
+pub fn accept_base_url(url: &str) -> bool {
     if let Some(rest) = url.strip_prefix("https://") {
         !rest.is_empty()
     } else if let Some(rest) = url.strip_prefix("http://") {
         rest.starts_with("localhost") || rest.starts_with("127.0.0.1") || rest.starts_with("[::1]")
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod base_url_tests {
+    use super::accept_base_url;
+
+    #[test]
+    fn accepts_https_and_loopback_http_only() {
+        assert!(accept_base_url("https://api.github.com"));
+        assert!(accept_base_url("http://localhost:8787"));
+        assert!(accept_base_url("http://127.0.0.1:9000"));
+        assert!(!accept_base_url("http://evil.example.com"));
+        assert!(!accept_base_url("ftp://x"));
+        assert!(!accept_base_url("https://"));
     }
 }
 

--- a/super-stt-indexer/Cargo.toml
+++ b/super-stt-indexer/Cargo.toml
@@ -30,7 +30,6 @@ toml = "1"
 url = "2"
 super-stt-registry-types = { path = "../super-stt-registry-types" }
 super-stt-forge = { version = "0.1.4-beta.2", path = "../super-stt-forge" }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [dev-dependencies]
 mockito = "1"

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -58,7 +58,7 @@ pub struct BuildFailure {
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() -> anyhow::Result<()> {
     // Workspace reqwest uses rustls without a bundled provider; install one.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    super_stt_forge::install_crypto_provider();
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     match Args::parse().command {
         Command::Build(args) => run_build(args).await,

--- a/super-stt-shared/Cargo.toml
+++ b/super-stt-shared/Cargo.toml
@@ -17,6 +17,8 @@ async-stream = "0.3.6"
     cpal = { workspace = true, optional = true }
     # Notification service dependencies
     dashmap.workspace = true
+dirs.workspace = true
+env_logger.workspace = true
 futures-util.workspace = true
     # Audio processing (optional feature)
     hound = { workspace = true, optional = true }
@@ -25,7 +27,7 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
 keyring.workspace = true
     libc.workspace = true
-    log.workspace = true
+log.workspace = true
     rubato = { workspace = true, optional = true }
     serde.workspace = true
     serde_json.workspace = true

--- a/super-stt-shared/src/daemon/http_client/internal/sse.rs
+++ b/super-stt-shared/src/daemon/http_client/internal/sse.rs
@@ -1,5 +1,54 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use futures_util::{Stream, StreamExt};
+use http_body_util::BodyStream;
+use hyper::body::Incoming;
+
+/// Frame an SSE response body into blocks and map each block — plus any
+/// body-read / non-UTF-8 error — to the caller's event type `T`. The loop
+/// skeleton (accumulate frames, split on the blank-line boundary, decode,
+/// dispatch) is identical for the `/transcribe` and `/events` client streams;
+/// callers supply only the per-block parser and the error constructor.
+pub(crate) fn block_stream<T, P, E>(
+    body: Incoming,
+    parse_block: P,
+    on_error: E,
+) -> impl Stream<Item = T>
+where
+    P: Fn(&str) -> Option<T>,
+    E: Fn(String) -> T,
+{
+    let mut body_stream = BodyStream::new(body);
+    async_stream::stream! {
+        let mut buffer: Vec<u8> = Vec::new();
+        while let Some(frame_res) = body_stream.next().await {
+            let frame = match frame_res {
+                Ok(f) => f,
+                Err(e) => {
+                    yield on_error(format!("body read error: {e}"));
+                    return;
+                }
+            };
+            if let Ok(data) = frame.into_data() {
+                buffer.extend_from_slice(&data);
+                while let Some(boundary) = find_blank_line(&buffer) {
+                    let block_bytes: Vec<u8> = buffer.drain(..boundary.end).collect();
+                    let block_text = match std::str::from_utf8(&block_bytes[..boundary.start]) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            yield on_error(format!("non-utf8 SSE block: {e}"));
+                            continue;
+                        }
+                    };
+                    if let Some(ev) = parse_block(block_text) {
+                        yield ev;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Returned span describes the bytes belonging to ONE SSE block.
 /// `start` is the byte index of the blank line, `end` is one past the
 /// final `\n` that closes the block.

--- a/super-stt-shared/src/daemon/http_client/internal/transport.rs
+++ b/super-stt-shared/src/daemon/http_client/internal/transport.rs
@@ -12,34 +12,11 @@ use serde::de::DeserializeOwned;
 /// URL on the wire is `/v1/ping`, `/v1/transcribe`, etc.
 pub(crate) const API_PREFIX: &str = "/v1";
 
-/// Body type wrapper so we can use either an empty body (GET) or a JSON body
-/// (POST) through the same hyper builder.
-pub(crate) enum RequestBody {
-    Empty(Empty<Bytes>),
-    Full(Full<Bytes>),
-}
-
-impl hyper::body::Body for RequestBody {
-    type Data = Bytes;
-    type Error = hyper::Error;
-
-    fn poll_frame(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Result<hyper::body::Frame<Bytes>, hyper::Error>>> {
-        // SAFETY: pin projection — RequestBody is a plain enum of two
-        // body types and we only forward to their poll_frame.
-        let this = unsafe { self.get_unchecked_mut() };
-        match this {
-            RequestBody::Empty(b) => unsafe { std::pin::Pin::new_unchecked(b) }
-                .poll_frame(cx)
-                .map(|opt| opt.map(|r| r.map_err(|never| match never {}))),
-            RequestBody::Full(b) => unsafe { std::pin::Pin::new_unchecked(b) }
-                .poll_frame(cx)
-                .map(|opt| opt.map(|r| r.map_err(|never| match never {}))),
-        }
-    }
-}
+/// Body type so a GET/DELETE (empty) and a POST (JSON) share one hyper request
+/// type. `http_body_util::Either` supplies the `Body` impl — both arms are
+/// `Bytes` bodies with an `Infallible` error — replacing a hand-rolled `unsafe`
+/// pin projection (this crate's only `unsafe`).
+pub(crate) type RequestBody = http_body_util::Either<Empty<Bytes>, Full<Bytes>>;
 
 pub(crate) fn build_get(path: &str, token: Option<&str>) -> Result<Request<RequestBody>, String> {
     let mut builder = Request::builder()
@@ -50,7 +27,7 @@ pub(crate) fn build_get(path: &str, token: Option<&str>) -> Result<Request<Reque
         builder = builder.header("authorization", format!("Bearer {t}"));
     }
     builder
-        .body(RequestBody::Empty(Empty::new()))
+        .body(http_body_util::Either::Left(Empty::new()))
         .map_err(|e| format!("Failed to build request: {e}"))
 }
 
@@ -70,7 +47,9 @@ pub(crate) fn build_post_json(
         builder = builder.header("authorization", format!("Bearer {t}"));
     }
     builder
-        .body(RequestBody::Full(Full::new(Bytes::from(body_bytes))))
+        .body(http_body_util::Either::Right(Full::new(Bytes::from(
+            body_bytes,
+        ))))
         .map_err(|e| format!("Failed to build request: {e}"))
 }
 
@@ -86,7 +65,7 @@ pub(crate) fn build_delete(
         builder = builder.header("authorization", format!("Bearer {t}"));
     }
     builder
-        .body(RequestBody::Empty(Empty::new()))
+        .body(http_body_util::Either::Left(Empty::new()))
         .map_err(|e| format!("Failed to build request: {e}"))
 }
 

--- a/super-stt-shared/src/daemon/http_client/v1/events.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/events.rs
@@ -65,7 +65,7 @@ fn build_events_request(
         .header("host", "stt.local")
         .header("accept", "text/event-stream")
         .header("authorization", format!("Bearer {token}"))
-        .body(transport::RequestBody::Empty(Empty::new()))
+        .body(http_body_util::Either::Left(Empty::new()))
         .map_err(|e| format!("Failed to build request: {e}"))
 }
 
@@ -76,49 +76,14 @@ fn build_events_request(
 fn parse_widget_event_stream(
     response: hyper::Response<hyper::body::Incoming>,
 ) -> impl futures_util::Stream<Item = WidgetEvent> + Send + 'static {
-    use http_body_util::BodyStream;
-    use hyper::body::Frame;
-    let body_stream = BodyStream::new(response.into_body());
-    async_stream::stream! {
-        let mut buffer: Vec<u8> = Vec::new();
-        let mut body_stream = body_stream;
-        use futures_util::StreamExt;
-        while let Some(frame_res) = body_stream.next().await {
-            let frame: Frame<_> = match frame_res {
-                Ok(f) => f,
-                Err(e) => {
-                    yield WidgetEvent {
-                        name: "error".to_string(),
-                        payload: serde_json::json!({
-                            "message": format!("body read error: {e}"),
-                        }),
-                    };
-                    return;
-                }
-            };
-            if let Ok(data) = frame.into_data() {
-                buffer.extend_from_slice(&data);
-                while let Some(boundary) = sse::find_blank_line(&buffer) {
-                    let block_bytes: Vec<u8> = buffer.drain(..boundary.end).collect();
-                    let block_text = match std::str::from_utf8(&block_bytes[..boundary.start]) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            yield WidgetEvent {
-                                name: "error".to_string(),
-                                payload: serde_json::json!({
-                                    "message": format!("non-utf8 SSE block: {e}"),
-                                }),
-                            };
-                            continue;
-                        }
-                    };
-                    if let Some(ev) = parse_widget_sse_block(block_text) {
-                        yield ev;
-                    }
-                }
-            }
+    // Shared SSE framing loop (Tier 2 #8); this stream maps each block to a
+    // `WidgetEvent` and body/UTF-8 errors to an `error`-named event.
+    sse::block_stream(response.into_body(), parse_widget_sse_block, |message| {
+        WidgetEvent {
+            name: "error".to_string(),
+            payload: serde_json::json!({ "message": message }),
         }
-    }
+    })
 }
 
 /// Parse one SSE block into a [`WidgetEvent`].

--- a/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
@@ -14,12 +14,11 @@ pub struct TranscribeOptions {
     pub wait: bool,
 }
 
-/// One event from the `/transcribe` NDJSON stream.
+/// One event from the `/transcribe` Server-Sent Events stream.
 ///
 /// Matches the daemon's wire-level event types — `preview` for
 /// in-flight text, `done` for the final transcription, `error` for a
-/// daemon-side failure. Mirrors the Mistral realtime event-stream
-/// pattern (one typed JSON object per line).
+/// daemon-side failure — each an SSE block of `event:` / `data:` lines.
 #[derive(Debug, Clone)]
 pub enum TranscribeEvent {
     /// Incremental preview text (full text so far, not a delta).
@@ -33,7 +32,7 @@ pub enum TranscribeEvent {
 }
 
 /// `POST /transcribe` — start a daemon-mic recording. Non-streaming
-/// variant: collapses the entire NDJSON event stream into a single
+/// variant: collapses the entire SSE event stream into a single
 /// final result.
 ///
 /// # Errors
@@ -86,9 +85,6 @@ pub async fn transcribe_stream(
     token: &str,
     opts: TranscribeOptions,
 ) -> HttpResult<impl futures_util::Stream<Item = TranscribeEvent> + Send + 'static> {
-    use http_body_util::BodyStream;
-    use hyper::body::Frame;
-
     let mut data = serde_json::json!({
         "write_mode": opts.write_mode,
         "wait":       opts.wait,
@@ -122,46 +118,15 @@ pub async fn transcribe_stream(
         return Err(HttpError::Other(message));
     }
 
-    // Parse Server-Sent Events as they arrive. Each event is a block
-    // of `field: value\n` lines terminated by a blank line (`\n\n`).
-    // We collect bytes into a buffer and split on the blank-line
-    // boundary; for each block we extract the `event:` and `data:`
-    // fields and emit a typed `TranscribeEvent`.
-    let body_stream = BodyStream::new(response.into_body());
-    let event_stream = async_stream::stream! {
-        let mut buffer: Vec<u8> = Vec::new();
-        let mut body_stream = body_stream;
-        use futures_util::StreamExt;
-        while let Some(frame_res) = body_stream.next().await {
-            let frame: Frame<_> = match frame_res {
-                Ok(f) => f,
-                Err(e) => {
-                    yield TranscribeEvent::Error(format!("body read error: {e}"));
-                    return;
-                }
-            };
-            if let Ok(data) = frame.into_data() {
-                buffer.extend_from_slice(&data);
-                while let Some(boundary) = sse::find_blank_line(&buffer) {
-                    let block_bytes: Vec<u8> = buffer.drain(..boundary.end).collect();
-                    let block_text = match std::str::from_utf8(&block_bytes[..boundary.start]) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            yield TranscribeEvent::Error(format!(
-                                "non-utf8 SSE block: {e}"
-                            ));
-                            continue;
-                        }
-                    };
-                    if let Some(ev) = parse_sse_block(block_text) {
-                        yield ev;
-                    }
-                }
-            }
-        }
-    };
-
-    Ok(event_stream)
+    // Parse Server-Sent Events as they arrive: each event is a block of
+    // `field: value\n` lines terminated by a blank line. The framing loop is
+    // shared with `/events` via `sse::block_stream` (Tier 2 #8); here it maps
+    // each block to a typed `TranscribeEvent`.
+    Ok(sse::block_stream(
+        response.into_body(),
+        parse_sse_block,
+        TranscribeEvent::Error,
+    ))
 }
 
 fn parse_sse_block(block: &str) -> Option<TranscribeEvent> {

--- a/super-stt-shared/src/daemon/mod.rs
+++ b/super-stt-shared/src/daemon/mod.rs
@@ -3,5 +3,6 @@
 
 pub mod http_client;
 pub mod retry;
+pub mod scopes;
 pub mod session;
 pub mod widget_subscription;

--- a/super-stt-shared/src/daemon/scopes.rs
+++ b/super-stt-shared/src/daemon/scopes.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! The auth scope catalog, shared so the daemon (which validates
+//! `/auth/request`) and the consent dialog (which describes each scope to the
+//! user) can't drift. When they drift, a scope the daemon accepts but the
+//! consent binary doesn't recognize renders the "unknown scope — deny is safe"
+//! warning on a legitimate prompt, teaching users to distrust real requests.
+
+/// The complete set of scope tokens the daemon understands, in wire
+/// (`snake_case`) form. A token may be granted any non-empty subset. Source of
+/// truth for `/auth/request` validation and the consent dialog; mirrors the
+/// scope catalog in `docs/protocol/auth.md`.
+pub const KNOWN_SCOPES: &[&str] = &[
+    "transcribe",
+    "settings",
+    "secrets",
+    "status",
+    "recording_events",
+    "audio_visualization",
+    "global_transcriptions",
+    "daemon_status",
+];
+
+/// True if `s` is a recognized scope token.
+#[must_use]
+pub fn is_known_scope(s: &str) -> bool {
+    KNOWN_SCOPES.contains(&s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KNOWN_SCOPES, is_known_scope};
+
+    #[test]
+    fn known_scopes_are_recognized() {
+        for s in KNOWN_SCOPES {
+            assert!(is_known_scope(s), "{s} should be a known scope");
+        }
+        assert!(
+            is_known_scope("secrets"),
+            "secrets must be an accepted scope"
+        );
+    }
+
+    #[test]
+    fn old_personas_and_garbage_are_rejected() {
+        for s in ["client", "widget", "", "Settings", "transcribe ", "global"] {
+            assert!(!is_known_scope(s), "{s:?} must not be a known scope");
+        }
+    }
+}

--- a/super-stt-shared/src/lib.rs
+++ b/super-stt-shared/src/lib.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pub mod daemon;
+pub mod logging;
 pub mod models;
+pub mod paths;
 pub mod registry;
 pub mod utils;
 pub mod validation;

--- a/super-stt-shared/src/logging.rs
+++ b/super-stt-shared/src/logging.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! One `env_logger` initializer for every Super STT binary.
+//!
+//! Replaces five near-identical setups (and one that silently defaulted to
+//! `error`, plus a CLI with none at all). `RUST_LOG` always wins; otherwise the
+//! level falls back to the caller's default. Call this ONCE, as early in `main`
+//! as possible — before any config load — so startup diagnostics (e.g. a
+//! "config invalid, reset to defaults" warning) aren't emitted before the logger
+//! exists and dropped.
+
+/// Initialize logging with an `Info` default level. `RUST_LOG` still overrides.
+pub fn init() {
+    init_with(log::LevelFilter::Info);
+}
+
+/// Initialize logging with an explicit default level. `RUST_LOG` still
+/// overrides (e.g. the daemon passes `Debug` under `--verbose`).
+pub fn init_with(default_level: log::LevelFilter) {
+    if std::env::var_os("RUST_LOG").is_some() {
+        env_logger::init();
+    } else {
+        env_logger::Builder::from_default_env()
+            .filter_level(default_level)
+            .init();
+    }
+}

--- a/super-stt-shared/src/models/wire_enum.rs
+++ b/super-stt-shared/src/models/wire_enum.rs
@@ -27,6 +27,11 @@ macro_rules! wire_enum_strings {
             pub fn as_wire_str(self) -> &'static str {
                 match self { $( Self::$variant => $wire, )+ }
             }
+
+            /// Every accepted wire/config token, in declaration order. Lets a
+            /// CLI build its `value_parser` (or help text) from the single
+            /// table instead of re-listing the strings.
+            pub const WIRE_VARIANTS: &'static [&'static str] = &[ $( $wire, )+ ];
         }
 
         impl ::std::fmt::Display for $ty {

--- a/super-stt-shared/src/paths.rs
+++ b/super-stt-shared/src/paths.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! One home for the Super STT XDG base directories.
+//!
+//! Replaces the byte-identical daemon↔applet `get_config_path` cores and the
+//! scattered `dirs`-miss fallbacks. Each helper returns the `super-stt`
+//! subdirectory of its XDG base, applying the same fallback the call sites used
+//! (so behavior is unchanged) — callers append their own filename. The
+//! validated runtime-socket path lives separately in
+//! [`crate::validation`] (`get_http_socket_path` etc.).
+
+use std::path::PathBuf;
+
+/// `$XDG_CONFIG_HOME/super-stt` (fallback `$HOME/.config/super-stt`, else
+/// `/tmp/.config/super-stt`). Daemon: append `daemon.toml`; applet: append
+/// `applet-<variant>.toml`.
+#[must_use]
+pub fn config_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| home_join(".config"))
+        .join("super-stt")
+}
+
+/// `$XDG_DATA_HOME/super-stt` (fallback `$HOME/.local/share/super-stt`, else
+/// `/tmp/.local/share/super-stt`). Used for installed backends.
+#[must_use]
+pub fn data_dir() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(|| home_join(".local/share"))
+        .join("super-stt")
+}
+
+/// `$XDG_CACHE_HOME/super-stt` (fallback `$TMPDIR/super-stt`). Used for the
+/// registry index cache and staged installs.
+#[must_use]
+pub fn cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("super-stt")
+}
+
+/// `$HOME/<suffix>`, falling back to `/tmp/<suffix>` when `HOME` is unset —
+/// the shared fallback for the config/data dirs above.
+fn home_join(suffix: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(suffix)
+}

--- a/super-stt-shared/src/validation/mod.rs
+++ b/super-stt-shared/src/validation/mod.rs
@@ -11,7 +11,9 @@ pub use inputs::{
     validate_limit, validate_optional_string, validate_required_string, validate_sample_rate,
     validate_string,
 };
-pub use paths::{generate_secure_client_id, get_http_socket_path, get_secure_socket_path};
+pub use paths::{
+    generate_secure_client_id, get_http_socket_path, get_secure_socket_path, secure_runtime_path,
+};
 
 /// Validation errors for better error reporting
 #[derive(Debug, thiserror::Error)]

--- a/super-stt-shared/src/validation/paths.rs
+++ b/super-stt-shared/src/validation/paths.rs
@@ -23,11 +23,16 @@ pub fn generate_secure_client_id(component: &str) -> String {
     format!("{component}-{pid}-{timestamp}-{uuid}")
 }
 
-/// Build a validated socket path `$XDG_RUNTIME_DIR/stt/<filename>` with
-/// path-traversal / prefix / length checks and a `/tmp/stt/<filename>`
-/// fallback.
-fn secure_socket_path(filename: &str) -> std::path::PathBuf {
-    let fallback = || std::path::PathBuf::from(format!("/tmp/stt/{filename}"));
+/// Build a validated runtime path `$XDG_RUNTIME_DIR/stt/<relative>` with
+/// path-traversal / prefix / length checks on the runtime dir and a
+/// `/tmp/stt/<relative>` fallback. `relative` is a caller-controlled subpath
+/// (a bare filename, or e.g. `backends/<name>.sock`) joined after `stt/`.
+///
+/// Shared entry point for every runtime socket so callers can't bypass the
+/// SSRF/traversal guards with a hand-rolled `$XDG_RUNTIME_DIR` join.
+#[must_use]
+pub fn secure_runtime_path(relative: &str) -> std::path::PathBuf {
+    let fallback = || std::path::PathBuf::from(format!("/tmp/stt/{relative}"));
     let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
         .unwrap_or_else(|_| format!("/run/user/{}", unsafe { libc::getuid() }));
 
@@ -46,12 +51,10 @@ fn secure_socket_path(filename: &str) -> std::path::PathBuf {
 
     let path = std::path::PathBuf::from(runtime_dir)
         .join("stt")
-        .join(filename);
+        .join(relative);
     if let Ok(canonical) = path.canonicalize() {
         if !canonical.starts_with("/run/user/") && !canonical.starts_with("/tmp/") {
-            log::warn!(
-                "Canonical {filename} socket path outside allowed directories, using fallback"
-            );
+            log::warn!("Canonical runtime path {relative} outside allowed directories, fallback");
             return fallback();
         }
         canonical
@@ -74,7 +77,7 @@ fn secure_socket_path(filename: &str) -> std::path::PathBuf {
 /// - Security event logging
 #[must_use]
 pub fn get_secure_socket_path() -> std::path::PathBuf {
-    secure_socket_path("super-stt.sock")
+    secure_runtime_path("super-stt.sock")
 }
 
 /// Get the path of the HTTP-protocol Unix socket (`super-stt-http.sock`).
@@ -84,7 +87,7 @@ pub fn get_secure_socket_path() -> std::path::PathBuf {
 /// side-by-side; clients pick whichever one matches their protocol.
 #[must_use]
 pub fn get_http_socket_path() -> std::path::PathBuf {
-    secure_socket_path("super-stt-http.sock")
+    secure_runtime_path("super-stt-http.sock")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes Tier 2 **#6, #7, #8** from `docs/audits/2026-07-code-quality.md` in one PR (the three items are tightly coupled at the `super-stt-shared` plumbing level, so they land as one commit).

## #6 — Logging init
One `super_stt_shared::logging::{init, init_with}` (`RUST_LOG` wins, else the given default). Wired into the app, **CLI** (previously had no logging), **applet** (bare `env_logger::init()` defaulted to `error` — now `Info` like its siblings), consent, and daemon. The daemon now initializes logging **before** `DaemonConfig::load()`, so the "config invalid, reset to defaults" warning is actually captured. `env_logger` dropped from four crates. The **indexer is deliberately left** on its own one-liner rather than coupling a standalone build tool to the daemon-protocol crate for a logging call.

## #7 — XDG path helpers
`super_stt_shared::paths::{config_dir, data_dir, cache_dir}` (each keeps its call sites' existing fallback — no behavior change) replaces the byte-identical daemon↔applet `get_config_path` and the five scattered `dirs`-miss sites. The private socket validator is generalized to `pub fn secure_runtime_path(relative)`, and the subprocess socket now routes through it (`backends/<name>.sock`) instead of a raw `$XDG_RUNTIME_DIR` join — inheriting the traversal/prefix/length guards. Dropped the applet's now-unused `dirs` dep.

## #8 — Smaller shared items (all six)
- **`accept_base_url`**: now `pub` in forge (tests moved there); daemon re-exports it.
- **CryptoProvider**: one `install_crypto_provider()` in `forge::http` beside the client factory (forge `rustls` promoted from dev-dep); daemon re-exports it, the redundant `download.rs` call is removed, and the indexer's inline install + now-unused `rustls` are dropped.
- **Consent scopes**: `KNOWN_SCOPES`/`is_known_scope` moved to `shared::daemon::scopes`; daemon re-exports, and consent gained a **conformance test** that every known scope has a specific description (no "deny is safe" fall-through when the daemon adds a scope).
- **CLI stop-mode**: values now come from `RecordingStopMode::WIRE_VARIANTS` (added to `wire_enum_strings!`), not a hand-copied array.
- **SSE framing**: the two duplicated loops collapse into `sse::block_stream(body, parse_block, on_error)`; stale "NDJSON" docs corrected to SSE.
- **unsafe pin projection**: `RequestBody` is now `http_body_util::Either<Empty, Full>`, deleting the crate's only hand-rolled `unsafe`.

## Verification
Full workspace build clean · workspace clippy pedantic clean · `just fmt` · `just check-features` (all daemon combos) · tests pass: shared 94, forge 9, daemon 231, applet 18, app 43, indexer 4, plus the new consent scope-conformance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)