### PR TITLE
Audit Tier 3 #5-#8: parking_lot audio, InflightMarker, set_config_field, bounded SSE

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -872,11 +872,23 @@ Tier 2 #4/#6/#8.
   an async online→local revert between the mutate and the persist and builds a
   revert-aware message, so it doesn't fit the couple-mutate-and-persist shape.
 
-### [ ] 8. 🟠 Daemon: SSE fan-out uses unbounded channels
+### [x] 8. 🟠 Daemon: SSE fan-out uses unbounded channels
 
 - **Where:** `http/v1/events.rs:75-76,164-190`.
 - **Problem:** a stalled reader buffers `frequency_bands` frames without bound.
 - **Fix:** bounded channel; drop visualization frames on overflow.
+- **Resolved (branch `refactor/audit-tier3-5-8`):** the per-connection `/events`
+  channel is now `mpsc::channel(SSE_CHANNEL_CAPACITY = 256)` (was
+  `unbounded_channel`), read out via `ReceiverStream`. A shared `try_emit_sse_event`
+  helper does `try_send`: a full channel drops the frame (the reader is stalled —
+  shed it, logging a warn) and only a `Closed` channel tears the forwarder down.
+  Keepalive uses the same `try_send` (drop the heartbeat when full; cancel only on
+  `Closed`); the `subscribed` ack and `revoked` frame go through it too. `frequency_bands`
+  is the dominant volume, so those are what overflow drops in practice; the
+  `/transcribe` stream keeps its unbounded channel (bounded per-recording lifetime,
+  non-droppable `preview`/`done`/`error` frames). Frame formatting is now a shared
+  `format_sse_frame` used by both the bounded fan-out and the unbounded
+  `emit_sse_event`.
 
 ### [ ] 9. 🟡 Daemon: minor items
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -823,12 +823,21 @@ Tier 2 #4/#6/#8.
   one-time startup cost — both want a dedicated single-writer persist task rather than
   a point wrap.
 
-### [ ] 5. 🟡 Daemon: mutex poison recovery copy-pasted ~10× in `audio/`
+### [x] 5. 🟡 Daemon: mutex poison recovery copy-pasted ~10× in `audio/`
 
 - **Where:** `recorder.rs`, `processing.rs`, `device.rs`, while the rest of the
   crate uses parking_lot.
 - **Fix:** switch audio to `parking_lot::Mutex` (cpal callbacks are sync-safe with
   it) or one `lock_recover` helper.
+- **Resolved (branch `refactor/audit-tier3-5-8`):** switched the three audio
+  mutexes (`audio_buffer`, `recording_state`, `audio_device_cache`) from
+  `std::sync::Mutex` to `parking_lot::Mutex`. `parking_lot` guards carry no poison
+  state, so all 11 `match .lock() { Ok => .., Err(poisoned) => poisoned.into_inner() }`
+  recovery blocks collapse to a direct `.lock()` — the cpal real-time callbacks stay
+  sync-safe. The type leaks through `get_audio_buffer_ref` into the preview loop, so
+  `RecordingSession::preview_buffer` and its one lock site moved too; the sibling
+  `actually_typed` stays `std::sync::Mutex` (not shared with a callback). Dropped the
+  now-false `# Panics` (poison) doc on `check_output_device_health`.
 
 ### [ ] 6. 🟡 Daemon: inflight cleanup hand-rolled in 8+ places despite an RAII guard
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -839,12 +839,23 @@ Tier 2 #4/#6/#8.
   `actually_typed` stays `std::sync::Mutex` (not shared with a callback). Dropped the
   now-false `# Panics` (poison) doc on `check_output_device_health`.
 
-### [ ] 6. 🟡 Daemon: inflight cleanup hand-rolled in 8+ places despite an RAII guard
+### [x] 6. 🟡 Daemon: inflight cleanup hand-rolled in 8+ places despite an RAII guard
 
 - **Where:** `install_inflight.write().remove()` on every error path
   (`install.rs:149-241`, `update.rs:70-168`) while `pipeline.rs`'s `InflightGuard`
   is only used inside the spawned task.
 - **Fix:** construct the guard at insert.
+- **Resolved (branch `refactor/audit-tier3-5-8`):** added `InflightMarker` in
+  `pipeline.rs` — a lightweight RAII guard that inserts the source (atomic
+  check+insert under one write lock) and removes it on `Drop`, but emits **no**
+  event (the synchronous phases fail with plain HTTP errors, not `Failed` install
+  events — unlike the pipeline's event-emitting `InflightGuard`). Phase 2 of both
+  handlers now returns the marker; the fallible phases (and the update no-op early
+  return) just `return`, so the marker's `Drop` cleans up. The happy path calls
+  `marker.defuse()` after spawning, handing removal duty to the pipeline's
+  `InflightGuard`. This deletes all 11 hand-rolled `install_inflight.write().remove()`
+  calls; the now-unused `source_key`/`source`/`&AppState` params drop from the phase
+  helpers.
 
 ### [ ] 7. 🟡 Daemon: settings handlers repeat a 25-line mutate→persist→respond block 6×
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -857,10 +857,20 @@ Tier 2 #4/#6/#8.
   calls; the now-unused `source_key`/`source`/`&AppState` params drop from the phase
   helpers.
 
-### [ ] 7. 🟡 Daemon: settings handlers repeat a 25-line mutate→persist→respond block 6×
+### [x] 7. 🟡 Daemon: settings handlers repeat a 25-line mutate→persist→respond block 6×
 
 - **Where:** `settings_handlers.rs:12-250`.
 - **Fix:** one `set_config_field` helper (also prevents Tier 1 #3 recurrences).
+- **Resolved (branch `refactor/audit-tier3-5-8`):** added `set_config_field`
+  (lock → mutate closure → `persist_config`, returning the persist `Result`) and a
+  `settings_saved` response helper (folds the persist outcome into the response,
+  appending `(save failed: {e})` and logging a warning on failure while keeping the
+  in-memory change). The four simple setters — preview typing, recording stop mode,
+  write method, custom models dir — now route through both, dropping their
+  hand-rolled `{ lock; mutate }` + `persist_config().await` + Ok/Err match.
+  `handle_set_allow_online_models` keeps its explicit mutate/persist: it interleaves
+  an async online→local revert between the mutate and the persist and builds a
+  revert-aware message, so it doesn't fit the couple-mutate-and-persist shape.
 
 ### [ ] 8. 🟠 Daemon: SSE fan-out uses unbounded channels
 

--- a/super-stt-daemon/src/audio/device.rs
+++ b/super-stt-daemon/src/audio/device.rs
@@ -3,7 +3,8 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, SupportedStreamConfig};
-use std::sync::{Arc, Mutex};
+use parking_lot::Mutex;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[derive(Clone)]
@@ -112,13 +113,7 @@ const DEVICE_VERIFICATION_ATTEMPTS: usize = 3;
 pub fn get_or_initialize_audio_device(
     audio_device_cache: &Arc<Mutex<Option<AudioDeviceCache>>>,
 ) -> Result<AudioDeviceCache> {
-    let mut cache = match audio_device_cache.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            log::warn!("Audio device cache lock was poisoned, attempting recovery");
-            poisoned.into_inner()
-        }
-    };
+    let mut cache = audio_device_cache.lock();
     if let Some(ref cached) = *cache
         && cached.last_verified.elapsed() < DEVICE_CACHE_VALIDITY
         && cached.initialization_verified
