### PR TITLE
Audit Tier 3 #13-#17: task builders, typed language payload, AppModel split, style dedup

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -978,26 +978,43 @@ Tier 2 #4/#6/#8.
 - **Resolved (PR #274):** the triple now lives in one `clear_loaded_model()` helper
   in `small_state.rs`; the call sites delegate to it.
 
-### [ ] 13. 🟡 App: shared task builders
+### [x] 13. 🟡 App: shared task builders
 
 - **Where:** registry catalog fetch, `list_backends` reload, and ping are re-rolled
   at 3–4 sites each.
 - **Fix:** `fetch_registry_catalog()`, `reload_backends()`, `ping_task()` beside
   the existing `build_load_settings_tasks()`.
+- **Resolved (branch `refactor/audit-tier3-13-17`):** moved `build_load_settings_tasks`
+  into a new `handlers/tasks.rs` and added `ping_task()`, `reload_backends()`, and
+  `fetch_registry_catalog(refresh: bool)` beside it. The 3 ping sites (+ startup), 3
+  `list_backends` reloads, and 3 registry-catalog fetches now call the shared builders
+  (the one `refresh`-then-`list` site passes `refresh: true`).
 
-### [ ] 14. 🟡 App: type the language payload
+### [x] 14. 🟡 App: type the language payload
 
 - **Where:** `model_language: Option<serde_json::Value>` parsed field-by-field in
   two views (`core/app/mod.rs:162-168`, `ui/views/models/active.rs:100-125`,
   `ui/views/language_picker.rs:25-35`).
 - **Fix:** deserialize a `LanguageResolution` struct at the client boundary.
+- **Resolved (branch `refactor/audit-tier3-13-17`):** added a `LanguageResolution`
+  struct (`state`) deserialized in the `get_/set_/clear_model_language` client fns; the
+  field, the `ModelLanguageLoaded` payload, and the two views now use typed
+  `effective`/`source`/`primary`/`supported` fields instead of `.get("...")` on a
+  `serde_json::Value`.
 
-### [ ] 15. 🟡 App: split `AppModel` (~45 fields)
+### [x] 15. 🟡 App: split `AppModel` (~45 fields)
 
 - **Fix:** extract `ModelsPageState` and `LanguageState` following the existing
   `RegistryState` template.
+- **Resolved (branch `refactor/audit-tier3-13-17`):** extracted `state::language::LanguageState`
+  (5 fields) and `state::models_page::ModelsPageState` (6 fields: the tab bar +
+  active-backend selection/staging/menu flags) as `RegistryState`-style sub-structs
+  embedded as `AppModel.language` / `AppModel.models_page`; `ModelsPageState::default`
+  builds the Installed/Browse tabs. All `self.<field>` / `app.<field>` accesses moved to
+  `self.language.<field>` / `self.models_page.<field>`. Model/device/backend-catalog
+  state stayed on `AppModel` (touched by `small_state.rs` / the global header).
 
-### [ ] 16. 🟡 App: style helpers duplicated across models views
+### [x] 16. 🟡 App: style helpers duplicated across models views
 
 - **Where:** accent-border card closure, glyph tile, and panel style each
   duplicated 2–3× (`surface.rs:94-126` vs `load_sheet.rs:138-157`;
@@ -1005,8 +1022,18 @@ Tier 2 #4/#6/#8.
   `installed.rs:176-203`, `chips.rs:297-311`); older pages still use emoji status
   glyphs vs the newer icon vocabulary (`connection.rs:13-18`,
   `recording.rs:54-63`).
+- **Resolved (branch `refactor/audit-tier3-13-17`):** hoisted `accent_border_color(active)`
+  and `pill_surface()` into `models/surface.rs` (used by the card + load-sheet row, and
+  the header pill + chips track respectively), and parameterized the glyph tile as
+  `glyph_tile(tile, glyph, radius_medium)` reused by `backend_glyph_tile` and the
+  empty-state ring. **Deferred:** the emoji→icon status-glyph migration
+  (`connection.rs`/`recording.rs`) — a visual redesign that needs new SVG assets, not a
+  dedup; and the full `card_surface`/overflow-menu unification (would shift radii/shadows).
 
-### [ ] 17. 🟡 App: `ui/views/models/download.rs:282` shows `{err:?}` Debug output to users
+### [x] 17. 🟡 App: `ui/views/models/download.rs:282` shows `{err:?}` Debug output to users
+
+- **Resolved (branch `refactor/audit-tier3-13-17`):** gave `InstallError` (shared) a
+  `Display` impl with human-readable phrasing; the Browse card now shows `Failed: {err}`.
 
 ### [ ] 18. 🟡 Applet: merge the bar renderers
 

--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -2,11 +2,11 @@
 
 use crate::core::app::AppModel;
 use crate::daemon::client::{
-    clear_backend_option, clear_backend_secret, list_backend_secrets, list_backends,
-    set_backend_option, set_backend_secret,
+    clear_backend_option, clear_backend_secret, list_backend_secrets, set_backend_option,
+    set_backend_secret,
 };
 use crate::state::ErrorScope;
-use crate::ui::messages::{BackendMessage, Message, ModelsPageMessage};
+use crate::ui::messages::{BackendMessage, Message};
 use cosmic::prelude::*;
 use super_stt_shared::daemon::http_client::HttpError;
 use super_stt_shared::models::provider::Provider;
@@ -87,22 +87,8 @@ impl AppModel {
                 // by source). Guarded so it fires a single time; the Browse tab's
                 // own first-open trigger then short-circuits.
                 if self.registry.backends.is_empty() && self.registry.last_refresh.is_none() {
-                    let filters = crate::daemon::registry::ListFilters {
-                        include_incompatible: Some(true),
-                        ..Default::default()
-                    };
-                    tasks.push(Task::perform(
-                        async move { crate::daemon::registry::list(&filters).await },
-                        |r| {
-                            cosmic::Action::App(match r {
-                                Ok(resp) => {
-                                    Message::ModelsPage(ModelsPageMessage::RegistryListLoaded(resp))
-                                }
-                                Err(e) => Message::ModelsPage(
-                                    ModelsPageMessage::RegistryListFailed(e.to_string()),
-                                ),
-                            })
-                        },
+                    tasks.push(crate::core::app::handlers::tasks::fetch_registry_catalog(
+                        false,
                     ));
                 }
                 Task::batch(tasks)
@@ -121,16 +107,7 @@ impl AppModel {
                 Task::none()
             }
 
-            BackendMessage::BackendsReload => {
-                Task::perform(list_backends(), |result| match result {
-                    Ok(backends) => cosmic::Action::App(Message::Backend(
-                        BackendMessage::BackendsLoaded(backends),
-                    )),
-                    Err(e) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsError(
-                        e.to_string(),
-                    ))),
-                })
-            }
+            BackendMessage::BackendsReload => crate::core::app::handlers::tasks::reload_backends(),
 
             _ => Task::none(),
         }

--- a/super-stt-app/src/core/app/handlers/daemon/events.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/events.rs
@@ -95,7 +95,7 @@ impl AppModel {
                     return None;
                 }
                 let mut tasks = vec![self.load_primary_language()];
-                if let Some((source, model)) = self.model_language_for.clone() {
+                if let Some((source, model)) = self.language.model_language_for.clone() {
                     tasks.push(self.load_model_language(source, model));
                 }
                 Some(Task::batch(tasks))

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -3,17 +3,12 @@
 mod events;
 
 use crate::core::app::events::classify_daemon_error;
+use crate::core::app::handlers::tasks::{build_load_settings_tasks, ping_task};
 use crate::core::app::subscription::SETTINGS_APP_ID;
 use crate::core::app::{AppModel, DeviceState, ModelOperationState};
-use crate::daemon::client::{
-    get_current_audio_theme, get_custom_models_dir, get_preview_typing, get_recording_stop_mode,
-    get_volume, get_write_method, ping_daemon, test_daemon_connection,
-};
+use crate::daemon::client::test_daemon_connection;
 use crate::state::{AudioTheme, DaemonStatus};
-use crate::ui::messages::{
-    DaemonMessage, Message, ModelMessage, PreviewTypingMessage, RecordingStopModeMessage,
-    WriteMethodMessage,
-};
+use crate::ui::messages::{DaemonMessage, Message, ModelMessage};
 use cosmic::prelude::*;
 use log::{info, warn};
 
@@ -84,12 +79,7 @@ impl AppModel {
                 // rather than letting the UI spin on the now-untimed POST.
                 self.check_switch_stall();
                 if self.daemon_status == DaemonStatus::Connected {
-                    Task::perform(ping_daemon(), |result| {
-                        cosmic::Action::App(Message::Daemon(match result {
-                            Ok(_) => DaemonMessage::DaemonConnected,
-                            Err(e) => DaemonMessage::DaemonError(e),
-                        }))
-                    })
+                    ping_task()
                 } else {
                     Task::none()
                 }
@@ -183,12 +173,7 @@ impl AppModel {
 
             DaemonMessage::RetryConnection => {
                 self.daemon_status = DaemonStatus::Connecting;
-                Task::perform(ping_daemon(), |result| {
-                    cosmic::Action::App(Message::Daemon(match result {
-                        Ok(_) => DaemonMessage::DaemonConnected,
-                        Err(e) => DaemonMessage::DaemonError(e),
-                    }))
-                })
+                ping_task()
             }
 
             DaemonMessage::WidgetBlocked(reason) => {
@@ -210,12 +195,7 @@ impl AppModel {
                 // ended with `Blocked`.
                 self.udp_restart_counter = self.udp_restart_counter.wrapping_add(1);
                 self.daemon_status = DaemonStatus::Connecting;
-                Task::perform(ping_daemon(), |result| {
-                    cosmic::Action::App(Message::Daemon(match result {
-                        Ok(_) => DaemonMessage::DaemonConnected,
-                        Err(e) => DaemonMessage::DaemonError(e),
-                    }))
-                })
+                ping_task()
             }
 
             _ => Task::none(),
@@ -253,82 +233,4 @@ impl AppModel {
             _ => Task::none(),
         }
     }
-}
-
-// Reload models, device info, and per-setting state on reconnect.
-// Each setting is fetched with its own dedicated GET call —
-// no bulk fetch_daemon_config anymore.
-pub(in crate::core::app) fn build_load_settings_tasks() -> Task<cosmic::Action<Message>> {
-    Task::batch([
-        Task::perform(get_current_audio_theme(), |result| match result {
-            Ok(theme) => cosmic::Action::App(Message::Daemon(
-                DaemonMessage::CurrentAudioThemeLoaded(theme),
-            )),
-            Err(e) => {
-                warn!("Failed to load audio theme: {e}");
-                cosmic::Action::App(Message::Daemon(DaemonMessage::CurrentAudioThemeLoaded(
-                    AudioTheme::default(),
-                )))
-            }
-        }),
-        Task::perform(get_volume(), |result| match result {
-            Ok(vol) => cosmic::Action::App(Message::Daemon(DaemonMessage::VolumeLoaded(vol))),
-            Err(e) => {
-                warn!("Failed to load volume: {e}");
-                cosmic::Action::App(Message::Daemon(DaemonMessage::VolumeLoaded(100)))
-            }
-        }),
-        Task::perform(get_custom_models_dir(), |result| match result {
-            Ok(dir) => {
-                cosmic::Action::App(Message::Daemon(DaemonMessage::CustomModelsDirLoaded(dir)))
-            }
-            Err(e) => {
-                warn!("Failed to load custom models dir: {e}");
-                cosmic::Action::App(Message::Daemon(DaemonMessage::CustomModelsDirLoaded(None)))
-            }
-        }),
-        Task::perform(get_preview_typing(), |result| match result {
-            Ok(enabled) => cosmic::Action::App(Message::PreviewTyping(
-                PreviewTypingMessage::SettingLoaded(enabled),
-            )),
-            Err(e) => {
-                log::warn!("Failed to load preview typing setting: {e}");
-                cosmic::Action::App(Message::PreviewTyping(PreviewTypingMessage::SettingLoaded(
-                    false,
-                )))
-            }
-        }),
-        Task::perform(get_recording_stop_mode(), |result| {
-            use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
-            match result {
-                Ok(mode_str) => {
-                    let mode = mode_str.parse::<RecordingStopMode>().unwrap_or_default();
-                    cosmic::Action::App(Message::RecordingStopMode(
-                        RecordingStopModeMessage::Loaded(mode),
-                    ))
-                }
-                Err(e) => {
-                    log::warn!("Failed to load recording stop mode: {e}");
-                    cosmic::Action::App(Message::RecordingStopMode(
-                        RecordingStopModeMessage::Loaded(RecordingStopMode::default()),
-                    ))
-                }
-            }
-        }),
-        Task::perform(get_write_method(), |result| {
-            use super_stt_shared::models::write_method::WriteMethod;
-            match result {
-                Ok(method_str) => {
-                    let method = method_str.parse::<WriteMethod>().unwrap_or_default();
-                    cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(method)))
-                }
-                Err(e) => {
-                    log::warn!("Failed to load write method: {e}");
-                    cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(
-                        WriteMethod::default(),
-                    )))
-                }
-            }
-        }),
-    ])
 }

