### PR TITLE
Audit Tier 3 #1-#4: share backend /v1, dedup device-switch, unify config persist, unblock the runtime

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -761,7 +761,7 @@ Tier 2 #4/#6/#8.
   the model under the write lock.
 - **Fix:** one `finalize_loaded_model()`; route unload through the real path.
 
-### [ ] 3. 🟠 Daemon: config persistence has three idioms
+### [x] 3. 🟠 Daemon: config persistence has three idioms
 
 - **Where:** self-saving `update_*` (blocking `fs::write` under the tokio config
   write lock, errors swallowed), pure mutation + `persist_config()`, and
@@ -770,6 +770,15 @@ Tier 2 #4/#6/#8.
   neither (Tier 1 #3).
 - **Fix:** make all mutators pure, persist via `persist_config()` in
   `spawn_blocking`; `save()`'s `Box<dyn Error>` → `anyhow::Result`.
+- **Resolved (branch `refactor/audit-tier3-1-4`):** all eight `update_*`/`clear_*`
+  config mutators are now pure (no `self.save()`); `persist_config_static` snapshots
+  the config under the lock, releases it, and does the blocking TOML-serialize +
+  `fs::write` in `spawn_blocking` — so no `fs::write` runs on an async worker under a
+  config lock. The six former double-write sites become single-write automatically;
+  the five sites that relied on the self-save (`update_active_backend` ×2,
+  `clear_active_backend`, `clear_preferred_model`, `update_backend_option`) gained an
+  explicit `persist_config()`, including the pre-load `active_backend` write that must
+  survive a load failure across a restart. `save()` now returns `anyhow::Result`.
 
 ### [ ] 4. 🟠 Daemon: blocking work on the async runtime
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -739,13 +739,20 @@ Ranked by drift risk. These answer "what should be standardized or reused."
 Indexer/forge/consent/cli defects live in Tier 1 #27–#31; their shared plumbing is
 Tier 2 #4/#6/#8.
 
-### [ ] 1. 🟡 Daemon: wasm/subprocess backends duplicate the `/v1` client
+### [x] 1. 🟡 Daemon: wasm/subprocess backends duplicate the `/v1` client
 
 - **Where:** ~35 lines already drifted — `wasm/mod.rs:400-443` vs
   `subprocess/mod.rs:324-361`, plus `invoke` vs `request`, `status`/`ping` vs
   `wait_for_ping`.
 - **Fix:** extract `build_transcribe_body` / `parse_transcribe_response` / a small
   `V1Transport` trait.
+- **Resolved (branch `refactor/audit-tier3-1-4`):** added a feature-agnostic
+  `stt_models::v1` module with `build_transcribe_body` and
+  `parse_transcribe_response` (the byte-identical, drifting parts); both backends'
+  `transcribe_audio` now call them. Kept the transports (`request` over a Unix
+  socket vs `invoke` through the WASM component) per-backend — they are genuinely
+  different, not duplication — so a `V1Transport` trait bought nothing over the two
+  free functions. Added unit tests for the shared build/parse.
 
 ### [ ] 2. 🟠 Daemon: device-switch success/recovery duplicate ~120 lines and bypass graceful unload
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -754,12 +754,21 @@ Tier 2 #4/#6/#8.
   different, not duplication — so a `V1Transport` trait bought nothing over the two
   free functions. Added unit tests for the shared build/parse.
 
-### [ ] 2. 🟠 Daemon: device-switch success/recovery duplicate ~120 lines and bypass graceful unload
+### [x] 2. 🟠 Daemon: device-switch success/recovery duplicate ~120 lines and bypass graceful unload
 
 - **Where:** `device_management.rs:236-321,361-421` vs `switch.rs:229-257`.
 - **Problem:** both bypass `unload_current_model()`'s graceful shutdown, dropping
   the model under the write lock.
 - **Fix:** one `finalize_loaded_model()`; route unload through the real path.
+- **Resolved (branch `refactor/audit-tier3-1-4`):** added
+  `finalize_loaded_model()` (normalize device → record actual device → install the
+  `LoadedModel`, returning the device label); the model-switch finalize and both
+  device-switch finalize sites (success + recovery) now call it instead of
+  re-implementing the normalize/model-set/actual-device triple. `prepare_device_switch`
+  no longer drops the model under the write lock — it routes through
+  `unload_current_model()`, so the backend is `shutdown()` outside the lock like every
+  other unload path. `unload_current_model`/`finalize_loaded_model` are
+  `pub(in crate::daemon)` so the sibling device-switch module can reach them.
 
 ### [x] 3. 🟠 Daemon: config persistence has three idioms
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -789,7 +789,7 @@ Tier 2 #4/#6/#8.
   explicit `persist_config()`, including the pre-load `active_backend` write that must
   survive a load failure across a restart. `save()` now returns `anyhow::Result`.
 
-### [ ] 4. 🟠 Daemon: blocking work on the async runtime
+### [x] 4. 🟠 Daemon: blocking work on the async runtime
 
 - **Where:** the portal backend spawns a thread + new tokio runtime per keysym then
   joins (`xdg_portal_backend.rs:122-153`, two runtime `expect`s); enigo sleeps per
@@ -800,6 +800,28 @@ Tier 2 #4/#6/#8.
 - **Fix:** make `Simulator` async (portal already holds an async zbus connection)
   or `spawn_blocking` throughout; `handle_get_gpu_info`
   (`device_management.rs:460-468`) shows the right pattern.
+- **Resolved (branch `refactor/audit-tier3-1-4`):** the two hot paths that actually
+  stall an async worker are now off-runtime via `spawn_blocking`.
+  - **Beep** — added `play_beep_sequence_async` (the `spawn_blocking` form of the
+    spin-waiting `play_beep_sequence`); `handle_test_audio_theme` and the recording
+    start-sound (`recorder::play_start_sound_and_wait`, now `async`) await it instead
+    of blocking the worker for the sound's full duration.
+  - **Keyring** — added `{get,set,delete,has}_backend_secret_async` (`spawn_blocking`
+    wrappers); the async secret handlers (`handle_set_backend_secret`,
+    `handle_clear_backend_secret`, the `secrets.rs` list/get endpoints) and the
+    WASM model-load secret read (`instantiate::backend_headers`) now await these, so a
+    locked-keyring DBus stall no longer parks a runtime thread.
+- **Deferred (follow-up, tracked as Tier 3 #35):** the keyboard `Simulator` path
+  (portal thread-per-keysym, enigo per-chunk sleeps) and the session-store keyring
+  writes (`TokenStore::flush_snapshot`/`load_persisted`). The `Simulator` is a sync
+  state machine driven while a `!Send` `std::Mutex` guard (`actually_typed`) is held
+  across the call, so offloading it needs the larger async-`Simulator` rewrite the
+  fix lists as the primary option (the portal path already spawns its own OS thread,
+  so it does not park a runtime worker today — only wastes a runtime per keysym).
+  `flush_snapshot` is called from the sync `mint`/`revoke`; a naive detached
+  `spawn_blocking` there would race the persist ordering, and `load_persisted` is a
+  one-time startup cost — both want a dedicated single-writer persist task rather than
+  a point wrap.
 
 ### [ ] 5. 🟡 Daemon: mutex poison recovery copy-pasted ~10× in `audio/`
 
@@ -997,6 +1019,25 @@ Tier 2 #4/#6/#8.
 - The three same-named `ResolveError` enums (custom_repo / local_dir / indexer
   resolve) are distinct concepts, not duplication — at most rename the indexer's.
   Same verdict for `Host` ×2 and `VisualizationConfig` ×2: no action needed.
+
+### [ ] 35. 🟠 Daemon: remaining blocking work (split off Tier 3 #4)
+
+- **Where:** the keyboard `Simulator` path — portal `notify_keysym` spins up an OS
+  thread + a fresh current-thread tokio runtime per keysym
+  (`xdg_portal_backend.rs:122-153`), enigo sleeps per 64-char chunk /per backspace
+  batch (`enigo_backend.rs:24-50`); and the session-store keyring writes
+  (`TokenStore::flush_snapshot`/`load_persisted`, `tokens.rs`).
+- **Why split:** Tier 3 #4 offloaded the two hot paths that park a runtime worker
+  (beep, request-handler keyring). These remaining ones need structure, not a point
+  wrap: `Simulator::{type_text,backspace_n}` are sync and driven while the `!Send`
+  `actually_typed` `std::Mutex` guard is held across the call, so they want the
+  async-`Simulator` rewrite (the portal already holds an async zbus connection, so it
+  can drop the thread+runtime entirely). `flush_snapshot` is called from the sync
+  `mint`/`revoke`; correctness wants a single-writer persist task (a detached
+  `spawn_blocking` per call would race the on-disk ordering), and `load_persisted` is
+  a one-time startup blocking read.
+- **Fix:** async `Simulator` (threads the `Typer`/preview loop off the `std::Mutex`
+  guard); a dedicated session-persist task fed over a channel.
 
 ---
 

--- a/super-stt-daemon/src/audio/beeper.rs
+++ b/super-stt-daemon/src/audio/beeper.rs
@@ -312,6 +312,29 @@ pub fn play_beep_sequence(
     Ok(())
 }
 
+/// Async wrapper over [`play_beep_sequence`]. The underlying call sets up a cpal
+/// stream and then spin-waits (with `std::thread::sleep`) for the whole beep to
+/// finish, which would stall an async worker for the sound's full duration; run
+/// it on a blocking thread instead (Tier 3 #4).
+///
+/// # Errors
+///
+/// Propagates the playback error (no output device, or stream build/play
+/// failure), or reports a task-join failure.
+pub async fn play_beep_sequence_async(
+    frequencies: Vec<f32>,
+    duration_ms: u64,
+    fade_in_ms: u64,
+    fade_out_ms: u64,
+    volume: f32,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        play_beep_sequence(&frequencies, duration_ms, fade_in_ms, fade_out_ms, volume)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("beep playback task failed: {e}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/super-stt-daemon/src/audio/recorder.rs
+++ b/super-stt-daemon/src/audio/recorder.rs
@@ -153,7 +153,7 @@ impl DaemonAudioRecorder {
         info!("🎤 Starting audio recording with streaming...");
 
         // Play start sound and wait for it to complete
-        self.play_start_sound_and_wait();
+        self.play_start_sound_and_wait().await;
 
         self.init_recording_state(silence_detection_disabled);
 
@@ -418,14 +418,17 @@ impl DaemonAudioRecorder {
         optimal_config.with_sample_rate(target_rate).pipe(Ok)
     }
 
-    /// Play start recording sound using current theme and wait for it to complete
-    fn play_start_sound_and_wait(&self) {
+    /// Play start recording sound using current theme and wait for it to
+    /// complete. `play_beep_sequence` spin-waits for the sound's full duration,
+    /// so run it off the async runtime (Tier 3 #4).
+    async fn play_start_sound_and_wait(&self) {
         if self.audio_theme == AudioTheme::Silent {
             return;
         }
         let (frequencies, duration, fade_in, fade_out) = self.audio_theme.start_sound();
         if let Err(e) =
-            beeper::play_beep_sequence(&frequencies, duration, fade_in, fade_out, self.volume)
+            beeper::play_beep_sequence_async(frequencies, duration, fade_in, fade_out, self.volume)
+                .await
         {
             log::warn!("Failed to play start sound (audio permissions may be missing): {e}");
         }

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -200,13 +200,14 @@ impl DaemonConfig {
         config
     }
 
-    /// Save configuration to disk
+    /// Save configuration to disk. Blocking (`std::fs::write`); on the async
+    /// runtime call it via `persist_config()` / `spawn_blocking`, not inline.
     ///
     /// # Errors
     ///
     /// Returns an error if the configuration directory cannot be created,
     /// serialization fails, or the file cannot be written.
-    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn save(&self) -> anyhow::Result<()> {
         let config_path = Self::get_config_path();
 
         // Create config directory if it doesn't exist
@@ -221,75 +222,57 @@ impl DaemonConfig {
         Ok(())
     }
 
-    /// Update preferred device and save to disk
+    // Config mutators are PURE (Tier 3 #3): they mutate in-memory state only.
+    // The caller persists once via `persist_config()` (which writes off the
+    // async runtime), so there are no blocking `fs::write`s under the config
+    // lock and no double writes.
+
+    /// Update preferred device.
     pub fn update_preferred_device(&mut self, device: String) {
         self.device.preferred_device = device;
-        if let Err(e) = self.save() {
-            error!("Failed to save config after device update: {e}");
-        }
     }
 
-    /// Update audio theme and save to disk
+    /// Update audio theme.
     pub fn update_audio_theme(&mut self, theme: AudioTheme) {
         self.audio.theme = theme;
-        if let Err(e) = self.save() {
-            error!("Failed to save config after audio theme update: {e}");
-        }
     }
 
-    /// Update preferred model + provider + source and save to disk.
+    /// Update preferred model + provider + source.
     pub fn update_preferred_model(&mut self, model: String, provider: Provider, source: String) {
         self.transcription.preferred_model = model;
         self.transcription.preferred_provider = provider;
         self.transcription.preferred_source = source;
-        if let Err(e) = self.save() {
-            error!("Failed to save config after model update: {e}");
-        }
     }
 
     /// Clear the loaded-model preference (model + source) while keeping the
-    /// active backend selected, then save. Used by the unload path so a daemon
-    /// restart stays idle instead of reloading the unloaded model. Bundling the
-    /// save with the clear guarantees the on-disk state can't drift from memory.
+    /// active backend selected. Used by the unload path so a daemon restart
+    /// stays idle instead of reloading the unloaded model.
     pub fn clear_preferred_model(&mut self) {
         self.transcription.preferred_model = String::new();
         self.transcription.preferred_source = String::new();
-        if let Err(e) = self.save() {
-            error!("Failed to save config after clearing preferred model: {e}");
-        }
     }
 
     /// Set the active backend (its relative install dir) and drop the loaded
-    /// model preference — selecting a backend does not load a model. Saves.
+    /// model preference — selecting a backend does not load a model.
     pub fn update_active_backend(&mut self, dir: String) {
         self.transcription.active_backend = Some(dir);
         self.transcription.preferred_model = String::new();
-        if let Err(e) = self.save() {
-            error!("Failed to save config after active backend update: {e}");
-        }
     }
 
-    /// Clear the active backend and the loaded-model preference (→ idle). Saves.
+    /// Clear the active backend and the loaded-model preference (→ idle).
     pub fn clear_active_backend(&mut self) {
         self.transcription.active_backend = None;
         self.transcription.preferred_model = String::new();
         self.transcription.preferred_source = String::new();
-        if let Err(e) = self.save() {
-            error!("Failed to save config after clearing active backend: {e}");
-        }
     }
 
-    /// Update master volume and save to disk
+    /// Update master volume.
     pub fn update_volume(&mut self, volume: u8) {
         self.audio.volume = volume;
-        if let Err(e) = self.save() {
-            error!("Failed to save config after volume update: {e}");
-        }
     }
 
-    /// Set or clear a backend option override and save to disk. An empty
-    /// `value` clears the override (the backend falls back to its manifest
-    /// default).
+    /// Set or clear a backend option override. An empty `value` clears the
+    /// override (the backend falls back to its manifest default).
     pub fn update_backend_option(&mut self, source: String, name: String, value: String) {
         if value.is_empty() {
             if let Some(opts) = self.backends.options.get_mut(&source) {
@@ -304,9 +287,6 @@ impl DaemonConfig {
                 .entry(source)
                 .or_default()
                 .insert(name, value);
-        }
-        if let Err(e) = self.save() {
-            error!("Failed to save config after backend option update: {e}");
         }
     }
 

--- a/super-stt-daemon/src/daemon/backend_config_handlers.rs
+++ b/super-stt-daemon/src/daemon/backend_config_handlers.rs
@@ -143,7 +143,9 @@ impl SuperSTTDaemon {
         name: String,
         value: String,
     ) -> DaemonResponse {
-        if let Err(e) = crate::keyring::set_backend_secret(&source, &name, &value) {
+        if let Err(e) =
+            crate::keyring::set_backend_secret_async(source.clone(), name.clone(), value).await
+        {
             return DaemonResponse::error(&format!("keyring_unavailable: {e}"));
         }
         let reload_warning = self.reload_if_source_active(&source).await;
@@ -160,7 +162,9 @@ impl SuperSTTDaemon {
         source: String,
         name: String,
     ) -> DaemonResponse {
-        if let Err(e) = crate::keyring::delete_backend_secret(&source, &name) {
+        if let Err(e) =
+            crate::keyring::delete_backend_secret_async(source.clone(), name.clone()).await
+        {
             return DaemonResponse::error(&format!("keyring_unavailable: {e}"));
         }
         let reload_warning = self.reload_if_source_active(&source).await;

--- a/super-stt-daemon/src/daemon/backend_config_handlers.rs
+++ b/super-stt-daemon/src/daemon/backend_config_handlers.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::daemon::types::SuperSTTDaemon;
-use log::info;
+use log::{info, warn};
 use super_stt_shared::models::backends::{BackendInfo, BackendModel, BackendOption, BackendSecret};
 use super_stt_shared::models::protocol::DaemonResponse;
 
@@ -119,6 +119,9 @@ impl SuperSTTDaemon {
         {
             let mut config = self.config.write().await;
             config.update_backend_option(source.clone(), name.clone(), value.clone());
+        }
+        if let Err(e) = self.persist_config().await {
+            warn!("Failed to persist config after backend option update: {e}");
         }
 
         let reload_warning = self.reload_if_source_active(&source).await;

--- a/super-stt-daemon/src/daemon/device_management.rs
+++ b/super-stt-daemon/src/daemon/device_management.rs
@@ -213,12 +213,11 @@ impl SuperSTTDaemon {
                 "timestamp": Utc::now().to_rfc3339(),
             }));
 
-        // Unload current model (free memory)
-        {
-            let mut model_guard = self.model.write().await;
-            *model_guard = None;
-            info!("Current model unloaded for device switch");
-        }
+        // Unload current model (free memory). Route through the shared graceful
+        // path so the backend is `shutdown()` outside the write lock rather than
+        // dropped under it — a subprocess `Drop` can block for seconds freeing
+        // GPU memory, which would stall every reader (Tier 3 #2).
+        self.unload_current_model().await;
     }
 
     /// Handle successful device switch
@@ -231,8 +230,6 @@ impl SuperSTTDaemon {
         source: &str,
         previous_device: &str,
     ) -> DaemonResponse {
-        let actual_device = crate::daemon::types::normalize_device(&model_instance.device());
-
         // Store the reloaded model. The backend serving it can be uninstalled
         // concurrently with the switch, so `resolve_definition` may now return
         // `None` — fail the request gracefully (leaving the daemon idle) rather
@@ -250,19 +247,13 @@ impl SuperSTTDaemon {
                  uninstalled during the device switch)"
             ));
         };
-        *self.model.write().await = Some(crate::daemon::types::LoadedModel {
-            definition,
-            instance: model_instance,
-        });
+        let actual_device = self.finalize_loaded_model(definition, model_instance).await;
 
-        // Update both preferred and actual device after successful reload
+        // Update the preferred device after successful reload (the actual
+        // device was already recorded by `finalize_loaded_model`).
         {
             let mut w = self.preferred_device.write().await;
             *w = device.to_string();
-        }
-        {
-            let mut w = self.actual_device.write().await;
-            w.clone_from(&actual_device);
         }
 
         // Update the config with new device preference and save to disk
@@ -340,10 +331,6 @@ impl SuperSTTDaemon {
             .await
         {
             Ok(model_instance) => {
-                // Update both preferred and actual device after successful recovery
-                let recovery_actual_device =
-                    crate::daemon::types::normalize_device(&model_instance.device());
-
                 let Some(definition) = self
                     .resolve_definition(model_to_reload, provider, source)
                     .await
@@ -357,17 +344,12 @@ impl SuperSTTDaemon {
                          model {model_to_reload} is no longer available."
                     ));
                 };
-                *self.model.write().await = Some(crate::daemon::types::LoadedModel {
-                    definition,
-                    instance: model_instance,
-                });
+                // Install the recovered model and record its actual device.
+                let recovery_actual_device =
+                    self.finalize_loaded_model(definition, model_instance).await;
                 {
                     let mut w = self.preferred_device.write().await;
                     *w = previous_device.to_string();
-                }
-                {
-                    let mut w = self.actual_device.write().await;
-                    w.clone_from(&recovery_actual_device);
                 }
 
                 // Update the config to revert to previous device

--- a/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
@@ -31,7 +31,9 @@ async fn list(State(s): State<AppState>, Path(source): Path<String>) -> Response
     };
     let mut out = Vec::with_capacity(backend.secrets.len());
     for sec in &backend.secrets {
-        let configured = crate::keyring::has_backend_secret(&source, &sec.name).unwrap_or(false);
+        let configured = crate::keyring::has_backend_secret_async(source.clone(), sec.name.clone())
+            .await
+            .unwrap_or(false);
         out.push(serde_json::json!({
             "name": sec.name,
             "label": sec.label.clone().unwrap_or_else(|| sec.name.clone()),
@@ -52,7 +54,9 @@ async fn get_one(
         Guard::NoBackend => json_error(StatusCode::NOT_FOUND, "unknown_backend"),
         Guard::NoItem => json_error(StatusCode::NOT_FOUND, "unknown_secret"),
         Guard::Ok => {
-            let configured = crate::keyring::has_backend_secret(&source, &name).unwrap_or(false);
+            let configured = crate::keyring::has_backend_secret_async(source.clone(), name.clone())
+                .await
+                .unwrap_or(false);
             ok(&serde_json::json!({ "status": "success", "name": name, "configured": configured }))
         }
     }

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -179,9 +179,13 @@ impl SuperSTTDaemon {
     async fn backend_headers(&self, backend: &DiscoveredBackend) -> Result<Vec<(String, String)>> {
         let mut headers = Vec::new();
         for secret in &backend.secrets {
-            let value = crate::keyring::get_backend_secret(&backend.source, &secret.name)
-                .map_err(|e| anyhow!(e))?
-                .filter(|v| !v.is_empty());
+            let value = crate::keyring::get_backend_secret_async(
+                backend.source.clone(),
+                secret.name.clone(),
+            )
+            .await
+            .map_err(|e| anyhow!(e))?
+            .filter(|v| !v.is_empty());
             match value {
                 Some(v) => headers.push((format!("x-stt-secret-{}", secret.name), v)),
                 // Safety-net error: the settings UI is expected to surface this

--- a/super-stt-daemon/src/daemon/model_management/lifecycle.rs
+++ b/super-stt-daemon/src/daemon/model_management/lifecycle.rs
@@ -124,7 +124,10 @@ impl SuperSTTDaemon {
             }));
     }
 
-    pub(super) async fn unload_current_model(&self) {
+    // `pub(in crate::daemon)` so the device-switch paths (a sibling module)
+    // route their unload through this graceful path instead of dropping the
+    // model under the write lock (Tier 3 #2).
+    pub(in crate::daemon) async fn unload_current_model(&self) {
         // Take the loaded model OUT of the lock first, then release the lock
         // before calling `shutdown()` — `shutdown()` may take several seconds
         // (e.g. SIGTERM to a CUDA-loaded subprocess that has to free GPU
@@ -142,6 +145,26 @@ impl SuperSTTDaemon {
             drop(loaded);
             info!("Current model unloaded");
         }
+    }
+
+    /// Install a freshly-loaded model as the active one: record its normalized
+    /// device label and write the `LoadedModel` into the slot, returning that
+    /// label. The caller must have already emptied the slot gracefully via
+    /// [`unload_current_model`], so this assignment drops nothing under the
+    /// write lock. Shared by the model-switch and device-switch finalize paths
+    /// (Tier 3 #2).
+    pub(in crate::daemon) async fn finalize_loaded_model(
+        &self,
+        definition: super_stt_shared::models::registry::ModelDefinition,
+        instance: Box<dyn Transcribe>,
+    ) -> String {
+        let actual_device = normalize_device(&instance.device());
+        *self.actual_device.write().await = actual_device.clone();
+        *self.model.write().await = Some(crate::daemon::types::LoadedModel {
+            definition,
+            instance,
+        });
+        actual_device
     }
 
     /// Unconditional unload used by the daemon's shutdown path. Bypasses the

--- a/super-stt-daemon/src/daemon/model_management/lifecycle.rs
+++ b/super-stt-daemon/src/daemon/model_management/lifecycle.rs
@@ -178,6 +178,9 @@ impl SuperSTTDaemon {
         // Drop the preferred model from config *and persist* so a daemon
         // restart stays idle instead of reloading the just-unloaded model.
         self.config.write().await.clear_preferred_model();
+        if let Err(e) = self.persist_config().await {
+            warn!("Failed to persist config after unloading model: {e}");
+        }
         self.events
             .publish_daemon_status_changed(serde_json::json!({
                 "status": "ready",

--- a/super-stt-daemon/src/daemon/model_management/switch.rs
+++ b/super-stt-daemon/src/daemon/model_management/switch.rs
@@ -109,6 +109,9 @@ impl SuperSTTDaemon {
             .write()
             .await
             .update_active_backend(dir_name.clone());
+        if let Err(e) = self.persist_config().await {
+            warn!("Failed to persist config after active-backend set: {e}");
+        }
         self.events
             .publish_daemon_status_changed(serde_json::json!({
                 "status": "active_backend_changed",
@@ -144,6 +147,9 @@ impl SuperSTTDaemon {
         self.unload_current_model().await;
         *self.active_backend.write().await = None;
         self.config.write().await.clear_active_backend();
+        if let Err(e) = self.persist_config().await {
+            warn!("Failed to persist config after active-backend clear: {e}");
+        }
         self.events
             .publish_daemon_status_changed(serde_json::json!({
                 "status": "active_backend_changed",
@@ -212,6 +218,11 @@ impl SuperSTTDaemon {
         if let Some(dir_name) = backend_dir {
             *self.active_backend.write().await = Some(dir_name.clone());
             self.config.write().await.update_active_backend(dir_name);
+            // Persist now (not just at finalize) so a subsequent load *failure*
+            // still durably records the selected backend across a restart.
+            if let Err(e) = self.persist_config().await {
+                warn!("Failed to persist config after active-backend select: {e}");
+            }
         }
 
         self.broadcast_model_loading_status(&model);

--- a/super-stt-daemon/src/daemon/model_management/switch.rs
+++ b/super-stt-daemon/src/daemon/model_management/switch.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::daemon::types::{LoadedModel, SuperSTTDaemon, normalize_device};
+use crate::daemon::types::SuperSTTDaemon;
 use crate::stt_models::backends;
 use crate::stt_models::transcribe::Transcribe;
 use chrono::Utc;
@@ -258,12 +258,7 @@ impl SuperSTTDaemon {
         definition: ModelDefinition,
         instance: Box<dyn Transcribe>,
     ) -> DaemonResponse {
-        let actual_device = normalize_device(&instance.device());
-        *self.actual_device.write().await = actual_device.clone();
-        *self.model.write().await = Some(LoadedModel {
-            definition,
-            instance,
-        });
+        let actual_device = self.finalize_loaded_model(definition, instance).await;
         {
             let mut config_guard = self.config.write().await;
             config_guard.update_preferred_model(model.clone(), provider.clone(), source.clone());

--- a/super-stt-daemon/src/daemon/theme_handlers.rs
+++ b/super-stt-daemon/src/daemon/theme_handlers.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::audio::beeper::play_beep_sequence;
+use crate::audio::beeper::play_beep_sequence_async;
 use crate::daemon::types::SuperSTTDaemon;
 use log::{error, info};
 use std::sync::Arc;
@@ -119,26 +119,30 @@ impl SuperSTTDaemon {
 
         // Test with start sound first
         info!("Playing start sound...");
-        match play_beep_sequence(
-            &start_frequencies,
+        match play_beep_sequence_async(
+            start_frequencies,
             start_duration,
             start_fade_in,
             start_fade_out,
             volume,
-        ) {
+        )
+        .await
+        {
             Ok(()) => {
                 info!("Start sound completed successfully");
 
                 // Test end sound as well
                 tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                 info!("Playing end sound...");
-                match play_beep_sequence(
-                    &end_frequencies,
+                match play_beep_sequence_async(
+                    end_frequencies,
                     end_duration,
                     end_fade_in,
                     end_fade_out,
                     volume,
-                ) {
+                )
+                .await
+                {
                     Ok(()) => {
                         info!("End sound completed successfully");
                         DaemonResponse::success()

--- a/super-stt-daemon/src/daemon/types.rs
+++ b/super-stt-daemon/src/daemon/types.rs
@@ -203,9 +203,13 @@ impl SuperSTTDaemon {
     pub async fn persist_config_static(
         config: &Arc<tokio::sync::RwLock<DaemonConfig>>,
     ) -> Result<(), anyhow::Error> {
-        let config_guard = config.read().await;
-        config_guard
-            .save()
+        // Snapshot under the lock (cheap clone), release it, then do the
+        // blocking TOML-serialize + `fs::write` on a blocking thread — never on
+        // an async worker while a config lock is held (Tier 3 #3).
+        let snapshot = config.read().await.clone();
+        tokio::task::spawn_blocking(move || snapshot.save())
+            .await
+            .map_err(|e| anyhow::anyhow!("config-persist task failed: {e}"))?
             .map_err(|e| anyhow::anyhow!("Failed to save config to disk: {e}"))?;
         log::debug!("Persisted config to disk");
         Ok(())

--- a/super-stt-daemon/src/keyring.rs
+++ b/super-stt-daemon/src/keyring.rs
@@ -207,6 +207,58 @@ pub fn has_backend_secret(source: &str, name: &str) -> Result<bool, String> {
     Ok(kv_get(&backend_secret_account(source, name))?.is_some())
 }
 
+// Async wrappers for the backend-secret accessors. A keyring lookup goes through
+// DBus to the secret service and can stall for seconds on a locked keyring; the
+// sync forms above are called from async request handlers, so route them through
+// `spawn_blocking` to keep those calls off the async runtime (Tier 3 #4).
+
+/// Async form of [`get_backend_secret`], run on a blocking thread.
+///
+/// # Errors
+/// Returns an error if the keyring is unavailable or access fails.
+pub async fn get_backend_secret_async(
+    source: String,
+    name: String,
+) -> Result<Option<String>, String> {
+    tokio::task::spawn_blocking(move || get_backend_secret(&source, &name))
+        .await
+        .map_err(|e| format!("keyring task failed: {e}"))?
+}
+
+/// Async form of [`set_backend_secret`], run on a blocking thread.
+///
+/// # Errors
+/// Returns an error if the keyring is unavailable or the write fails.
+pub async fn set_backend_secret_async(
+    source: String,
+    name: String,
+    value: String,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || set_backend_secret(&source, &name, &value))
+        .await
+        .map_err(|e| format!("keyring task failed: {e}"))?
+}
+
+/// Async form of [`delete_backend_secret`], run on a blocking thread.
+///
+/// # Errors
+/// Returns an error if the keyring is unavailable or the delete fails.
+pub async fn delete_backend_secret_async(source: String, name: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || delete_backend_secret(&source, &name))
+        .await
+        .map_err(|e| format!("keyring task failed: {e}"))?
+}
+
+/// Async form of [`has_backend_secret`], run on a blocking thread.
+///
+/// # Errors
+/// Returns an error if the keyring is unavailable or access fails.
+pub async fn has_backend_secret_async(source: String, name: String) -> Result<bool, String> {
+    tokio::task::spawn_blocking(move || has_backend_secret(&source, &name))
+        .await
+        .map_err(|e| format!("keyring task failed: {e}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/super-stt-daemon/src/stt_models/mod.rs
+++ b/super-stt-daemon/src/stt_models/mod.rs
@@ -15,5 +15,7 @@ pub mod download;
 #[cfg(feature = "subprocess-backends")]
 pub mod subprocess;
 pub mod transcribe;
+#[cfg(any(feature = "wasm-backends", feature = "subprocess-backends"))]
+pub mod v1;
 #[cfg(feature = "wasm-backends")]
 pub mod wasm;

--- a/super-stt-daemon/src/stt_models/subprocess/mod.rs
+++ b/super-stt-daemon/src/stt_models/subprocess/mod.rs
@@ -337,35 +337,13 @@ impl Transcribe for SubprocessBackend {
     ) -> Result<String> {
         // The daemon owns resampling; backends receive 16 kHz.
         let audio16 = resample(audio, sample_rate, SAMPLE_RATE, ResampleQuality::Fast)?;
-        let mut body_json = serde_json::json!({
-            "audio_data": audio16,
-            "sample_rate": SAMPLE_RATE,
-        });
-        if let Some(lang) = language {
-            body_json["language"] = serde_json::Value::String(lang.to_string());
-        }
-        let body = serde_json::to_vec(&body_json)?;
+        let body = crate::stt_models::v1::build_transcribe_body(&audio16, SAMPLE_RATE, language)?;
         let mut headers = json_headers();
         headers.push(("x-stt-model".to_string(), self.model_id.clone()));
         let (status, resp) = self
             .request("POST", "/v1/transcribe", &headers, body)
             .await?;
-        let json: serde_json::Value = serde_json::from_slice(&resp)?;
-        if status == 200 {
-            json["transcription"]
-                .as_str()
-                .map(String::from)
-                .ok_or_else(|| anyhow!("backend response missing transcription"))
-        } else {
-            // Surface the backend's own error message (shown to the user)
-            // rather than the raw HTTP body.
-            let msg = json
-                .get("detail")
-                .and_then(|v| v.as_str())
-                .or_else(|| json.get("message").and_then(|v| v.as_str()))
-                .unwrap_or("transcription failed");
-            bail!("{msg}");
-        }
+        crate::stt_models::v1::parse_transcribe_response(status, &resp)
     }
 }
 

--- a/super-stt-daemon/src/stt_models/v1.rs
+++ b/super-stt-daemon/src/stt_models/v1.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Shared `/v1/transcribe` request/response plumbing for the backend hosts.
+//!
+//! The wasm and subprocess hosts differ only in transport (an in-process
+//! component invocation vs a Unix-socket HTTP dial). The request-body build and
+//! the response parsing were byte-identical in both — and had started to drift —
+//! so they live here. Feature-agnostic: compiled whenever either backend is on.
+
+use anyhow::{Result, anyhow, bail};
+
+/// Serialize a `/v1/transcribe` request body: `audio` samples embedded as-is at
+/// `sample_rate` (the caller resamples first if its transport needs a fixed
+/// rate), plus an optional `language` override.
+///
+/// # Errors
+/// Returns an error if JSON serialization fails (not expected for this shape).
+pub(crate) fn build_transcribe_body(
+    audio: &[f32],
+    sample_rate: u32,
+    language: Option<&str>,
+) -> Result<Vec<u8>> {
+    let mut body = serde_json::json!({
+        "audio_data": audio,
+        "sample_rate": sample_rate,
+    });
+    if let Some(lang) = language {
+        body["language"] = serde_json::Value::String(lang.to_string());
+    }
+    Ok(serde_json::to_vec(&body)?)
+}
+
+/// Parse a `/v1/transcribe` response: the transcript on `200`, else the
+/// backend's own `detail`/`message` surfaced as the error (it's shown to the
+/// user, so prefer it over the raw HTTP body).
+///
+/// # Errors
+/// Returns an error if the body isn't JSON, a `200` is missing `transcription`,
+/// or a non-`200` carries a backend error message.
+pub(crate) fn parse_transcribe_response(status: u16, resp: &[u8]) -> Result<String> {
+    let json: serde_json::Value = serde_json::from_slice(resp)
+        .map_err(|e| anyhow!("parsing backend transcribe response: {e}"))?;
+    if status == 200 {
+        json["transcription"]
+            .as_str()
+            .map(String::from)
+            .ok_or_else(|| anyhow!("backend response missing transcription"))
+    } else {
+        let msg = json
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .or_else(|| json.get("message").and_then(|v| v.as_str()))
+            .unwrap_or("transcription failed");
+        bail!("{msg}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_transcribe_body, parse_transcribe_response};
+
+    #[test]
+    fn body_embeds_audio_rate_and_optional_language() {
+        let with_lang = build_transcribe_body(&[0.1, -0.2], 16000, Some("en")).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&with_lang).unwrap();
+        assert_eq!(v["sample_rate"], 16000);
+        assert_eq!(v["audio_data"].as_array().unwrap().len(), 2);
+        assert_eq!(v["language"], "en");
+
+        let no_lang = build_transcribe_body(&[], 8000, None).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&no_lang).unwrap();
+        assert!(v.get("language").is_none());
+    }
+
+    #[test]
+    fn parse_returns_transcription_on_200() {
+        let text = parse_transcribe_response(200, br#"{"transcription":"hello"}"#).unwrap();
+        assert_eq!(text, "hello");
+    }
+
+    #[test]
+    fn parse_surfaces_detail_then_message_on_error() {
+        let e = parse_transcribe_response(500, br#"{"detail":"oom","message":"m"}"#).unwrap_err();
+        assert_eq!(e.to_string(), "oom");
+        let e = parse_transcribe_response(500, br#"{"message":"just message"}"#).unwrap_err();
+        assert_eq!(e.to_string(), "just message");
+        let e = parse_transcribe_response(500, br#"{}"#).unwrap_err();
+        assert_eq!(e.to_string(), "transcription failed");
+    }
+
+    #[test]
+    fn parse_errors_on_200_without_transcription() {
+        assert!(parse_transcribe_response(200, br#"{"other":1}"#).is_err());
+    }
+}

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -409,37 +409,13 @@ impl Transcribe for WasmBackend {
         if self.realtime {
             return self.transcribe_via_realtime(audio, sample_rate).await;
         }
-        let mut body_json = serde_json::json!({
-            "audio_data": audio,
-            "sample_rate": sample_rate,
-        });
-        if let Some(lang) = language {
-            body_json["language"] = serde_json::Value::String(lang.to_string());
-        }
-        let body = serde_json::to_vec(&body_json)?;
+        let body = crate::stt_models::v1::build_transcribe_body(audio, sample_rate, language)?;
         let mut headers = self.transcribe_headers.clone();
         headers.push(("x-stt-model".to_string(), self.model_id.clone()));
         let (status, resp) = self
             .invoke("POST", "/v1/transcribe", &headers, body)
             .await?;
-        let json: serde_json::Value =
-            serde_json::from_slice(&resp).context("parsing backend transcribe response")?;
-        if status == 200 {
-            json["transcription"]
-                .as_str()
-                .map(String::from)
-                .ok_or_else(|| anyhow!("backend response missing transcription"))
-        } else {
-            // Surface the backend's own error message (it is shown to the
-            // user) rather than the raw HTTP body. Prefer a human-readable
-            // `detail`, falling back to the machine `message`.
-            let msg = json
-                .get("detail")
-                .and_then(|v| v.as_str())
-                .or_else(|| json.get("message").and_then(|v| v.as_str()))
-                .unwrap_or("transcription failed");
-            bail!("{msg}");
-        }
+        crate::stt_models::v1::parse_transcribe_response(status, &resp)
     }
 
     /// Run one consumer realtime session: instantiate the component and invoke


### PR DESCRIPTION
Continues the code-quality audit cleanup (`docs/audits/2026-07-code-quality.md`), Tier 3 items #1–#4. One commit per item.

## #1 — Share the backend `/v1` transcribe body-build and response-parse
The wasm and subprocess backends had drifted copies of the `/v1` transcribe request-body build and response parse. Extracted a feature-agnostic `stt_models::v1` module with `build_transcribe_body` / `parse_transcribe_response` (the byte-identical, drifting parts) + unit tests; both backends call them. Kept the per-backend transports (Unix-socket `request` vs WASM-component `invoke`) — genuinely different, not duplication, so a `V1Transport` trait bought nothing.

## #2 — Route device-switch through graceful unload and shared finalize
Added `finalize_loaded_model()` (normalize device → record actual device → install the `LoadedModel`); the model-switch and both device-switch finalize paths (success + recovery) now call it instead of re-implementing the triple. `prepare_device_switch` no longer drops the model under the write lock — it routes through `unload_current_model()`, so the backend is `shutdown()` outside the lock like every other unload path.

## #3 — Make config mutators pure; persist once off the async runtime
All eight `update_*`/`clear_*` config mutators are now pure (no self-`save()`); `persist_config_static` snapshots the config under the lock, releases it, and does the blocking TOML-serialize + `fs::write` in `spawn_blocking`. The former double/triple-write sites collapse to a single write; the five sites that relied on the self-save gained an explicit `persist_config()`. `save()` now returns `anyhow::Result`.

## #4 — Move beep and request-handler keyring off the async runtime
The two hot paths that actually park a runtime worker are now offloaded via `spawn_blocking`:
- **Beep:** `play_beep_sequence_async` wraps the spin-waiting `play_beep_sequence`; the audio-theme test and the recording start-sound await it.
- **Keyring:** `{get,set,delete,has}_backend_secret_async` wrappers; the async secret handlers/endpoints and the WASM model-load secret read await them, so a locked-keyring DBus stall no longer parks a runtime thread.

The remaining blocking work (the keyboard `Simulator` path and the session-store keyring writes) needs the larger async-`Simulator` rewrite / a single-writer persist task, split off as Tier 3 #35.

## Verification
- `cargo build -p super-stt-daemon --lib --all-features` ✅
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` ✅
- `cargo test -p super-stt-daemon --lib --all-features` → 235 passed ✅
- `cargo test -p super-stt-daemon --all-features --no-run` (integration-test callers) ✅
- `just check-features` (incl. `--no-default-features`) ✅
- `just fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)