@@ -168,9 +163,7 @@ pub fn verify_audio_device_readiness(
         match attempt_device_verification(device_cache, attempt) {
             Ok(()) => {
                 log::debug!("Audio device verification successful on attempt {attempt}");
-                if let Ok(mut cache) = audio_device_cache.lock()
-                    && let Some(ref mut cached) = cache.as_mut()
-                {
+                if let Some(ref mut cached) = audio_device_cache.lock().as_mut() {
                     cached.initialization_verified = true;
                     cached.last_verified = Instant::now();
                 }
@@ -259,10 +252,6 @@ fn attempt_device_verification(device_cache: &AudioDeviceCache, _attempt: usize)
 
 /// Check health and details of the output audio device.
 ///
-/// # Panics
-///
-/// Panics if the device cache mutex is poisoned.
-///
 /// # Errors
 ///
 /// Returns an error if no default output device is available or
@@ -271,15 +260,7 @@ pub fn check_output_device_health(
     audio_device_cache: &Arc<Mutex<Option<AudioDeviceCache>>>,
 ) -> Result<AudioDeviceInfo> {
     let device_result = {
-        let cache_guard = match audio_device_cache.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                log::warn!(
-                    "Audio device cache lock was poisoned during device check, attempting recovery"
-                );
-                poisoned.into_inner()
-            }
-        };
+        let cache_guard = audio_device_cache.lock();
         if let Some(ref cached) = *cache_guard {
             if cached.last_verified.elapsed() < DEVICE_CACHE_VALIDITY {
                 Ok((cached.output_device.clone(), cached.output_config.clone()))

--- a/super-stt-daemon/src/audio/processing.rs
+++ b/super-stt-daemon/src/audio/processing.rs
@@ -1,35 +1,27 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::audio::state::{GRACE_PERIOD, NO_SPEECH_TIMEOUT, RecordingState, SILENCE_TIMEOUT};
+use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 use super_stt_shared::models::audio::AudioLevel;
 use tokio::sync::broadcast;
 
-/// Process mono audio samples for recording state and levels
+/// Process mono audio samples for recording state and levels.
 ///
-/// Handles poisoned locks gracefully by logging warnings and recovering the data.
+/// Uses `parking_lot::Mutex`, whose guards carry no poison state — a panic
+/// while another thread holds the lock cannot poison it, so there is no
+/// recovery to hand-roll. cpal invokes this on the real-time input thread, and
+/// `parking_lot` locks are safe in sync callbacks.
 pub fn process_audio_samples(
     mono_samples: &[f32],
     buffer: &Arc<Mutex<VecDeque<f32>>>,
     state: &Arc<Mutex<RecordingState>>,
     level_tx: &broadcast::Sender<AudioLevel>,
 ) {
-    let mut buffer = match buffer.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            log::warn!("Audio buffer lock was poisoned in processing, attempting recovery");
-            poisoned.into_inner()
-        }
-    };
-    let mut state = match state.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            log::warn!("Recording state lock was poisoned in processing, attempting recovery");
-            poisoned.into_inner()
-        }
-    };
+    let mut buffer = buffer.lock();
+    let mut state = state.lock();
 
     // mono_samples.len() is a chunk size (typically a few hundred to a few thousand);
     // fits in u32 and thus in f32 exactly.

--- a/super-stt-daemon/src/audio/recorder.rs
+++ b/super-stt-daemon/src/audio/recorder.rs
@@ -14,8 +14,9 @@ use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, SampleFormat, Stream, StreamConfig};
 use log::info;
+use parking_lot::Mutex;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use super_stt_shared::AudioAnalyzer;
 use super_stt_shared::audio_utils::ResampleQuality;
@@ -191,22 +192,10 @@ impl DaemonAudioRecorder {
 
     /// Clear the audio buffer and reset recording state before a new recording.
     fn init_recording_state(&self, silence_detection_disabled: bool) {
-        let mut buffer = match self.audio_buffer.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                log::warn!("Audio buffer lock was poisoned, attempting recovery");
-                poisoned.into_inner()
-            }
-        };
+        let mut buffer = self.audio_buffer.lock();
         buffer.clear();
 
-        let mut state = match self.recording_state.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                log::warn!("Recording state lock was poisoned, attempting recovery");
-                poisoned.into_inner()
-            }
-        };
+        let mut state = self.recording_state.lock();
         *state = RecordingState::new();
         state.recording_start = Some(Instant::now());
         state.silence_detection_disabled = silence_detection_disabled;
@@ -302,18 +291,7 @@ impl DaemonAudioRecorder {
                 time::sleep(AUDIO_LOOP_INTERVAL).await;
             }
 