--- a/super-stt-app/src/core/app/handlers/language.rs
+++ b/super-stt-app/src/core/app/handlers/language.rs
@@ -12,8 +12,8 @@ impl AppModel {
     ) -> Task<cosmic::Action<Message>> {
         match message {
             LanguageMessage::OpenLanguagePicker { model } => {
-                self.language_picker_target = model;
-                self.language_picker_query.clear();
+                self.language.language_picker_target = model;
+                self.language.language_picker_query.clear();
                 self.context_page = ContextPage::LanguagePicker;
                 self.core.window.show_context = true;
                 Task::none()
@@ -23,15 +23,15 @@ impl AppModel {
                 Task::none()
             }
             LanguageMessage::LanguagePickerQueryChanged(q) => {
-                self.language_picker_query = q;
+                self.language.language_picker_query = q;
                 Task::none()
             }
             LanguageMessage::PrimaryLanguageLoaded(lang) => {
-                self.primary_language = lang;
+                self.language.primary_language = lang;
                 Task::none()
             }
             LanguageMessage::PrimaryLanguageSelected(choice) => {
-                self.primary_language.clone_from(&choice);
+                self.language.primary_language.clone_from(&choice);
                 self.core.window.show_context = false;
                 Task::perform(
                     async move {
@@ -55,8 +55,8 @@ impl AppModel {
                 model,
                 block,
             } => {
-                self.model_language = Some(block);
-                self.model_language_for = Some((source, model));
+                self.language.model_language = Some(block);
+                self.language.model_language_for = Some((source, model));
                 Task::none()
             }
             LanguageMessage::ModelLanguageSelected {

--- a/super-stt-app/src/core/app/handlers/mod.rs
+++ b/super-stt-app/src/core/app/handlers/mod.rs
@@ -9,3 +9,4 @@ mod models_page;
 mod recording;
 mod settings;
 mod shell;
+pub(in crate::core::app) mod tasks;

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -3,11 +3,9 @@
 use crate::core::app::{AppModel, ModelOperationState};
 use crate::daemon::client::{
     get_active_backend, get_current_device, get_current_model, get_gpu_info, list_available_models,
-    list_backends, set_allow_online_models,
+    set_allow_online_models,
 };
-use crate::ui::messages::{
-    BackendMessage, DeviceMessage, Message, ModelMessage, ModelsPageMessage,
-};
+use crate::ui::messages::{DeviceMessage, Message, ModelMessage, ModelsPageMessage};
 use cosmic::prelude::*;
 use log::info;
 use log::warn;
@@ -61,14 +59,7 @@ impl AppModel {
             // add an online-capable backend, not a runtime toggle, so
             // ensure the daemon permits them. Fire-and-forget.
             Task::perform(set_allow_online_models(true), |_| cosmic::Action::None),
-            Task::perform(list_backends(), |result| match result {
-                Ok(backends) => {
-                    cosmic::Action::App(Message::Backend(BackendMessage::BackendsLoaded(backends)))
-                }
-                Err(e) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsError(
-                    e.to_string(),
-                ))),
-            }),
+            crate::core::app::handlers::tasks::reload_backends(),
             Task::perform(get_active_backend(), |result| {
                 cosmic::Action::App(Message::ModelsPage(ModelsPageMessage::ActiveBackendLoaded(
                     result.unwrap_or(None),

--- a/super-stt-app/src/core/app/handlers/models_page/install.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/install.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::AppModel;
-use crate::daemon::client::list_backends;
 use crate::ui::messages::{BackendMessage, Message, ModelsPageMessage};
 use cosmic::prelude::*;
 
@@ -177,14 +176,7 @@ impl AppModel {
                 self.registry.install_errors.remove(&source);
                 // Refresh the installed-backends list so the new install
                 // shows up in the Installed tab.
-                Task::perform(list_backends(), |result| match result {
-                    Ok(backends) => cosmic::Action::App(Message::Backend(
-                        BackendMessage::BackendsLoaded(backends),
-                    )),
-                    Err(e) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsError(
-                        e.to_string(),
-                    ))),
-                })
+                crate::core::app::handlers::tasks::reload_backends()
             }
 
             ModelsPageMessage::InstallFailed {

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -73,10 +73,11 @@ impl AppModel {
     ) -> Task<cosmic::Action<Message>> {
         match message {
             ModelsPageMessage::ModelsTabActivated(entity) => {
-                self.models_tabs.activate(entity);
+                self.models_page.models_tabs.activate(entity);
                 // Trigger initial registry fetch when the Download tab is opened
                 // for the first time (backends empty and no prior refresh attempt).
                 let switched_to_download = self
+                    .models_page
                     .models_tabs
                     .data::<ModelsTab>(entity)
                     .is_some_and(|t| *t == ModelsTab::Download);
@@ -84,21 +85,7 @@ impl AppModel {
                     && self.registry.backends.is_empty()
                     && self.registry.last_refresh.is_none()
                 {
-                    // Fetch the full annotated catalog (including incompatible
-                    // entries); all filtering is applied client-side.
-                    let filters = crate::daemon::registry::ListFilters {
-                        include_incompatible: Some(true),
-                        ..Default::default()
-                    };
-                    return Task::perform(
-                        async move { crate::daemon::registry::list(&filters).await },
-                        |r| {
-                            cosmic::Action::App(Message::ModelsPage(match r {
-                                Ok(resp) => ModelsPageMessage::RegistryListLoaded(resp),
-                                Err(e) => ModelsPageMessage::RegistryListFailed(e.to_string()),
-                            }))
-                        },
-                    );
+                    return crate::core::app::handlers::tasks::fetch_registry_catalog(false);
                 }
                 Task::none()
             }
@@ -109,7 +96,7 @@ impl AppModel {
                 // device to the model's first supported entry (so a single-
                 // device model needs no extra click; multi-device models
                 // surface the dropdown).
-                let source = self.active_backend.clone();
+                let source = self.models_page.active_backend.clone();
                 let device = source.as_ref().and_then(|src| {
                     self.backends
                         .iter()
@@ -121,8 +108,8 @@ impl AppModel {
                         .first()
                         .cloned()
                 });
-                self.staged_model = Some(model.clone());
-                self.staged_device = device;
+                self.models_page.staged_model = Some(model.clone());
+                self.models_page.staged_device = device;
                 // Fetch the per-model language block at selection time so the
                 // active-backend card can show the language control before Load.
                 // Wire point 2: model staged (StageActiveModel).
@@ -134,7 +121,7 @@ impl AppModel {
             }
 
             ModelsPageMessage::StageActiveDevice(device) => {
-                self.staged_device = Some(device);
+                self.models_page.staged_device = Some(device);
                 Task::none()
             }
 
@@ -146,8 +133,8 @@ impl AppModel {
                 // state immediately; the daemon's `ready` event with
                 // `model_loaded: false` is the source of truth.
                 self.clear_loaded_model();
-                self.staged_model = None;
-                self.staged_device = None;
+                self.models_page.staged_model = None;
+                self.models_page.staged_device = None;
                 self.model_operation_state = ModelOperationState::Ready;
                 Task::perform(unload_active_model(), |result| match result {
                     Ok(_) => cosmic::Action::None,
@@ -162,11 +149,11 @@ impl AppModel {
     }
 
     fn handle_load_staged_model(&mut self) -> Task<cosmic::Action<Message>> {
-        let Some(source) = self.active_backend.clone() else {
+        let Some(source) = self.models_page.active_backend.clone() else {
             log::warn!("LoadStagedModel ignored — no active backend");
             return Task::none();
         };
-        let Some(model) = self.staged_model.clone() else {
+        let Some(model) = self.models_page.staged_model.clone() else {
             log::warn!("LoadStagedModel ignored — no staged model");
             return Task::none();
         };
@@ -193,7 +180,8 @@ impl AppModel {
         let device_to_set = if online {
             None
         } else {
-            self.staged_device
+            self.models_page
+                .staged_device
                 .clone()
                 .filter(|d| d != "none" && *d != self.current_device)
         };
@@ -243,24 +231,24 @@ impl AppModel {
                 // Open the per-backend configuration as a right-side sheet over
                 // the current list (active card or Installed tab), instead of a
                 // full-page takeover. Also closes the card's overflow menu.
-                self.configure_backend = Some(source);
+                self.models_page.configure_backend = Some(source);
                 self.context_page = ContextPage::ConfigureBackend;
                 self.core.window.show_context = true;
-                self.installed_menu_open = None;
+                self.models_page.installed_menu_open = None;
                 // Start the sheet without a stale save-error banner.
                 self.action_error = None;
                 Task::none()
             }
 
             ModelsPageMessage::CloseBackendConfig => {
-                self.configure_backend = None;
+                self.models_page.configure_backend = None;
                 self.core.window.show_context = false;
                 self.action_error = None;
                 Task::none()
             }
 
             ModelsPageMessage::ActiveBackendLoaded(source) => {
-                self.active_backend = source;
+                self.models_page.active_backend = source;
                 Task::none()
             }
 
@@ -288,10 +276,10 @@ impl AppModel {
                 // Select the backend WITHOUT loading a model — the card moves
                 // to the top fixed header, any model from a different backend
                 // is unloaded. (`set_model` is the way to also load a model.)
-                if self.active_backend.as_deref() == Some(source.as_str()) {
+                if self.models_page.active_backend.as_deref() == Some(source.as_str()) {
                     return Task::none();
                 }
-                self.active_backend = Some(source.clone());
+                self.models_page.active_backend = Some(source.clone());
                 self.clear_loaded_model();
                 self.model_operation_state = ModelOperationState::Ready;
                 // Activation comes from the Models page's "Load a backend" sheet;
@@ -309,10 +297,10 @@ impl AppModel {
                 // Optimistically clear the active backend + loaded model; the
                 // daemon goes idle. (Rejected only mid-recording — an edge case
                 // that self-heals on the next refresh.)
-                self.active_backend = None;
+                self.models_page.active_backend = None;
                 self.clear_loaded_model();
                 self.model_operation_state = ModelOperationState::Ready;
-                self.configure_backend = None;
+                self.models_page.configure_backend = None;
                 // Close the configuration sheet if it was open for this backend.
                 self.core.window.show_context = false;
                 Task::perform(clear_active_backend(), |_| cosmic::Action::None)
@@ -320,16 +308,16 @@ impl AppModel {
 
             ModelsPageMessage::ToggleInstalledMenu(source) => {
                 // Toggle this card's overflow menu; opening one closes any other.
-                if self.installed_menu_open.as_deref() == Some(source.as_str()) {
-                    self.installed_menu_open = None;
+                if self.models_page.installed_menu_open.as_deref() == Some(source.as_str()) {
+                    self.models_page.installed_menu_open = None;
                 } else {
-                    self.installed_menu_open = Some(source);
+                    self.models_page.installed_menu_open = Some(source);
                 }
                 Task::none()
             }
 
             ModelsPageMessage::CloseInstalledMenu => {
-                self.installed_menu_open = None;
+                self.models_page.installed_menu_open = None;
                 Task::none()
             }
 

--- a/super-stt-app/src/core/app/handlers/models_page/registry.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/registry.rs
@@ -11,24 +11,9 @@ impl AppModel {
     ) -> Task<cosmic::Action<Message>> {
         match message {
             ModelsPageMessage::RefreshRegistry => {
-                // Always fetch the full annotated catalog; filtering is
-                // client-side so the toggles never need a round-trip.
-                let filters = crate::daemon::registry::ListFilters {
-                    include_incompatible: Some(true),
-                    ..Default::default()
-                };
-                Task::perform(
-                    async move {
-                        let _ = crate::daemon::registry::refresh().await;
-                        crate::daemon::registry::list(&filters).await
-                    },
-                    |r| {
-                        cosmic::Action::App(Message::ModelsPage(match r {
-                            Ok(resp) => ModelsPageMessage::RegistryListLoaded(resp),
-                            Err(e) => ModelsPageMessage::RegistryListFailed(e.to_string()),
-                        }))
-                    },
-                )
+                // Refresh the index, then fetch the full annotated catalog;
+                // filtering is client-side so the toggles never need a round-trip.
+                crate::core::app::handlers::tasks::fetch_registry_catalog(true)
             }
 
             ModelsPageMessage::RegistryListLoaded(resp) => {

--- a/super-stt-app/src/core/app/handlers/tasks.rs
+++ b/super-stt-app/src/core/app/handlers/tasks.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Shared `Task` builders re-used across handlers, so the same daemon call +
+//! result-to-`Message` mapping isn't re-rolled at each call site.
+
+use crate::daemon::client::{
+    get_current_audio_theme, get_custom_models_dir, get_preview_typing, get_recording_stop_mode,
+    get_volume, get_write_method, list_backends, ping_daemon,
+};
+use crate::state::AudioTheme;
+use crate::ui::messages::{
+    BackendMessage, DaemonMessage, Message, ModelsPageMessage, PreviewTypingMessage,
+    RecordingStopModeMessage, WriteMethodMessage,
+};
+use cosmic::prelude::*;
+use log::warn;
+
+/// Ping the daemon and map the result to `DaemonConnected` / `DaemonError`.
+/// Shared by the periodic keep-alive, the reconnect retries, and the startup
+/// ping.
+pub(in crate::core::app) fn ping_task() -> Task<cosmic::Action<Message>> {
+    Task::perform(ping_daemon(), |result| {
+        cosmic::Action::App(Message::Daemon(match result {
+            Ok(_) => DaemonMessage::DaemonConnected,
+            Err(e) => DaemonMessage::DaemonError(e),
+        }))
+    })
+}
+
+/// Reload the installed-backend catalog and map the result to `BackendsLoaded`
+/// / `BackendsError`.
+pub(in crate::core::app) fn reload_backends() -> Task<cosmic::Action<Message>> {
+    Task::perform(list_backends(), |result| {
+        cosmic::Action::App(match result {
+            Ok(backends) => Message::Backend(BackendMessage::BackendsLoaded(backends)),
+            Err(e) => Message::Backend(BackendMessage::BackendsError(e.to_string())),
+        })
+    })
+}
+
+/// Fetch the full annotated registry catalog (optionally refreshing the index
+/// first) and map the result to `RegistryListLoaded` / `RegistryListFailed`.
+/// The catalog always includes incompatible entries; filtering is client-side.
+pub(in crate::core::app) fn fetch_registry_catalog(refresh: bool) -> Task<cosmic::Action<Message>> {
+    let filters = crate::daemon::registry::ListFilters {
+        include_incompatible: Some(true),
+        ..Default::default()
+    };
+    Task::perform(
+        async move {
+            if refresh {
+                let _ = crate::daemon::registry::refresh().await;
+            }
+            crate::daemon::registry::list(&filters).await
+        },
+        |r| {
+            cosmic::Action::App(Message::ModelsPage(match r {
+                Ok(resp) => ModelsPageMessage::RegistryListLoaded(resp),
+                Err(e) => ModelsPageMessage::RegistryListFailed(e.to_string()),
+            }))
+        },
+    )
+}
+
+/// Reload models, device info, and per-setting state on reconnect. Each setting
+/// is fetched with its own dedicated GET call — no bulk `fetch_daemon_config`.
+pub(in crate::core::app) fn build_load_settings_tasks() -> Task<cosmic::Action<Message>> {
+    Task::batch([
+        Task::perform(get_current_audio_theme(), |result| match result {
+            Ok(theme) => cosmic::Action::App(Message::Daemon(
+                DaemonMessage::CurrentAudioThemeLoaded(theme),
+            )),
+            Err(e) => {
+                warn!("Failed to load audio theme: {e}");
+                cosmic::Action::App(Message::Daemon(DaemonMessage::CurrentAudioThemeLoaded(
+                    AudioTheme::default(),
+                )))
+            }
+        }),
+        Task::perform(get_volume(), |result| match result {
+            Ok(vol) => cosmic::Action::App(Message::Daemon(DaemonMessage::VolumeLoaded(vol))),
+            Err(e) => {
+                warn!("Failed to load volume: {e}");
+                cosmic::Action::App(Message::Daemon(DaemonMessage::VolumeLoaded(100)))
+            }
+        }),
+        Task::perform(get_custom_models_dir(), |result| match result {
+            Ok(dir) => {
+                cosmic::Action::App(Message::Daemon(DaemonMessage::CustomModelsDirLoaded(dir)))
+            }
+            Err(e) => {
+                warn!("Failed to load custom models dir: {e}");
+                cosmic::Action::App(Message::Daemon(DaemonMessage::CustomModelsDirLoaded(None)))
+            }
+        }),
+        Task::perform(get_preview_typing(), |result| match result {
+            Ok(enabled) => cosmic::Action::App(Message::PreviewTyping(
+                PreviewTypingMessage::SettingLoaded(enabled),
+            )),
+            Err(e) => {
+                log::warn!("Failed to load preview typing setting: {e}");
+                cosmic::Action::App(Message::PreviewTyping(PreviewTypingMessage::SettingLoaded(
+                    false,
+                )))
+            }
+        }),
+        Task::perform(get_recording_stop_mode(), |result| {
+            use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
+            match result {
+                Ok(mode_str) => {
+                    let mode = mode_str.parse::<RecordingStopMode>().unwrap_or_default();
+                    cosmic::Action::App(Message::RecordingStopMode(
+                        RecordingStopModeMessage::Loaded(mode),
+                    ))
+                }
+                Err(e) => {
+                    log::warn!("Failed to load recording stop mode: {e}");
+                    cosmic::Action::App(Message::RecordingStopMode(
+                        RecordingStopModeMessage::Loaded(RecordingStopMode::default()),
+                    ))
+                }
+            }
+        }),
+        Task::perform(get_write_method(), |result| {
+            use super_stt_shared::models::write_method::WriteMethod;
+            match result {
+                Ok(method_str) => {
+                    let method = method_str.parse::<WriteMethod>().unwrap_or_default();
+                    cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(method)))
+                }
+                Err(e) => {
+                    log::warn!("Failed to load write method: {e}");
+                    cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(
+                        WriteMethod::default(),
+                    )))
+                }
+            }
+        }),
+    ])
+}

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::daemon::client::{load_audio_themes, ping_daemon};
-use crate::state::{AudioTheme, ContextPage, DaemonStatus, ModelsTab, RecordingStatus};
+use crate::daemon::client::load_audio_themes;
+use crate::state::{AudioTheme, ContextPage, DaemonStatus, RecordingStatus};
 use crate::ui::icons;
-use crate::ui::messages::{DaemonMessage, Message, ModelMessage, RecordingMessage};
+use crate::ui::messages::{Message, ModelMessage, RecordingMessage};
 use cosmic::prelude::*;
-use cosmic::widget::{nav_bar, segmented_button};
+use cosmic::widget::nav_bar;
 use std::collections::HashMap;
 use super_stt_shared::models::provider::Provider;
 
@@ -51,21 +51,6 @@ fn build_nav() -> nav_bar::Model {
     nav
 }
 
-/// Builds the Models-page tab bar with Installed and Browse tabs.
-fn build_models_tabs() -> segmented_button::SingleSelectModel {
-    let mut models_tabs = segmented_button::SingleSelectModel::default();
-    models_tabs
-        .insert()
-        .text("Installed")
-        .data(ModelsTab::Installed)
-        .activate();
-    models_tabs
-        .insert()
-        .text("Browse")
-        .data(ModelsTab::Download);
-    models_tabs
-}
-
 /// Builds the initial batch of startup tasks (audio themes, daemon ping, data load).
 fn initial_load_tasks(
     title_command: Task<cosmic::Action<Message>>,
@@ -78,12 +63,7 @@ fn initial_load_tasks(
     });
 
     // Try to ping the daemon on startup
-    let initial_ping = Task::perform(ping_daemon(), |result| {
-        cosmic::Action::App(match result {
-            Ok(_) => Message::Daemon(DaemonMessage::DaemonConnected),
-            Err(e) => Message::Daemon(DaemonMessage::DaemonError(e)),
-        })
-    });
+    let initial_ping = crate::core::app::handlers::tasks::ping_task();
 
     // Load initial data (models + device info) on startup
     let load_initial_data = Task::perform(
@@ -104,7 +84,6 @@ impl AppModel {
         _flags: (),
     ) -> (Self, Task<cosmic::Action<Message>>) {
         let nav = build_nav();
-        let models_tabs = build_models_tabs();
 
         // Construct the app model with the runtime's core.
         let mut app = AppModel {
@@ -157,19 +136,10 @@ impl AppModel {
             custom_models_dir_input: String::new(),
 
             // Models page UI state
-            models_tabs,
-            active_backend: None,
-            staged_model: None,
-            staged_device: None,
-            configure_backend: None,
-            installed_menu_open: None,
+            models_page: crate::state::models_page::ModelsPageState::default(),
 
             // Transcription language state
-            primary_language: None,
-            model_language: None,
-            model_language_for: None,
-            language_picker_target: None,
-            language_picker_query: String::new(),
+            language: crate::state::language::LanguageState::default(),
 
             // Backend catalog + per-backend configuration state
             backends: Vec::new(),

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -15,7 +15,7 @@ use crate::ui::messages::{DaemonMessage, Message, ModelsPageMessage, ShellMessag
 use cosmic::app::context_drawer;
 use cosmic::iced::Subscription;
 use cosmic::prelude::*;
-use cosmic::widget::{menu, nav_bar, segmented_button};
+use cosmic::widget::{menu, nav_bar};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use super_stt_shared::models::provider::Provider;
@@ -141,42 +141,11 @@ pub struct AppModel {
     pub custom_models_dir: Option<String>,
     pub custom_models_dir_input: String,
 
-    // Models page UI state
-    /// Installed / Download tab bar for the Models page (active tab carries a
-    /// [`ModelsTab`] as its data).
-    pub models_tabs: segmented_button::SingleSelectModel,
-    /// Source of the currently-selected (active) backend, shown in the card
-    /// above the tabs. `None` when the daemon is idle.
-    pub active_backend: Option<String>,
-    /// Model the user has picked in the active-backend card's dropdown but
-    /// hasn't yet committed via the Load button. Cleared once a model is
-    /// loaded or the user changes backends.
-    pub staged_model: Option<String>,
-    /// Device the user has picked for the staged model (CPU / CUDA / Metal,
-    /// or `"none"` for an online model that needs no device choice). Cleared
-    /// alongside [`Self::staged_model`].
-    pub staged_device: Option<String>,
-    /// The backend whose configuration sub-view is open, if any (`source`).
-    pub configure_backend: Option<String>,
+    // Models page UI state (tabs, active-backend card selection/staging, menus).
+    pub models_page: crate::state::models_page::ModelsPageState,
 
-    // Transcription language state.
-    /// Global Primary Language from the daemon (None = unset). Display-only cache.
-    pub primary_language: Option<String>,
-    /// Resolution block from `GET /backends/{source}/models/{model}/language`
-    /// for the model identified by `model_language_for`.
-    pub model_language: Option<serde_json::Value>,
-    /// Which `(source, model)` pair `model_language` belongs to. Guards
-    /// stale-block display: only use `model_language` when this matches
-    /// the target `(source, model)`.
-    pub model_language_for: Option<(String, String)>,
-    /// The `(source, model)` pair the open per-model language sheet configures.
-    /// `None` when the sheet is in global mode.
-    pub language_picker_target: Option<(String, String)>,
-    /// Live query text for the language search sheet.
-    pub language_picker_query: String,
-    /// `source` of the installed-backend card whose overflow ("⋯") menu is
-    /// open, if any. Only one is open at a time.
-    pub installed_menu_open: Option<String>,
+    // Transcription language state (global Primary Language + per-model picker).
+    pub language: crate::state::language::LanguageState,
 
     // Installed-backend catalog and per-backend configuration state.
     /// Backends discovered by the daemon, with the models/secrets/options
@@ -351,7 +320,7 @@ impl cosmic::Application for AppModel {
         // (e.g. the Models page's "Add backend" / configuration drawer) and
         // any open per-card overflow menu.
         self.core.window.show_context = false;
-        self.installed_menu_open = None;
+        self.models_page.installed_menu_open = None;
 
         self.update_title()
     }

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -94,7 +94,7 @@ impl AppModel {
             // Language picker sheet — a search-box + scrollable selectable list
             // for setting the global Primary Language or the active-model override.
             ContextPage::LanguagePicker => {
-                let title = if self.language_picker_target.is_some() {
+                let title = if self.language.language_picker_target.is_some() {
                     "Model language"
                 } else {
                     "Primary Language"
@@ -117,6 +117,7 @@ impl AppModel {
                         Some(Page::Models | Page::Library)
                     );
                 let backend = self
+                    .models_page
                     .configure_backend
                     .as_ref()
                     .and_then(|src| self.backends.iter().find(|b| &b.source == src));
@@ -155,7 +156,7 @@ impl AppModel {
                 &self.audio_themes,
                 &self.selected_audio_theme,
                 self.volume,
-                self.primary_language.as_deref(),
+                self.language.primary_language.as_deref(),
                 self.action_error_for(crate::state::ErrorScope::Customization),
             ),
             Page::Recording => views::recording::page(

--- a/super-stt-app/src/daemon/client/v1/settings/language.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/language.rs
@@ -58,7 +58,10 @@ pub async fn clear_primary_language() -> HttpResult<()> {
 /// Returns the full resolution `Value` (object with `effective`, `source`,
 /// `multilingual`, `supported`, `primary`, `override`), or `Value::Null`
 /// when the model is not found.
-pub async fn get_model_language(source: String, model: String) -> HttpResult<serde_json::Value> {
+pub async fn get_model_language(
+    source: String,
+    model: String,
+) -> HttpResult<crate::state::LanguageResolution> {
     with_settings_token(move |socket, token| {
         let (source, model) = (source.clone(), model.clone());
         async move {
@@ -67,7 +70,13 @@ pub async fn get_model_language(source: String, model: String) -> HttpResult<ser
                 transport::settings_get(socket, &token, &path).await?,
                 "get_model_language",
             )?;
-            Ok(resp.language.unwrap_or(serde_json::Value::Null))
+            // Deserialize the block into a typed resolution here at the boundary;
+            // an absent or malformed block yields the empty default rather than
+            // being poked field-by-field in the views.
+            Ok(resp
+                .language
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or_default())
         }
     })
     .await
@@ -80,7 +89,7 @@ pub async fn set_model_language(
     source: String,
     model: String,
     language: String,
-) -> HttpResult<serde_json::Value> {
+) -> HttpResult<crate::state::LanguageResolution> {
     with_settings_token(move |socket, token| {
         let (source, model, language) = (source.clone(), model.clone(), language.clone());
         async move {
@@ -95,7 +104,10 @@ pub async fn set_model_language(
                 .await?,
                 "set_model_language",
             )?;
-            Ok(resp.language.unwrap_or(serde_json::Value::Null))
+            Ok(resp
+                .language
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or_default())
         }
     })
     .await
@@ -104,7 +116,10 @@ pub async fn set_model_language(
 /// Clear a specific model's language override
 /// (HTTP `DELETE /backends/{source}/models/{model}/language`).
 /// Returns the updated resolution block.
-pub async fn clear_model_language(source: String, model: String) -> HttpResult<serde_json::Value> {
+pub async fn clear_model_language(
+    source: String,
+    model: String,
+) -> HttpResult<crate::state::LanguageResolution> {
     with_settings_token(move |socket, token| {
         let (source, model) = (source.clone(), model.clone());
         async move {
@@ -113,7 +128,10 @@ pub async fn clear_model_language(source: String, model: String) -> HttpResult<s
                 transport::settings_delete(socket, &token, &path).await?,
                 "clear_model_language",
             )?;
-            Ok(resp.language.unwrap_or(serde_json::Value::Null))
+            Ok(resp
+                .language
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or_default())
         }
     })
     .await

--- a/super-stt-app/src/state/language.rs
+++ b/super-stt-app/src/state/language.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Transcription-language UI state, extracted from `AppModel` following the
+//! `RegistryState` template (App Tier 3 #15).
+
+use crate::state::LanguageResolution;
+
+/// The global Primary Language plus the per-model override picker state.
+#[derive(Debug, Clone, Default)]
+pub struct LanguageState {
+    /// Global Primary Language from the daemon (`None` = unset). Display-only cache.
+    pub primary_language: Option<String>,
+    /// Resolution block from `GET /backends/{source}/models/{model}/language`
+    /// for the model identified by `model_language_for`.
+    pub model_language: Option<LanguageResolution>,
+    /// Which `(source, model)` pair `model_language` belongs to. Guards
+    /// stale-block display: only use `model_language` when this matches the
+    /// target `(source, model)`.
+    pub model_language_for: Option<(String, String)>,
+    /// The `(source, model)` pair the open per-model language sheet configures.
+    /// `None` when the sheet is in global mode.
+    pub language_picker_target: Option<(String, String)>,
+    /// Live query text for the language search sheet.
+    pub language_picker_query: String,
+}

--- a/super-stt-app/src/state/mod.rs
+++ b/super-stt-app/src/state/mod.rs
@@ -2,11 +2,13 @@
 
 //! Application state and domain models.
 
+pub mod language;
 pub mod models;
+pub mod models_page;
 pub mod registry;
 
 // Re-export commonly used types
 pub use models::{
-    ActionError, AudioTheme, ContextPage, DaemonStatus, ErrorScope, MenuAction, ModelsTab, Page,
-    RecordingStatus,
+    ActionError, AudioTheme, ContextPage, DaemonStatus, ErrorScope, LanguageResolution, MenuAction,
+    ModelsTab, Page, RecordingStatus,
 };

--- a/super-stt-app/src/state/models.rs
+++ b/super-stt-app/src/state/models.rs
@@ -97,6 +97,27 @@ pub struct ActionError {
     pub message: String,
 }
 
+/// The per-model language resolution block returned by
+/// `GET /backends/{source}/models/{model}/language`, deserialized once at the
+/// client boundary instead of being poked field-by-field as a
+/// `serde_json::Value` in the views. Unknown/absent fields default so a partial
+/// or null block yields an empty, harmless resolution.
+#[derive(Clone, Debug, Default, serde::Deserialize)]
+pub struct LanguageResolution {
+    /// The effective BCP-47 tag in use, if any (`None` when unresolved).
+    #[serde(default)]
+    pub effective: Option<String>,
+    /// How `effective` was resolved: `"override"`, `"global"`, or `"default"`.
+    #[serde(default)]
+    pub source: String,
+    /// The global Primary Language tag used as the default fallback.
+    #[serde(default)]
+    pub primary: String,
+    /// The languages this model supports.
+    #[serde(default)]
+    pub supported: Vec<String>,
+}
+
 /// Which tab of the Models page is active.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum ModelsTab {

--- a/super-stt-app/src/state/models_page.rs
+++ b/super-stt-app/src/state/models_page.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Models-page UI selection/menu state, extracted from `AppModel` following the
+//! `RegistryState` template (App Tier 3 #15).
+
+use cosmic::widget::segmented_button;
+
+use crate::state::ModelsTab;
+
+/// Ephemeral Models-page UI state: the Installed/Browse tab bar plus the
+/// active-backend card's selection, staging, and menu flags.
+pub struct ModelsPageState {
+    /// Installed / Download tab bar (the active tab carries a [`ModelsTab`]).
+    pub models_tabs: segmented_button::SingleSelectModel,
+    /// Source of the currently-selected (active) backend, shown in the card
+    /// above the tabs. `None` when the daemon is idle.
+    pub active_backend: Option<String>,
+    /// Model the user has picked in the active-backend card's dropdown but
+    /// hasn't yet committed via the Load button.
+    pub staged_model: Option<String>,
+    /// Device the user has picked for the staged model (`"none"` for an online
+    /// model that needs no device choice).
+    pub staged_device: Option<String>,
+    /// The backend whose configuration sub-view is open, if any (`source`).
+    pub configure_backend: Option<String>,
+    /// `source` of the installed-backend card whose overflow ("⋯") menu is
+    /// open, if any. Only one is open at a time.
+    pub installed_menu_open: Option<String>,
+}
+
+impl Default for ModelsPageState {
+    fn default() -> Self {
+        let mut models_tabs = segmented_button::SingleSelectModel::default();
+        models_tabs
+            .insert()
+            .text("Installed")
+            .data(ModelsTab::Installed)
+            .activate();
+        models_tabs
+            .insert()
+            .text("Browse")
+            .data(ModelsTab::Download);
+        Self {
+            models_tabs,
+            active_backend: None,
+            staged_model: None,
+            staged_device: None,
+            configure_backend: None,
+            installed_menu_open: None,
+        }
+    }
+}

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -318,7 +318,7 @@ pub enum LanguageMessage {
     ModelLanguageLoaded {
         source: String,
         model: String,
-        block: serde_json::Value,
+        block: crate::state::LanguageResolution,
     },
     /// User picked a per-model override.
     /// `choice = None` → Follow global (DELETE override);

--- a/super-stt-app/src/ui/views/language_picker.rs
+++ b/super-stt-app/src/ui/views/language_picker.rs
@@ -9,28 +9,27 @@ use crate::ui::messages::{LanguageMessage, Message};
 
 pub fn sheet(app: &AppModel) -> Element<'_, Message> {
     let spacing = cosmic::theme::spacing();
-    let q = app.language_picker_query.to_lowercase();
+    let q = app.language.language_picker_query.to_lowercase();
 
     // Build the candidate (tag, label) list for the active mode. Special
     // entries stay pinned at the top; the language entries are sorted
     // alphabetically by display name.
     let mut pinned: Vec<(Option<String>, String)> = Vec::new();
     let mut langs: Vec<(Option<String>, String)> = Vec::new();
-    if let Some((ref src, ref mdl)) = app.language_picker_target {
+    if let Some((ref src, ref mdl)) = app.language.language_picker_target {
         // Per-model sheet.
         pinned.push((None, "Follow global".to_string())); // clear → DELETE
         pinned.push((Some("auto".to_string()), friendly_name("auto"))); // "Auto-detect"
         // Supported languages from the resolution block — but only when the
         // block belongs to this exact (source, model) pair (stale-block guard).
-        if app.model_language_for.as_ref() == Some(&(src.clone(), mdl.clone()))
-            && let Some(block) = &app.model_language
-            && let Some(arr) = block.get("supported").and_then(|v| v.as_array())
+        if app.language.model_language_for.as_ref() == Some(&(src.clone(), mdl.clone()))
+            && let Some(block) = &app.language.model_language
         {
-            for tag in arr.iter().filter_map(|v| v.as_str()) {
+            for tag in &block.supported {
                 if tag.eq_ignore_ascii_case("auto") {
                     continue; // already pinned as "Auto-detect"
                 }
-                langs.push((Some(tag.to_string()), friendly_name(tag)));
+                langs.push((Some(tag.clone()), friendly_name(tag)));
             }
         }
     } else {
@@ -57,13 +56,13 @@ pub fn sheet(app: &AppModel) -> Element<'_, Message> {
         .collect();
 
     // Search field pinned at the top.
-    let search = text_input("Search languages…", &app.language_picker_query)
+    let search = text_input("Search languages…", &app.language.language_picker_query)
         .on_input(|s| Message::Language(LanguageMessage::LanguagePickerQueryChanged(s)))
         .width(Length::Fill);
 
     let mut list = column::with_capacity(rows.len()).spacing(spacing.space_xxs);
     for (tag, label) in rows {
-        let msg = if let Some((ref src, ref mdl)) = app.language_picker_target {
+        let msg = if let Some((ref src, ref mdl)) = app.language.language_picker_target {
             Message::Language(LanguageMessage::ModelLanguageSelected {
                 source: src.clone(),
                 model: mdl.clone(),

--- a/super-stt-app/src/ui/views/models/active.rs
+++ b/super-stt-app/src/ui/views/models/active.rs
@@ -21,30 +21,41 @@ use super::fmt::vram_warning;
 use super::status::unmet_requirements;
 use super::surface::{card_divider, card_surface};
 
-/// The leading glyph tile shared by every backend card: a soft accent-tinted
-/// rounded square holding the "models" brain glyph. Gives each card a
-/// consistent anchor on the left that lines up with the two-line name/source
-/// block beside it.
-pub(super) fn backend_glyph_tile<'a>() -> Element<'a, Message> {
+/// A soft accent-tinted rounded square holding the "models" brain glyph.
+/// `tile` is the square's side, `glyph` the icon size; `radius_medium` picks the
+/// larger corner radius for the big empty-state ring vs. the small card tile.
+pub(super) fn glyph_tile<'a>(tile: f32, glyph: f32, radius_medium: bool) -> Element<'a, Message> {
     let accent: cosmic::iced::Color = cosmic::theme::active().cosmic().accent.base.into();
     let mut fill = accent;
     fill.a = 0.16;
-    let size = 40.0_f32;
 
-    widget::container(icons::phosphor_tinted(icons::BRAIN, 22.0, accent))
-        .center_x(Length::Fixed(size))
-        .center_y(Length::Fixed(size))
+    widget::container(icons::phosphor_tinted(icons::BRAIN, glyph, accent))
+        .center_x(Length::Fixed(tile))
+        .center_y(Length::Fixed(tile))
         .class(cosmic::theme::Container::custom(move |theme| {
+            let radii = theme.cosmic().corner_radii;
             cosmic::iced_widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(fill)),
                 border: cosmic::iced::Border {
-                    radius: theme.cosmic().corner_radii.radius_s.into(),
+                    radius: if radius_medium {
+                        radii.radius_m
+                    } else {
+                        radii.radius_s
+                    }
+                    .into(),
                     ..Default::default()
                 },
                 ..Default::default()
             }
         }))
         .into()
+}
+
+/// The leading glyph tile shared by every backend card: gives each card a
+/// consistent anchor on the left that lines up with the two-line name/source
+/// block beside it.
+pub(super) fn backend_glyph_tile<'a>() -> Element<'a, Message> {
+    glyph_tile(40.0, 22.0, false)
 }
 
 /// Assemble a backend card's header: the leading glyph tile, a two-line name +
@@ -82,7 +93,7 @@ pub(super) fn backend_header(
 /// `None` for a mono-lingual model so the caller can skip the push entirely.
 ///
 /// The button label reflects the current per-model resolution block when
-/// `app.model_language_for` matches `(backend.source, selected_model)`;
+/// `app.language.model_language_for` matches `(backend.source, selected_model)`;
 /// otherwise it falls back to a neutral `"Language"` label (block not yet
 /// fetched — stale-block guard). It opens the language picker for this model.
 fn language_button<'a>(
@@ -100,31 +111,31 @@ fn language_button<'a>(
 
     // Build the trigger label from the resolution block — but only when the
     // block belongs to this exact (source, model) pair (stale-block guard).
-    let label =
-        if app.model_language_for.as_ref() == Some(&(source.clone(), selected_model.to_string())) {
-            if let Some(block) = &app.model_language {
-                let effective = block.get("effective").and_then(serde_json::Value::as_str);
-                let source_str = block
-                    .get("source")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("default");
-                let primary = block
-                    .get("primary")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("");
-                match (effective, source_str) {
-                    (Some(tag), "override") => crate::ui::languages::friendly_name(tag),
-                    (Some(tag), "global") => {
-                        format!("{} · global", crate::ui::languages::friendly_name(tag))
-                    }
-                    _ => format!("{} · default", crate::ui::languages::friendly_name(primary)),
-                }
+    let label = if app.language.model_language_for.as_ref()
+        == Some(&(source.clone(), selected_model.to_string()))
+    {
+        if let Some(block) = &app.language.model_language {
+            let source_str = if block.source.is_empty() {
+                "default"
             } else {
-                "Language".to_string()
+                block.source.as_str()
+            };
+            match (block.effective.as_deref(), source_str) {
+                (Some(tag), "override") => crate::ui::languages::friendly_name(tag),
+                (Some(tag), "global") => {
+                    format!("{} · global", crate::ui::languages::friendly_name(tag))
+                }
+                _ => format!(
+                    "{} · default",
+                    crate::ui::languages::friendly_name(&block.primary)
+                ),
             }
         } else {
             "Language".to_string()
-        };
+        }
+    } else {
+        "Language".to_string()
+    };
 
     Some(
         widget::button::standard(label)
@@ -300,14 +311,14 @@ pub(super) fn vram_shortfall(
 /// model's VRAM estimate vs. the primary GPU's free memory (falling back to
 /// its total when the daemon didn't report free).
 pub(super) fn staged_vram_shortfall(backend: &BackendInfo, app: &AppModel) -> Option<(u64, u64)> {
-    let model_name = app.staged_model.as_deref()?;
+    let model_name = app.models_page.staged_model.as_deref()?;
     let model = backend.models.iter().find(|m| m.name == model_name)?;
     let gpu_available = app
         .gpu_info
         .first()
         .map(|g| g.free_bytes.unwrap_or(g.total_bytes));
     vram_shortfall(
-        app.staged_device.as_deref(),
+        app.models_page.staged_device.as_deref(),
         model.estimated_vram_bytes,
         gpu_available,
     )
@@ -325,9 +336,9 @@ pub(super) fn staged_model_picker<'a>(
 ) -> Element<'a, Message> {
     let spacing = cosmic::theme::spacing();
 
-    // Model dropdown — staged picks live in `app.staged_model`, not loaded.
+    // Model dropdown — staged picks live in `app.models_page.staged_model`, not loaded.
     let model_names: Vec<String> = backend.models.iter().map(|m| m.name.clone()).collect();
-    let staged_model = app.staged_model.as_deref();
+    let staged_model = app.models_page.staged_model.as_deref();
     let model_index = staged_model.and_then(|m| model_names.iter().position(|n| n == m));
     let model_names_pick = model_names.clone();
     // Model select takes twice the width of the device select (2:1 flex ratio).
@@ -355,6 +366,7 @@ pub(super) fn staged_model_picker<'a>(
     if show_device_picker {
         let devices: Vec<String> = staged_model_supports.unwrap_or(&[]).to_vec();
         let device_index = app
+            .models_page
             .staged_device
             .as_deref()
             .and_then(|d| devices.iter().position(|x| x == d));
@@ -380,8 +392,8 @@ pub(super) fn staged_model_picker<'a>(
     // Load button — enabled only when a model is staged AND (the staged
     // device is set OR the model is the online-only `"none"` one, where
     // there is no device to pick).
-    let staged_ok = app.staged_model.is_some()
-        && (app.staged_device.is_some()
+    let staged_ok = app.models_page.staged_model.is_some()
+        && (app.models_page.staged_device.is_some()
             || staged_model_supports.is_some_and(|d| d == ["none".to_string()]));
     let load_button = button::suggested("Load model")
         .leading_icon(icons::phosphor_handle(icons::PLAY))

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -296,19 +296,9 @@ pub(super) fn chip_group(
     // with a small inset so the active chip visually sits within it.
     let track = widget::container(segments)
         .padding(3)
-        .class(cosmic::theme::Container::custom(|theme| {
-            let cosmic = theme.cosmic();
-            let component = &theme.current_container().component;
-            cosmic::iced_widget::container::Style {
-                background: Some(cosmic::iced::Background::Color(component.base.into())),
-                border: cosmic::iced::Border {
-                    radius: cosmic.corner_radii.radius_xl.into(),
-                    width: 1.0,
-                    color: component.divider.into(),
-                },
-                ..Default::default()
-            }
-        }));
+        .class(cosmic::theme::Container::custom(
+            super::surface::pill_surface,
+        ));
 
     row![
         text::caption(label.to_uppercase()).class(cosmic::theme::Text::Color(muted)),

--- a/super-stt-app/src/ui/views/models/download.rs
+++ b/super-stt-app/src/ui/views/models/download.rs
@@ -287,7 +287,7 @@ pub(super) fn download_card<'a>(
 
     let note: Element<'a, Message> = if let Some(s) = in_flight {
         match (&s.error, s.bytes_total) {
-            (Some(err), _) => text::caption(format!("Failed: {err:?}"))
+            (Some(err), _) => text::caption(format!("Failed: {err}"))
                 .class(cosmic::theme::Text::Color(muted))
                 .into(),
             (None, Some(total)) if total > 0 => {

--- a/super-stt-app/src/ui/views/models/installed.rs
+++ b/super-stt-app/src/ui/views/models/installed.rs
@@ -64,7 +64,7 @@ pub(super) fn installed_card<'a>(
 
     // Overflow ("⋯") menu: the optional Update, then Uninstall. Configure left
     // the menu to become a visible button beside it.
-    let menu_open = app.installed_menu_open.as_deref() == Some(source.as_str());
+    let menu_open = app.models_page.installed_menu_open.as_deref() == Some(source.as_str());
     let trigger = button::icon(icons::phosphor_handle(icons::DOTS_THREE_VERTICAL)).on_press(
         Message::ModelsPage(ModelsPageMessage::ToggleInstalledMenu(source.clone())),
     );

--- a/super-stt-app/src/ui/views/models/load_sheet.rs
+++ b/super-stt-app/src/ui/views/models/load_sheet.rs
@@ -21,23 +21,7 @@ use super::surface::muted_text_color;
 /// [`load_backend_sheet`]. Fills the page so it sits centered.
 pub(super) fn no_backend_empty_state<'a>() -> Element<'a, Message> {
     let spacing = cosmic::theme::spacing();
-    let accent: cosmic::iced::Color = cosmic::theme::active().cosmic().accent.base.into();
-    let mut fill = accent;
-    fill.a = 0.16;
-
-    let ring = widget::container(icons::phosphor_tinted(icons::BRAIN, 34.0, accent))
-        .center_x(Length::Fixed(72.0))
-        .center_y(Length::Fixed(72.0))
-        .class(cosmic::theme::Container::custom(move |theme| {
-            cosmic::iced_widget::container::Style {
-                background: Some(cosmic::iced::Background::Color(fill)),
-                border: cosmic::iced::Border {
-                    radius: theme.cosmic().corner_radii.radius_m.into(),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }
-        }));
+    let ring = super::active::glyph_tile(72.0, 34.0, true);
 
     let col = widget::column::with_capacity(4)
         .align_x(Alignment::Center)
@@ -70,7 +54,7 @@ pub(super) fn no_backend_empty_state<'a>() -> Element<'a, Message> {
 pub fn load_backend_sheet(app: &AppModel) -> Element<'_, Message> {
     let spacing = cosmic::theme::spacing();
     let muted = muted_text_color();
-    let active = app.active_backend.as_deref();
+    let active = app.models_page.active_backend.as_deref();
 
     let mut col = widget::column::with_capacity(app.backends.len() + 1)
         .spacing(spacing.space_xs)
@@ -142,19 +126,12 @@ fn load_backend_row(backend: &BackendInfo, is_active: bool) -> Element<'static, 
         .class(cosmic::theme::Container::custom(move |theme| {
             let cosmic = theme.cosmic();
             let component = &theme.current_container().component;
-            let border_color = if is_active {
-                let mut a: cosmic::iced::Color = cosmic.accent.base.into();
-                a.a = 0.55;
-                a
-            } else {
-                component.divider.into()
-            };
             cosmic::iced_widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(component.base.into())),
                 border: cosmic::iced::Border {
                     radius: cosmic.corner_radii.radius_s.into(),
                     width: 1.0,
-                    color: border_color,
+                    color: super::surface::accent_border_color(theme, is_active),
                 },
                 ..Default::default()
             }

--- a/super-stt-app/src/ui/views/models/mod.rs
+++ b/super-stt-app/src/ui/views/models/mod.rs
@@ -45,19 +45,7 @@ pub use load_sheet::load_backend_sheet;
 pub(crate) fn header_pill<'a>(content: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
     widget::container(content.into())
         .padding([8, 12])
-        .class(cosmic::theme::Container::custom(|theme| {
-            let cosmic = theme.cosmic();
-            let component = &theme.current_container().component;
-            cosmic::iced_widget::container::Style {
-                background: Some(cosmic::iced::Background::Color(component.base.into())),
-                border: cosmic::iced::Border {
-                    radius: cosmic.corner_radii.radius_xl.into(),
-                    width: 1.0,
-                    color: component.divider.into(),
-                },
-                ..Default::default()
-            }
-        }))
+        .class(cosmic::theme::Container::custom(surface::pill_surface))
         .into()
 }
 
@@ -190,6 +178,7 @@ pub fn page(app: &AppModel) -> Element<'_, Message> {
     // The active backend's card when one is selected (and still installed);
     // otherwise the empty state that opens the "Load a backend" sheet.
     let body = match app
+        .models_page
         .active_backend
         .as_deref()
         .and_then(|source| app.backends.iter().find(|b| b.source == source))
@@ -211,6 +200,7 @@ pub fn page(app: &AppModel) -> Element<'_, Message> {
 /// backends (no activation); Browse installs new ones.
 pub fn library_page(app: &AppModel) -> Element<'_, Message> {
     let active_tab = app
+        .models_page
         .models_tabs
         .active_data::<ModelsTab>()
         .copied()

--- a/super-stt-app/src/ui/views/models/status.rs
+++ b/super-stt-app/src/ui/views/models/status.rs
@@ -228,7 +228,7 @@ pub(super) enum ModelStatus {
 /// that drives the in-card warning rows is also what flips the dot's color.
 pub(super) fn model_status(app: &AppModel) -> ModelStatus {
     classify_model_status(
-        app.active_backend.as_deref(),
+        app.models_page.active_backend.as_deref(),
         &app.backends,
         &app.backend_secret_configured,
         &app.current_model,

--- a/super-stt-app/src/ui/views/models/surface.rs
+++ b/super-stt-app/src/ui/views/models/surface.rs
@@ -80,6 +80,36 @@ pub(super) fn toolbar_container<'a>(
         .into()
 }
 
+/// The border color a selectable panel takes: a translucent accent when
+/// active, else the neutral divider. Shared by the active-backend card and the
+/// load-sheet backend rows so "selected" reads the same everywhere.
+pub(super) fn accent_border_color(theme: &cosmic::Theme, active: bool) -> cosmic::iced::Color {
+    if active {
+        let mut a: cosmic::iced::Color = theme.cosmic().accent.base.into();
+        a.a = 0.55;
+        a
+    } else {
+        theme.current_container().component.divider.into()
+    }
+}
+
+/// The shared "pill" container style: list-container fill, a hairline divider
+/// border, and an extra-large corner radius (no shadow). Used by the header
+/// pills and the segmented-control track.
+pub(super) fn pill_surface(theme: &cosmic::Theme) -> cosmic::iced_widget::container::Style {
+    let cosmic = theme.cosmic();
+    let component = &theme.current_container().component;
+    cosmic::iced_widget::container::Style {
+        background: Some(cosmic::iced::Background::Color(component.base.into())),
+        border: cosmic::iced::Border {
+            radius: cosmic.corner_radii.radius_xl.into(),
+            width: 1.0,
+            color: component.divider.into(),
+        },
+        ..Default::default()
+    }
+}
+
 /// Wrap a card's content column in the shared card surface: a panel matching
 /// the list-container fill, lifted with a soft border, rounded corners, and a
 /// subtle shadow. The active backend's card takes an accent border to set it
@@ -94,13 +124,7 @@ pub(super) fn card_surface<'a>(
         .class(cosmic::theme::Container::custom(move |theme| {
             let cosmic = theme.cosmic();
             let component = &theme.current_container().component;
-            let border_color = if active {
-                let mut a: cosmic::iced::Color = cosmic.accent.base.into();
-                a.a = 0.55;
-                a
-            } else {
-                component.divider.into()
-            };
+            let border_color = accent_border_color(theme, active);
             cosmic::iced_widget::container::Style {
                 icon_color: Some(component.on.into()),
                 text_color: Some(component.on.into()),

--- a/super-stt-app/src/ui/views/models/tabs.rs
+++ b/super-stt-app/src/ui/views/models/tabs.rs
@@ -11,16 +11,17 @@ use crate::ui::messages::{Message, ModelsPageMessage};
 /// Replaces the native `tab_bar`'s raised-button look, which read as separate
 /// buttons.
 ///
-/// Still driven by `app.models_tabs`, so clicking a tab emits the same
+/// Still driven by `app.models_page.models_tabs`, so clicking a tab emits the same
 /// [`ModelsPageMessage::ModelsTabActivated`] the segmented-button model expects.
 pub(super) fn models_tab_switcher(app: &AppModel) -> Element<'_, Message> {
     let spacing = cosmic::theme::spacing();
-    let active = app.models_tabs.active();
+    let active = app.models_page.models_tabs.active();
 
     let mut row = widget::row::with_capacity(2).spacing(spacing.space_xxs);
-    for entity in app.models_tabs.iter().collect::<Vec<_>>() {
+    for entity in app.models_page.models_tabs.iter().collect::<Vec<_>>() {
         let is_active = entity == active;
         let label = app
+            .models_page
             .models_tabs
             .text(entity)
             .map(ToOwned::to_owned)

--- a/super-stt-shared/src/registry/events.rs
+++ b/super-stt-shared/src/registry/events.rs
@@ -63,3 +63,18 @@ pub enum InstallError {
     /// with the index entry.
     ManifestInvalid,
 }
+
+impl std::fmt::Display for InstallError {
+    /// Human-readable phrasing for the install-failure reason, so clients can
+    /// surface it directly instead of printing the `Debug` variant name.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Incompatible => "no compatible asset for this system",
+            Self::DownloadFailed => "download failed",
+            Self::AssetHashMismatch => "the downloaded file failed its integrity check",
+            Self::TarballUnsafe => "the archive contained unsafe paths",
+            Self::InstallIoError => "a filesystem error occurred during install",
+            Self::ManifestInvalid => "the backend manifest was missing or invalid",
+        })
+    }
+}


### PR DESCRIPTION
Continues the code-quality audit cleanup (`docs/audits/2026-07-code-quality.md`), Tier 3 items #13–#17 (all App, plus a small shared `Display` for #17). Squash-merge collapses history, and #15's crate-wide field-access rename interleaves with the other items across shared files, so this lands as one commit.

## #13 — Shared task builders
Moved `build_load_settings_tasks` into a new `handlers/tasks.rs` and added `ping_task()`, `reload_backends()`, and `fetch_registry_catalog(refresh: bool)` beside it. The 3 ping sites (+ startup), 3 `list_backends` reloads, and 3 registry-catalog fetches now call the shared builders (the `refresh`-then-`list` site passes `refresh: true`).

## #14 — Type the language payload
Added a `LanguageResolution` struct deserialized in the `get_/set_/clear_model_language` client fns; the app field, the `ModelLanguageLoaded` message payload, and the two views now read typed `effective`/`source`/`primary`/`supported` fields instead of `.get("...")` on a `serde_json::Value`.

## #15 — Split `AppModel`
Extracted `state::language::LanguageState` (5 fields) and `state::models_page::ModelsPageState` (6 fields) as `RegistryState`-style sub-structs, embedded as `AppModel.language` / `AppModel.models_page`; `ModelsPageState::default` builds the Installed/Browse tabs. All accesses moved to `self.language.*` / `self.models_page.*`. Model/device/backend-catalog state stayed on `AppModel` (shared with `small_state.rs` and the global header).

## #16 — Style-helper dedup
Hoisted `accent_border_color(active)` and `pill_surface()` into `models/surface.rs` (card + load-sheet row; header pill + chips track), and parameterized the glyph tile as `glyph_tile(tile, glyph, radius_medium)` reused by `backend_glyph_tile` and the empty-state ring. **Deferred:** the emoji→icon status-glyph migration (a visual redesign needing new SVG assets) and the full `card_surface`/overflow-menu unification (would shift radii/shadows).

## #17 — Debug output shown to users
Gave `InstallError` (shared) a `Display` impl with human-readable phrasing; the Browse card shows `Failed: {err}` instead of `{err:?}`.

## Verification
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` ✅
- `cargo test -p super-stt-app` → 43 passed; `cargo test -p super-stt-shared --lib` → 94 passed ✅
- `just check-features` ✅
- `just fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)