### PR TITLE
Audit Tier 3 #9-#11: daemon minor cleanups, Message sub-enums, one error surface

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -939,7 +939,7 @@ Tier 2 #4/#6/#8.
   exhaustiveness guarantee lives at the sub-enum boundary, which is what silently no-op'd
   before.
 
-### [ ] 11. 🟠 App: one error surface
+### [x] 11. 🟠 App: one error surface
 
 - **Where:** four ad-hoc patterns today — transcription-box hijack, log-only,
   invisible, escalate-to-connection-page (Tier 1 #13/#15).
@@ -947,6 +947,26 @@ Tier 2 #4/#6/#8.
   `ui/views/models/active.rs:437-445`) is the good template; add a shared
   scope-tagged error slot rendered per page, and roll back optimistic state on
   failure.
+- **Resolved (branch `refactor/audit-tier3-9-11`):** generalized the existing
+  scope-tagged `action_error` slot. `ErrorScope` gained `Recording` and
+  `InputSimulation`; the Recording and Input Simulation pages now render the shared
+  `error_banner` (via `action_error_for(scope)`) like Customization already did. Added
+  `set_action_error`/`clear_action_error` helpers (scope-safe: clearing one page's
+  banner can't wipe another's). Converged the ad-hoc error paths onto it:
+  - **Log-only → banner:** the preview-typing / stop-mode / write-method save errors
+    and the language-save error now populate their page's banner instead of only
+    `log::warn!`.
+  - **Transcription-box hijack → Models card:** `DeviceError` and `DownloadError` set
+    `ModelOperationState::Error` (the good template) instead of overwriting the
+    Recording page's `transcription_text`.
+- **Deferred (follow-up, Tier 3 #37):** rolling back optimistic state on failure
+  (audio theme / volume / select-backend / staged-device). Doing it right needs a
+  captured previous value threaded through a per-setting success/failure message
+  (the failure arrives as a separate message that doesn't carry the prior value), and
+  the drift self-heals on the next reconnect refetch (`VolumeLoaded` /
+  `CurrentAudioThemeLoaded` / `ActiveBackendLoaded`), so it's a refinement rather than
+  a correctness gap. The `escalate-to-connection-page` behavior (whole-UI takeover on
+  `DaemonStatus::Error`) is intentional for a lost daemon and stays.
 
 ### [x] 12. 🟡 App: `clear_loaded_model()` helper for the copy-pasted current-model triple
 
@@ -1128,6 +1148,21 @@ Tier 2 #4/#6/#8.
   for marginal benefit.
 - **Fix:** route sessions through `kv_get`/`kv_set` and delete
   `install_mock_if_requested`; introduce a small keyring error enum.
+
+### [ ] 37. 🟡 App: roll back optimistic UI state on save failure (split off Tier 3 #11)
+
+- **Where:** the optimistic-then-banner sites — audio theme / feedback
+  (`handlers/recording.rs`), volume commit (same), `SelectBackend` /
+  `LoadStagedModel` staged device (`handlers/models_page/mod.rs`).
+- **Why split:** Tier 3 #11 landed the "one error surface" (scoped banners + Models
+  card, no more transcription hijack or log-only). Rollback is separable: the failure
+  arrives as its own message that doesn't carry the pre-optimistic value, so each site
+  needs a captured previous value threaded through a per-setting success/failure
+  message (and volume needs a stored last-committed value, since the drag already
+  overwrote `self.volume`). The drift also self-heals on the next reconnect refetch
+  (`VolumeLoaded`/`CurrentAudioThemeLoaded`/`ActiveBackendLoaded`).
+- **Fix:** capture the prior value at the optimistic set and restore it in a
+  dedicated failure message that also raises the banner.
 
 ---
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -917,12 +917,27 @@ Tier 2 #4/#6/#8.
   (including the async wrappers added in Tier 3 #4) for marginal benefit; better as a
   focused pass than bundled here.
 
-### [ ] 10. 🟡 App: group the flat ~90-variant `Message` enum into sub-enums
+### [x] 10. 🟡 App: group the flat ~90-variant `Message` enum into sub-enums
 
 - **Where:** routing is declared twice — nine `matches!` lists in
   `core/app/update.rs:21-211` + per-handler `_ => Task::none()` catch-alls.
 - **Problem:** a forgotten variant silently no-ops.
 - **Fix:** sub-enums make dispatch exhaustive and delete both lists.
+- **Resolved (branch `refactor/audit-tier3-9-11`):** the flat 103-variant `Message`
+  is now 12 per-area sub-enums (`ShellMessage`, `DaemonMessage`, `ModelMessage`,
+  `ModelsPageMessage`, `DeviceMessage`, `DownloadMessage`, `PreviewTypingMessage`,
+  `RecordingStopModeMessage`, `WriteMethodMessage`, `BackendMessage`, `LanguageMessage`,
+  `RecordingMessage`) wrapped by `Message`, plus the still-top-level `SettingActionFailed`
+  (handled inline). `dispatch` is one exhaustive `match` (the twelve `matches!` lists are
+  gone), and each `handle_*_messages` takes and `match`es its own sub-enum — so all the
+  top-level `_ => Task::none()` catch-alls are deleted and a forgotten variant is a compile
+  error at both ends. `From<XMessage> for Message` impls exist for ergonomics. Now that the
+  group name carries the context, the three redundant-prefix settings enums shed it
+  (`PreviewTypingMessage::Toggled`, `RecordingStopModeMessage::Changed`, etc.). The few
+  intra-group delegate sub-handlers (daemon, models_page, download) keep a narrow
+  `_ => Task::none()` since they each receive the full sub-enum but handle a subset — the
+  exhaustiveness guarantee lives at the sub-enum boundary, which is what silently no-op'd
+  before.
 
 ### [ ] 11. 🟠 App: one error surface
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -890,7 +890,7 @@ Tier 2 #4/#6/#8.
   `format_sse_frame` used by both the bounded fan-out and the unbounded
   `emit_sse_event`.
 
-### [ ] 9. 🟡 Daemon: minor items
+### [x] 9. 🟡 Daemon: minor items
 
 - Five identical `emit_*` DBus wrappers (`services/dbus.rs:131-198`).
 - Dead spinner scaffolding in `transcribe_with_spinner`
@@ -899,6 +899,23 @@ Tier 2 #4/#6/#8.
 - Keyring sessions-blob accessors bypass `kv_get`/`kv_set` with a second mock
   mechanism (`keyring.rs:157-247`).
 - Stringly `Result<_, String>` in keyring/download-progress.
+- **Resolved (branch `refactor/audit-tier3-9-11`):**
+  - The five `emit_*` DBus wrappers collapse to an `emit_signal!` macro (they
+    differed only in the signal method + event type; a generic async helper can't
+    express it — the closure would return a future borrowing the emitter). The
+    repeated object path is now an `OBJECT_PATH` const, reused by `.at(..)` too.
+  - `transcribe_with_spinner` → `transcribe_final`: the spinner apparatus was
+    entirely dead (`spinner_handle` never assigned, cancel/counter never read), and
+    the `_typer`/`_write_mode` params were unused — all removed.
+  - Deleted the one-use `PipeExt` trait; the single `.pipe(Ok)` is now `Ok(..)`.
+- **Deferred (follow-up, Tier 3 #36):** the keyring sessions-blob → `kv_get`/`kv_set`
+  unification and the `Result<_, String>` → typed-error conversion. The first changes
+  session-persistence behavior under `SUPER_STT_KEYRING_MOCK` (the sessions blob would
+  move from the keyring-crate mock to the process-global `mock_store`), which the
+  `http_smoke_full` restart test exercises — wants its own verified change. The second
+  is a type-system change rippling through every keyring/download-progress caller
+  (including the async wrappers added in Tier 3 #4) for marginal benefit; better as a
+  focused pass than bundled here.
 
 ### [ ] 10. 🟡 App: group the flat ~90-variant `Message` enum into sub-enums
 
@@ -1080,6 +1097,22 @@ Tier 2 #4/#6/#8.
   a one-time startup blocking read.
 - **Fix:** async `Simulator` (threads the `Typer`/preview loop off the `std::Mutex`
   guard); a dedicated session-persist task fed over a channel.
+
+### [ ] 36. 🟡 Daemon: keyring cleanup deferred from Tier 3 #9
+
+- **Where:** the sessions-blob accessors (`keyring.rs` `get_sessions_blob`/
+  `set_sessions_blob`) build `keyring::Entry` directly and rely on
+  `install_mock_if_requested` (the keyring-crate credential-builder mock), a second
+  mock mechanism alongside the process-global `mock_store` that `kv_get`/`kv_set` use.
+  Plus the stringly `Result<_, String>` across keyring and download-progress.
+- **Why split:** routing the sessions blob through `kv_get`/`kv_set` changes its
+  behavior under `SUPER_STT_KEYRING_MOCK` (persists in-process via `mock_store`
+  instead of the isolated-per-`Entry` keyring mock), which the `http_smoke_full`
+  restart test exercises — a verified change, not a drive-by. Typed errors ripple
+  through every keyring/download-progress caller (incl. the Tier 3 #4 async wrappers)
+  for marginal benefit.
+- **Fix:** route sessions through `kv_get`/`kv_set` and delete
+  `install_mock_if_requested`; introduce a small keyring error enum.
 
 ---
 

--- a/super-stt-app/src/core/app/events.rs
+++ b/super-stt-app/src/core/app/events.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::DaemonStatus;
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, Message, ModelsPageMessage, RecordingMessage};
 use log::warn;
 
 /// Classify a daemon [`HttpError`] into the right next `DaemonStatus`.
@@ -36,27 +36,29 @@ pub(super) fn settings_widget_event_to_message(
     use serde_json::Value;
     let p: &Value = &evt.payload;
     match evt.name.as_str() {
-        "recording_state" => Some(Message::WidgetRecordingState(
+        "recording_state" => Some(Message::Recording(RecordingMessage::WidgetRecordingState(
             p.get("is_recording")
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
-        )),
+        ))),
         "frequency_bands" => {
             // reason: audio energy values are small positive floats well within f32 range; precision loss is acceptable for level display.
             #[allow(clippy::cast_possible_truncation)]
             let total_energy = p.get("total_energy").and_then(Value::as_f64).unwrap_or(0.0) as f32;
             let level = raw_level_to_db_display_percent(total_energy);
             let is_speech = total_energy > 0.0001;
-            Some(Message::WidgetAudioLevel { level, is_speech })
+            Some(Message::Recording(RecordingMessage::WidgetAudioLevel {
+                level,
+                is_speech,
+            }))
         }
         // `daemon_status_changed` and `download_progress` arrive as
         // settings-scope SSE topics now; the existing
         // `Message::DaemonEventsReceived` handler already knows how to
         // dispatch the legacy JSON shape, so we wrap each event in a
         // singleton `NotificationEvent` and feed it through unchanged.
-        "daemon_status_changed" | "download_progress" => {
-            widget_event_to_notification(evt).map(|n| Message::DaemonEventsReceived(vec![n]))
-        }
+        "daemon_status_changed" | "download_progress" => widget_event_to_notification(evt)
+            .map(|n| Message::Daemon(DaemonMessage::DaemonEventsReceived(vec![n]))),
         "registry_install" => {
             use super_stt_shared::registry::events::RegistryEvent;
             let p = &evt.payload;
@@ -68,27 +70,29 @@ pub(super) fn settings_widget_event_to_message(
                         phase,
                         bytes_done,
                         bytes_total,
-                    } => Some(Message::InstallProgress {
+                    } => Some(Message::ModelsPage(ModelsPageMessage::InstallProgress {
                         install_id,
                         source,
                         phase,
                         bytes_done,
                         bytes_total,
-                    }),
+                    })),
                     RegistryEvent::Completed { source, .. } => {
-                        Some(Message::InstallCompleted { source })
+                        Some(Message::ModelsPage(ModelsPageMessage::InstallCompleted {
+                            source,
+                        }))
                     }
                     RegistryEvent::Failed {
                         install_id,
                         source,
                         phase,
                         error,
-                    } => Some(Message::InstallFailed {
+                    } => Some(Message::ModelsPage(ModelsPageMessage::InstallFailed {
                         install_id,
                         source,
                         phase,
                         error,
-                    }),
+                    })),
                     RegistryEvent::RefreshCompleted { .. }
                     | RegistryEvent::RefreshFailed { .. } => None,
                 }

--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -6,7 +6,7 @@ use crate::daemon::client::{
     set_backend_option, set_backend_secret,
 };
 use crate::state::ErrorScope;
-use crate::ui::messages::Message;
+use crate::ui::messages::{BackendMessage, Message, ModelsPageMessage};
 use cosmic::prelude::*;
 use super_stt_shared::daemon::http_client::HttpError;
 use super_stt_shared::models::provider::Provider;
@@ -24,31 +24,31 @@ impl AppModel {
     /// (used by the Configure sub-view).
     pub(in crate::core::app) fn handle_backend_messages(
         &mut self,
-        message: Message,
+        message: BackendMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::BackendsLoaded(_)
-            | Message::BackendsError(_)
-            | Message::BackendsReload
-            | Message::BackendSecretsConfigured { .. } => self.handle_backend_catalog(message),
+            BackendMessage::BackendsLoaded(_)
+            | BackendMessage::BackendsError(_)
+            | BackendMessage::BackendsReload
+            | BackendMessage::BackendSecretsConfigured { .. } => {
+                self.handle_backend_catalog(message)
+            }
 
-            Message::BackendSecretInputChanged { .. }
-            | Message::BackendSecretSaved { .. }
-            | Message::BackendSecretStored { .. }
-            | Message::BackendSecretRemoved { .. }
-            | Message::BackendOptionInputChanged { .. }
-            | Message::BackendOptionSaved { .. }
-            | Message::BackendOptionReset { .. } => self.handle_backend_config(message),
-
-            _ => Task::none(),
+            BackendMessage::BackendSecretInputChanged { .. }
+            | BackendMessage::BackendSecretSaved { .. }
+            | BackendMessage::BackendSecretStored { .. }
+            | BackendMessage::BackendSecretRemoved { .. }
+            | BackendMessage::BackendOptionInputChanged { .. }
+            | BackendMessage::BackendOptionSaved { .. }
+            | BackendMessage::BackendOptionReset { .. } => self.handle_backend_config(message),
         }
     }
 
     /// Handle backend catalog messages: `BackendsLoaded`, `BackendsError`, `BackendsReload`,
     /// `BackendSecretsConfigured`.
-    fn handle_backend_catalog(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_backend_catalog(&mut self, message: BackendMessage) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::BackendsLoaded(backends) => {
+            BackendMessage::BackendsLoaded(backends) => {
                 // Prefill option input buffers from each option's current value.
                 // Secret configured-flags are now daemon-sourced: dispatch
                 // list_backend_secrets per backend and fold via BackendSecretsConfigured.
@@ -72,10 +72,12 @@ impl AppModel {
                         let source = b.source.clone();
                         Task::perform(list_backend_secrets(source.clone()), move |res| {
                             let items = res.unwrap_or_default();
-                            cosmic::Action::App(Message::BackendSecretsConfigured {
-                                source: source.clone(),
-                                items,
-                            })
+                            cosmic::Action::App(Message::Backend(
+                                BackendMessage::BackendSecretsConfigured {
+                                    source: source.clone(),
+                                    items,
+                                },
+                            ))
                         })
                     })
                     .collect();
@@ -93,8 +95,12 @@ impl AppModel {
                         async move { crate::daemon::registry::list(&filters).await },
                         |r| {
                             cosmic::Action::App(match r {
-                                Ok(resp) => Message::RegistryListLoaded(resp),
-                                Err(e) => Message::RegistryListFailed(e.to_string()),
+                                Ok(resp) => {
+                                    Message::ModelsPage(ModelsPageMessage::RegistryListLoaded(resp))
+                                }
+                                Err(e) => Message::ModelsPage(
+                                    ModelsPageMessage::RegistryListFailed(e.to_string()),
+                                ),
                             })
                         },
                     ));
@@ -102,7 +108,7 @@ impl AppModel {
                 Task::batch(tasks)
             }
 
-            Message::BackendSecretsConfigured { source, items } => {
+            BackendMessage::BackendSecretsConfigured { source, items } => {
                 for (name, configured) in items {
                     self.backend_secret_configured
                         .insert((source.clone(), name), configured);
@@ -110,24 +116,30 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::BackendsError(err) => {
+            BackendMessage::BackendsError(err) => {
                 log::warn!("Backends load error: {err}");
                 Task::none()
             }
 
-            Message::BackendsReload => Task::perform(list_backends(), |result| match result {
-                Ok(backends) => cosmic::Action::App(Message::BackendsLoaded(backends)),
-                Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
-            }),
+            BackendMessage::BackendsReload => {
+                Task::perform(list_backends(), |result| match result {
+                    Ok(backends) => cosmic::Action::App(Message::Backend(
+                        BackendMessage::BackendsLoaded(backends),
+                    )),
+                    Err(e) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsError(
+                        e.to_string(),
+                    ))),
+                })
+            }
 
             _ => Task::none(),
         }
     }
 
     /// Handle per-backend secret and option configuration messages.
-    fn handle_backend_config(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_backend_config(&mut self, message: BackendMessage) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::BackendSecretInputChanged {
+            BackendMessage::BackendSecretInputChanged {
                 source,
                 name,
                 value,
@@ -142,7 +154,7 @@ impl AppModel {
             // The input buffer is NOT cleared here — it is cleared only on
             // success via BackendSecretStored, so a transient failure leaves
             // the typed value intact for retry.
-            Message::BackendSecretSaved { source, name } => {
+            BackendMessage::BackendSecretSaved { source, name } => {
                 // Clear any stale Configure-sheet banner as the user retries.
                 self.action_error = None;
                 let key = (source.clone(), name.clone());
@@ -155,10 +167,12 @@ impl AppModel {
                 Task::perform(
                     set_backend_secret(source.clone(), name.clone(), value),
                     move |res| match res {
-                        Ok(()) => cosmic::Action::App(Message::BackendSecretStored {
-                            source: source.clone(),
-                            name: name.clone(),
-                        }),
+                        Ok(()) => cosmic::Action::App(Message::Backend(
+                            BackendMessage::BackendSecretStored {
+                                source: source.clone(),
+                                name: name.clone(),
+                            },
+                        )),
                         Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                     },
                 )
@@ -166,23 +180,23 @@ impl AppModel {
 
             // Daemon confirmed the secret was written — clear the input buffer
             // and refresh the catalog so the configured flag updates.
-            Message::BackendSecretStored { source, name } => {
+            BackendMessage::BackendSecretStored { source, name } => {
                 self.backend_secret_inputs.remove(&(source, name));
-                self.handle_backend_catalog(Message::BackendsReload)
+                self.handle_backend_catalog(BackendMessage::BackendsReload)
             }
 
             // Clear secret via daemon; daemon reloads-if-active itself.
-            Message::BackendSecretRemoved { source, name } => {
+            BackendMessage::BackendSecretRemoved { source, name } => {
                 self.action_error = None;
                 self.backend_secret_inputs
                     .remove(&(source.clone(), name.clone()));
                 Task::perform(clear_backend_secret(source, name), move |res| match res {
-                    Ok(()) => cosmic::Action::App(Message::BackendsReload),
+                    Ok(()) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload)),
                     Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                 })
             }
 
-            Message::BackendOptionInputChanged {
+            BackendMessage::BackendOptionInputChanged {
                 source,
                 name,
                 value,
@@ -193,7 +207,7 @@ impl AppModel {
 
             // Options go to the daemon config. If the input is empty, clear the
             // override; otherwise set the new value. The daemon reloads-if-active.
-            Message::BackendOptionSaved { source, name } => {
+            BackendMessage::BackendOptionSaved { source, name } => {
                 self.action_error = None;
                 let value = self
                     .backend_option_inputs
@@ -202,14 +216,18 @@ impl AppModel {
                     .unwrap_or_default();
                 if value.is_empty() {
                     Task::perform(clear_backend_option(source, name), |result| match result {
-                        Ok(()) => cosmic::Action::App(Message::BackendsReload),
+                        Ok(()) => {
+                            cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload))
+                        }
                         Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                     })
                 } else {
                     Task::perform(
                         set_backend_option(source, name, value),
                         |result| match result {
-                            Ok(()) => cosmic::Action::App(Message::BackendsReload),
+                            Ok(()) => cosmic::Action::App(Message::Backend(
+                                BackendMessage::BackendsReload,
+                            )),
                             Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                         },
                     )
@@ -218,10 +236,10 @@ impl AppModel {
 
             // Explicit reset: clear the stored override and reload so the
             // option reverts to its daemon default.
-            Message::BackendOptionReset { source, name } => {
+            BackendMessage::BackendOptionReset { source, name } => {
                 self.action_error = None;
                 Task::perform(clear_backend_option(source, name), |result| match result {
-                    Ok(()) => cosmic::Action::App(Message::BackendsReload),
+                    Ok(()) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload)),
                     Err(e) => cosmic::Action::App(configure_backend_error(&e)),
                 })
             }

--- a/super-stt-app/src/core/app/handlers/daemon/events.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/events.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::{AppModel, DeviceState, ModelOperationState};
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, DeviceMessage, DownloadMessage, Message};
 use cosmic::prelude::*;
 use log::{debug, info, warn};
 use super_stt_shared::models::protocol::NotificationEvent;
@@ -10,10 +10,10 @@ use super_stt_shared::models::provider::Provider;
 impl AppModel {
     pub(in crate::core::app) fn handle_daemon_events(
         &mut self,
-        message: Message,
+        message: DaemonMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DaemonEventsReceived(events) => {
+            DaemonMessage::DaemonEventsReceived(events) => {
                 debug!("Received {} daemon events", events.len());
                 // Process EVERY event and collect their tasks. Returning on the
                 // first event that yields a task dropped the rest of the batch
@@ -42,6 +42,9 @@ impl AppModel {
             _ => Task::none(),
         }
     }
+    // ^ `handle_daemon_events` only ever receives `DaemonEventsReceived`, but it
+    // takes the full `DaemonMessage` for a uniform delegate signature; the
+    // catch-all covers the other (unreachable) variants without a panic.
 
     pub(in crate::core::app) fn process_daemon_status_event(
         &mut self,
@@ -158,7 +161,7 @@ impl AppModel {
             let error_message = error_msg.to_string();
             // Show error to user
             return Some(Task::perform(async move { error_message }, |msg| {
-                cosmic::Action::App(Message::DeviceError(msg))
+                cosmic::Action::App(Message::Device(DeviceMessage::DeviceError(msg)))
             }));
         }
         None
@@ -232,11 +235,11 @@ impl AppModel {
             // Send download completed message; model_switched event from the daemon
             // will update state if needed — no explicit reload required.
             return Some(Task::perform(async move { progress.model_name }, |model| {
-                cosmic::Action::App(Message::DownloadCompleted(model))
+                cosmic::Action::App(Message::Download(DownloadMessage::DownloadCompleted(model)))
             }));
         } else if progress.status == "cancelled" {
             return Some(Task::perform(async move { progress.model_name }, |model| {
-                cosmic::Action::App(Message::DownloadCancelled(model))
+                cosmic::Action::App(Message::Download(DownloadMessage::DownloadCancelled(model)))
             }));
         }
         None

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -10,7 +10,10 @@ use crate::daemon::client::{
     get_volume, get_write_method, ping_daemon, test_daemon_connection,
 };
 use crate::state::{AudioTheme, DaemonStatus};
-use crate::ui::messages::Message;
+use crate::ui::messages::{
+    DaemonMessage, Message, ModelMessage, PreviewTypingMessage, RecordingStopModeMessage,
+    WriteMethodMessage,
+};
 use cosmic::prelude::*;
 use log::{info, warn};
 
@@ -18,16 +21,16 @@ impl AppModel {
     /// Handle daemon connection messages
     pub(in crate::core::app) fn handle_daemon_messages(
         &mut self,
-        message: Message,
+        message: DaemonMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DaemonConnectionResult(_)
-            | Message::RefreshDaemonStatus
-            | Message::PingTimeout => self.handle_daemon_connect_result(message),
+            DaemonMessage::DaemonConnectionResult(_)
+            | DaemonMessage::RefreshDaemonStatus
+            | DaemonMessage::PingTimeout => self.handle_daemon_connect_result(message),
 
-            Message::DaemonConnected => self.handle_daemon_connected(),
+            DaemonMessage::DaemonConnected => self.handle_daemon_connected(),
 
-            Message::EventStreamConnected => {
+            DaemonMessage::EventStreamConnected => {
                 // Same connection-status handling as DaemonConnected, plus a
                 // current-model re-fetch: the live event stream is now
                 // subscribed, so re-read the daemon's authoritative model state
@@ -38,24 +41,25 @@ impl AppModel {
                 Task::batch([self.handle_daemon_connected(), self.fetch_current_model()])
             }
 
-            Message::DaemonError(_)
-            | Message::RetryConnection
-            | Message::WidgetBlocked(_)
-            | Message::RetryAuthorization => self.handle_daemon_errors_retry(message),
+            DaemonMessage::DaemonError(_)
+            | DaemonMessage::RetryConnection
+            | DaemonMessage::WidgetBlocked(_)
+            | DaemonMessage::RetryAuthorization => self.handle_daemon_errors_retry(message),
 
-            Message::CurrentAudioThemeLoaded(_)
-            | Message::VolumeLoaded(_)
-            | Message::CustomModelsDirLoaded(_) => self.handle_daemon_initial_loads(message),
+            DaemonMessage::CurrentAudioThemeLoaded(_)
+            | DaemonMessage::VolumeLoaded(_)
+            | DaemonMessage::CustomModelsDirLoaded(_) => self.handle_daemon_initial_loads(message),
 
-            Message::DaemonEventsReceived(_) => self.handle_daemon_events(message),
-
-            _ => Task::none(),
+            DaemonMessage::DaemonEventsReceived(_) => self.handle_daemon_events(message),
         }
     }
 
-    fn handle_daemon_connect_result(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_daemon_connect_result(
+        &mut self,
+        message: DaemonMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DaemonConnectionResult(result) => {
+            DaemonMessage::DaemonConnectionResult(result) => {
                 match result {
                     Ok(()) => {
                         self.daemon_status = DaemonStatus::Connected;
@@ -67,20 +71,24 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::RefreshDaemonStatus => Task::perform(test_daemon_connection(), |result| {
-                cosmic::Action::App(Message::DaemonConnectionResult(result))
-            }),
+            DaemonMessage::RefreshDaemonStatus => {
+                Task::perform(test_daemon_connection(), |result| {
+                    cosmic::Action::App(Message::Daemon(DaemonMessage::DaemonConnectionResult(
+                        result,
+                    )))
+                })
+            }
 
-            Message::PingTimeout => {
+            DaemonMessage::PingTimeout => {
                 // Surface a stalled model switch (no progress for too long)
                 // rather than letting the UI spin on the now-untimed POST.
                 self.check_switch_stall();
                 if self.daemon_status == DaemonStatus::Connected {
                     Task::perform(ping_daemon(), |result| {
-                        cosmic::Action::App(match result {
-                            Ok(_) => Message::DaemonConnected,
-                            Err(e) => Message::DaemonError(e),
-                        })
+                        cosmic::Action::App(Message::Daemon(match result {
+                            Ok(_) => DaemonMessage::DaemonConnected,
+                            Err(e) => DaemonMessage::DaemonError(e),
+                        }))
                     })
                 } else {
                     Task::none()
@@ -132,7 +140,7 @@ impl AppModel {
             // Fresh connection — drop any banner left over from before the drop.
             self.action_error = None;
             Task::batch([
-                self.handle_model_messages(Message::LoadInitialData),
+                self.handle_model_messages(ModelMessage::LoadInitialData),
                 build_load_settings_tasks(),
                 self.load_primary_language(),
             ])
@@ -141,9 +149,12 @@ impl AppModel {
         }
     }
 
-    fn handle_daemon_errors_retry(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_daemon_errors_retry(
+        &mut self,
+        message: DaemonMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DaemonError(err) => {
+            DaemonMessage::DaemonError(err) => {
                 // Route user-denied responses into the Blocked state
                 // so we don't keep pinging the daemon every 5s and
                 // re-priming its in-memory deny cache. Any other
@@ -165,28 +176,28 @@ impl AppModel {
                         async move {
                             tokio::time::sleep(delay).await;
                         },
-                        |()| cosmic::Action::App(Message::RetryConnection),
+                        |()| cosmic::Action::App(Message::Daemon(DaemonMessage::RetryConnection)),
                     )
                 }
             }
 
-            Message::RetryConnection => {
+            DaemonMessage::RetryConnection => {
                 self.daemon_status = DaemonStatus::Connecting;
                 Task::perform(ping_daemon(), |result| {
-                    cosmic::Action::App(match result {
-                        Ok(_) => Message::DaemonConnected,
-                        Err(e) => Message::DaemonError(e),
-                    })
+                    cosmic::Action::App(Message::Daemon(match result {
+                        Ok(_) => DaemonMessage::DaemonConnected,
+                        Err(e) => DaemonMessage::DaemonError(e),
+                    }))
                 })
             }
 
-            Message::WidgetBlocked(reason) => {
+            DaemonMessage::WidgetBlocked(reason) => {
                 warn!("Widget subscription blocked ({reason}); halting auto-retry");
                 self.daemon_status = DaemonStatus::Blocked(reason);
                 Task::none()
             }
 
-            Message::RetryAuthorization => {
+            DaemonMessage::RetryAuthorization => {
                 info!("Retrying authorization after user denial");
                 // Drop the cached settings token so the next
                 // session::obtain fires /auth/request and (after a
@@ -200,10 +211,10 @@ impl AppModel {
                 self.udp_restart_counter = self.udp_restart_counter.wrapping_add(1);
                 self.daemon_status = DaemonStatus::Connecting;
                 Task::perform(ping_daemon(), |result| {
-                    cosmic::Action::App(match result {
-                        Ok(_) => Message::DaemonConnected,
-                        Err(e) => Message::DaemonError(e),
-                    })
+                    cosmic::Action::App(Message::Daemon(match result {
+                        Ok(_) => DaemonMessage::DaemonConnected,
+                        Err(e) => DaemonMessage::DaemonError(e),
+                    }))
                 })
             }
 
@@ -211,9 +222,12 @@ impl AppModel {
         }
     }
 
-    fn handle_daemon_initial_loads(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_daemon_initial_loads(
+        &mut self,
+        message: DaemonMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::CurrentAudioThemeLoaded(theme) => {
+            DaemonMessage::CurrentAudioThemeLoaded(theme) => {
                 self.selected_audio_theme = theme;
                 if theme != AudioTheme::Silent {
                     self.last_non_silent_theme = theme;
@@ -221,12 +235,12 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::VolumeLoaded(vol) => {
+            DaemonMessage::VolumeLoaded(vol) => {
                 self.volume = vol;
                 Task::none()
             }
 
-            Message::CustomModelsDirLoaded(custom_path) => {
+            DaemonMessage::CustomModelsDirLoaded(custom_path) => {
                 let old_committed = self.custom_models_dir.as_deref().unwrap_or_default();
                 if self.custom_models_dir_input == old_committed {
                     self.custom_models_dir_input =
@@ -247,31 +261,41 @@ impl AppModel {
 pub(in crate::core::app) fn build_load_settings_tasks() -> Task<cosmic::Action<Message>> {
     Task::batch([
         Task::perform(get_current_audio_theme(), |result| match result {
-            Ok(theme) => cosmic::Action::App(Message::CurrentAudioThemeLoaded(theme)),
+            Ok(theme) => cosmic::Action::App(Message::Daemon(
+                DaemonMessage::CurrentAudioThemeLoaded(theme),
+            )),
             Err(e) => {
                 warn!("Failed to load audio theme: {e}");
-                cosmic::Action::App(Message::CurrentAudioThemeLoaded(AudioTheme::default()))
+                cosmic::Action::App(Message::Daemon(DaemonMessage::CurrentAudioThemeLoaded(
+                    AudioTheme::default(),
+                )))
             }
         }),
         Task::perform(get_volume(), |result| match result {
-            Ok(vol) => cosmic::Action::App(Message::VolumeLoaded(vol)),
+            Ok(vol) => cosmic::Action::App(Message::Daemon(DaemonMessage::VolumeLoaded(vol))),
             Err(e) => {
                 warn!("Failed to load volume: {e}");
-                cosmic::Action::App(Message::VolumeLoaded(100))
+                cosmic::Action::App(Message::Daemon(DaemonMessage::VolumeLoaded(100)))
             }
         }),
         Task::perform(get_custom_models_dir(), |result| match result {
-            Ok(dir) => cosmic::Action::App(Message::CustomModelsDirLoaded(dir)),
+            Ok(dir) => {
+                cosmic::Action::App(Message::Daemon(DaemonMessage::CustomModelsDirLoaded(dir)))
+            }
             Err(e) => {
                 warn!("Failed to load custom models dir: {e}");
-                cosmic::Action::App(Message::CustomModelsDirLoaded(None))
+                cosmic::Action::App(Message::Daemon(DaemonMessage::CustomModelsDirLoaded(None)))
             }
         }),
         Task::perform(get_preview_typing(), |result| match result {
-            Ok(enabled) => cosmic::Action::App(Message::PreviewTypingSettingLoaded(enabled)),
+            Ok(enabled) => cosmic::Action::App(Message::PreviewTyping(
+                PreviewTypingMessage::SettingLoaded(enabled),
+            )),
             Err(e) => {
                 log::warn!("Failed to load preview typing setting: {e}");
-                cosmic::Action::App(Message::PreviewTypingSettingLoaded(false))
+                cosmic::Action::App(Message::PreviewTyping(PreviewTypingMessage::SettingLoaded(
+                    false,
+                )))
             }
         }),
         Task::perform(get_recording_stop_mode(), |result| {
@@ -279,12 +303,14 @@ pub(in crate::core::app) fn build_load_settings_tasks() -> Task<cosmic::Action<M
             match result {
                 Ok(mode_str) => {
                     let mode = mode_str.parse::<RecordingStopMode>().unwrap_or_default();
-                    cosmic::Action::App(Message::RecordingStopModeLoaded(mode))
+                    cosmic::Action::App(Message::RecordingStopMode(
+                        RecordingStopModeMessage::Loaded(mode),
+                    ))
                 }
                 Err(e) => {
                     log::warn!("Failed to load recording stop mode: {e}");
-                    cosmic::Action::App(Message::RecordingStopModeLoaded(
-                        RecordingStopMode::default(),
+                    cosmic::Action::App(Message::RecordingStopMode(
+                        RecordingStopModeMessage::Loaded(RecordingStopMode::default()),
                     ))
                 }
             }
@@ -294,11 +320,13 @@ pub(in crate::core::app) fn build_load_settings_tasks() -> Task<cosmic::Action<M
             match result {
                 Ok(method_str) => {
                     let method = method_str.parse::<WriteMethod>().unwrap_or_default();
-                    cosmic::Action::App(Message::WriteMethodLoaded(method))
+                    cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(method)))
                 }
                 Err(e) => {
                     log::warn!("Failed to load write method: {e}");
-                    cosmic::Action::App(Message::WriteMethodLoaded(WriteMethod::default()))
+                    cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(
+                        WriteMethod::default(),
+                    )))
                 }
             }
         }),

--- a/super-stt-app/src/core/app/handlers/device.rs
+++ b/super-stt-app/src/core/app/handlers/device.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::core::app::{AppModel, DeviceState};
+use crate::core::app::{AppModel, DeviceState, ModelOperationState};
 use crate::ui::messages::{DeviceMessage, Message};
 use cosmic::prelude::*;
 use log::info;
@@ -29,8 +29,13 @@ impl AppModel {
             }
 
             DeviceMessage::DeviceError(err) => {
+                // A device switch is a Models-page operation, so surface the
+                // failure on that page's card banner rather than hijacking the
+                // Recording page's transcription box (Tier 3 #11).
                 self.device_state = DeviceState::Ready;
-                self.transcription_text = format!("Device Error: {err}");
+                self.model_operation_state = ModelOperationState::Error {
+                    message: format!("Device error: {err}"),
+                };
                 Task::none()
             }
         }

--- a/super-stt-app/src/core/app/handlers/device.rs
+++ b/super-stt-app/src/core/app/handlers/device.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::{AppModel, DeviceState};
-use crate::ui::messages::Message;
+use crate::ui::messages::{DeviceMessage, Message};
 use cosmic::prelude::*;
 use log::info;
 
@@ -9,10 +9,10 @@ impl AppModel {
     /// Handle device management messages
     pub(in crate::core::app) fn handle_device_messages(
         &mut self,
-        message: Message,
+        message: DeviceMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DeviceInfoLoaded(device, available_devices) => {
+            DeviceMessage::DeviceInfoLoaded(device, available_devices) => {
                 info!("DeviceInfoLoaded: device={device}, available_devices={available_devices:?}");
                 self.current_device.clone_from(&device);
                 self.available_devices.clone_from(&available_devices);
@@ -28,13 +28,11 @@ impl AppModel {
                 }
             }
 
-            Message::DeviceError(err) => {
+            DeviceMessage::DeviceError(err) => {
                 self.device_state = DeviceState::Ready;
                 self.transcription_text = format!("Device Error: {err}");
                 Task::none()
             }
-
-            _ => Task::none(),
         }
     }
 }

--- a/super-stt-app/src/core/app/handlers/download.rs
+++ b/super-stt-app/src/core/app/handlers/download.rs
@@ -2,7 +2,7 @@
 
 use crate::core::app::{AppModel, ModelOperationState};
 use crate::daemon::client::{cancel_download, get_download_status};
-use crate::ui::messages::Message;
+use crate::ui::messages::{DownloadMessage, Message};
 use cosmic::prelude::*;
 use log::info;
 use log::warn;
@@ -11,41 +11,48 @@ impl AppModel {
     /// Handle download progress messages
     pub(in crate::core::app) fn handle_download_messages(
         &mut self,
-        message: Message,
+        message: DownloadMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DownloadProgressUpdate(_)
-            | Message::CancelDownload
-            | Message::CheckDownloadStatus
-            | Message::NoDownloadInProgress => self.handle_download_progress(message),
+            DownloadMessage::DownloadProgressUpdate(_)
+            | DownloadMessage::CancelDownload
+            | DownloadMessage::CheckDownloadStatus
+            | DownloadMessage::NoDownloadInProgress => self.handle_download_progress(message),
 
-            Message::DownloadCompleted(_)
-            | Message::DownloadCancelled(_)
-            | Message::DownloadError { .. } => self.handle_download_completion(message),
-
-            _ => Task::none(),
+            DownloadMessage::DownloadCompleted(_)
+            | DownloadMessage::DownloadCancelled(_)
+            | DownloadMessage::DownloadError { .. } => self.handle_download_completion(message),
         }
     }
 
     /// Handle active-download messages: progress updates, cancellation requests,
     /// status polling, and the no-download-in-progress sentinel.
-    fn handle_download_progress(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_download_progress(
+        &mut self,
+        message: DownloadMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DownloadProgressUpdate(progress) => {
+            DownloadMessage::DownloadProgressUpdate(progress) => {
                 // We have an actual download in progress
                 self.apply_download_progress(&progress);
                 Task::none()
             }
 
-            Message::CancelDownload => Task::perform(cancel_download(), |result| match result {
-                Ok(_) => cosmic::Action::App(Message::DownloadCancelled(String::new())),
-                Err(e) => cosmic::Action::App(Message::DownloadError {
-                    model: String::new(),
-                    error: e.to_string(),
-                }),
-            }),
+            DownloadMessage::CancelDownload => {
+                Task::perform(cancel_download(), |result| match result {
+                    Ok(_) => cosmic::Action::App(Message::Download(
+                        DownloadMessage::DownloadCancelled(String::new()),
+                    )),
+                    Err(e) => {
+                        cosmic::Action::App(Message::Download(DownloadMessage::DownloadError {
+                            model: String::new(),
+                            error: e.to_string(),
+                        }))
+                    }
+                })
+            }
 
-            Message::CheckDownloadStatus => {
+            DownloadMessage::CheckDownloadStatus => {
                 // Only poll while a switch is actually pending. A Ready state
                 // needs no poll, and an Error state (e.g. a switch that just
                 // failed) must keep its banner rather than be cleared here.
@@ -56,18 +63,22 @@ impl AppModel {
                     Task::perform(get_download_status(), |result| match result {
                         Ok(Some(progress)) => {
                             // Download is actually happening
-                            cosmic::Action::App(Message::DownloadProgressUpdate(progress))
+                            cosmic::Action::App(Message::Download(
+                                DownloadMessage::DownloadProgressUpdate(progress),
+                            ))
                         }
                         // No download in progress (loaded from cache, or the
                         // switch failed): fall through to NoDownloadInProgress.
-                        Ok(None) | Err(_) => cosmic::Action::App(Message::NoDownloadInProgress),
+                        Ok(None) | Err(_) => cosmic::Action::App(Message::Download(
+                            DownloadMessage::NoDownloadInProgress,
+                        )),
                     })
                 } else {
                     Task::none()
                 }
             }
 
-            Message::NoDownloadInProgress => {
+            DownloadMessage::NoDownloadInProgress => {
                 // Only clear a `Downloading` state. A `Loading` state means
                 // the daemon's `set_model` HTTP call is still in flight (the
                 // subprocess might still be spawning, or the WASM component
@@ -94,15 +105,18 @@ impl AppModel {
     }
 
     /// Handle terminal download outcomes: completed, cancelled, and error.
-    fn handle_download_completion(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_download_completion(
+        &mut self,
+        message: DownloadMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::DownloadCompleted(model_name) => {
+            DownloadMessage::DownloadCompleted(model_name) => {
                 info!("Model {model_name} finished downloading");
                 // Model information will be updated via daemon events (model_switched, ready)
                 Task::none()
             }
 
-            Message::DownloadCancelled(model_name) => {
+            DownloadMessage::DownloadCancelled(model_name) => {
                 info!("Model {model_name} download was cancelled");
                 // The daemon already unloaded the previous model before
                 // the failed instantiate, so it's now idle (with the
@@ -115,7 +129,7 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::DownloadError { model, error } => {
+            DownloadMessage::DownloadError { model, error } => {
                 warn!("Download error for model {model}: {error}");
                 self.model_operation_state = ModelOperationState::Ready;
                 self.transcription_text = format!("Download Error: {error}");

--- a/super-stt-app/src/core/app/handlers/download.rs
+++ b/super-stt-app/src/core/app/handlers/download.rs
@@ -131,8 +131,11 @@ impl AppModel {
 
             DownloadMessage::DownloadError { model, error } => {
                 warn!("Download error for model {model}: {error}");
-                self.model_operation_state = ModelOperationState::Ready;
-                self.transcription_text = format!("Download Error: {error}");
+                // Surface on the Models card banner instead of hijacking the
+                // Recording page's transcription box (Tier 3 #11).
+                self.model_operation_state = ModelOperationState::Error {
+                    message: format!("Download failed: {error}"),
+                };
                 self.clear_loaded_model();
                 Task::none()
             }

--- a/super-stt-app/src/core/app/handlers/language.rs
+++ b/super-stt-app/src/core/app/handlers/language.rs
@@ -2,35 +2,35 @@
 use crate::core::app::AppModel;
 use crate::daemon::client::v1::settings::language as client;
 use crate::state::models::ContextPage;
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, LanguageMessage, Message};
 use cosmic::prelude::*;
 
 impl AppModel {
     pub(in crate::core::app) fn handle_language_messages(
         &mut self,
-        message: Message,
+        message: LanguageMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::OpenLanguagePicker { model } => {
+            LanguageMessage::OpenLanguagePicker { model } => {
                 self.language_picker_target = model;
                 self.language_picker_query.clear();
                 self.context_page = ContextPage::LanguagePicker;
                 self.core.window.show_context = true;
                 Task::none()
             }
-            Message::CloseLanguagePicker => {
+            LanguageMessage::CloseLanguagePicker => {
                 self.core.window.show_context = false;
                 Task::none()
             }
-            Message::LanguagePickerQueryChanged(q) => {
+            LanguageMessage::LanguagePickerQueryChanged(q) => {
                 self.language_picker_query = q;
                 Task::none()
             }
-            Message::PrimaryLanguageLoaded(lang) => {
+            LanguageMessage::PrimaryLanguageLoaded(lang) => {
                 self.primary_language = lang;
                 Task::none()
             }
-            Message::PrimaryLanguageSelected(choice) => {
+            LanguageMessage::PrimaryLanguageSelected(choice) => {
                 self.primary_language.clone_from(&choice);
                 self.core.window.show_context = false;
                 Task::perform(
@@ -41,12 +41,16 @@ impl AppModel {
                         }
                     },
                     |res| match res {
-                        Ok(()) => cosmic::Action::App(Message::RefreshDaemonStatus),
-                        Err(e) => cosmic::Action::App(Message::LanguageError(e.to_string())),
+                        Ok(()) => {
+                            cosmic::Action::App(Message::Daemon(DaemonMessage::RefreshDaemonStatus))
+                        }
+                        Err(e) => cosmic::Action::App(Message::Language(
+                            LanguageMessage::LanguageError(e.to_string()),
+                        )),
                     },
                 )
             }
-            Message::ModelLanguageLoaded {
+            LanguageMessage::ModelLanguageLoaded {
                 source,
                 model,
                 block,
@@ -55,7 +59,7 @@ impl AppModel {
                 self.model_language_for = Some((source, model));
                 Task::none()
             }
-            Message::ModelLanguageSelected {
+            LanguageMessage::ModelLanguageSelected {
                 source,
                 model,
                 choice,
@@ -71,20 +75,23 @@ impl AppModel {
                         }
                     },
                     move |res| match res {
-                        Ok(block) => cosmic::Action::App(Message::ModelLanguageLoaded {
-                            source: src.clone(),
-                            model: mdl.clone(),
-                            block,
-                        }),
-                        Err(e) => cosmic::Action::App(Message::LanguageError(e.to_string())),
+                        Ok(block) => cosmic::Action::App(Message::Language(
+                            LanguageMessage::ModelLanguageLoaded {
+                                source: src.clone(),
+                                model: mdl.clone(),
+                                block,
+                            },
+                        )),
+                        Err(e) => cosmic::Action::App(Message::Language(
+                            LanguageMessage::LanguageError(e.to_string()),
+                        )),
                     },
                 )
             }
-            Message::LanguageError(e) => {
+            LanguageMessage::LanguageError(e) => {
                 log::warn!("Language settings error: {e}");
                 Task::none()
             }
-            _ => Task::none(),
         }
     }
 
@@ -92,8 +99,12 @@ impl AppModel {
     #[allow(clippy::unused_self)]
     pub(in crate::core::app) fn load_primary_language(&self) -> Task<cosmic::Action<Message>> {
         Task::perform(client::get_primary_language(), |res| match res {
-            Ok(lang) => cosmic::Action::App(Message::PrimaryLanguageLoaded(lang)),
-            Err(e) => cosmic::Action::App(Message::LanguageError(e.to_string())),
+            Ok(lang) => cosmic::Action::App(Message::Language(
+                LanguageMessage::PrimaryLanguageLoaded(lang),
+            )),
+            Err(e) => cosmic::Action::App(Message::Language(LanguageMessage::LanguageError(
+                e.to_string(),
+            ))),
         })
     }
 
@@ -111,12 +122,16 @@ impl AppModel {
         Task::perform(
             client::get_model_language(source, model),
             move |res| match res {
-                Ok(block) => cosmic::Action::App(Message::ModelLanguageLoaded {
-                    source: src.clone(),
-                    model: mdl.clone(),
-                    block,
-                }),
-                Err(e) => cosmic::Action::App(Message::LanguageError(e.to_string())),
+                Ok(block) => {
+                    cosmic::Action::App(Message::Language(LanguageMessage::ModelLanguageLoaded {
+                        source: src.clone(),
+                        model: mdl.clone(),
+                        block,
+                    }))
+                }
+                Err(e) => cosmic::Action::App(Message::Language(LanguageMessage::LanguageError(
+                    e.to_string(),
+                ))),
             },
         )
     }

--- a/super-stt-app/src/core/app/handlers/language.rs
+++ b/super-stt-app/src/core/app/handlers/language.rs
@@ -89,7 +89,14 @@ impl AppModel {
                 )
             }
             LanguageMessage::LanguageError(e) => {
+                // The language picker lives on the Customization page — surface
+                // the failure on that page's banner instead of only logging it
+                // (Tier 3 #11).
                 log::warn!("Language settings error: {e}");
+                self.set_action_error(
+                    crate::state::ErrorScope::Customization,
+                    format!("Couldn't update language: {e}"),
+                );
                 Task::none()
             }
         }

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -5,7 +5,9 @@ use crate::daemon::client::{
     get_active_backend, get_current_device, get_current_model, get_gpu_info, list_available_models,
     list_backends, set_allow_online_models,
 };
-use crate::ui::messages::Message;
+use crate::ui::messages::{
+    BackendMessage, DeviceMessage, Message, ModelMessage, ModelsPageMessage,
+};
 use cosmic::prelude::*;
 use log::info;
 use log::warn;
@@ -14,17 +16,15 @@ impl AppModel {
     /// Handle model management messages
     pub(in crate::core::app) fn handle_model_messages(
         &mut self,
-        message: Message,
+        message: ModelMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::LoadInitialData => self.handle_model_load_commands(),
+            ModelMessage::LoadInitialData => self.handle_model_load_commands(),
 
-            Message::AvailableModelsLoaded(_)
-            | Message::CurrentModelLoaded { .. }
-            | Message::ModelChanged { .. }
-            | Message::ModelError(_) => self.handle_model_results(message),
-
-            _ => Task::none(),
+            ModelMessage::AvailableModelsLoaded(_)
+            | ModelMessage::CurrentModelLoaded { .. }
+            | ModelMessage::ModelChanged { .. }
+            | ModelMessage::ModelError(_) => self.handle_model_results(message),
         }
     }
 
@@ -34,8 +34,12 @@ impl AppModel {
         // One-time startup load: models + device info
         Task::batch([
             Task::perform(list_available_models(), |result| match result {
-                Ok(models) => cosmic::Action::App(Message::AvailableModelsLoaded(models)),
-                Err(e) => cosmic::Action::App(Message::ModelError(e.to_string())),
+                Ok(models) => {
+                    cosmic::Action::App(Message::Model(ModelMessage::AvailableModelsLoaded(models)))
+                }
+                Err(e) => {
+                    cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string())))
+                }
             }),
             self.fetch_current_model(),
             Task::perform(get_current_device(), |result| match result {
@@ -43,11 +47,14 @@ impl AppModel {
                     info!(
                         "Initial device load successful: device={device}, available_devices={available_devices:?}"
                     );
-                    cosmic::Action::App(Message::DeviceInfoLoaded(device, available_devices))
+                    cosmic::Action::App(Message::Device(DeviceMessage::DeviceInfoLoaded(
+                        device,
+                        available_devices,
+                    )))
                 }
                 Err(e) => {
                     warn!("Initial device load failed: {e}");
-                    cosmic::Action::App(Message::DeviceError(e.to_string()))
+                    cosmic::Action::App(Message::Device(DeviceMessage::DeviceError(e.to_string())))
                 }
             }),
             // Online backends are gated by the install-time choice to
@@ -55,27 +62,35 @@ impl AppModel {
             // ensure the daemon permits them. Fire-and-forget.
             Task::perform(set_allow_online_models(true), |_| cosmic::Action::None),
             Task::perform(list_backends(), |result| match result {
-                Ok(backends) => cosmic::Action::App(Message::BackendsLoaded(backends)),
-                Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                Ok(backends) => {
+                    cosmic::Action::App(Message::Backend(BackendMessage::BackendsLoaded(backends)))
+                }
+                Err(e) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsError(
+                    e.to_string(),
+                ))),
             }),
             Task::perform(get_active_backend(), |result| {
-                cosmic::Action::App(Message::ActiveBackendLoaded(result.unwrap_or(None)))
+                cosmic::Action::App(Message::ModelsPage(ModelsPageMessage::ActiveBackendLoaded(
+                    result.unwrap_or(None),
+                )))
             }),
             Task::perform(get_gpu_info(), |result| {
-                cosmic::Action::App(Message::GpuInfoLoaded(result.unwrap_or_default()))
+                cosmic::Action::App(Message::ModelsPage(ModelsPageMessage::GpuInfoLoaded(
+                    result.unwrap_or_default(),
+                )))
             }),
         ])
     }
 
     /// Handle model result messages: loads, changes, and errors.
-    fn handle_model_results(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_model_results(&mut self, message: ModelMessage) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::AvailableModelsLoaded(models) => {
+            ModelMessage::AvailableModelsLoaded(models) => {
                 self.available_models = models;
                 Task::none()
             }
 
-            Message::CurrentModelLoaded {
+            ModelMessage::CurrentModelLoaded {
                 model,
                 provider,
                 source,
@@ -96,7 +111,7 @@ impl AppModel {
                 self.load_model_language(source, model)
             }
 
-            Message::ModelChanged {
+            ModelMessage::ModelChanged {
                 model,
                 provider,
                 source,
@@ -114,7 +129,7 @@ impl AppModel {
                 self.load_model_language(source, model)
             }
 
-            Message::ModelError(err) => {
+            ModelMessage::ModelError(err) => {
                 warn!("Model operation failed: {err}");
                 let home = std::env::var("HOME").unwrap_or_default();
                 let sanitized = sanitize_home(&err, &home);
@@ -125,7 +140,9 @@ impl AppModel {
                 Task::none()
             }
 
-            _ => Task::none(),
+            // Startup load is driven by the sibling `handle_model_load_commands`
+            // arm; nothing to do here.
+            ModelMessage::LoadInitialData => Task::none(),
         }
     }
 
@@ -138,13 +155,15 @@ impl AppModel {
     pub(in crate::core::app) fn fetch_current_model(&self) -> Task<cosmic::Action<Message>> {
         let epoch = self.current_model_epoch;
         Task::perform(get_current_model(), move |result| match result {
-            Ok((model, provider, source)) => cosmic::Action::App(Message::CurrentModelLoaded {
-                model,
-                provider,
-                source,
-                epoch,
-            }),
-            Err(e) => cosmic::Action::App(Message::ModelError(e.to_string())),
+            Ok((model, provider, source)) => {
+                cosmic::Action::App(Message::Model(ModelMessage::CurrentModelLoaded {
+                    model,
+                    provider,
+                    source,
+                    epoch,
+                }))
+            }
+            Err(e) => cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string()))),
         })
     }
 }

--- a/super-stt-app/src/core/app/handlers/models_page/install.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/install.rs
@@ -2,58 +2,58 @@
 
 use crate::core::app::AppModel;
 use crate::daemon::client::list_backends;
-use crate::ui::messages::Message;
+use crate::ui::messages::{BackendMessage, Message, ModelsPageMessage};
 use cosmic::prelude::*;
 
 impl AppModel {
     pub(in crate::core::app) fn handle_models_install_lifecycle(
         &mut self,
-        message: Message,
+        message: ModelsPageMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
             // Registry / Download-tab messages
-            Message::InstallBackend(source) => {
+            ModelsPageMessage::InstallBackend(source) => {
                 // Clear a prior "failed to start" so the card reads "Installing…".
                 self.registry.install_errors.remove(&source);
                 let s = source.clone();
                 Task::perform(
                     async move { crate::daemon::registry::install_by_source(&s).await },
                     move |res| {
-                        cosmic::Action::App(match res {
-                            Ok(a) => Message::InstallAccepted {
+                        cosmic::Action::App(Message::ModelsPage(match res {
+                            Ok(a) => ModelsPageMessage::InstallAccepted {
                                 source: source.clone(),
                                 install_id: a.install_id,
                             },
-                            Err(e) => Message::InstallFailedToStart {
+                            Err(e) => ModelsPageMessage::InstallFailedToStart {
                                 source: source.clone(),
                                 error: e.to_string(),
                             },
-                        })
+                        }))
                     },
                 )
             }
 
-            Message::InstallBackendFromRepoUrl(url) => {
+            ModelsPageMessage::InstallBackendFromRepoUrl(url) => {
                 self.registry.install_errors.remove(&url);
                 let u = url.clone();
                 Task::perform(
                     async move { crate::daemon::registry::install_by_repo_url(&u).await },
                     move |res| {
-                        cosmic::Action::App(match res {
-                            Ok(a) => Message::InstallAccepted {
+                        cosmic::Action::App(Message::ModelsPage(match res {
+                            Ok(a) => ModelsPageMessage::InstallAccepted {
                                 source: url.clone(),
                                 install_id: a.install_id,
                             },
-                            Err(e) => Message::InstallFailedToStart {
+                            Err(e) => ModelsPageMessage::InstallFailedToStart {
                                 source: url.clone(),
                                 error: e.to_string(),
                             },
-                        })
+                        }))
                     },
                 )
             }
 
-            Message::InstallAccepted { source, install_id } => {
+            ModelsPageMessage::InstallAccepted { source, install_id } => {
                 use crate::state::registry::InstallStatus;
                 use super_stt_shared::registry::events::InstallPhase;
                 // The request was accepted — retire any prior start error.
@@ -71,7 +71,7 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::InstallFailedToStart { source, error } => {
+            ModelsPageMessage::InstallFailedToStart { source, error } => {
                 log::error!("install({source}) failed to start: {error}");
                 // Drop the pending marker (there is no background install) and
                 // record the reason so the Browse card shows "Failed" + a note
@@ -81,7 +81,7 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::UpdateBackend(source) => {
+            ModelsPageMessage::UpdateBackend(source) => {
                 self.registry.install_errors.remove(&source);
                 let s = source.clone();
                 Task::perform(
@@ -91,16 +91,18 @@ impl AppModel {
                             Ok(r) if r.noop => {
                                 log::info!("update({source}) noop — already at {}", r.to_version);
                                 // Nothing to do; let the UI settle naturally.
-                                Message::BackendsReload
+                                Message::Backend(BackendMessage::BackendsReload)
                             }
-                            Ok(r) => Message::InstallAccepted {
+                            Ok(r) => Message::ModelsPage(ModelsPageMessage::InstallAccepted {
                                 source: source.clone(),
                                 install_id: r.install_id.unwrap_or_default(),
-                            },
-                            Err(e) => Message::InstallFailedToStart {
-                                source: source.clone(),
-                                error: e.to_string(),
-                            },
+                            }),
+                            Err(e) => {
+                                Message::ModelsPage(ModelsPageMessage::InstallFailedToStart {
+                                    source: source.clone(),
+                                    error: e.to_string(),
+                                })
+                            }
                         })
                     },
                 )
@@ -113,10 +115,10 @@ impl AppModel {
     /// Uninstall lifecycle: kick off the request and surface its failure.
     pub(in crate::core::app) fn handle_models_uninstall(
         &mut self,
-        message: Message,
+        message: ModelsPageMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::UninstallBackend(source) => {
+            ModelsPageMessage::UninstallBackend(source) => {
                 // Clear any stale failure so the row reads "in progress" on retry.
                 self.registry.uninstall_errors.remove(&source);
                 let s = source.clone();
@@ -124,17 +126,17 @@ impl AppModel {
                     async move { crate::daemon::registry::uninstall(&s).await },
                     move |res| {
                         cosmic::Action::App(match res {
-                            Ok(_) => Message::BackendsReload,
-                            Err(error) => Message::UninstallFailed {
+                            Ok(_) => Message::Backend(BackendMessage::BackendsReload),
+                            Err(error) => Message::ModelsPage(ModelsPageMessage::UninstallFailed {
                                 source: source.clone(),
                                 error: error.to_string(),
-                            },
+                            }),
                         })
                     },
                 )
             }
 
-            Message::UninstallFailed { source, error } => {
+            ModelsPageMessage::UninstallFailed { source, error } => {
                 log::error!("uninstall({source}) failed: {error}");
                 self.registry.uninstall_errors.insert(source, error);
                 Task::none()
@@ -146,10 +148,10 @@ impl AppModel {
 
     pub(in crate::core::app) fn handle_models_install_progress(
         &mut self,
-        message: Message,
+        message: ModelsPageMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::InstallProgress {
+            ModelsPageMessage::InstallProgress {
                 install_id,
                 source,
                 phase,
@@ -170,18 +172,22 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::InstallCompleted { source } => {
+            ModelsPageMessage::InstallCompleted { source } => {
                 self.registry.installs.remove(&source);
                 self.registry.install_errors.remove(&source);
                 // Refresh the installed-backends list so the new install
                 // shows up in the Installed tab.
                 Task::perform(list_backends(), |result| match result {
-                    Ok(backends) => cosmic::Action::App(Message::BackendsLoaded(backends)),
-                    Err(e) => cosmic::Action::App(Message::BackendsError(e.to_string())),
+                    Ok(backends) => cosmic::Action::App(Message::Backend(
+                        BackendMessage::BackendsLoaded(backends),
+                    )),
+                    Err(e) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsError(
+                        e.to_string(),
+                    ))),
                 })
             }
 
-            Message::InstallFailed {
+            ModelsPageMessage::InstallFailed {
                 install_id,
                 source,
                 phase,

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -9,7 +9,7 @@ use crate::daemon::client::{
     unload_active_model,
 };
 use crate::state::{ContextPage, DaemonStatus, ModelsTab};
-use crate::ui::messages::Message;
+use crate::ui::messages::{DownloadMessage, Message, ModelMessage, ModelsPageMessage};
 use cosmic::prelude::*;
 use log::debug;
 
@@ -18,56 +18,61 @@ impl AppModel {
     /// configuration sub-view, and the (UI-only) download actions.
     pub(in crate::core::app) fn handle_models_page_messages(
         &mut self,
-        message: Message,
+        message: ModelsPageMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::ModelsTabActivated(_)
-            | Message::StageActiveModel(_)
-            | Message::StageActiveDevice(_)
-            | Message::LoadStagedModel
-            | Message::UnloadActiveModel => self.handle_models_tab_selection(message),
+            ModelsPageMessage::ModelsTabActivated(_)
+            | ModelsPageMessage::StageActiveModel(_)
+            | ModelsPageMessage::StageActiveDevice(_)
+            | ModelsPageMessage::LoadStagedModel
+            | ModelsPageMessage::UnloadActiveModel => self.handle_models_tab_selection(message),
 
-            Message::OpenBackendConfig(_)
-            | Message::CloseBackendConfig
-            | Message::SelectBackend(_)
-            | Message::DeselectBackend
-            | Message::ActiveBackendLoaded(_)
-            | Message::RefreshGpuInfo
-            | Message::GpuInfoLoaded(_)
-            | Message::ToggleInstalledMenu(_)
-            | Message::CloseInstalledMenu => self.handle_models_backend_config(message),
+            ModelsPageMessage::OpenBackendConfig(_)
+            | ModelsPageMessage::CloseBackendConfig
+            | ModelsPageMessage::SelectBackend(_)
+            | ModelsPageMessage::DeselectBackend
+            | ModelsPageMessage::ActiveBackendLoaded(_)
+            | ModelsPageMessage::RefreshGpuInfo
+            | ModelsPageMessage::GpuInfoLoaded(_)
+            | ModelsPageMessage::ToggleInstalledMenu(_)
+            | ModelsPageMessage::CloseInstalledMenu => self.handle_models_backend_config(message),
 
-            Message::InstallBackend(_)
-            | Message::InstallBackendFromRepoUrl(_)
-            | Message::InstallAccepted { .. }
-            | Message::InstallFailedToStart { .. }
-            | Message::UpdateBackend(_) => self.handle_models_install_lifecycle(message),
+            ModelsPageMessage::InstallBackend(_)
+            | ModelsPageMessage::InstallBackendFromRepoUrl(_)
+            | ModelsPageMessage::InstallAccepted { .. }
+            | ModelsPageMessage::InstallFailedToStart { .. }
+            | ModelsPageMessage::UpdateBackend(_) => self.handle_models_install_lifecycle(message),
 
-            Message::UninstallBackend(_) | Message::UninstallFailed { .. } => {
+            ModelsPageMessage::UninstallBackend(_) | ModelsPageMessage::UninstallFailed { .. } => {
                 self.handle_models_uninstall(message)
             }
 
-            Message::InstallProgress { .. }
-            | Message::InstallCompleted { .. }
-            | Message::InstallFailed { .. } => self.handle_models_install_progress(message),
+            ModelsPageMessage::InstallProgress { .. }
+            | ModelsPageMessage::InstallCompleted { .. }
+            | ModelsPageMessage::InstallFailed { .. } => {
+                self.handle_models_install_progress(message)
+            }
 
-            Message::RefreshRegistry
-            | Message::RegistryListLoaded(_)
-            | Message::RegistryListFailed(_)
-            | Message::RegistrySearchChanged(_)
-            | Message::RegistryIncludeIncompatible(_)
-            | Message::RegistryOnlineFilter(_)
-            | Message::ImportBackendFromDir
-            | Message::ImportBackendFromDirPicked(_)
-            | Message::RegistryCustomRepoInputChanged(_) => self.handle_models_registry(message),
-
-            _ => Task::none(),
+            ModelsPageMessage::RefreshRegistry
+            | ModelsPageMessage::RegistryListLoaded(_)
+            | ModelsPageMessage::RegistryListFailed(_)
+            | ModelsPageMessage::RegistrySearchChanged(_)
+            | ModelsPageMessage::RegistryIncludeIncompatible(_)
+            | ModelsPageMessage::RegistryOnlineFilter(_)
+            | ModelsPageMessage::ImportBackendFromDir
+            | ModelsPageMessage::ImportBackendFromDirPicked(_)
+            | ModelsPageMessage::RegistryCustomRepoInputChanged(_) => {
+                self.handle_models_registry(message)
+            }
         }
     }
 
-    fn handle_models_tab_selection(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_models_tab_selection(
+        &mut self,
+        message: ModelsPageMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::ModelsTabActivated(entity) => {
+            ModelsPageMessage::ModelsTabActivated(entity) => {
                 self.models_tabs.activate(entity);
                 // Trigger initial registry fetch when the Download tab is opened
                 // for the first time (backends empty and no prior refresh attempt).
@@ -88,17 +93,17 @@ impl AppModel {
                     return Task::perform(
                         async move { crate::daemon::registry::list(&filters).await },
                         |r| {
-                            cosmic::Action::App(match r {
-                                Ok(resp) => Message::RegistryListLoaded(resp),
-                                Err(e) => Message::RegistryListFailed(e.to_string()),
-                            })
+                            cosmic::Action::App(Message::ModelsPage(match r {
+                                Ok(resp) => ModelsPageMessage::RegistryListLoaded(resp),
+                                Err(e) => ModelsPageMessage::RegistryListFailed(e.to_string()),
+                            }))
                         },
                     );
                 }
                 Task::none()
             }
 
-            Message::StageActiveModel(model) => {
+            ModelsPageMessage::StageActiveModel(model) => {
                 // Stage the pick. The Load button reads `staged_model` /
                 // `staged_device` and only then calls the daemon. Default the
                 // device to the model's first supported entry (so a single-
@@ -128,14 +133,14 @@ impl AppModel {
                 }
             }
 
-            Message::StageActiveDevice(device) => {
+            ModelsPageMessage::StageActiveDevice(device) => {
                 self.staged_device = Some(device);
                 Task::none()
             }
 
-            Message::LoadStagedModel => self.handle_load_staged_model(),
+            ModelsPageMessage::LoadStagedModel => self.handle_load_staged_model(),
 
-            Message::UnloadActiveModel => {
+            ModelsPageMessage::UnloadActiveModel => {
                 // Drop the loaded model but keep the backend selected.
                 // Optimistic clear so the UI returns to the staged-pickers
                 // state immediately; the daemon's `ready` event with
@@ -146,7 +151,9 @@ impl AppModel {
                 self.model_operation_state = ModelOperationState::Ready;
                 Task::perform(unload_active_model(), |result| match result {
                     Ok(_) => cosmic::Action::None,
-                    Err(e) => cosmic::Action::App(Message::ModelError(e.to_string())),
+                    Err(e) => {
+                        cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string())))
+                    }
                 })
             }
 
@@ -208,26 +215,31 @@ impl AppModel {
                     set_model(model, provider, source).await.map(|_| ())
                 },
                 move |result| match result {
-                    Ok(()) => cosmic::Action::App(Message::ModelChanged {
+                    Ok(()) => cosmic::Action::App(Message::Model(ModelMessage::ModelChanged {
                         model: model_label.clone(),
                         provider: provider_label.clone(),
                         source: source_label.clone(),
-                    }),
-                    Err(e) => cosmic::Action::App(Message::ModelError(e.to_string())),
+                    })),
+                    Err(e) => {
+                        cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string())))
+                    }
                 },
             ),
             Task::perform(
                 async {
                     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
                 },
-                |()| cosmic::Action::App(Message::CheckDownloadStatus),
+                |()| cosmic::Action::App(Message::Download(DownloadMessage::CheckDownloadStatus)),
             ),
         ])
     }
 
-    fn handle_models_backend_config(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_models_backend_config(
+        &mut self,
+        message: ModelsPageMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::OpenBackendConfig(source) => {
+            ModelsPageMessage::OpenBackendConfig(source) => {
                 // Open the per-backend configuration as a right-side sheet over
                 // the current list (active card or Installed tab), instead of a
                 // full-page takeover. Also closes the card's overflow menu.
@@ -240,37 +252,39 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::CloseBackendConfig => {
+            ModelsPageMessage::CloseBackendConfig => {
                 self.configure_backend = None;
                 self.core.window.show_context = false;
                 self.action_error = None;
                 Task::none()
             }
 
-            Message::ActiveBackendLoaded(source) => {
+            ModelsPageMessage::ActiveBackendLoaded(source) => {
                 self.active_backend = source;
                 Task::none()
             }
 
-            Message::RefreshGpuInfo => {
+            ModelsPageMessage::RefreshGpuInfo => {
                 // Periodic poll — only query when connected so the disconnected
                 // state doesn't spam failing requests.
                 if self.daemon_status == DaemonStatus::Connected {
                     Task::perform(get_gpu_info(), |result| {
-                        cosmic::Action::App(Message::GpuInfoLoaded(result.unwrap_or_default()))
+                        cosmic::Action::App(Message::ModelsPage(ModelsPageMessage::GpuInfoLoaded(
+                            result.unwrap_or_default(),
+                        )))
                     })
                 } else {
                     Task::none()
                 }
             }
 
-            Message::GpuInfoLoaded(gpus) => {
+            ModelsPageMessage::GpuInfoLoaded(gpus) => {
                 debug!("GpuInfoLoaded: storing {} GPU(s) in app state", gpus.len());
                 self.gpu_info = gpus;
                 Task::none()
             }
 
-            Message::SelectBackend(source) => {
+            ModelsPageMessage::SelectBackend(source) => {
                 // Select the backend WITHOUT loading a model — the card moves
                 // to the top fixed header, any model from a different backend
                 // is unloaded. (`set_model` is the way to also load a model.)
@@ -285,11 +299,13 @@ impl AppModel {
                 self.core.window.show_context = false;
                 Task::perform(set_active_backend(source), |result| match result {
                     Ok(()) => cosmic::Action::None,
-                    Err(e) => cosmic::Action::App(Message::ModelError(e.to_string())),
+                    Err(e) => {
+                        cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string())))
+                    }
                 })
             }
 
-            Message::DeselectBackend => {
+            ModelsPageMessage::DeselectBackend => {
                 // Optimistically clear the active backend + loaded model; the
                 // daemon goes idle. (Rejected only mid-recording — an edge case
                 // that self-heals on the next refresh.)
@@ -302,7 +318,7 @@ impl AppModel {
                 Task::perform(clear_active_backend(), |_| cosmic::Action::None)
             }
 
-            Message::ToggleInstalledMenu(source) => {
+            ModelsPageMessage::ToggleInstalledMenu(source) => {
                 // Toggle this card's overflow menu; opening one closes any other.
                 if self.installed_menu_open.as_deref() == Some(source.as_str()) {
                     self.installed_menu_open = None;
@@ -312,7 +328,7 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::CloseInstalledMenu => {
+            ModelsPageMessage::CloseInstalledMenu => {
                 self.installed_menu_open = None;
                 Task::none()
             }

--- a/super-stt-app/src/core/app/handlers/models_page/registry.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/registry.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::AppModel;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ModelsPageMessage};
 use cosmic::prelude::*;
 
 impl AppModel {
     pub(in crate::core::app) fn handle_models_registry(
         &mut self,
-        message: Message,
+        message: ModelsPageMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::RefreshRegistry => {
+            ModelsPageMessage::RefreshRegistry => {
                 // Always fetch the full annotated catalog; filtering is
                 // client-side so the toggles never need a round-trip.
                 let filters = crate::daemon::registry::ListFilters {
@@ -23,45 +23,45 @@ impl AppModel {
                         crate::daemon::registry::list(&filters).await
                     },
                     |r| {
-                        cosmic::Action::App(match r {
-                            Ok(resp) => Message::RegistryListLoaded(resp),
-                            Err(e) => Message::RegistryListFailed(e.to_string()),
-                        })
+                        cosmic::Action::App(Message::ModelsPage(match r {
+                            Ok(resp) => ModelsPageMessage::RegistryListLoaded(resp),
+                            Err(e) => ModelsPageMessage::RegistryListFailed(e.to_string()),
+                        }))
                     },
                 )
             }
 
-            Message::RegistryListLoaded(resp) => {
+            ModelsPageMessage::RegistryListLoaded(resp) => {
                 self.registry.backends = resp.backends;
                 self.registry.generated_at = Some(resp.generated_at);
                 self.registry.last_refresh = Some(crate::state::registry::RefreshOutcome::Ok);
                 Task::none()
             }
 
-            Message::RegistryListFailed(err) => {
+            ModelsPageMessage::RegistryListFailed(err) => {
                 self.registry.last_refresh =
                     Some(crate::state::registry::RefreshOutcome::Failed(err));
                 Task::none()
             }
 
-            Message::RegistrySearchChanged(s) => {
+            ModelsPageMessage::RegistrySearchChanged(s) => {
                 self.registry.filters.search = s;
                 Task::none()
             }
 
-            Message::RegistryIncludeIncompatible(b) => {
+            ModelsPageMessage::RegistryIncludeIncompatible(b) => {
                 // The full catalog (incl. incompatible entries) is already
                 // fetched; this is a pure client-side filter.
                 self.registry.filters.include_incompatible = b;
                 Task::none()
             }
 
-            Message::RegistryOnlineFilter(o) => {
+            ModelsPageMessage::RegistryOnlineFilter(o) => {
                 self.registry.filters.online = o;
                 Task::none()
             }
 
-            Message::ImportBackendFromDir => Task::perform(
+            ModelsPageMessage::ImportBackendFromDir => Task::perform(
                 async {
                     rfd::AsyncFileDialog::new()
                         .set_title("Import backend directory")
@@ -69,10 +69,14 @@ impl AppModel {
                         .await
                         .map(|h| h.path().to_string_lossy().into_owned())
                 },
-                |picked| cosmic::Action::App(Message::ImportBackendFromDirPicked(picked)),
+                |picked| {
+                    cosmic::Action::App(Message::ModelsPage(
+                        ModelsPageMessage::ImportBackendFromDirPicked(picked),
+                    ))
+                },
             ),
 
-            Message::ImportBackendFromDirPicked(picked) => {
+            ModelsPageMessage::ImportBackendFromDirPicked(picked) => {
                 let Some(path) = picked else {
                     // User cancelled the picker — nothing to do.
                     return Task::none();
@@ -81,21 +85,21 @@ impl AppModel {
                 Task::perform(
                     async move { crate::daemon::registry::install_by_local_path(&path).await },
                     move |res| {
-                        cosmic::Action::App(match res {
-                            Ok(a) => Message::InstallAccepted {
+                        cosmic::Action::App(Message::ModelsPage(match res {
+                            Ok(a) => ModelsPageMessage::InstallAccepted {
                                 source: key.clone(),
                                 install_id: a.install_id,
                             },
-                            Err(e) => Message::InstallFailedToStart {
+                            Err(e) => ModelsPageMessage::InstallFailedToStart {
                                 source: key.clone(),
                                 error: e.to_string(),
                             },
-                        })
+                        }))
                     },
                 )
             }
 
-            Message::RegistryCustomRepoInputChanged(s) => {
+            ModelsPageMessage::RegistryCustomRepoInputChanged(s) => {
                 self.registry.custom_repo_input = s;
                 Task::none()
             }

--- a/super-stt-app/src/core/app/handlers/recording.rs
+++ b/super-stt-app/src/core/app/handlers/recording.rs
@@ -104,7 +104,7 @@ impl AppModel {
         match message {
             RecordingMessage::AudioFeedbackToggled(enabled) => {
                 // Clear any stale Customization banner as the user retries.
-                self.action_error = None;
+                self.clear_action_error(ErrorScope::Customization);
                 let theme = if enabled {
                     self.last_non_silent_theme
                 } else {
@@ -123,7 +123,7 @@ impl AppModel {
             }
 
             RecordingMessage::AudioThemeSelected(theme) => {
-                self.action_error = None;
+                self.clear_action_error(ErrorScope::Customization);
                 self.selected_audio_theme = theme;
                 if theme != AudioTheme::Silent {
                     self.last_non_silent_theme = theme;
@@ -148,7 +148,7 @@ impl AppModel {
             }
 
             RecordingMessage::VolumeCommit => {
-                self.action_error = None;
+                self.clear_action_error(ErrorScope::Customization);
                 Task::perform(set_volume(self.volume), |result| match result {
                     Ok(()) => cosmic::Action::None,
                     Err(e) => cosmic::Action::App(customization_error(&e)),

--- a/super-stt-app/src/core/app/handlers/recording.rs
+++ b/super-stt-app/src/core/app/handlers/recording.rs
@@ -6,7 +6,7 @@ use crate::daemon::client::{
     stop_record_command,
 };
 use crate::state::{AudioTheme, ErrorScope, RecordingStatus};
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, RecordingMessage};
 use cosmic::prelude::*;
 use futures_util::StreamExt;
 use super_stt_shared::daemon::http_client::HttpError;
@@ -23,30 +23,31 @@ impl AppModel {
     /// Route recording/audio messages to the appropriate helper.
     pub(in crate::core::app) fn handle_recording_messages(
         &mut self,
-        message: Message,
+        message: RecordingMessage,
     ) -> Task<cosmic::Action<Message>> {
         match &message {
-            Message::StartRecording
-            | Message::StopRecording
-            | Message::PreviewTextReceived(_)
-            | Message::TranscriptionReceived(_) => self.handle_recording_control(message),
+            RecordingMessage::StartRecording
+            | RecordingMessage::StopRecording
+            | RecordingMessage::PreviewTextReceived(_)
+            | RecordingMessage::TranscriptionReceived(_) => self.handle_recording_control(message),
 
-            Message::AudioFeedbackToggled(_)
-            | Message::AudioThemeSelected(_)
-            | Message::AudioThemesLoaded(_)
-            | Message::VolumeChanged(_)
-            | Message::VolumeCommit
-            | Message::WidgetAudioLevel { .. }
-            | Message::WidgetRecordingState(_) => self.handle_audio_messages(message),
-
-            _ => Task::none(),
+            RecordingMessage::AudioFeedbackToggled(_)
+            | RecordingMessage::AudioThemeSelected(_)
+            | RecordingMessage::AudioThemesLoaded(_)
+            | RecordingMessage::VolumeChanged(_)
+            | RecordingMessage::VolumeCommit
+            | RecordingMessage::WidgetAudioLevel { .. }
+            | RecordingMessage::WidgetRecordingState(_) => self.handle_audio_messages(message),
         }
     }
 
     /// Handle recording control messages: start/stop recording and transcription results.
-    fn handle_recording_control(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_recording_control(
+        &mut self,
+        message: RecordingMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::StartRecording => {
+            RecordingMessage::StartRecording => {
                 if matches!(self.recording_status, RecordingStatus::Recording) {
                     return Task::none();
                 }
@@ -56,31 +57,31 @@ impl AppModel {
 
                 let stream = record_command_stream();
                 cosmic::task::stream(stream.map(|event| match event {
-                    RecordEvent::Preview(text) => {
-                        cosmic::Action::App(Message::PreviewTextReceived(text))
-                    }
-                    RecordEvent::Final(Ok(text)) => {
-                        cosmic::Action::App(Message::TranscriptionReceived(text))
-                    }
-                    RecordEvent::Final(Err(e)) => {
-                        cosmic::Action::App(Message::TranscriptionReceived(format!("Error: {e}")))
-                    }
+                    RecordEvent::Preview(text) => cosmic::Action::App(Message::Recording(
+                        RecordingMessage::PreviewTextReceived(text),
+                    )),
+                    RecordEvent::Final(Ok(text)) => cosmic::Action::App(Message::Recording(
+                        RecordingMessage::TranscriptionReceived(text),
+                    )),
+                    RecordEvent::Final(Err(e)) => cosmic::Action::App(Message::Recording(
+                        RecordingMessage::TranscriptionReceived(format!("Error: {e}")),
+                    )),
                 }))
             }
 
-            Message::StopRecording => Task::perform(stop_record_command(), |result| {
+            RecordingMessage::StopRecording => Task::perform(stop_record_command(), |result| {
                 if let Err(e) = result {
                     log::warn!("Stop recording failed: {e}");
                 }
                 cosmic::Action::None
             }),
 
-            Message::PreviewTextReceived(text) => {
+            RecordingMessage::PreviewTextReceived(text) => {
                 self.transcription_text = text;
                 Task::none()
             }
 
-            Message::TranscriptionReceived(text) => {
+            RecordingMessage::TranscriptionReceived(text) => {
                 log::info!(
                     "TranscriptionReceived: '{}'",
                     text.chars().take(50).collect::<String>()
@@ -96,9 +97,12 @@ impl AppModel {
     }
 
     /// Handle audio-level, theme, and volume messages.
-    fn handle_audio_messages(&mut self, message: Message) -> Task<cosmic::Action<Message>> {
+    fn handle_audio_messages(
+        &mut self,
+        message: RecordingMessage,
+    ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::AudioFeedbackToggled(enabled) => {
+            RecordingMessage::AudioFeedbackToggled(enabled) => {
                 // Clear any stale Customization banner as the user retries.
                 self.action_error = None;
                 let theme = if enabled {
@@ -118,7 +122,7 @@ impl AppModel {
                 })
             }
 
-            Message::AudioThemeSelected(theme) => {
+            RecordingMessage::AudioThemeSelected(theme) => {
                 self.action_error = None;
                 self.selected_audio_theme = theme;
                 if theme != AudioTheme::Silent {
@@ -130,12 +134,12 @@ impl AppModel {
                 })
             }
 
-            Message::AudioThemesLoaded(themes) => {
+            RecordingMessage::AudioThemesLoaded(themes) => {
                 self.audio_themes = themes;
                 Task::none()
             }
 
-            Message::VolumeChanged(vol) => {
+            RecordingMessage::VolumeChanged(vol) => {
                 // Drag tick: update the slider locally only. The daemon POST is
                 // deferred to VolumeCommit (on release) so a drag doesn't fire
                 // one set_volume per tick (Tier 1 #19).
@@ -143,7 +147,7 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::VolumeCommit => {
+            RecordingMessage::VolumeCommit => {
                 self.action_error = None;
                 Task::perform(set_volume(self.volume), |result| match result {
                     Ok(()) => cosmic::Action::None,
@@ -151,14 +155,14 @@ impl AppModel {
                 })
             }
 
-            Message::WidgetAudioLevel { level, is_speech } => {
+            RecordingMessage::WidgetAudioLevel { level, is_speech } => {
                 self.last_udp_data = std::time::Instant::now();
                 self.audio_level = level;
                 self.is_speech_detected = is_speech;
                 Task::none()
             }
 
-            Message::WidgetRecordingState(is_recording) => {
+            RecordingMessage::WidgetRecordingState(is_recording) => {
                 self.last_udp_data = std::time::Instant::now();
                 self.recording_status = if is_recording {
                     RecordingStatus::Recording

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -2,106 +2,112 @@
 
 use crate::core::app::AppModel;
 use crate::daemon::client::{set_preview_typing, set_recording_stop_mode, set_write_method};
-use crate::ui::messages::Message;
+use crate::ui::messages::{
+    Message, PreviewTypingMessage, RecordingStopModeMessage, WriteMethodMessage,
+};
 use cosmic::prelude::*;
 
 impl AppModel {
     /// Handle preview typing messages
     pub(in crate::core::app) fn handle_preview_typing_messages(
         &mut self,
-        message: Message,
+        message: PreviewTypingMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
             // Confirm-then-apply: the local value is set only when the daemon
             // acks the save (via `PreviewTypingSettingLoaded`). A failed POST
             // therefore leaves the toggle on its old, correct value instead of
             // stranding an un-rolled-back optimistic one (Tier 1 #15).
-            Message::PreviewTypingToggled(enabled) => {
+            PreviewTypingMessage::Toggled(enabled) => {
                 Task::perform(set_preview_typing(enabled), move |result| match result {
-                    Ok(()) => cosmic::Action::App(Message::PreviewTypingSettingLoaded(enabled)),
-                    Err(e) => cosmic::Action::App(Message::PreviewTypingError(e.to_string())),
+                    Ok(()) => cosmic::Action::App(Message::PreviewTyping(
+                        PreviewTypingMessage::SettingLoaded(enabled),
+                    )),
+                    Err(e) => cosmic::Action::App(Message::PreviewTyping(
+                        PreviewTypingMessage::Error(e.to_string()),
+                    )),
                 })
             }
 
-            Message::PreviewTypingSettingLoaded(enabled) => {
+            PreviewTypingMessage::SettingLoaded(enabled) => {
                 self.preview_typing_enabled = enabled;
                 Task::none()
             }
 
-            Message::PreviewTypingError(err) => {
+            PreviewTypingMessage::Error(err) => {
                 // The toggle already reflects the daemon's last-known value (we
                 // never applied optimistically), so just log — no transcription
                 // box abuse.
                 log::warn!("Preview typing error: {err}");
                 Task::none()
             }
-
-            _ => Task::none(),
         }
     }
 
     /// Handle recording stop mode messages
     pub(in crate::core::app) fn handle_recording_stop_mode_messages(
         &mut self,
-        message: Message,
+        message: RecordingStopModeMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
             // Confirm-then-apply (see `PreviewTypingToggled`): apply only on the
             // daemon ack so a failed save doesn't strand an optimistic value.
-            Message::RecordingStopModeChanged(mode) => {
+            RecordingStopModeMessage::Changed(mode) => {
                 let mode_str = mode.to_string();
                 Task::perform(
                     set_recording_stop_mode(mode_str),
                     move |result| match result {
-                        Ok(()) => cosmic::Action::App(Message::RecordingStopModeLoaded(mode)),
-                        Err(e) => {
-                            cosmic::Action::App(Message::RecordingStopModeError(e.to_string()))
-                        }
+                        Ok(()) => cosmic::Action::App(Message::RecordingStopMode(
+                            RecordingStopModeMessage::Loaded(mode),
+                        )),
+                        Err(e) => cosmic::Action::App(Message::RecordingStopMode(
+                            RecordingStopModeMessage::Error(e.to_string()),
+                        )),
                     },
                 )
             }
 
-            Message::RecordingStopModeLoaded(mode) => {
+            RecordingStopModeMessage::Loaded(mode) => {
                 self.recording_stop_mode = mode;
                 Task::none()
             }
 
-            Message::RecordingStopModeError(err) => {
+            RecordingStopModeMessage::Error(err) => {
                 log::warn!("Recording stop mode error: {err}");
                 Task::none()
             }
-
-            _ => Task::none(),
         }
     }
 
     /// Handle write method messages
     pub(in crate::core::app) fn handle_write_method_messages(
         &mut self,
-        message: Message,
+        message: WriteMethodMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
             // Confirm-then-apply (see `PreviewTypingToggled`): apply only on the
             // daemon ack so a failed save doesn't strand an optimistic value.
-            Message::WriteMethodChanged(method) => {
+            WriteMethodMessage::Changed(method) => {
                 let method_str = method.to_string();
                 Task::perform(set_write_method(method_str), move |result| match result {
-                    Ok(()) => cosmic::Action::App(Message::WriteMethodLoaded(method)),
-                    Err(e) => cosmic::Action::App(Message::WriteMethodError(e.to_string())),
+                    Ok(()) => cosmic::Action::App(Message::WriteMethod(
+                        WriteMethodMessage::Loaded(method),
+                    )),
+                    Err(e) => cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Error(
+                        e.to_string(),
+                    ))),
                 })
             }
 
-            Message::WriteMethodLoaded(method) => {
+            WriteMethodMessage::Loaded(method) => {
                 self.write_method = method;
                 Task::none()
             }
 
-            Message::WriteMethodError(err) => {
+            WriteMethodMessage::Error(err) => {
                 log::warn!("Write method error: {err}");
                 Task::none()
             }
-
-            _ => Task::none(),
         }
     }
 }

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -31,14 +31,20 @@ impl AppModel {
 
             PreviewTypingMessage::SettingLoaded(enabled) => {
                 self.preview_typing_enabled = enabled;
+                self.clear_action_error(crate::state::ErrorScope::Recording);
                 Task::none()
             }
 
             PreviewTypingMessage::Error(err) => {
                 // The toggle already reflects the daemon's last-known value (we
-                // never applied optimistically), so just log — no transcription
-                // box abuse.
+                // never applied optimistically), so there's nothing to roll back
+                // — surface the failure on the Recording page's banner instead of
+                // only logging it (Tier 3 #11).
                 log::warn!("Preview typing error: {err}");
+                self.set_action_error(
+                    crate::state::ErrorScope::Recording,
+                    format!("Couldn't save preview typing: {err}"),
+                );
                 Task::none()
             }
         }
@@ -69,11 +75,16 @@ impl AppModel {
 
             RecordingStopModeMessage::Loaded(mode) => {
                 self.recording_stop_mode = mode;
+                self.clear_action_error(crate::state::ErrorScope::Recording);
                 Task::none()
             }
 
             RecordingStopModeMessage::Error(err) => {
                 log::warn!("Recording stop mode error: {err}");
+                self.set_action_error(
+                    crate::state::ErrorScope::Recording,
+                    format!("Couldn't save recording stop mode: {err}"),
+                );
                 Task::none()
             }
         }
@@ -101,11 +112,16 @@ impl AppModel {
 
             WriteMethodMessage::Loaded(method) => {
                 self.write_method = method;
+                self.clear_action_error(crate::state::ErrorScope::InputSimulation);
                 Task::none()
             }
 
             WriteMethodMessage::Error(err) => {
                 log::warn!("Write method error: {err}");
+                self.set_action_error(
+                    crate::state::ErrorScope::InputSimulation,
+                    format!("Couldn't save write method: {err}"),
+                );
                 Task::none()
             }
         }

--- a/super-stt-app/src/core/app/handlers/shell.rs
+++ b/super-stt-app/src/core/app/handlers/shell.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::AppModel;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ShellMessage};
 use crate::ui::views;
 use cosmic::prelude::*;
 
@@ -9,15 +9,15 @@ impl AppModel {
     /// Handle template/shell messages: URL opening, context page toggles, and URL launching.
     pub(in crate::core::app) fn handle_shell_messages(
         &mut self,
-        message: Message,
+        message: ShellMessage,
     ) -> Task<cosmic::Action<Message>> {
         match message {
-            Message::OpenRepositoryUrl => {
+            ShellMessage::OpenRepositoryUrl => {
                 _ = open::that_detached(views::about::REPOSITORY);
                 Task::none()
             }
 
-            Message::ToggleContextPage(context_page) => {
+            ShellMessage::ToggleContextPage(context_page) => {
                 if self.context_page == context_page {
                     self.core.window.show_context = !self.core.window.show_context;
                 } else {
@@ -27,7 +27,7 @@ impl AppModel {
                 Task::none()
             }
 
-            Message::LaunchUrl(url) => {
+            ShellMessage::LaunchUrl(url) => {
                 match open::that_detached(&url) {
                     Ok(()) => {}
                     Err(err) => {
@@ -36,8 +36,6 @@ impl AppModel {
                 }
                 Task::none()
             }
-
-            _ => Task::none(),
         }
     }
 }

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -3,7 +3,7 @@
 use crate::daemon::client::{load_audio_themes, ping_daemon};
 use crate::state::{AudioTheme, ContextPage, DaemonStatus, ModelsTab, RecordingStatus};
 use crate::ui::icons;
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, Message, ModelMessage, RecordingMessage};
 use cosmic::prelude::*;
 use cosmic::widget::{nav_bar, segmented_button};
 use std::collections::HashMap;
@@ -72,14 +72,16 @@ fn initial_load_tasks(
 ) -> Task<cosmic::Action<Message>> {
     // Load audio themes on startup (always available)
     let load_themes = Task::perform(load_audio_themes(), |themes| {
-        cosmic::Action::App(Message::AudioThemesLoaded(themes))
+        cosmic::Action::App(Message::Recording(RecordingMessage::AudioThemesLoaded(
+            themes,
+        )))
     });
 
     // Try to ping the daemon on startup
     let initial_ping = Task::perform(ping_daemon(), |result| {
         cosmic::Action::App(match result {
-            Ok(_) => Message::DaemonConnected,
-            Err(e) => Message::DaemonError(e),
+            Ok(_) => Message::Daemon(DaemonMessage::DaemonConnected),
+            Err(e) => Message::Daemon(DaemonMessage::DaemonError(e)),
         })
     });
 
@@ -89,7 +91,7 @@ fn initial_load_tasks(
             // Small delay to let daemon connection establish
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         },
-        |()| cosmic::Action::App(Message::LoadInitialData),
+        |()| cosmic::Action::App(Message::Model(ModelMessage::LoadInitialData)),
     );
 
     Task::batch([title_command, load_themes, initial_ping, load_initial_data])

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -11,7 +11,7 @@ use subscription::{UdpSubscriptionId, audio_events_subscription};
 
 use crate::daemon::backends::BackendInfo;
 use crate::state::{AudioTheme, ContextPage, DaemonStatus, MenuAction, RecordingStatus};
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, Message, ModelsPageMessage, ShellMessage};
 use cosmic::app::context_drawer;
 use cosmic::iced::Subscription;
 use cosmic::prelude::*;
@@ -312,11 +312,11 @@ impl cosmic::Application for AppModel {
             ),
             // Periodic connection monitoring
             cosmic::iced::time::every(std::time::Duration::from_secs(PING_INTERVAL_SECS))
-                .map(|_| Message::PingTimeout),
+                .map(|_| Message::Daemon(DaemonMessage::PingTimeout)),
             // Periodic GPU inventory/memory refresh (gated on connection in the
             // handler, so it's a no-op while disconnected).
             cosmic::iced::time::every(std::time::Duration::from_secs(GPU_POLL_INTERVAL_SECS))
-                .map(|_| Message::RefreshGpuInfo),
+                .map(|_| Message::ModelsPage(ModelsPageMessage::RefreshGpuInfo)),
         ])
     }
 
@@ -347,7 +347,9 @@ impl menu::action::MenuAction for MenuAction {
 
     fn message(&self) -> Self::Message {
         match self {
-            MenuAction::About => Message::ToggleContextPage(ContextPage::About),
+            MenuAction::About => {
+                Message::Shell(ShellMessage::ToggleContextPage(ContextPage::About))
+            }
         }
     }
 }

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -209,6 +209,21 @@ impl AppModel {
             .filter(|e| e.scope == scope)
             .map(|e| e.message.as_str())
     }
+
+    /// Park a failed action in the single scope-tagged banner slot. The one
+    /// slot is deliberate — only one page is visible at a time, and
+    /// [`action_error_for`](Self::action_error_for) gates rendering by scope.
+    pub fn set_action_error(&mut self, scope: crate::state::ErrorScope, message: String) {
+        self.action_error = Some(crate::state::ActionError { scope, message });
+    }
+
+    /// Clear the banner only if it currently belongs to `scope`, so retrying or
+    /// succeeding at one page's action can't wipe another page's pending error.
+    pub fn clear_action_error(&mut self, scope: crate::state::ErrorScope) {
+        if self.action_error.as_ref().is_some_and(|e| e.scope == scope) {
+            self.action_error = None;
+        }
+    }
 }
 
 /// Create a COSMIC application from the app model

--- a/super-stt-app/src/core/app/subscription.rs
+++ b/super-stt-app/src/core/app/subscription.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::daemon::client::internal::session::SETTINGS_SCOPES;
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, Message};
 use futures_util::SinkExt;
 use log::{info, warn};
 
@@ -66,7 +66,7 @@ pub(super) fn audio_events_subscription(
                     // re-fetch now that live events are flowing — so a model
                     // that finished loading before this subscription completed
                     // is still picked up.
-                    Message::EventStreamConnected
+                    Message::Daemon(DaemonMessage::EventStreamConnected)
                 }
                 WidgetSubscriptionUpdate::Event(evt) => {
                     match settings_widget_event_to_message(&evt) {
@@ -89,7 +89,7 @@ pub(super) fn audio_events_subscription(
                     // Forward to the update loop so the UI flips to
                     // the Blocked state (Retry button) instead of
                     // sitting silently with a dead audio meter.
-                    Message::WidgetBlocked(reason)
+                    Message::Daemon(DaemonMessage::WidgetBlocked(reason))
                 }
             };
             if channel.send(msg).await.is_err() {

--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -5,215 +5,34 @@ use crate::ui::messages::Message;
 use cosmic::prelude::*;
 
 impl AppModel {
-    /// Pure message dispatcher — routes every [`Message`] variant to the
-    /// appropriate handler method and returns the resulting [`Task`].
+    /// Pure message dispatcher — routes every [`Message`] group to its handler
+    /// and returns the resulting [`Task`]. The `match` is exhaustive: a newly
+    /// added sub-enum forces a new arm here, and each handler `match`es its
+    /// sub-enum exhaustively, so a forgotten variant is a compile error rather
+    /// than a silent no-op.
     pub(in crate::core::app) fn dispatch(
         &mut self,
         message: Message,
     ) -> Task<cosmic::Action<Message>> {
-        if let Some(task) = self.dispatch_core(message) {
-            return task;
+        match message {
+            Message::Shell(m) => self.handle_shell_messages(m),
+            Message::Daemon(m) => self.handle_daemon_messages(m),
+            Message::Model(m) => self.handle_model_messages(m),
+            Message::ModelsPage(m) => self.handle_models_page_messages(m),
+            Message::Device(m) => self.handle_device_messages(m),
+            Message::Download(m) => self.handle_download_messages(m),
+            Message::PreviewTyping(m) => self.handle_preview_typing_messages(m),
+            Message::RecordingStopMode(m) => self.handle_recording_stop_mode_messages(m),
+            Message::WriteMethod(m) => self.handle_write_method_messages(m),
+            Message::Backend(m) => self.handle_backend_messages(m),
+            Message::Language(m) => self.handle_language_messages(m),
+            Message::Recording(m) => self.handle_recording_messages(m),
+
+            // Scoped action failure: park it in the per-page banner slot.
+            Message::SettingActionFailed { scope, message } => {
+                self.action_error = Some(crate::state::ActionError { scope, message });
+                Task::none()
+            }
         }
-        Task::none()
-    }
-
-    /// Routes daemon, model, models-page, device, and download messages.
-    fn dispatch_core(&mut self, message: Message) -> Option<Task<cosmic::Action<Message>>> {
-        // Scoped action failure: park it in the per-page banner slot.
-        if let Message::SettingActionFailed { scope, message } = message {
-            self.action_error = Some(crate::state::ActionError { scope, message });
-            return Some(Task::none());
-        }
-
-        // Daemon-related messages
-        if matches!(
-            message,
-            Message::DaemonConnectionResult(_)
-                | Message::DaemonConnected
-                | Message::EventStreamConnected
-                | Message::CurrentAudioThemeLoaded(_)
-                | Message::VolumeLoaded(_)
-                | Message::CustomModelsDirLoaded(_)
-                | Message::DaemonError(_)
-                | Message::RetryConnection
-                | Message::WidgetBlocked(_)
-                | Message::RetryAuthorization
-                | Message::RefreshDaemonStatus
-                | Message::PingTimeout
-                | Message::DaemonEventsReceived(_)
-        ) {
-            return Some(self.handle_daemon_messages(message));
-        }
-
-        // Model-related messages
-        if matches!(
-            message,
-            Message::LoadInitialData
-                | Message::AvailableModelsLoaded(_)
-                | Message::CurrentModelLoaded { .. }
-                | Message::ModelChanged { .. }
-                | Message::ModelError(_)
-        ) {
-            return Some(self.handle_model_messages(message));
-        }
-
-        // Models-page UI: tabs, per-backend dropdown / GPU / select,
-        // configuration sub-view, and the (UI-only) download actions.
-        if matches!(
-            message,
-            Message::ModelsTabActivated(_)
-                | Message::StageActiveModel(_)
-                | Message::StageActiveDevice(_)
-                | Message::LoadStagedModel
-                | Message::UnloadActiveModel
-                | Message::OpenBackendConfig(_)
-                | Message::CloseBackendConfig
-                | Message::SelectBackend(_)
-                | Message::DeselectBackend
-                | Message::ActiveBackendLoaded(_)
-                | Message::RefreshGpuInfo
-                | Message::GpuInfoLoaded(_)
-                | Message::InstallBackend(_)
-                | Message::InstallBackendFromRepoUrl(_)
-                | Message::InstallAccepted { .. }
-                | Message::InstallFailedToStart { .. }
-                | Message::InstallProgress { .. }
-                | Message::InstallCompleted { .. }
-                | Message::InstallFailed { .. }
-                | Message::UpdateBackend(_)
-                | Message::UninstallBackend(_)
-                | Message::UninstallFailed { .. }
-                | Message::RefreshRegistry
-                | Message::RegistryListLoaded(_)
-                | Message::RegistryListFailed(_)
-                | Message::RegistrySearchChanged(_)
-                | Message::RegistryIncludeIncompatible(_)
-                | Message::RegistryOnlineFilter(_)
-                | Message::ToggleInstalledMenu(_)
-                | Message::CloseInstalledMenu
-                | Message::ImportBackendFromDir
-                | Message::ImportBackendFromDirPicked(_)
-                | Message::RegistryCustomRepoInputChanged(_)
-        ) {
-            return Some(self.handle_models_page_messages(message));
-        }
-
-        // Device-related messages
-        if matches!(
-            message,
-            Message::DeviceInfoLoaded(_, _) | Message::DeviceError(_)
-        ) {
-            return Some(self.handle_device_messages(message));
-        }
-
-        // Download-related messages
-        if matches!(
-            message,
-            Message::DownloadProgressUpdate(_)
-                | Message::CancelDownload
-                | Message::DownloadCompleted(_)
-                | Message::DownloadCancelled(_)
-                | Message::DownloadError { .. }
-                | Message::CheckDownloadStatus
-                | Message::NoDownloadInProgress
-        ) {
-            return Some(self.handle_download_messages(message));
-        }
-
-        self.dispatch_settings(message)
-    }
-
-    /// Routes settings, backend, shell, and recording/audio messages.
-    fn dispatch_settings(&mut self, message: Message) -> Option<Task<cosmic::Action<Message>>> {
-        // Preview typing-related messages
-        if matches!(
-            message,
-            Message::PreviewTypingToggled(_)
-                | Message::PreviewTypingSettingLoaded(_)
-                | Message::PreviewTypingError(_)
-        ) {
-            return Some(self.handle_preview_typing_messages(message));
-        }
-
-        // Recording stop mode messages
-        if matches!(
-            message,
-            Message::RecordingStopModeChanged(_)
-                | Message::RecordingStopModeLoaded(_)
-                | Message::RecordingStopModeError(_)
-        ) {
-            return Some(self.handle_recording_stop_mode_messages(message));
-        }
-
-        // Write method messages
-        if matches!(
-            message,
-            Message::WriteMethodChanged(_)
-                | Message::WriteMethodLoaded(_)
-                | Message::WriteMethodError(_)
-        ) {
-            return Some(self.handle_write_method_messages(message));
-        }
-
-        // Backend catalog + per-backend secret/option configuration
-        if matches!(
-            message,
-            Message::BackendsLoaded(_)
-                | Message::BackendsReload
-                | Message::BackendsError(_)
-                | Message::BackendSecretInputChanged { .. }
-                | Message::BackendSecretSaved { .. }
-                | Message::BackendSecretRemoved { .. }
-                | Message::BackendSecretStored { .. }
-                | Message::BackendSecretsConfigured { .. }
-                | Message::BackendOptionInputChanged { .. }
-                | Message::BackendOptionSaved { .. }
-                | Message::BackendOptionReset { .. }
-        ) {
-            return Some(self.handle_backend_messages(message));
-        }
-
-        // Transcription language messages
-        if matches!(
-            message,
-            Message::OpenLanguagePicker { .. }
-                | Message::CloseLanguagePicker
-                | Message::LanguagePickerQueryChanged(_)
-                | Message::PrimaryLanguageLoaded(_)
-                | Message::PrimaryLanguageSelected(_)
-                | Message::ModelLanguageLoaded { .. }
-                | Message::ModelLanguageSelected { .. }
-                | Message::LanguageError(_)
-        ) {
-            return Some(self.handle_language_messages(message));
-        }
-
-        // Template/shell messages
-        if matches!(
-            message,
-            Message::OpenRepositoryUrl | Message::ToggleContextPage(_) | Message::LaunchUrl(_)
-        ) {
-            return Some(self.handle_shell_messages(message));
-        }
-
-        // Recording/audio/widget messages
-        if matches!(
-            message,
-            Message::StartRecording
-                | Message::StopRecording
-                | Message::PreviewTextReceived(_)
-                | Message::TranscriptionReceived(_)
-                | Message::AudioFeedbackToggled(_)
-                | Message::AudioThemeSelected(_)
-                | Message::AudioThemesLoaded(_)
-                | Message::VolumeChanged(_)
-                | Message::VolumeCommit
-                | Message::WidgetAudioLevel { .. }
-                | Message::WidgetRecordingState(_)
-        ) {
-            return Some(self.handle_recording_messages(message));
-        }
-
-        None
     }
 }

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -165,8 +165,12 @@ impl AppModel {
                 &self.transcription_text,
                 self.audio_level,
                 self.is_speech_detected,
+                self.action_error_for(crate::state::ErrorScope::Recording),
             ),
-            Page::InputSimulation => views::input_simulation::page(self.write_method),
+            Page::InputSimulation => views::input_simulation::page(
+                self.write_method,
+                self.action_error_for(crate::state::ErrorScope::InputSimulation),
+            ),
             Page::Models => views::models::page(self),
             Page::Library => views::models::library_page(self),
             Page::Connection => views::connection::page(

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::state::{ContextPage, DaemonStatus, Page};
-use crate::ui::messages::Message;
+use crate::ui::messages::{LanguageMessage, Message, ModelsPageMessage, ShellMessage};
 use crate::ui::views;
 use cosmic::app::context_drawer;
 use cosmic::prelude::*;
@@ -57,7 +57,7 @@ impl AppModel {
             ContextPage::About => Some(
                 context_drawer::context_drawer(
                     views::about::page(),
-                    Message::ToggleContextPage(ContextPage::About),
+                    Message::Shell(ShellMessage::ToggleContextPage(ContextPage::About)),
                 )
                 .title("About"),
             ),
@@ -73,7 +73,7 @@ impl AppModel {
                 on_library_page.then(|| {
                     context_drawer::context_drawer(
                         views::models::add_backend_sheet(self),
-                        Message::ToggleContextPage(ContextPage::AddBackend),
+                        Message::Shell(ShellMessage::ToggleContextPage(ContextPage::AddBackend)),
                     )
                     .title("Add a backend")
                 })
@@ -86,7 +86,7 @@ impl AppModel {
                 on_models_page.then(|| {
                     context_drawer::context_drawer(
                         views::models::load_backend_sheet(self),
-                        Message::ToggleContextPage(ContextPage::LoadBackend),
+                        Message::Shell(ShellMessage::ToggleContextPage(ContextPage::LoadBackend)),
                     )
                     .title("Load a backend")
                 })
@@ -102,7 +102,7 @@ impl AppModel {
                 Some(
                     context_drawer::context_drawer(
                         views::language_picker::sheet(self),
-                        Message::CloseLanguagePicker,
+                        Message::Language(LanguageMessage::CloseLanguagePicker),
                     )
                     .title(title),
                 )
@@ -123,7 +123,7 @@ impl AppModel {
                 backend.filter(|_| on_backend_page).map(|backend| {
                     context_drawer::context_drawer(
                         views::models::configure_sheet(backend, self),
-                        Message::CloseBackendConfig,
+                        Message::ModelsPage(ModelsPageMessage::CloseBackendConfig),
                     )
                     .title(format!("{} configuration", backend.name))
                 })

--- a/super-stt-app/src/state/models.rs
+++ b/super-stt-app/src/state/models.rs
@@ -76,10 +76,16 @@ pub enum ContextPage {
 /// surface" (App Tier 3 #11) generalizes this.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorScope {
-    /// The Customization page's Audio section: theme / volume / feedback saves.
+    /// The Customization page's Audio section: theme / volume / feedback saves,
+    /// and the global Primary Language save.
     Customization,
     /// The per-backend Configure sheet: secret / option saves.
     ConfigureBackend,
+    /// The Recording page: preview-typing / stop-mode saves and the daemon-mic
+    /// recording result.
+    Recording,
+    /// The Input Simulation page: write-method save.
+    InputSimulation,
 }
 
 /// A scope-tagged, transient action failure rendered as an inline banner on the

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 //! Message types for the Super STT application.
+//!
+//! The top-level [`Message`] groups its variants into per-area sub-enums (one
+//! per `handle_*_messages` handler). Dispatch (`core/app/update.rs`) is then an
+//! exhaustive `match` that hands each sub-enum to its handler, and each handler
+//! `match`es its sub-enum exhaustively — so a newly added variant is a compile
+//! error at both ends instead of silently falling through to `Task::none()`.
 
 use super_stt_shared::models::provider::Provider;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
@@ -11,17 +17,43 @@ use cosmic::widget::segmented_button;
 use crate::daemon::backends::BackendInfo;
 use crate::state::{AudioTheme, ContextPage};
 
-/// Messages emitted by the application and its widgets
+/// Messages emitted by the application and its widgets.
 #[derive(Debug, Clone)]
 pub enum Message {
+    Shell(ShellMessage),
+    Daemon(DaemonMessage),
+    Model(ModelMessage),
+    ModelsPage(ModelsPageMessage),
+    Device(DeviceMessage),
+    Download(DownloadMessage),
+    PreviewTyping(PreviewTypingMessage),
+    RecordingStopMode(RecordingStopModeMessage),
+    WriteMethod(WriteMethodMessage),
+    Backend(BackendMessage),
+    Language(LanguageMessage),
+    Recording(RecordingMessage),
+
+    /// A scoped settings/backend save failed. Stored in `AppModel::action_error`
+    /// and rendered as an inline banner on the page named by `scope`, instead of
+    /// hijacking the UI (Tier 1 #13) or being dropped to the log (Tier 1 #15).
+    /// Handled inline in `dispatch` (no dedicated handler).
+    SettingActionFailed {
+        scope: crate::state::ErrorScope,
+        message: String,
+    },
+}
+
+/// Template / shell-chrome messages.
+#[derive(Debug, Clone)]
+pub enum ShellMessage {
     OpenRepositoryUrl,
     ToggleContextPage(ContextPage),
     LaunchUrl(String),
+}
 
-    // Super STT specific messages
-    StartRecording,
-    StopRecording,
-    PreviewTextReceived(String),
+/// Daemon connection, connection-time settings loads, and the SSE event stream.
+#[derive(Debug, Clone)]
+pub enum DaemonMessage {
     DaemonConnectionResult(super_stt_shared::daemon::http_client::HttpResult<()>),
     DaemonConnected,
     /// The `/events` SSE stream finished (re)subscribing. Distinct from
@@ -40,21 +72,7 @@ pub enum Message {
     // Carries the typed error so `classify_daemon_error` can decide
     // blocked-vs-retry on the variant, not the wording.
     DaemonError(super_stt_shared::daemon::http_client::HttpError),
-    TranscriptionReceived(String),
-    AudioFeedbackToggled(bool),
-    AudioThemeSelected(AudioTheme),
-    AudioThemesLoaded(Vec<AudioTheme>),
     RefreshDaemonStatus,
-    /// `frequency_bands` event from the daemon's `/events` SSE stream
-    /// — already converted to (`display_level_percent`, `is_speech`) so
-    /// the settings UI can drive its meter unchanged.
-    WidgetAudioLevel {
-        level: f32,
-        is_speech: bool,
-    },
-    /// `recording_state` event from `/events` — coarse `is_recording`
-    /// flag the UI projects into a `RecordingStatus`.
-    WidgetRecordingState(bool),
     RetryConnection,
     /// User denied (or had been denying via deny cache) settings-scope
     /// consent. Halts the auto-retry loop and surfaces a Retry
@@ -65,10 +83,35 @@ pub enum Message {
     /// consent flow.
     RetryAuthorization,
     PingTimeout,
-    DaemonEventsReceived(Vec<super_stt_shared::models::protocol::NotificationEvent>), // Received events
+    DaemonEventsReceived(Vec<super_stt_shared::models::protocol::NotificationEvent>),
+}
 
-    // Model management messages
+/// Model identity: startup load, catalog, and the current/loaded model.
+#[derive(Debug, Clone)]
+pub enum ModelMessage {
     LoadInitialData, // Load models + device info at startup
+    AvailableModelsLoaded(Vec<(String, Provider, String)>),
+    CurrentModelLoaded {
+        model: String,
+        provider: Provider,
+        source: String,
+        /// `current_model_epoch` captured when this snapshot was requested.
+        /// The handler applies the snapshot only if the epoch is unchanged —
+        /// otherwise a live `model_switched` superseded it and wins.
+        epoch: u64,
+    },
+    ModelChanged {
+        model: String,
+        provider: Provider,
+        source: String,
+    },
+    ModelError(String),
+}
+
+/// Models-page UI: tabs, active-backend card, GPU readout, backend
+/// select/config, and the registry / download-tab install lifecycle.
+#[derive(Debug, Clone)]
+pub enum ModelsPageMessage {
     /// Activate a Models-page tab (Installed / Download) in the tab bar.
     ModelsTabActivated(segmented_button::Entity),
     /// User picked a model in the active-backend card's model dropdown.
@@ -98,7 +141,7 @@ pub enum Message {
     ActiveBackendLoaded(Option<String>),
     /// Periodic tick that re-fetches GPU inventory + memory so the header
     /// readout stays live. No-op when disconnected; on success it emits
-    /// [`Message::GpuInfoLoaded`].
+    /// [`ModelsPageMessage::GpuInfoLoaded`].
     RefreshGpuInfo,
     /// GPU inventory + memory loaded from the daemon (empty when none detected).
     GpuInfoLoaded(Vec<super_stt_shared::models::protocol::GpuInfo>),
@@ -108,15 +151,9 @@ pub enum Message {
     /// User clicked Install on the Custom-repo input.
     InstallBackendFromRepoUrl(String),
     /// Daemon accepted the install request.
-    InstallAccepted {
-        source: String,
-        install_id: String,
-    },
+    InstallAccepted { source: String, install_id: String },
     /// Install POST failed (couldn't start).
-    InstallFailedToStart {
-        source: String,
-        error: String,
-    },
+    InstallFailedToStart { source: String, error: String },
     /// SSE: registry.install.progress
     InstallProgress {
         install_id: String,
@@ -126,9 +163,7 @@ pub enum Message {
         bytes_total: Option<u64>,
     },
     /// SSE: registry.install.completed
-    InstallCompleted {
-        source: String,
-    },
+    InstallCompleted { source: String },
     /// SSE: registry.install.failed
     InstallFailed {
         install_id: String,
@@ -142,10 +177,7 @@ pub enum Message {
     UninstallBackend(String),
     /// An uninstall request failed; carries the backend `source` and a
     /// human-readable error to surface on the installed card.
-    UninstallFailed {
-        source: String,
-        error: String,
-    },
+    UninstallFailed { source: String, error: String },
     /// User clicked Retry on the Download-tab empty state, or any other refresh trigger.
     RefreshRegistry,
     /// Initial fetch of /registry/backends succeeded.
@@ -165,82 +197,67 @@ pub enum Message {
     CloseInstalledMenu,
     /// User clicked "+ Import from dir" on the Download tab. Opens an async
     /// folder picker; if the user picks one, the path comes back as
-    /// [`Message::ImportBackendFromDirPicked`].
+    /// [`ModelsPageMessage::ImportBackendFromDirPicked`].
     ImportBackendFromDir,
     /// Async folder picker resolved. `None` means the user cancelled — no-op.
     ImportBackendFromDirPicked(Option<String>),
     /// User typed in the Custom-repo URL field in the Download tab.
     RegistryCustomRepoInputChanged(String),
-    AvailableModelsLoaded(Vec<(String, Provider, String)>),
-    CurrentModelLoaded {
-        model: String,
-        provider: Provider,
-        source: String,
-        /// `current_model_epoch` captured when this snapshot was requested.
-        /// The handler applies the snapshot only if the epoch is unchanged —
-        /// otherwise a live `model_switched` superseded it and wins.
-        epoch: u64,
-    },
-    ModelChanged {
-        model: String,
-        provider: Provider,
-        source: String,
-    },
-    ModelError(String),
+}
 
-    // Device management messages
+/// Device inventory + device-switch errors.
+#[derive(Debug, Clone)]
+pub enum DeviceMessage {
     DeviceInfoLoaded(String, Vec<String>), // Current device, available devices
     DeviceError(String),                   // Device switching error
+}
 
-    // Download progress messages
+/// Model-download progress lifecycle.
+#[derive(Debug, Clone)]
+pub enum DownloadMessage {
     DownloadProgressUpdate(super_stt_shared::models::protocol::DownloadProgress),
     CancelDownload,
     DownloadCompleted(String), // model name
     DownloadCancelled(String), // model name
-    DownloadError {
-        model: String,
-        error: String,
-    },
+    DownloadError { model: String, error: String },
     CheckDownloadStatus,
     NoDownloadInProgress,
+}
 
-    // Preview typing messages
-    PreviewTypingToggled(bool),       // User toggled the setting
-    PreviewTypingSettingLoaded(bool), // Setting loaded from daemon
-    PreviewTypingError(String),       // Error setting or getting preview typing
+/// Preview-typing setting.
+#[derive(Debug, Clone)]
+pub enum PreviewTypingMessage {
+    Toggled(bool),       // User toggled the setting
+    SettingLoaded(bool), // Setting loaded from daemon
+    Error(String),       // Error setting or getting preview typing
+}
 
-    // Recording stop mode messages
-    RecordingStopModeChanged(RecordingStopMode),
-    RecordingStopModeLoaded(RecordingStopMode),
-    RecordingStopModeError(String),
+/// Recording stop-mode setting.
+#[derive(Debug, Clone)]
+pub enum RecordingStopModeMessage {
+    Changed(RecordingStopMode),
+    Loaded(RecordingStopMode),
+    Error(String),
+}
 
-    // Write method messages
-    WriteMethodChanged(WriteMethod),
-    WriteMethodLoaded(WriteMethod),
-    WriteMethodError(String),
+/// Write-method setting.
+#[derive(Debug, Clone)]
+pub enum WriteMethodMessage {
+    Changed(WriteMethod),
+    Loaded(WriteMethod),
+    Error(String),
+}
 
-    // Volume messages
-    /// A drag tick: updates the local slider value only (no daemon POST).
-    VolumeChanged(u8),
-    /// The slider was released: commit the current value to the daemon once,
-    /// rather than one POST per drag tick (Tier 1 #19).
-    VolumeCommit,
-
-    // Backend catalog + per-backend secret/option configuration.
-    // Secrets are managed via the daemon's secrets endpoints.
-    // Options go to the daemon config via the client.
+/// Backend catalog + per-backend secret/option configuration.
+/// Secrets are managed via the daemon's secrets endpoints; options go to the
+/// daemon config via the client.
+#[derive(Debug, Clone)]
+pub enum BackendMessage {
     BackendsLoaded(Vec<BackendInfo>),
     /// Re-fetch the backend catalog (e.g. after a secret/option save) so the
     /// UI reflects the new effective values.
     BackendsReload,
     BackendsError(String),
-    /// A scoped settings/backend save failed. Stored in `AppModel::action_error`
-    /// and rendered as an inline banner on the page named by `scope`, instead of
-    /// hijacking the UI (Tier 1 #13) or being dropped to the log (Tier 1 #15).
-    SettingActionFailed {
-        scope: crate::state::ErrorScope,
-        message: String,
-    },
     /// Daemon-sourced configured flags for a backend's secrets, received after
     /// `BackendsLoaded`. Folds `(name, configured)` into `backend_secret_configured`.
     BackendSecretsConfigured {
@@ -279,8 +296,11 @@ pub enum Message {
         source: String,
         name: String,
     },
+}
 
-    // Transcription language (global Primary Language + per-model override).
+/// Transcription language (global Primary Language + per-model override).
+#[derive(Debug, Clone)]
+pub enum LanguageMessage {
     /// Open the language search sheet.
     /// `model = None` → global Primary Language sheet.
     /// `model = Some((source, model))` → per-model sheet for that specific model.
@@ -310,4 +330,58 @@ pub enum Message {
         choice: Option<String>,
     },
     LanguageError(String),
+}
+
+/// Recording / audio / widget (SSE-driven meter + coarse recording state).
+#[derive(Debug, Clone)]
+pub enum RecordingMessage {
+    StartRecording,
+    StopRecording,
+    PreviewTextReceived(String),
+    TranscriptionReceived(String),
+    AudioFeedbackToggled(bool),
+    AudioThemeSelected(AudioTheme),
+    AudioThemesLoaded(Vec<AudioTheme>),
+    /// A drag tick: updates the local slider value only (no daemon POST).
+    VolumeChanged(u8),
+    /// The slider was released: commit the current value to the daemon once,
+    /// rather than one POST per drag tick (Tier 1 #19).
+    VolumeCommit,
+    /// `frequency_bands` event from the daemon's `/events` SSE stream
+    /// — already converted to (`display_level_percent`, `is_speech`) so
+    /// the settings UI can drive its meter unchanged.
+    WidgetAudioLevel {
+        level: f32,
+        is_speech: bool,
+    },
+    /// `recording_state` event from `/events` — coarse `is_recording`
+    /// flag the UI projects into a `RecordingStatus`.
+    WidgetRecordingState(bool),
+}
+
+macro_rules! message_from {
+    ($($variant:ident => $ty:ident),+ $(,)?) => {
+        $(
+            impl From<$ty> for Message {
+                fn from(m: $ty) -> Self {
+                    Message::$variant(m)
+                }
+            }
+        )+
+    };
+}
+
+message_from! {
+    Shell => ShellMessage,
+    Daemon => DaemonMessage,
+    Model => ModelMessage,
+    ModelsPage => ModelsPageMessage,
+    Device => DeviceMessage,
+    Download => DownloadMessage,
+    PreviewTyping => PreviewTypingMessage,
+    RecordingStopMode => RecordingStopModeMessage,
+    WriteMethod => WriteMethodMessage,
+    Backend => BackendMessage,
+    Language => LanguageMessage,
+    Recording => RecordingMessage,
 }

--- a/super-stt-app/src/ui/views/about.rs
+++ b/super-stt-app/src/ui/views/about.rs
@@ -6,7 +6,7 @@ use cosmic::iced_widget::column;
 use cosmic::widget::{self, button};
 use cosmic::{Element, cosmic_theme, theme};
 
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ShellMessage};
 
 const APP_ICON: &[u8] =
     include_bytes!("../../../resources/icons/hicolor/scalable/apps/super-stt-app.svg");
@@ -25,7 +25,7 @@ pub fn page() -> Element<'static, Message> {
     let date = env!("VERGEN_GIT_COMMIT_DATE");
 
     let link = widget::button::link(REPOSITORY)
-        .on_press(Message::OpenRepositoryUrl)
+        .on_press(Message::Shell(ShellMessage::OpenRepositoryUrl))
         .padding(0);
 
     column![
@@ -33,7 +33,9 @@ pub fn page() -> Element<'static, Message> {
         title,
         link,
         button::link(format!("Git: {short_hash} ({date})"))
-            .on_press(Message::LaunchUrl(format!("{REPOSITORY}/commits/{hash}")))
+            .on_press(Message::Shell(ShellMessage::LaunchUrl(format!(
+                "{REPOSITORY}/commits/{hash}"
+            ))))
             .padding(0),
     ]
     .align_x(Alignment::Center)

--- a/super-stt-app/src/ui/views/connection.rs
+++ b/super-stt-app/src/ui/views/connection.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use super::common::page_layout;
 use crate::state::DaemonStatus;
-use crate::ui::messages::Message;
+use crate::ui::messages::{DaemonMessage, Message};
 use cosmic::{
     Element,
     widget::{button, settings, text},
@@ -34,7 +34,8 @@ pub fn page(daemon_status: &DaemonStatus, socket_path: String) -> Element<'_, Me
             ))
             .add(settings::item(
                 "",
-                button::standard("Retry authorization").on_press(Message::RetryAuthorization),
+                button::standard("Retry authorization")
+                    .on_press(Message::Daemon(DaemonMessage::RetryAuthorization)),
             ));
     }
 

--- a/super-stt-app/src/ui/views/customization.rs
+++ b/super-stt-app/src/ui/views/customization.rs
@@ -5,7 +5,7 @@ use cosmic::{Apply, Element};
 use super_stt_shared::theme::AudioTheme;
 
 use super::common::{error_banner, page_layout};
-use crate::ui::messages::Message;
+use crate::ui::messages::{LanguageMessage, Message, RecordingMessage};
 
 /// Customization page: audio feedback toggle, theme selection, volume, and language.
 pub fn page<'a>(
@@ -34,7 +34,8 @@ pub fn page<'a>(
         settings::item::builder("Audio Feedback")
             .description("Play sounds when recording starts and stops")
             .control(
-                cosmic::widget::toggler(audio_enabled).on_toggle(Message::AudioFeedbackToggled),
+                cosmic::widget::toggler(audio_enabled)
+                    .on_toggle(|b| Message::Recording(RecordingMessage::AudioFeedbackToggled(b))),
             ),
     );
 
@@ -46,9 +47,9 @@ pub fn page<'a>(
         } else {
             widget::dropdown(theme_names, selected_index, move |index| {
                 if let Some(&theme) = non_silent_clone.get(index) {
-                    Message::AudioThemeSelected(theme)
+                    Message::Recording(RecordingMessage::AudioThemeSelected(theme))
                 } else {
-                    Message::AudioThemeSelected(AudioTheme::Classic)
+                    Message::Recording(RecordingMessage::AudioThemeSelected(AudioTheme::Classic))
                 }
             })
             .into()
@@ -57,11 +58,13 @@ pub fn page<'a>(
         // Drag ticks update the local value; the daemon POST fires once on
         // release (Tier 1 #19), so a single drag isn't hundreds of set_volume
         // requests.
-        let slider = widget::slider(0..=100, volume, Message::VolumeChanged)
-            .on_release(Message::VolumeCommit)
-            .width(Length::Fill)
-            .apply(widget::container)
-            .max_width(250.);
+        let slider = widget::slider(0..=100, volume, |v| {
+            Message::Recording(RecordingMessage::VolumeChanged(v))
+        })
+        .on_release(Message::Recording(RecordingMessage::VolumeCommit))
+        .width(Length::Fill)
+        .apply(widget::container)
+        .max_width(250.);
 
         let volume_control = widget::row::with_capacity(3)
             .align_y(Alignment::Center)
@@ -94,8 +97,9 @@ pub fn page<'a>(
         settings::item::builder("Primary Language")
             .description("Default transcription language for models that support it")
             .control(
-                widget::button::standard(lang_label)
-                    .on_press(Message::OpenLanguagePicker { model: None }),
+                widget::button::standard(lang_label).on_press(Message::Language(
+                    LanguageMessage::OpenLanguagePicker { model: None },
+                )),
             ),
     );
 

--- a/super-stt-app/src/ui/views/input_simulation.rs
+++ b/super-stt-app/src/ui/views/input_simulation.rs
@@ -4,7 +4,7 @@ use cosmic::widget::{self, settings};
 use super_stt_shared::models::write_method::WriteMethod;
 
 use super::common::page_layout;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, WriteMethodMessage};
 
 /// Input simulation page: write method selection
 pub fn page(write_method: WriteMethod) -> Element<'static, Message> {
@@ -29,7 +29,9 @@ pub fn page(write_method: WriteMethod) -> Element<'static, Message> {
                     .control(widget::dropdown(
                         method_names,
                         selected_index,
-                        move |index| Message::WriteMethodChanged(methods[index]),
+                        move |index| {
+                            Message::WriteMethod(WriteMethodMessage::Changed(methods[index]))
+                        },
                     )),
             )
             .into(),

--- a/super-stt-app/src/ui/views/input_simulation.rs
+++ b/super-stt-app/src/ui/views/input_simulation.rs
@@ -3,11 +3,11 @@ use cosmic::Element;
 use cosmic::widget::{self, settings};
 use super_stt_shared::models::write_method::WriteMethod;
 
-use super::common::page_layout;
+use super::common::{error_banner, page_layout};
 use crate::ui::messages::{Message, WriteMethodMessage};
 
 /// Input simulation page: write method selection
-pub fn page(write_method: WriteMethod) -> Element<'static, Message> {
+pub fn page(write_method: WriteMethod, action_error: Option<&str>) -> Element<'_, Message> {
     let methods = [
         WriteMethod::Auto,
         WriteMethod::XdgDesktopPortal,
@@ -20,7 +20,11 @@ pub fn page(write_method: WriteMethod) -> Element<'static, Message> {
         .collect();
     let selected_index = methods.iter().position(|m| *m == write_method);
 
-    let sections = settings::view_column(vec![
+    let mut blocks = Vec::new();
+    if let Some(message) = action_error {
+        blocks.push(error_banner(message));
+    }
+    blocks.push(
         settings::section()
             .title("Input Simulation")
             .add(
@@ -35,7 +39,7 @@ pub fn page(write_method: WriteMethod) -> Element<'static, Message> {
                     )),
             )
             .into(),
-    ]);
+    );
 
-    page_layout("Input Simulation", sections)
+    page_layout("Input Simulation", settings::view_column(blocks))
 }

--- a/super-stt-app/src/ui/views/language_picker.rs
+++ b/super-stt-app/src/ui/views/language_picker.rs
@@ -5,7 +5,7 @@ use cosmic::widget::{self, button, column, scrollable, text_input};
 
 use crate::core::app::AppModel;
 use crate::ui::languages::{GLOBAL_LANGUAGES, friendly_name};
-use crate::ui::messages::Message;
+use crate::ui::messages::{LanguageMessage, Message};
 
 pub fn sheet(app: &AppModel) -> Element<'_, Message> {
     let spacing = cosmic::theme::spacing();
@@ -58,19 +58,19 @@ pub fn sheet(app: &AppModel) -> Element<'_, Message> {
 
     // Search field pinned at the top.
     let search = text_input("Search languages…", &app.language_picker_query)
-        .on_input(Message::LanguagePickerQueryChanged)
+        .on_input(|s| Message::Language(LanguageMessage::LanguagePickerQueryChanged(s)))
         .width(Length::Fill);
 
     let mut list = column::with_capacity(rows.len()).spacing(spacing.space_xxs);
     for (tag, label) in rows {
         let msg = if let Some((ref src, ref mdl)) = app.language_picker_target {
-            Message::ModelLanguageSelected {
+            Message::Language(LanguageMessage::ModelLanguageSelected {
                 source: src.clone(),
                 model: mdl.clone(),
                 choice: tag,
-            }
+            })
         } else {
-            Message::PrimaryLanguageSelected(tag)
+            Message::Language(LanguageMessage::PrimaryLanguageSelected(tag))
         };
         list = list.push(button::text(label).width(Length::Fill).on_press(msg));
     }

--- a/super-stt-app/src/ui/views/models/active.rs
+++ b/super-stt-app/src/ui/views/models/active.rs
@@ -9,7 +9,9 @@ use crate::core::app::{AppModel, ModelOperationState};
 use crate::daemon::backends::BackendInfo;
 use crate::state::ContextPage;
 use crate::ui::icons;
-use crate::ui::messages::Message;
+use crate::ui::messages::{
+    DownloadMessage, LanguageMessage, Message, ModelsPageMessage, ShellMessage,
+};
 
 use super::chips::{
     backend_is_online, backend_supports_cpu, backend_supports_gpu, capability_chips, count_chip,
@@ -126,9 +128,9 @@ fn language_button<'a>(
 
     Some(
         widget::button::standard(label)
-            .on_press(Message::OpenLanguagePicker {
+            .on_press(Message::Language(LanguageMessage::OpenLanguagePicker {
                 model: Some((source.clone(), selected_model.to_string())),
-            })
+            }))
             .into(),
     )
 }
@@ -152,10 +154,14 @@ pub(super) fn active_backend_card<'a>(
     let description = super::surface::backend_description(app, &source);
     let actions = row![
         super::surface::repo_button(&source),
-        button::standard("Switch backend")
-            .on_press(Message::ToggleContextPage(ContextPage::LoadBackend)),
-        button::standard("Configure").on_press(Message::OpenBackendConfig(source.clone())),
-        button::destructive("Deselect").on_press(Message::DeselectBackend),
+        button::standard("Switch backend").on_press(Message::Shell(
+            ShellMessage::ToggleContextPage(ContextPage::LoadBackend),
+        )),
+        button::standard("Configure").on_press(Message::ModelsPage(
+            ModelsPageMessage::OpenBackendConfig(source.clone()),
+        )),
+        button::destructive("Deselect")
+            .on_press(Message::ModelsPage(ModelsPageMessage::DeselectBackend)),
     ]
     .spacing(spacing.space_xs)
     .align_y(Alignment::Center);
@@ -267,7 +273,7 @@ pub(super) fn loaded_model_summary<'a>(
         .push(
             button::standard("Unload")
                 .leading_icon(icons::phosphor_handle(icons::STOP))
-                .on_press(Message::UnloadActiveModel),
+                .on_press(Message::ModelsPage(ModelsPageMessage::UnloadActiveModel)),
         )
         .into()
 }
@@ -326,7 +332,9 @@ pub(super) fn staged_model_picker<'a>(
     let model_names_pick = model_names.clone();
     // Model select takes twice the width of the device select (2:1 flex ratio).
     let model_dropdown = widget::dropdown(model_names, model_index, move |index| {
-        Message::StageActiveModel(model_names_pick[index].clone())
+        Message::ModelsPage(ModelsPageMessage::StageActiveModel(
+            model_names_pick[index].clone(),
+        ))
     })
     .placeholder("Select model")
     .width(Length::FillPortion(2));
@@ -352,7 +360,9 @@ pub(super) fn staged_model_picker<'a>(
             .and_then(|d| devices.iter().position(|x| x == d));
         let devices_pick = devices.clone();
         let device_dropdown = widget::dropdown(devices, device_index, move |index| {
-            Message::StageActiveDevice(devices_pick[index].clone())
+            Message::ModelsPage(ModelsPageMessage::StageActiveDevice(
+                devices_pick[index].clone(),
+            ))
         })
         .placeholder("Device")
         .width(Length::FillPortion(1));
@@ -375,7 +385,10 @@ pub(super) fn staged_model_picker<'a>(
             || staged_model_supports.is_some_and(|d| d == ["none".to_string()]));
     let load_button = button::suggested("Load model")
         .leading_icon(icons::phosphor_handle(icons::PLAY))
-        .on_press_maybe((staged_ok && app.is_model_ready()).then_some(Message::LoadStagedModel));
+        .on_press_maybe(
+            (staged_ok && app.is_model_ready())
+                .then_some(Message::ModelsPage(ModelsPageMessage::LoadStagedModel)),
+        );
     picker_row = picker_row.push(load_button);
 
     // A staged CUDA load whose conservative VRAM estimate exceeds the GPU's
@@ -421,7 +434,8 @@ pub(super) fn card_download_progress<'a>(
         widget::progress_bar(0.0..=1.0, fraction.max(0.05)),
         row![
             text::caption(bytes).width(Length::Fill),
-            widget::button::destructive("Cancel").on_press(Message::CancelDownload),
+            widget::button::destructive("Cancel")
+                .on_press(Message::Download(DownloadMessage::CancelDownload)),
         ]
         .align_y(Alignment::Center),
     ]

--- a/super-stt-app/src/ui/views/models/add_sheet.rs
+++ b/super-stt-app/src/ui/views/models/add_sheet.rs
@@ -6,7 +6,7 @@ use cosmic::{Apply, Element};
 
 use crate::core::app::AppModel;
 use crate::ui::icons;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ModelsPageMessage};
 
 use super::surface::muted_text_color;
 
@@ -22,8 +22,8 @@ pub fn add_backend_sheet(app: &AppModel) -> Element<'_, Message> {
     // From a repository: URL input + Install, with the unverified-source note.
     let can_install = !app.registry.custom_repo_input.trim().is_empty();
     let install_btn = if can_install {
-        button::suggested("Install").on_press(Message::InstallBackendFromRepoUrl(
-            app.registry.custom_repo_input.clone(),
+        button::suggested("Install").on_press(Message::ModelsPage(
+            ModelsPageMessage::InstallBackendFromRepoUrl(app.registry.custom_repo_input.clone()),
         ))
     } else {
         button::suggested("Install")
@@ -40,7 +40,7 @@ pub fn add_backend_sheet(app: &AppModel) -> Element<'_, Message> {
                 "https://github.com/owner/backend",
                 &app.registry.custom_repo_input
             )
-            .on_input(Message::RegistryCustomRepoInputChanged)
+            .on_input(|x| Message::ModelsPage(ModelsPageMessage::RegistryCustomRepoInputChanged(x)))
             .width(Length::Fill),
             install_btn,
         ]
@@ -64,7 +64,8 @@ pub fn add_backend_sheet(app: &AppModel) -> Element<'_, Message> {
         text::title4("From a folder"),
         text::body("Point Super STT at a local directory that contains a backend.toml manifest.")
             .class(cosmic::theme::Text::Color(muted)),
-        button::standard("Choose folder\u{2026}").on_press(Message::ImportBackendFromDir),
+        button::standard("Choose folder\u{2026}")
+            .on_press(Message::ModelsPage(ModelsPageMessage::ImportBackendFromDir)),
     ]
     .spacing(spacing.space_s)
     .apply(widget::container)

--- a/super-stt-app/src/ui/views/models/configure.rs
+++ b/super-stt-app/src/ui/views/models/configure.rs
@@ -6,7 +6,7 @@ use cosmic::widget::{self, settings, text};
 
 use crate::core::app::AppModel;
 use crate::daemon::backends::{BackendInfo, BackendOption, BackendSecret};
-use crate::ui::messages::Message;
+use crate::ui::messages::{BackendMessage, Message};
 
 use super::surface::muted_text_color;
 
@@ -111,10 +111,12 @@ pub(super) fn secret_row<'a>(
         let remove_name = name_owned.clone();
         row![
             text::body("Configured").width(Length::Fill),
-            widget::button::destructive("Remove").on_press(Message::BackendSecretRemoved {
-                source: remove_source,
-                name: remove_name,
-            }),
+            widget::button::destructive("Remove").on_press(Message::Backend(
+                BackendMessage::BackendSecretRemoved {
+                    source: remove_source,
+                    name: remove_name,
+                },
+            )),
         ]
         .spacing(spacing.space_s)
         .align_y(Alignment::Center)
@@ -123,17 +125,21 @@ pub(super) fn secret_row<'a>(
         let input_source = source_owned.clone();
         let input_name = name_owned.clone();
         let field = widget::text_input("Enter API key...", input)
-            .on_input(move |value| Message::BackendSecretInputChanged {
-                source: input_source.clone(),
-                name: input_name.clone(),
-                value,
+            .on_input(move |value| {
+                Message::Backend(BackendMessage::BackendSecretInputChanged {
+                    source: input_source.clone(),
+                    name: input_name.clone(),
+                    value,
+                })
             })
             .password()
             .width(Length::Fill);
-        let save = widget::button::standard("Save").on_press(Message::BackendSecretSaved {
-            source: source_owned,
-            name: name_owned,
-        });
+        let save = widget::button::standard("Save").on_press(Message::Backend(
+            BackendMessage::BackendSecretSaved {
+                source: source_owned,
+                name: name_owned,
+            },
+        ));
         row![field, save]
             .spacing(spacing.space_xs)
             .align_y(Alignment::Center)
@@ -181,26 +187,32 @@ pub(super) fn option_row<'a>(
     let save_name = input_name.clone();
 
     let field = widget::text_input("", input)
-        .on_input(move |value| Message::BackendOptionInputChanged {
-            source: input_source.clone(),
-            name: input_name.clone(),
-            value,
+        .on_input(move |value| {
+            Message::Backend(BackendMessage::BackendOptionInputChanged {
+                source: input_source.clone(),
+                name: input_name.clone(),
+                value,
+            })
         })
         .width(Length::Fill);
-    let save = widget::button::standard("Save").on_press(Message::BackendOptionSaved {
-        source: save_source,
-        name: save_name,
-    });
+    let save = widget::button::standard("Save").on_press(Message::Backend(
+        BackendMessage::BackendOptionSaved {
+            source: save_source,
+            name: save_name,
+        },
+    ));
 
     // Show Reset only when an override is stored (value differs from default).
     let has_override = option.value.as_deref() != option.default.as_deref();
     let control: Element<'a, Message> = if has_override {
         let reset_source = source.to_string();
         let reset_name = option.name.clone();
-        let reset = widget::button::standard("Reset").on_press(Message::BackendOptionReset {
-            source: reset_source,
-            name: reset_name,
-        });
+        let reset = widget::button::standard("Reset").on_press(Message::Backend(
+            BackendMessage::BackendOptionReset {
+                source: reset_source,
+                name: reset_name,
+            },
+        ));
         row![field, save, reset]
             .spacing(spacing.space_xs)
             .align_y(Alignment::Center)

--- a/super-stt-app/src/ui/views/models/download.rs
+++ b/super-stt-app/src/ui/views/models/download.rs
@@ -7,7 +7,7 @@ use cosmic::{Apply, Element};
 use crate::core::app::AppModel;
 use crate::state::ContextPage;
 use crate::ui::icons;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ModelsPageMessage, ShellMessage};
 
 use super::active::backend_header;
 use super::chips::{capability_chips, result_count};
@@ -97,12 +97,15 @@ pub(super) fn download_toolbar<'a>(
         "Search backends, models, or providers\u{2026}",
         &filters.search,
     )
-    .on_input(Message::RegistrySearchChanged)
-    .on_clear(Message::RegistrySearchChanged(String::new()))
+    .on_input(|x| Message::ModelsPage(ModelsPageMessage::RegistrySearchChanged(x)))
+    .on_clear(Message::ModelsPage(
+        ModelsPageMessage::RegistrySearchChanged(String::new()),
+    ))
     .width(Length::Fill);
 
-    let add_btn = button::suggested("+ Add backend")
-        .on_press(Message::ToggleContextPage(ContextPage::AddBackend));
+    let add_btn = button::suggested("+ Add backend").on_press(Message::Shell(
+        ShellMessage::ToggleContextPage(ContextPage::AddBackend),
+    ));
     // Refresh shows as an icon-only button (a refresh glyph) with a tooltip
     // rather than a text label. A `Standard`-classed custom button gives it the
     // surface fill + hairline border that matches the neighbouring text buttons.
@@ -120,7 +123,7 @@ pub(super) fn download_toolbar<'a>(
         .class(cosmic::theme::Button::Standard)
         .padding(0)
         .height(Length::Fixed(f32::from(btn_height)))
-        .on_press(Message::RefreshRegistry),
+        .on_press(Message::ModelsPage(ModelsPageMessage::RefreshRegistry)),
         widget::container(text::body("Refresh registry")).padding(spacing.space_xxs),
         widget::tooltip::Position::Bottom,
     );
@@ -137,24 +140,24 @@ pub(super) fn download_toolbar<'a>(
             (
                 "All",
                 filters.online.is_none(),
-                Message::RegistryOnlineFilter(None),
+                Message::ModelsPage(ModelsPageMessage::RegistryOnlineFilter(None)),
             ),
             (
                 "Local",
                 filters.online == Some(false),
-                Message::RegistryOnlineFilter(Some(false)),
+                Message::ModelsPage(ModelsPageMessage::RegistryOnlineFilter(Some(false))),
             ),
             (
                 "Cloud",
                 filters.online == Some(true),
-                Message::RegistryOnlineFilter(Some(true)),
+                Message::ModelsPage(ModelsPageMessage::RegistryOnlineFilter(Some(true))),
             ),
         ],
     );
     let show_incompat = cosmic::widget::toggler(filters.include_incompatible)
         .label("Show incompatible".to_string())
         .spacing(spacing.space_xs)
-        .on_toggle(Message::RegistryIncludeIncompatible);
+        .on_toggle(|x| Message::ModelsPage(ModelsPageMessage::RegistryIncludeIncompatible(x)));
 
     // RUNS ON chips on the left; the incompatible toggle pushed to the right edge.
     let filter_row = row![runs_on, horizontal_space(), show_incompat]
@@ -217,7 +220,7 @@ pub(super) fn download_empty_state(app: &AppModel) -> Element<'_, Message> {
     );
     column![
         text::body(msg),
-        button::standard("Retry").on_press(Message::RefreshRegistry),
+        button::standard("Retry").on_press(Message::ModelsPage(ModelsPageMessage::RefreshRegistry)),
         widget::text(updated_label).size(10),
     ]
     .spacing(cosmic::theme::spacing().space_s)
@@ -274,7 +277,9 @@ pub(super) fn download_card<'a>(
         button::standard(label).into()
     } else if entry.compatibility.compatible {
         button::suggested("Install")
-            .on_press(Message::InstallBackend(entry.source.clone()))
+            .on_press(Message::ModelsPage(ModelsPageMessage::InstallBackend(
+                entry.source.clone(),
+            )))
             .into()
     } else {
         button::standard("Not compatible").into()

--- a/super-stt-app/src/ui/views/models/installed.rs
+++ b/super-stt-app/src/ui/views/models/installed.rs
@@ -7,7 +7,7 @@ use cosmic::widget::{self, button, text};
 use crate::core::app::AppModel;
 use crate::daemon::backends::BackendInfo;
 use crate::ui::icons;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ModelsPageMessage};
 
 use super::active::backend_glyph_tile;
 use super::chips::{
@@ -65,18 +65,21 @@ pub(super) fn installed_card<'a>(
     // Overflow ("⋯") menu: the optional Update, then Uninstall. Configure left
     // the menu to become a visible button beside it.
     let menu_open = app.installed_menu_open.as_deref() == Some(source.as_str());
-    let trigger = button::icon(icons::phosphor_handle(icons::DOTS_THREE_VERTICAL))
-        .on_press(Message::ToggleInstalledMenu(source.clone()));
+    let trigger = button::icon(icons::phosphor_handle(icons::DOTS_THREE_VERTICAL)).on_press(
+        Message::ModelsPage(ModelsPageMessage::ToggleInstalledMenu(source.clone())),
+    );
     let mut overflow = widget::popover(trigger).position(widget::popover::Position::Bottom);
     if menu_open {
         overflow = overflow
             .popup(installed_overflow_menu(&source, update_version))
-            .on_close(Message::CloseInstalledMenu);
+            .on_close(Message::ModelsPage(ModelsPageMessage::CloseInstalledMenu));
     }
 
     let actions = row![
         repo_button(&source),
-        button::standard("Configure").on_press(Message::OpenBackendConfig(source.clone())),
+        button::standard("Configure").on_press(Message::ModelsPage(
+            ModelsPageMessage::OpenBackendConfig(source.clone()),
+        )),
         overflow,
     ]
     .spacing(spacing.space_xs)
@@ -153,12 +156,12 @@ pub(super) fn installed_overflow_menu(
     if let Some(v) = update_version {
         col = col.push(item(
             format!("Update to {v}"),
-            Message::UpdateBackend(source.to_string()),
+            Message::ModelsPage(ModelsPageMessage::UpdateBackend(source.to_string())),
         ));
     }
     col = col.push(item(
         "Uninstall".to_string(),
-        Message::UninstallBackend(source.to_string()),
+        Message::ModelsPage(ModelsPageMessage::UninstallBackend(source.to_string())),
     ));
 
     widget::container(col)

--- a/super-stt-app/src/ui/views/models/load_sheet.rs
+++ b/super-stt-app/src/ui/views/models/load_sheet.rs
@@ -8,7 +8,7 @@ use crate::core::app::AppModel;
 use crate::daemon::backends::BackendInfo;
 use crate::state::ContextPage;
 use crate::ui::icons;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ModelsPageMessage, ShellMessage};
 
 use super::active::backend_glyph_tile;
 use super::chips::{
@@ -51,7 +51,9 @@ pub(super) fn no_backend_empty_state<'a>() -> Element<'a, Message> {
         .push(
             button::suggested("Load a backend")
                 .leading_icon(icons::phosphor_handle(icons::PLAY))
-                .on_press(Message::ToggleContextPage(ContextPage::LoadBackend)),
+                .on_press(Message::Shell(ShellMessage::ToggleContextPage(
+                    ContextPage::LoadBackend,
+                ))),
         );
 
     widget::container(col)
@@ -124,7 +126,9 @@ fn load_backend_row(backend: &BackendInfo, is_active: bool) -> Element<'static, 
     } else {
         button::suggested("Load")
             .leading_icon(icons::phosphor_handle(icons::PLAY))
-            .on_press(Message::SelectBackend(backend.source.clone()))
+            .on_press(Message::ModelsPage(ModelsPageMessage::SelectBackend(
+                backend.source.clone(),
+            )))
             .into()
     };
 

--- a/super-stt-app/src/ui/views/models/surface.rs
+++ b/super-stt-app/src/ui/views/models/surface.rs
@@ -4,7 +4,7 @@ use cosmic::widget::{self, text};
 use cosmic::{Apply, Element};
 
 use crate::core::app::AppModel;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ShellMessage};
 
 /// Wrap the Models page's tab body in a bordered, page-width frame: the
 /// scrollable list sits *inside* the border, so the outline stays fixed while
@@ -169,7 +169,7 @@ pub(super) fn repo_button(source: &str) -> Element<'static, Message> {
     let url = format!("https://{source}");
     rounded_tooltip(
         widget::button::icon(icons::phosphor_handle(icons::GIT_BRANCH))
-            .on_press(Message::LaunchUrl(url)),
+            .on_press(Message::Shell(ShellMessage::LaunchUrl(url))),
         text::body("Open repository"),
         widget::tooltip::Position::Top,
     )

--- a/super-stt-app/src/ui/views/models/tabs.rs
+++ b/super-stt-app/src/ui/views/models/tabs.rs
@@ -4,7 +4,7 @@ use cosmic::iced::Length;
 use cosmic::widget::{self, button, text};
 
 use crate::core::app::AppModel;
-use crate::ui::messages::Message;
+use crate::ui::messages::{Message, ModelsPageMessage};
 
 /// Tab switcher for the Models page (Installed / Browse): flat text tabs with an
 /// accent border marking the active one, over a full-width hairline divider.
@@ -12,7 +12,7 @@ use crate::ui::messages::Message;
 /// buttons.
 ///
 /// Still driven by `app.models_tabs`, so clicking a tab emits the same
-/// [`Message::ModelsTabActivated`] the segmented-button model expects.
+/// [`ModelsPageMessage::ModelsTabActivated`] the segmented-button model expects.
 pub(super) fn models_tab_switcher(app: &AppModel) -> Element<'_, Message> {
     let spacing = cosmic::theme::spacing();
     let active = app.models_tabs.active();
@@ -34,7 +34,9 @@ pub(super) fn models_tab_switcher(app: &AppModel) -> Element<'_, Message> {
 
         let inner = button::custom(label_text)
             .padding([spacing.space_xxs, spacing.space_s])
-            .on_press(Message::ModelsTabActivated(entity))
+            .on_press(Message::ModelsPage(ModelsPageMessage::ModelsTabActivated(
+                entity,
+            )))
             .class(tab_inner_class(is_active));
 
         // Accent border on the top and sides only (open at the bottom): an

--- a/super-stt-app/src/ui/views/recording.rs
+++ b/super-stt-app/src/ui/views/recording.rs
@@ -7,7 +7,9 @@ use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 
 use super::common::page_layout;
 use crate::state::RecordingStatus;
-use crate::ui::messages::Message;
+use crate::ui::messages::{
+    Message, PreviewTypingMessage, RecordingMessage, RecordingStopModeMessage,
+};
 
 /// Recording settings section: stop mode + preview typing
 fn settings_section(
@@ -28,7 +30,7 @@ fn settings_section(
             settings::item::builder("Stop Mode")
                 .description("Controls how to stop transcribing")
                 .control(widget::dropdown(mode_names, selected_index, move |index| {
-                    Message::RecordingStopModeChanged(modes[index])
+                    Message::RecordingStopMode(RecordingStopModeMessage::Changed(modes[index]))
                 })),
         )
         .add(
@@ -38,7 +40,7 @@ fn settings_section(
                 )
                 .control(
                     cosmic::widget::toggler(preview_typing_enabled)
-                        .on_toggle(Message::PreviewTypingToggled),
+                        .on_toggle(|b| Message::PreviewTyping(PreviewTypingMessage::Toggled(b))),
                 ),
         )
         .into()
@@ -63,12 +65,10 @@ fn test_section<'a>(
     };
 
     let record_button = match recording_status {
-        RecordingStatus::Recording => {
-            button::destructive("Stop Recording").on_press(Message::StopRecording)
-        }
-        RecordingStatus::Idle => {
-            button::suggested("Test Recording").on_press(Message::StartRecording)
-        }
+        RecordingStatus::Recording => button::destructive("Stop Recording")
+            .on_press(Message::Recording(RecordingMessage::StopRecording)),
+        RecordingStatus::Idle => button::suggested("Test Recording")
+            .on_press(Message::Recording(RecordingMessage::StartRecording)),
     };
 
     let audio_widget = row![

--- a/super-stt-app/src/ui/views/recording.rs
+++ b/super-stt-app/src/ui/views/recording.rs
@@ -5,7 +5,7 @@ use cosmic::iced_widget::row;
 use cosmic::widget::{self, button, settings, text};
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 
-use super::common::page_layout;
+use super::common::{error_banner, page_layout};
 use crate::state::RecordingStatus;
 use crate::ui::messages::{
     Message, PreviewTypingMessage, RecordingMessage, RecordingStopModeMessage,
@@ -113,16 +113,22 @@ pub fn page<'a>(
     transcription_text: &'a str,
     audio_level: f32,
     is_speech_detected: bool,
+    action_error: Option<&'a str>,
 ) -> Element<'a, Message> {
-    let sections = settings::view_column(vec![
-        settings_section(recording_stop_mode, preview_typing_enabled),
-        test_section(
-            recording_status,
-            transcription_text,
-            audio_level,
-            is_speech_detected,
-        ),
-    ]);
+    let mut blocks = Vec::new();
+    if let Some(message) = action_error {
+        blocks.push(error_banner(message));
+    }
+    blocks.push(settings_section(
+        recording_stop_mode,
+        preview_typing_enabled,
+    ));
+    blocks.push(test_section(
+        recording_status,
+        transcription_text,
+        audio_level,
+        is_speech_detected,
+    ));
 
-    page_layout("Recording", sections)
+    page_layout("Recording", settings::view_column(blocks))
 }

--- a/super-stt-daemon/src/audio/recorder.rs
+++ b/super-stt-daemon/src/audio/recorder.rs
@@ -372,7 +372,7 @@ impl DaemonAudioRecorder {
             optimal_config.max_sample_rate()
         };
 
-        optimal_config.with_sample_rate(target_rate).pipe(Ok)
+        Ok(optimal_config.with_sample_rate(target_rate))
     }
 
     /// Play start recording sound using current theme and wait for it to
@@ -516,19 +516,5 @@ impl DaemonAudioRecorder {
     #[must_use]
     pub fn get_audio_buffer_ref(&self) -> Arc<Mutex<VecDeque<f32>>> {
         Arc::clone(&self.audio_buffer)
-    }
-}
-trait PipeExt<T> {
-    fn pipe<F, U>(self, f: F) -> U
-    where
-        F: FnOnce(T) -> U;
-}
-
-impl<T> PipeExt<T> for T {
-    fn pipe<F, U>(self, f: F) -> U
-    where
-        F: FnOnce(T) -> U,
-    {
-        f(self)
     }
 }

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -145,10 +145,7 @@ impl SuperSTTDaemon {
 
         // Phase 4: final transcription.
         self.emit_transcribing_started();
-        let transcription_result = match self
-            .transcribe_with_spinner(typer, &full_audio_data, write_mode)
-            .await
-        {
+        let transcription_result = match self.transcribe_final(&full_audio_data).await {
             Ok(text) => text,
             Err(e) => {
                 // A transcription failure is not typed into the user's focused

--- a/super-stt-daemon/src/daemon/recording/transcribe.rs
+++ b/super-stt-daemon/src/daemon/recording/transcribe.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::daemon::types::SuperSTTDaemon;
-use crate::output::typer::Typer;
 use crate::stt_models::dispatch::{DispatchError, dispatch_transcription};
 use anyhow::{Context, Result};
 use log::{debug, error, info, warn};
@@ -60,65 +59,35 @@ impl SuperSTTDaemon {
         }
     }
 
-    /// Transcribe audio with spinner if needed
-    pub(super) async fn transcribe_with_spinner(
-        &self,
-        _typer: &mut Typer,
-        audio_data: &[f32],
-        _write_mode: bool,
-    ) -> Result<String> {
-        // If we'll type the result, show a simple spinner by typing characters and backspacing
-        // This indicates work while transcription runs.
-        let mut spinner_handle: Option<tokio::task::JoinHandle<()>> = None;
-        let spinner_cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        // Track how many temporary spinner characters are visible (0-3)
-        let _visible_temp_chars = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        // Disable loader for now since it interferes with keyboard
-        // TODO: Implement proper loader that doesn't conflict with final typing
-
-        // Process audio
+    /// Run the final transcription pass over the full recording. Unlike the
+    /// best-effort preview path, a backend failure here surfaces to the caller
+    /// as an `Err` (it must not look like silence).
+    pub(super) async fn transcribe_final(&self, audio_data: &[f32]) -> Result<String> {
         let processed_audio = self
             .audio_processor
             .process_audio(audio_data, 16000)
             .context("Failed to process audio")?;
 
-        // Transcribe the audio.
         let language = self.resolve_active_language().await;
         let start_time = std::time::Instant::now();
 
-        // The final pass surfaces backend errors to the caller — unlike the
-        // best-effort preview path, a failure here must not look like silence.
-        let transcription_result =
-            match dispatch_transcription(&self.model, processed_audio, 16000, language).await {
-                Ok(text) => {
-                    info!(
-                        "Transcription completed in {:?}: '{text}'",
-                        start_time.elapsed()
-                    );
-                    Ok(text)
-                }
-                Err(DispatchError::Failed(e)) => {
-                    warn!("Transcription failed: {e}");
-                    Err(e)
-                }
-                Err(DispatchError::NotLoaded) => {
-                    error!("Model not loaded");
-                    Err(anyhow::anyhow!("Model not loaded"))
-                }
-                Err(DispatchError::Join(e)) => {
-                    Err(anyhow::anyhow!("Transcription task failed: {e}"))
-                }
-            };
-
-        // Stop spinner if it was started
-        if let Some(handle) = spinner_handle.take() {
-            spinner_cancel.store(true, std::sync::atomic::Ordering::Relaxed);
-            // Wait for the spinner task to exit and clean up
-            if let Err(e) = handle.await {
-                warn!("Spinner task panicked: {e}");
+        match dispatch_transcription(&self.model, processed_audio, 16000, language).await {
+            Ok(text) => {
+                info!(
+                    "Transcription completed in {:?}: '{text}'",
+                    start_time.elapsed()
+                );
+                Ok(text)
             }
+            Err(DispatchError::Failed(e)) => {
+                warn!("Transcription failed: {e}");
+                Err(e)
+            }
+            Err(DispatchError::NotLoaded) => {
+                error!("Model not loaded");
+                Err(anyhow::anyhow!("Model not loaded"))
+            }
+            Err(DispatchError::Join(e)) => Err(anyhow::anyhow!("Transcription task failed: {e}")),
         }
-
-        transcription_result
     }
 }

--- a/super-stt-daemon/src/services/dbus.rs
+++ b/super-stt-daemon/src/services/dbus.rs
@@ -98,6 +98,31 @@ impl SuperSTTDBusService {
     }
 }
 
+/// Object path the interface is served at (and the target of every signal).
+const OBJECT_PATH: &str = "/com/github/jorge_menjivar/SuperSTT";
+
+/// Define an `emit_*` wrapper that looks up the served interface and fires one
+/// of the `#[zbus(signal)]` methods. The five wrappers differ only in the
+/// signal method and its event type, so generate them from one template. A
+/// generic async helper can't express this cleanly (the closure would return a
+/// future borrowing the emitter), so a macro is the idiomatic dedup.
+macro_rules! emit_signal {
+    ($(#[$meta:meta])* $method:ident => $signal:ident($event:ty)) => {
+        $(#[$meta])*
+        ///
+        /// # Errors
+        /// Returns an error if the signal cannot be emitted.
+        pub async fn $method(&self, event: $event) -> Result<()> {
+            let object_server = self.connection.object_server();
+            let iface_ref = object_server
+                .interface::<_, SuperSTTDBusService>(OBJECT_PATH)
+                .await?;
+            SuperSTTDBusService::$signal(iface_ref.signal_emitter(), event).await?;
+            Ok(())
+        }
+    };
+}
+
 pub struct DBusManager {
     connection: Connection,
 }
@@ -118,84 +143,36 @@ impl DBusManager {
         // Serve the interface
         connection
             .object_server()
-            .at("/com/github/jorge_menjivar/SuperSTT", SuperSTTDBusService)
+            .at(OBJECT_PATH, SuperSTTDBusService)
             .await?;
 
         Ok(Self { connection })
     }
 
-    /// Emit a signal indicating that listening has started.
-    ///
-    /// # Errors
-    /// This function will return an error if the signal cannot be emitted.
-    pub async fn emit_listening_started(&self, event: ListeningEvent) -> Result<()> {
-        let object_server = self.connection.object_server();
-        let iface_ref = object_server
-            .interface::<_, SuperSTTDBusService>("/com/github/jorge_menjivar/SuperSTT")
-            .await?;
+    emit_signal!(
+        /// Emit a signal indicating that listening has started.
+        emit_listening_started => listening_started(ListeningEvent)
+    );
 
-        SuperSTTDBusService::listening_started(iface_ref.signal_emitter(), event).await?;
-        Ok(())
-    }
+    emit_signal!(
+        /// Emit a signal indicating that listening has stopped.
+        emit_listening_stopped => listening_stopped(ListeningStoppedEvent)
+    );
 
-    /// Emit a signal indicating that listening has stopped.
-    ///
-    /// # Errors
-    /// This function will return an error if the signal cannot be emitted.
-    pub async fn emit_listening_stopped(&self, event: ListeningStoppedEvent) -> Result<()> {
-        let object_server = self.connection.object_server();
-        let iface_ref = object_server
-            .interface::<_, SuperSTTDBusService>("/com/github/jorge_menjivar/SuperSTT")
-            .await?;
+    emit_signal!(
+        /// Emit a signal indicating that transcription has started.
+        emit_transcription_started => transcription_started(TranscriptionStartedEvent)
+    );
 
-        SuperSTTDBusService::listening_stopped(iface_ref.signal_emitter(), event).await?;
-        Ok(())
-    }
+    emit_signal!(
+        /// Emit a signal indicating that transcription has completed.
+        emit_transcription_completed => transcription_completed(TranscriptionCompletedEvent)
+    );
 
-    /// Emit a signal indicating that transcription has started.
-    ///
-    /// # Errors
-    /// This function will return an error if the signal cannot be emitted.
-    pub async fn emit_transcription_started(&self, event: TranscriptionStartedEvent) -> Result<()> {
-        let object_server = self.connection.object_server();
-        let iface_ref = object_server
-            .interface::<_, SuperSTTDBusService>("/com/github/jorge_menjivar/SuperSTT")
-            .await?;
-
-        SuperSTTDBusService::transcription_started(iface_ref.signal_emitter(), event).await?;
-        Ok(())
-    }
-
-    /// Emit a signal indicating that transcription has completed.
-    ///
-    /// # Errors
-    /// This function will return an error if the signal cannot be emitted.
-    pub async fn emit_transcription_completed(
-        &self,
-        event: TranscriptionCompletedEvent,
-    ) -> Result<()> {
-        let object_server = self.connection.object_server();
-        let iface_ref = object_server
-            .interface::<_, SuperSTTDBusService>("/com/github/jorge_menjivar/SuperSTT")
-            .await?;
-
-        SuperSTTDBusService::transcription_completed(iface_ref.signal_emitter(), event).await?;
-        Ok(())
-    }
-
-    /// Emit a signal for real-time audio level updates.
-    ///
-    /// # Errors
-    /// This function will return an error if the signal cannot be emitted.
-    pub async fn emit_audio_level(&self, event: AudioLevelEvent) -> Result<()> {
-        let object_server = self.connection.object_server();
-        let iface_ref = object_server
-            .interface::<_, SuperSTTDBusService>("/com/github/jorge_menjivar/SuperSTT")
-            .await?;
-
-        SuperSTTDBusService::audio_level(iface_ref.signal_emitter(), event).await?;
-        Ok(())
-    }
+    emit_signal!(
+        /// Emit a signal for real-time audio level updates.
+        emit_audio_level => audio_level(AudioLevelEvent)
+    );
 
     pub fn connection(&self) -> &Connection {
         &self.connection


### PR DESCRIPTION
Continues the code-quality audit cleanup (`docs/audits/2026-07-code-quality.md`), Tier 3 items #9–#11. One combined PR (daemon + app), one commit per item.

## #9 — Daemon minor cleanups
- Five near-identical `emit_*` DBus wrappers → one `emit_signal!` macro (a generic async helper can't express it — the closure would return a future borrowing the emitter); the repeated object path is now an `OBJECT_PATH` const.
- `transcribe_with_spinner` → `transcribe_final`: the spinner apparatus was entirely dead (handle never assigned, cancel/counter never read) and the `_typer`/`_write_mode` params unused — removed.
- Deleted the one-use `PipeExt` trait; the single `.pipe(Ok)` is now `Ok(..)`.
- Deferred (Tier 3 #36): the keyring sessions-blob mock unification (changes `SUPER_STT_KEYRING_MOCK` behavior the smoke test exercises) and the `Result<_, String>` → typed-error conversion.

## #10 — Group the flat `Message` enum into sub-enums
The flat 103-variant `Message` is now 12 per-area sub-enums (`ShellMessage`, `DaemonMessage`, `ModelMessage`, `ModelsPageMessage`, `DeviceMessage`, `DownloadMessage`, `PreviewTypingMessage`, `RecordingStopModeMessage`, `WriteMethodMessage`, `BackendMessage`, `LanguageMessage`, `RecordingMessage`) wrapped by `Message`, plus the top-level `SettingActionFailed`. `dispatch` is one exhaustive `match` (the twelve `matches!` lists are gone); each `handle_*_messages` takes and matches its own sub-enum exhaustively, so the top-level `_ => Task::none()` catch-alls are deleted and **a forgotten variant is a compile error at both ends** instead of a silent no-op. `From<XMessage> for Message` impls for ergonomics; the three redundant-prefix settings enums shed the prefix now that the group carries it. ~35 files, mechanical/compiler-guided.

## #11 — One error surface
Generalized the existing scope-tagged `action_error` slot. `ErrorScope` gained `Recording`/`InputSimulation`, rendered per page via the shared `error_banner` (like Customization already did), plus scope-safe `set_action_error`/`clear_action_error` helpers. Converged the ad-hoc error paths:
- **log-only → banner:** preview-typing / stop-mode / write-method / language save errors now populate their page's banner.
- **transcription-box hijack → Models card:** `DeviceError`/`DownloadError` set `ModelOperationState::Error` (the good template) instead of overwriting the Recording page's `transcription_text`.
- Deferred (Tier 3 #37): rolling back optimistic state on failure (needs a captured previous value threaded through per-setting failure messages; the drift self-heals on the next reconnect refetch).

## Verification
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` ✅
- `cargo test -p super-stt-daemon --lib --all-features` → 235 passed ✅
- `cargo test -p super-stt-app` → 43 passed ✅
- `cargo test -p super-stt-daemon --all-features --no-run` (integration-test callers) ✅
- `just check-features` (default / subprocess / wasm / no-default) ✅
- `just fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)