-            let should_stop = {
-                let state = match self.recording_state.lock() {
-                    Ok(guard) => guard,
-                    Err(poisoned) => {
-                        log::warn!(
-                            "Recording state lock was poisoned during recording, attempting recovery"
-                        );
-                        poisoned.into_inner()
-                    }
-                };
-                state.should_stop()
-            };
+            let should_stop = self.recording_state.lock().should_stop();
 
             if should_stop {
                 break;
@@ -323,18 +301,8 @@ impl DaemonAudioRecorder {
             // (not applicable when silence detection is disabled)
             if !silence_detection_disabled {
                 let elapsed = start_time.elapsed();
-                let has_detected_speech = {
-                    let state = match self.recording_state.lock() {
-                        Ok(guard) => guard,
-                        Err(poisoned) => {
-                            log::warn!(
-                                "Recording state lock was poisoned while checking speech detection, attempting recovery"
-                            );
-                            poisoned.into_inner()
-                        }
-                    };
-                    state.recording // Check if speech has been detected and recording started
-                };
+                // Check if speech has been detected and recording started.
+                let has_detected_speech = self.recording_state.lock().recording;
 
                 // If speech has been detected, rely on silence detection instead of timeout
                 // Only timeout if no speech has been detected at all
@@ -350,18 +318,7 @@ impl DaemonAudioRecorder {
 
     /// Extract buffered audio and resample to the target rate when needed.
     fn drain_and_resample(&self, device_sample_rate: u32) -> Result<Vec<f32>> {
-        let audio_data: Vec<f32> = {
-            let buffer = match self.audio_buffer.lock() {
-                Ok(guard) => guard,
-                Err(poisoned) => {
-                    log::warn!(
-                        "Audio buffer lock was poisoned during extraction, attempting recovery"
-                    );
-                    poisoned.into_inner()
-                }
-            };
-            buffer.iter().copied().collect()
-        };
+        let audio_data: Vec<f32> = self.audio_buffer.lock().iter().copied().collect();
 
         if audio_data.is_empty() {
             return Err(anyhow::anyhow!("No audio recorded"));
@@ -543,17 +500,7 @@ impl DaemonAudioRecorder {
     ///
     /// Returns an error if the audio buffer cannot be accessed
     pub fn get_full_audio_data(&self) -> Result<Vec<f32>> {
-        let buffer = match self.audio_buffer.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                log::warn!(
-                    "Audio buffer lock was poisoned during get_full_audio_data, attempting recovery"
-                );
-                poisoned.into_inner()
-            }
-        };
-
-        let audio_data: Vec<f32> = buffer.iter().copied().collect();
+        let audio_data: Vec<f32> = self.audio_buffer.lock().iter().copied().collect();
         Ok(audio_data)
     }
 
@@ -561,16 +508,7 @@ impl DaemonAudioRecorder {
     /// This checks the internal recording state
     #[must_use]
     pub fn is_still_recording(&self) -> bool {
-        match self.recording_state.lock() {
-            Ok(state) => !state.should_stop(),
-            Err(poisoned) => {
-                log::warn!(
-                    "Recording state lock was poisoned during is_still_recording check, attempting recovery"
-                );
-                let state = poisoned.into_inner();
-                !state.should_stop()
-            }
-        }
+        !self.recording_state.lock().should_stop()
     }
 
     /// Get a reference to the internal audio buffer for direct access during recording

--- a/super-stt-daemon/src/daemon/http/v1/events.rs
+++ b/super-stt-daemon/src/daemon/http/v1/events.rs
@@ -3,13 +3,42 @@ use crate::daemon::http::internal::auth::middleware::AuthContext;
 use crate::daemon::http::internal::auth::tokens::TokenStore;
 use crate::daemon::http::internal::helpers::responses::{invalid_session, reason, scope_denied};
 use crate::daemon::http::state::{AppState, PeerInfo};
-use crate::daemon::http::v1::transcribe::emit_sse_event;
+use crate::daemon::http::v1::transcribe::format_sse_frame;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use std::path::PathBuf;
 
 // ---------- /events (SSE) --------------------------------------------------
+
+/// Per-connection SSE channel capacity. The channel serializes every frame
+/// (all topic forwarders + keepalive + revocation) into the response body. A
+/// widget that stops draining its side would otherwise buffer `frequency_bands`
+/// frames — emitted many times per second — without bound; capping the channel
+/// and dropping frames once it fills sheds that load instead (Tier 3 #8). The
+/// dominant volume is visualization frames, so those are what overflow drops in
+/// practice; low-rate control frames only shed for an already-stalled reader,
+/// which the keepalive / exe-watch task then tears down.
+const SSE_CHANNEL_CAPACITY: usize = 256;
+
+/// Convenience alias for the bounded per-connection SSE sender.
+type SseSender = tokio::sync::mpsc::Sender<Result<axum::body::Bytes, std::io::Error>>;
+
+/// Try to enqueue an SSE frame on the bounded per-connection channel. Returns
+/// `false` only when the receiver is gone (client disconnected), so the caller
+/// tears down. A full channel drops the frame — the reader is stalled, so shed
+/// it — and returns `true`.
+fn try_emit_sse_event(tx: &SseSender, event: &str, data: &serde_json::Value) -> bool {
+    use tokio::sync::mpsc::error::TrySendError;
+    match tx.try_send(Ok(format_sse_frame(event, data))) {
+        Ok(()) => true,
+        Err(TrySendError::Full(_)) => {
+            log::warn!("widget SSE backpressured; dropped a {event} frame");
+            true
+        }
+        Err(TrySendError::Closed(_)) => false,
+    }
+}
 
 #[derive(serde::Deserialize)]
 pub(crate) struct EventsQuery {
@@ -70,10 +99,12 @@ pub(crate) async fn events(
         return scope_denied();
     }
 
-    // mpsc that serializes all SSE writes (broadcast forwarders +
-    // keepalive + revocation).
-    let (sse_tx, sse_rx) =
-        tokio::sync::mpsc::unbounded_channel::<Result<axum::body::Bytes, std::io::Error>>();
+    // Bounded mpsc that serializes all SSE writes (broadcast forwarders +
+    // keepalive + revocation). Bounded so a stalled reader sheds frames instead
+    // of buffering without limit — see [`SSE_CHANNEL_CAPACITY`].
+    let (sse_tx, sse_rx) = tokio::sync::mpsc::channel::<Result<axum::body::Bytes, std::io::Error>>(
+        SSE_CHANNEL_CAPACITY,
+    );
 
     // Subscribe BEFORE emitting `subscribed`. Subscribing creates the
     // broadcast::Receiver that captures any event fired from this
@@ -88,8 +119,9 @@ pub(crate) async fn events(
         spawn_topic_forwarder(rx, sse_tx.clone(), cancel.clone());
     }
 
-    // Now that the receivers exist, ack the client.
-    let _ = emit_sse_event(
+    // Now that the receivers exist, ack the client. The channel is fresh so
+    // this frame always has room.
+    let _ = try_emit_sse_event(
         &sse_tx,
         "subscribed",
         &serde_json::json!({
@@ -112,7 +144,7 @@ pub(crate) async fn events(
     // finish, the mpsc receiver yields None and the response body ends.
     drop(sse_tx);
 
-    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(sse_rx);
+    let stream = tokio_stream::wrappers::ReceiverStream::new(sse_rx);
     let body = axum::body::Body::from_stream(stream);
 
     Response::builder()
@@ -163,7 +195,7 @@ fn parse_events_topics(q: &EventsQuery) -> Result<Vec<crate::daemon::events::Top
 /// channel, or when the SSE response body has been dropped.
 fn spawn_topic_forwarder(
     mut rx: crate::daemon::events::AnyReceiver,
-    tx: tokio::sync::mpsc::UnboundedSender<Result<axum::body::Bytes, std::io::Error>>,
+    tx: SseSender,
     cancel: tokio_util::sync::CancellationToken,
 ) {
     tokio::spawn(async move {
@@ -174,7 +206,7 @@ fn spawn_topic_forwarder(
                 res = rx.recv_json() => {
                     match res {
                         Ok((name, payload)) => {
-                            if !emit_sse_event(&tx, name, &payload) {
+                            if !try_emit_sse_event(&tx, name, &payload) {
                                 break;
                             }
                         }
@@ -194,7 +226,7 @@ fn spawn_topic_forwarder(
 /// `revoked` event, calls `TokenStore::revoke`, and triggers the
 /// shared `cancel` token to tear down the rest of the subscription.
 fn spawn_events_keepalive_and_exe_watch(
-    tx: tokio::sync::mpsc::UnboundedSender<Result<axum::body::Bytes, std::io::Error>>,
+    tx: SseSender,
     cancel: tokio_util::sync::CancellationToken,
     peer_pid: Option<u32>,
     tokens: TokenStore,
@@ -218,9 +250,12 @@ fn spawn_events_keepalive_and_exe_watch(
                 biased;
                 () = cancel.cancelled() => break,
                 _ = keepalive.tick() => {
-                    if tx
-                        .send(Ok(axum::body::Bytes::from_static(b": keepalive\n\n")))
-                        .is_err()
+                    // Only a gone receiver (client disconnected) tears down; a
+                    // full channel means a stalled-but-live reader, so drop this
+                    // heartbeat rather than cancel.
+                    use tokio::sync::mpsc::error::TrySendError;
+                    if let Err(TrySendError::Closed(_)) =
+                        tx.try_send(Ok(axum::body::Bytes::from_static(b": keepalive\n\n")))
                     {
                         cancel.cancel();
                         break;
@@ -237,7 +272,7 @@ fn spawn_events_keepalive_and_exe_watch(
                         stored_exe.display(),
                         current,
                     );
-                    let _ = emit_sse_event(
+                    let _ = try_emit_sse_event(
                         &tx,
                         "revoked",
                         &serde_json::json!({ "reason": "exe_changed" }),

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use super::pipeline::spawn_install_pipeline;
+use super::pipeline::{InflightMarker, spawn_install_pipeline};
 
 /// Request body for `POST /registry/backends/install`.
 #[derive(Deserialize)]
@@ -118,42 +118,41 @@ fn parse_install_body(
     Ok((body, source_key))
 }
 
-/// Phase 2 — Acquire the inflight guard (conflict check + insert).
+/// Phase 2 — Acquire the inflight marker (conflict check + insert).
 ///
-/// On conflict returns a `409` response. On success inserts `source_key`
-/// into the set and returns `()`.
-fn acquire_install_inflight(s: &AppState, source_key: &str) -> Result<(), ErrResp> {
-    let mut guard = s.install_inflight.write();
-    if guard.contains(source_key) {
-        return Err(Box::new(super::registry_error(
-            StatusCode::CONFLICT,
-            "install_in_progress",
-        )));
-    }
-    guard.insert(source_key.to_owned());
-    Ok(())
+/// On conflict returns a `409` response. On success inserts `source_key` into
+/// the set and returns an [`InflightMarker`] whose `Drop` removes it again, so
+/// the later synchronous phases can bail with a bare `return` and still clean
+/// up. The happy path calls [`InflightMarker::defuse`] to hand that duty to the
+/// spawned pipeline.
+fn acquire_install_inflight(s: &AppState, source_key: &str) -> Result<InflightMarker, ErrResp> {
+    InflightMarker::acquire(Arc::clone(&s.install_inflight), source_key.to_owned()).ok_or_else(
+        || {
+            Box::new(super::registry_error(
+                StatusCode::CONFLICT,
+                "install_in_progress",
+            ))
+        },
+    )
 }
 
 /// Phase 3 — Resolve the registry entry from whichever of
 /// `source` / `repo_url` / `local_path` was supplied.
 ///
-/// On any error the inflight set is cleaned up and an HTTP error response is
-/// returned.
+/// On any error an HTTP error response is returned; the caller's
+/// [`InflightMarker`] cleans up the inflight set.
 async fn resolve_install_entry(
     s: &AppState,
     body: &InstallBody,
-    source_key: &str,
 ) -> Result<crate::registry::index_schema::IndexBackend, ErrResp> {
     if let Some(ref src) = body.source {
         let Ok(index) = s.registry_client.get().await else {
-            s.install_inflight.write().remove(source_key);
             return Err(Box::new(super::registry_error(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "registry_unavailable",
             )));
         };
         let Some(found) = index.backends.iter().find(|b| &b.source == src).cloned() else {
-            s.install_inflight.write().remove(source_key);
             return Err(Box::new(super::registry_error(
                 StatusCode::NOT_FOUND,
                 "not_found",
@@ -162,7 +161,6 @@ async fn resolve_install_entry(
         Ok(found)
     } else if let Some(ref repo_url) = body.repo_url {
         let Some(forge) = body.forge else {
-            s.install_inflight.write().remove(source_key);
             return Err(Box::new(super::registry_error_msg(
                 StatusCode::BAD_REQUEST,
                 "bad_request",
@@ -173,7 +171,6 @@ async fn resolve_install_entry(
         match crate::registry::custom_repo::resolve(client.as_ref(), repo_url).await {
             Ok(entry) => Ok(entry),
             Err(e) => {
-                s.install_inflight.write().remove(source_key);
                 let (status, error) = custom_repo_error_response(&e);
                 Err(Box::new(super::registry_error_msg(
                     status,
@@ -190,7 +187,6 @@ async fn resolve_install_entry(
         match crate::registry::local_dir::resolve(path) {
             Ok(entry) => Ok(entry),
             Err(e) => {
-                s.install_inflight.write().remove(source_key);
                 let (status, error) = local_dir_error_response(&e);
                 Err(Box::new(super::registry_error_msg(
                     status,
@@ -208,12 +204,11 @@ async fn resolve_install_entry(
 /// `accel = "local"` marker that documents how the bytes landed on disk.
 /// The registry / custom-repo paths route through `compat::select`.
 ///
-/// On incompatibility the inflight set is cleaned up and a `422` is returned.
+/// On incompatibility a `422` is returned; the caller's [`InflightMarker`]
+/// cleans up the inflight set.
 fn select_install_compat(
-    s: &AppState,
     entry: &crate::registry::index_schema::IndexBackend,
     local_src: Option<&PathBuf>,
-    source_key: &str,
 ) -> Result<
     (
         crate::registry::compat::Selection,
@@ -238,7 +233,6 @@ fn select_install_compat(
     let host = host_detect::detect();
     let sel = compat::select(&host, entry);
     let Some(asset) = compat::to_selected_asset(entry, &sel) else {
-        s.install_inflight.write().remove(source_key);
         return Err(Box::new(super::registry_error(
             StatusCode::UNPROCESSABLE_ENTITY,
             "incompatible",
@@ -262,24 +256,26 @@ pub(crate) async fn install_registry_backend(
         Err(r) => return *r,
     };
 
-    // Phase 2: conflict guard.
-    if let Err(r) = acquire_install_inflight(&s, &source_key) {
-        return *r;
-    }
+    // Phase 2: conflict guard. `marker` removes `source_key` from the inflight
+    // set if dropped, so the fallible phases below just `return` on error and
+    // cleanup is automatic; the happy path defuses it before spawning.
+    let marker = match acquire_install_inflight(&s, &source_key) {
+        Ok(m) => m,
+        Err(r) => return *r,
+    };
 
     // Phase 3: resolve registry entry.
     let local_src: Option<PathBuf> = body.local_path.as_deref().map(PathBuf::from);
-    let entry = match resolve_install_entry(&s, &body, &source_key).await {
+    let entry = match resolve_install_entry(&s, &body).await {
         Ok(e) => e,
         Err(r) => return *r,
     };
 
     // Phase 4: compat selection.
-    let (sel, selected_asset_resp) =
-        match select_install_compat(&s, &entry, local_src.as_ref(), &source_key) {
-            Ok(v) => v,
-            Err(r) => return *r,
-        };
+    let (sel, selected_asset_resp) = match select_install_compat(&entry, local_src.as_ref()) {
+        Ok(v) => v,
+        Err(r) => return *r,
+    };
 
     // Phase 5: shape response and spawn background pipeline.
     let install_id = format!("ins_{}", ulid::Ulid::new());
@@ -312,6 +308,8 @@ pub(crate) async fn install_registry_backend(
         source_key,
         local_src,
     );
+    // The spawned pipeline's own `InflightGuard` now owns the marker's removal.
+    marker.defuse();
 
     (
         StatusCode::ACCEPTED,

--- a/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
@@ -67,6 +67,55 @@ impl Drop for InflightGuard {
     }
 }
 
+/// Removes a `source` from the inflight set when dropped — unless
+/// [`InflightMarker::defuse`]d. Used by the *synchronous* pre-spawn phases of
+/// the install/update handlers so every early error return cleans up the
+/// inflight marker automatically instead of a hand-rolled
+/// `inflight.write().remove(...)` at each bail site. Unlike [`InflightGuard`] it
+/// emits no progress event: these phases fail with plain HTTP errors
+/// (400/404/409/422/503), not `Failed` install events. On the happy path the
+/// handler calls [`InflightMarker::defuse`] to hand the removal duty off to the
+/// spawned pipeline's [`InflightGuard`].
+pub(super) struct InflightMarker {
+    inflight: Arc<ParkingRwLock<HashSet<String>>>,
+    source: String,
+    armed: bool,
+}
+
+impl InflightMarker {
+    /// Insert `source` into the inflight set, returning a marker that removes it
+    /// on drop. Returns `None` if `source` was already in flight (the set
+    /// already contained it) — the caller maps that to its own `409`. The
+    /// check-and-insert is atomic under one write lock.
+    pub(super) fn acquire(
+        inflight: Arc<ParkingRwLock<HashSet<String>>>,
+        source: String,
+    ) -> Option<Self> {
+        if !inflight.write().insert(source.clone()) {
+            return None;
+        }
+        Some(Self {
+            inflight,
+            source,
+            armed: true,
+        })
+    }
+
+    /// Hand the removal duty to the spawned pipeline's [`InflightGuard`]: leave
+    /// the entry in place and do nothing on drop.
+    pub(super) fn defuse(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for InflightMarker {
+    fn drop(&mut self) {
+        if self.armed {
+            self.inflight.write().remove(&self.source);
+        }
+    }
+}
+
 /// Shared background pipeline spawner used by both the install and update
 /// handlers. The caller has already inserted `source_bg` into the inflight
 /// set; this function takes ownership of that responsibility via

--- a/super-stt-daemon/src/daemon/http/v1/registry/update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/update.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use super::pipeline::spawn_install_pipeline;
+use super::pipeline::{InflightMarker, spawn_install_pipeline};
 use crate::daemon::http::state::AppState;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -33,18 +33,20 @@ fn parse_update_body(raw: Option<axum::Json<UpdateBody>>) -> Result<UpdateBody, 
     Ok(body)
 }
 
-/// Phase 2 — Acquire the inflight guard (conflict check + insert).
+/// Phase 2 — Acquire the inflight marker (conflict check + insert).
 ///
-/// Single write-lock so the check+insert is atomic.
-/// Returns `Err` with a `409` response when an update is already in progress.
-fn acquire_update_inflight(s: &AppState, source: &str) -> Result<(), ErrResp> {
-    if !s.install_inflight.write().insert(source.to_owned()) {
-        return Err(Box::new(super::registry_error(
+/// Check+insert is atomic under one write lock. Returns `Err` with a `409` when
+/// an update is already in progress; otherwise an [`InflightMarker`] whose
+/// `Drop` removes the marker, so the later synchronous phases (and the no-op
+/// early return) bail with a bare `return` and cleanup is automatic. The happy
+/// path defuses it before spawning.
+fn acquire_update_inflight(s: &AppState, source: &str) -> Result<InflightMarker, ErrResp> {
+    InflightMarker::acquire(Arc::clone(&s.install_inflight), source.to_owned()).ok_or_else(|| {
+        Box::new(super::registry_error(
             StatusCode::CONFLICT,
             "update_in_progress",
-        )));
-    }
-    Ok(())
+        ))
+    })
 }
 
 /// Outcome of the version-lookup phase.
@@ -55,8 +57,9 @@ struct VersionLookup {
 
 /// Phase 3 — Fetch the registry entry and determine the installed version.
 ///
-/// Cleans up the inflight marker and returns an HTTP error on any failure:
-/// registry unavailable, source not in index, not installed on disk.
+/// Returns an HTTP error on any failure (registry unavailable, source not in
+/// index, not installed on disk); the caller's [`InflightMarker`] cleans up the
+/// inflight set.
 async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, ErrResp> {
     let backends_dir = {
         let c = s.daemon.config.read().await;
@@ -67,7 +70,6 @@ async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, Er
     };
 
     let Ok(index) = s.registry_client.get().await else {
-        s.install_inflight.write().remove(source);
         return Err(Box::new(super::registry_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "registry_unavailable",
@@ -75,7 +77,6 @@ async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, Er
     };
 
     let Some(entry) = index.backends.iter().find(|b| b.source == source).cloned() else {
-        s.install_inflight.write().remove(source);
         return Err(Box::new(super::registry_error(
             StatusCode::NOT_FOUND,
             "not_found",
@@ -95,7 +96,6 @@ async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, Er
     };
 
     let Some(from_version) = installed_version else {
-        s.install_inflight.write().remove(source);
         return Err(Box::new(super::registry_error(
             StatusCode::NOT_FOUND,
             "not_installed",
@@ -110,11 +110,10 @@ async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, Er
 
 /// Phase 4 — Select a compatible asset for the current host.
 ///
-/// Cleans up the inflight marker and returns `422` if no asset matches.
+/// Returns `422` if no asset matches; the caller's [`InflightMarker`] cleans up
+/// the inflight set.
 fn select_update_compat(
-    s: &AppState,
     entry: &crate::registry::index_schema::IndexBackend,
-    source: &str,
 ) -> Result<crate::registry::compat::Selection, ErrResp> {
     use crate::registry::{compat, host_detect};
 
@@ -122,7 +121,6 @@ fn select_update_compat(
     let sel = compat::select(&host, entry);
 
     if compat::to_selected_asset(entry, &sel).is_none() {
-        s.install_inflight.write().remove(source);
         return Err(Box::new(super::registry_error(
             StatusCode::UNPROCESSABLE_ENTITY,
             "incompatible",
@@ -149,10 +147,14 @@ pub(crate) async fn update_registry_backend(
         Err(r) => return *r,
     };
 
-    // Phase 2: conflict guard.
-    if let Err(r) = acquire_update_inflight(&s, &body.source) {
-        return *r;
-    }
+    // Phase 2: conflict guard. `marker` removes `body.source` from the inflight
+    // set if dropped, so the fallible phases and the no-op early return below
+    // just `return` and cleanup is automatic; the happy path defuses it before
+    // spawning.
+    let marker = match acquire_update_inflight(&s, &body.source) {
+        Ok(m) => m,
+        Err(r) => return *r,
+    };
 
     // Phase 3: look up registry entry + installed version.
     let VersionLookup {
@@ -168,7 +170,7 @@ pub(crate) async fn update_registry_backend(
     // registry version happily "updated" into a downgrade (Tier 1 #31); the
     // shared semver check refuses anything not strictly newer.
     if !super_stt_registry_types::version::update_available(&from_version, &entry.version) {
-        s.install_inflight.write().remove(&body.source);
+        // `marker` drops here → removes the inflight entry.
         let resp = UpdateResponse {
             install_id: None,
             from_version: from_version.clone(),
@@ -184,7 +186,7 @@ pub(crate) async fn update_registry_backend(
     }
 
     // Phase 4: compat selection.
-    let sel = match select_update_compat(&s, &entry, &body.source) {
+    let sel = match select_update_compat(&entry) {
         Ok(s) => s,
         Err(r) => return *r,
     };
@@ -194,7 +196,7 @@ pub(crate) async fn update_registry_backend(
     let to_version = entry.version.clone();
 
     // Spawn background install (same pipeline as install handler).
-    // (source already marked inflight by the guard above)
+    // (source already marked inflight by the marker above)
     spawn_install_pipeline(
         Arc::clone(&s.daemon),
         Arc::clone(&s.install_inflight),
@@ -204,6 +206,8 @@ pub(crate) async fn update_registry_backend(
         body.source.clone(),
         None, // update never uses local_src
     );
+    // The spawned pipeline's own `InflightGuard` now owns the marker's removal.
+    marker.defuse();
 
     let resp = UpdateResponse {
         install_id: Some(install_id),

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -177,19 +177,25 @@ async fn run_realtime_session(socket: axum::extract::ws::WebSocket, daemon: Arc<
 /// `done` / `error` and the connection closes. Closing the
 /// connection mid-stream cancels the recording (the daemon detects
 /// the disconnect on its next write attempt).
-/// Emit a single SSE `event: <name>\ndata: <json>\n\n` frame onto the
-/// outbound stream. Returns `false` if the receiver is gone (client
-/// disconnected). `serde_json::to_string` never embeds raw newlines, so
-/// the JSON fits on the single `data:` line by construction.
+/// Build the raw bytes of one SSE `event: <name>\ndata: <json>\n\n` frame.
+/// `serde_json::to_string` never embeds raw newlines, so the JSON fits on the
+/// single `data:` line by construction. Shared by the unbounded `/transcribe`
+/// stream ([`emit_sse_event`]) and the bounded `/events` fan-out.
+pub(crate) fn format_sse_frame(event: &str, data: &serde_json::Value) -> axum::body::Bytes {
+    let mut bytes = format!("event: {event}\ndata: ").into_bytes();
+    bytes.extend_from_slice(serde_json::to_string(data).unwrap_or_default().as_bytes());
+    bytes.extend_from_slice(b"\n\n");
+    axum::body::Bytes::from(bytes)
+}
+
+/// Emit a single SSE frame onto the unbounded `/transcribe` stream. Returns
+/// `false` if the receiver is gone (client disconnected).
 pub(crate) fn emit_sse_event(
     tx: &tokio::sync::mpsc::UnboundedSender<Result<axum::body::Bytes, std::io::Error>>,
     event: &str,
     data: &serde_json::Value,
 ) -> bool {
-    let mut bytes = format!("event: {event}\ndata: ").into_bytes();
-    bytes.extend_from_slice(serde_json::to_string(data).unwrap_or_default().as_bytes());
-    bytes.extend_from_slice(b"\n\n");
-    tx.send(Ok(axum::body::Bytes::from(bytes))).is_ok()
+    tx.send(Ok(format_sse_frame(event, data))).is_ok()
 }
 
 /// Monotonic id identifying one `/transcribe` request's claim on the shared

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -23,7 +23,9 @@ struct RecordingSession {
     pub(super) recorder_handle: tokio::task::JoinHandle<Result<Vec<f32>>>,
     pub(super) model_processing_interval: std::time::Duration,
     pub(super) actually_typed: Arc<std::sync::Mutex<String>>,
-    pub(super) preview_buffer: Arc<std::sync::Mutex<VecDeque<f32>>>,
+    // Shared with the recorder's ring buffer (`get_audio_buffer_ref`), which is
+    // a `parking_lot::Mutex` (Tier 3 #5).
+    pub(super) preview_buffer: Arc<parking_lot::Mutex<VecDeque<f32>>>,
     pub(super) device_sample_rate: u32,
     pub(super) start_time: Instant,
 }

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -161,13 +161,7 @@ impl SuperSTTDaemon {
     fn read_preview_audio_from_buffer(session: &RecordingSession) -> Vec<f32> {
         // Get last 5 seconds of audio data directly from buffer for preview
         debug!("About to get 10 secs from buffer");
-        let buffer_guard = match session.preview_buffer.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                debug!("Buffer lock poisoned, recovering");
-                poisoned.into_inner()
-            }
-        };
+        let buffer_guard = session.preview_buffer.lock();
 
         let total_samples = buffer_guard.len();
 

--- a/super-stt-daemon/src/daemon/settings_handlers.rs
+++ b/super-stt-daemon/src/daemon/settings_handlers.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::config::DaemonConfig;
 use crate::daemon::types::SuperSTTDaemon;
 use log::{info, warn};
 use super_stt_shared::models::protocol::DaemonResponse;
@@ -7,45 +8,57 @@ use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::models::write_method::WriteMethod;
 
 impl SuperSTTDaemon {
+    /// Mutate the config under the write lock, then persist it. Centralizes the
+    /// lock → mutate → persist sequence so a settings handler can't hand-roll it
+    /// and forget the persist (see Tier 1 #3). Returns the persist outcome so the
+    /// caller can fold a save failure into its response.
+    async fn set_config_field<F>(&self, mutate: F) -> anyhow::Result<()>
+    where
+        F: FnOnce(&mut DaemonConfig),
+    {
+        {
+            let mut config = self.config.write().await;
+            mutate(&mut config);
+        }
+        self.persist_config().await
+    }
+
+    /// Fold a persist outcome into a settings response. `base` already carries
+    /// the setting-specific `.with_*` field and `message` is the success text.
+    /// A save failure keeps the (already-applied) in-memory change — the daemon
+    /// stays authoritative for the process lifetime — and appends the error to
+    /// the message, logging a warning.
+    fn settings_saved(
+        base: DaemonResponse,
+        message: String,
+        persist: anyhow::Result<()>,
+    ) -> DaemonResponse {
+        match persist {
+            Ok(()) => base.with_message(message),
+            Err(e) => {
+                warn!("Setting changed but config save failed: {e}");
+                base.with_message(format!("{message} (save failed: {e})"))
+            }
+        }
+    }
     /// Handle set preview typing command - enable or disable preview typing
     #[must_use]
     pub async fn handle_set_preview_typing(&self, enabled: bool) -> DaemonResponse {
-        // Update the in-memory setting
+        // Update the in-memory setting.
         self.preview_typing_enabled
             .store(enabled, std::sync::atomic::Ordering::Relaxed);
 
-        // Update the config directly (don't clone)
-        {
-            let mut config_guard = self.config.write().await;
-            config_guard.transcription.preview_typing_enabled = enabled;
-        }
+        let persist = self
+            .set_config_field(|c| c.transcription.preview_typing_enabled = enabled)
+            .await;
 
-        // Persist the change to disk so it survives a restart.
-        let persist_result = self.persist_config().await;
-
-        match persist_result {
-            Ok(()) => {
-                info!(
-                    "Preview typing {} and saved to config",
-                    if enabled { "enabled" } else { "disabled" }
-                );
-                DaemonResponse::success()
-                    .with_preview_typing_enabled(enabled)
-                    .with_message(format!(
-                        "Preview typing {} and saved",
-                        if enabled { "enabled" } else { "disabled" }
-                    ))
-            }
-            Err(e) => {
-                warn!("Preview typing setting changed but failed to save to config: {e}");
-                DaemonResponse::success()
-                    .with_preview_typing_enabled(enabled)
-                    .with_message(format!(
-                        "Preview typing {} (config save failed: {e})",
-                        if enabled { "enabled" } else { "disabled" }
-                    ))
-            }
-        }
+        let state = if enabled { "enabled" } else { "disabled" };
+        info!("Preview typing {state}");
+        Self::settings_saved(
+            DaemonResponse::success().with_preview_typing_enabled(enabled),
+            format!("Preview typing {state}"),
+            persist,
+        )
     }
 
     /// Handle get preview typing command - return current preview typing setting
@@ -62,29 +75,16 @@ impl SuperSTTDaemon {
 
     /// Handle set recording stop mode command
     pub async fn handle_set_recording_stop_mode(&self, mode: RecordingStopMode) -> DaemonResponse {
-        {
-            let mut config_guard = self.config.write().await;
-            config_guard.transcription.recording_stop_mode = mode;
-        }
+        let persist = self
+            .set_config_field(|c| c.transcription.recording_stop_mode = mode)
+            .await;
 
-        let persist_result = self.persist_config().await;
-
-        match persist_result {
-            Ok(()) => {
-                info!("Recording stop mode set to {mode} and saved to config");
-                DaemonResponse::success()
-                    .with_recording_stop_mode(mode.to_string())
-                    .with_message(format!("Recording stop mode set to {mode}"))
-            }
-            Err(e) => {
-                warn!("Recording stop mode changed but failed to save: {e}");
-                DaemonResponse::success()
-                    .with_recording_stop_mode(mode.to_string())
-                    .with_message(format!(
-                        "Recording stop mode set to {mode} (save failed: {e})"
-                    ))
-            }
-        }
+        info!("Recording stop mode set to {mode}");
+        Self::settings_saved(
+            DaemonResponse::success().with_recording_stop_mode(mode.to_string()),
+            format!("Recording stop mode set to {mode}"),
+            persist,
+        )
     }
 
     /// Handle get recording stop mode command
@@ -96,29 +96,18 @@ impl SuperSTTDaemon {
 
     /// Handle set write method command
     pub async fn handle_set_write_method(&self, method: WriteMethod) -> DaemonResponse {
-        {
-            let mut config_guard = self.config.write().await;
-            config_guard.transcription.write_method = method;
-        }
+        let persist = self
+            .set_config_field(|c| c.transcription.write_method = method)
+            .await;
         // Invalidate the cached simulator so the next recording creates a fresh one.
         *self.simulator.write().await = None;
 
-        let persist_result = self.persist_config().await;
-
-        match persist_result {
-            Ok(()) => {
-                info!("Write method set to {method} and saved to config");
-                DaemonResponse::success()
-                    .with_write_method(method.to_string())
-                    .with_message(format!("Write method set to {method}"))
-            }
-            Err(e) => {
-                warn!("Write method changed but failed to save: {e}");
-                DaemonResponse::success()
-                    .with_write_method(method.to_string())
-                    .with_message(format!("Write method set to {method} (save failed: {e})"))
-            }
-        }
+        info!("Write method set to {method}");
+        Self::settings_saved(
+            DaemonResponse::success().with_write_method(method.to_string()),
+            format!("Write method set to {method}"),
+            persist,
+        )
     }
 
     /// Handle get write method command
@@ -227,25 +216,15 @@ impl SuperSTTDaemon {
     pub async fn handle_set_custom_models_dir(&self, path: Option<String>) -> DaemonResponse {
         let path_display = path.as_deref().unwrap_or("none").to_string();
 
-        {
-            let mut config_guard = self.config.write().await;
-            config_guard.transcription.custom_models_dir = path;
-        }
+        let persist = self
+            .set_config_field(|c| c.transcription.custom_models_dir = path)
+            .await;
 
-        let persist_result = self.persist_config().await;
-
-        match persist_result {
-            Ok(()) => {
-                info!("Custom models directory set to {path_display} and saved to config");
-                DaemonResponse::success()
-                    .with_message(format!("Custom models directory set to {path_display}"))
-            }
-            Err(e) => {
-                warn!("Custom models directory changed but failed to save: {e}");
-                DaemonResponse::success().with_message(format!(
-                    "Custom models directory set to {path_display} (save failed: {e})"
-                ))
-            }
-        }
+        info!("Custom models directory set to {path_display}");
+        Self::settings_saved(
+            DaemonResponse::success(),
+            format!("Custom models directory set to {path_display}"),
+            persist,
+        )
     }
 }


### PR DESCRIPTION
Continues the code-quality audit cleanup (`docs/audits/2026-07-code-quality.md`), Tier 3 items #5–#8. One commit per item; all daemon-side.

## #5 — Switch audio mutexes to `parking_lot`; drop poison-recovery boilerplate
The three audio mutexes (`audio_buffer`, `recording_state`, `audio_device_cache`) moved from `std::sync::Mutex` to `parking_lot::Mutex`. parking_lot guards carry no poison state, so all 11 `match .lock() { Ok => .., Err(poisoned) => poisoned.into_inner() }` recovery blocks collapse to a direct `.lock()` (cpal real-time callbacks stay sync-safe). The type leaks through `get_audio_buffer_ref`, so `RecordingSession::preview_buffer` and its one lock site moved too. Net −84 lines.

## #6 — Add `InflightMarker` RAII guard; drop hand-rolled inflight cleanup
New `InflightMarker` in `pipeline.rs`: atomic check+insert, removes on `Drop`, emits **no** event (unlike the pipeline's event-emitting `InflightGuard`). Both install/update handlers hold the marker across their synchronous phases and `defuse()` it on the happy path (handing removal to the spawned pipeline's guard). Deletes all 11 hand-rolled `install_inflight.write().remove()` error-path calls.

## #7 — `set_config_field` helper for the settings mutate→persist→respond block
`set_config_field` (lock → mutate closure → `persist_config`) + a `settings_saved` response helper. The four simple setters (preview typing, recording stop mode, write method, custom models dir) route through both. `handle_set_allow_online_models` keeps its explicit path — it interleaves an async online→local revert between mutate and persist.

## #8 — Bound the `/events` SSE channel; drop frames on overflow
The per-connection `/events` channel is now `mpsc::channel(256)` (was `unbounded_channel`), read via `ReceiverStream`. A shared `try_emit_sse_event` does `try_send`: a full channel drops the frame (stalled reader — shed it) and only `Closed` tears down. `frequency_bands` is the dominant volume, so those overflow in practice. `/transcribe` keeps its unbounded channel (bounded per-recording lifetime, non-droppable frames). Frame formatting factored into a shared `format_sse_frame`.

## Verification
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` ✅
- `cargo test -p super-stt-daemon --lib --all-features` → 235 passed ✅
- `cargo test -p super-stt-daemon --all-features --no-run` (integration-test callers) ✅
- `just check-features` (default / subprocess / wasm / no-default) ✅
- `just fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)