### PR TITLE
Audit Tier 3 #18-#21: merge bar renderers, unify applet config/identity

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -1035,30 +1035,32 @@ Tier 2 #4/#6/#8.
 - **Resolved (branch `refactor/audit-tier3-13-17`):** gave `InstallError` (shared) a
   `Display` impl with human-readable phrasing; the Browse card now shows `Failed: {err}`.
 
-### [ ] 18. 🟡 Applet: merge the bar renderers
+### [x] 18. 🟡 Applet: merge the bar renderers
 
 - **Where:** `equalizer.rs:36-106` and `centered_bars.rs:35-104` differ only in the
   y-anchor; the side-split band selection is triplicated (+`waveform.rs:102-107`).
 - **Fix:** one renderer with an anchor enum + `visible_band_range` helper; hoist
   `get_color_with_theme` out of the per-bar loop (recomputed 32×/frame).
 
-### [ ] 19. 🟡 Applet: single daemon identity module
+### [x] 19. 🟡 Applet: single daemon identity module
 
 - **Where:** AppId/name/scopes defined in both `daemon/client.rs:14-19` and
   `app/subscription.rs:26-28`; display names already disagree, and the
   shared-token-cache invariant is enforced by eyeball.
 
-### [ ] 20. 🟡 Applet: one config source of truth
+### [x] 20. 🟡 Applet: one config source of truth
 
 - **Where:** `theme_config` mirrors `config.visualization.*` and both must be
   updated by hand (`app/mod.rs:38,46`, `update.rs:194-203,427-441`); the settings
   UI reads adjacent selectors from different structs (`settings/section.rs:70-71`).
 - **Fix:** delete `ThemeConfig`.
 
-### [ ] 21. 🟡 Applet: collapse the seven `update_*` config methods
+### [x] 21. 🟡 Applet: collapse the seven `update_*` config methods
 
 - **Where:** `config/settings.rs:130-183`.
-- **Fix:** one closure-based `update()`; store `variant` in the struct.
+- **Fix:** one closure-based `update()`; `save()` derives the variant from
+  `visualization.side` (fixed per binary at load) instead of threading a
+  `variant` string, so the `variant_name` field drops entirely.
 
 ### [ ] 22. 🟡 Applet: type `icon_alignment`
 

--- a/super-stt-cosmic-applet/src/app/init.rs
+++ b/super-stt-cosmic-applet/src/app/init.rs
@@ -10,7 +10,7 @@ use crate::app::Message;
 use crate::config::AppletConfig;
 use crate::daemon::{RetryStrategy, ping_daemon};
 use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
-use crate::models::theme::{ThemeConfig, VisualizationSide};
+use crate::models::theme::VisualizationSide;
 use crate::ui::components::sound_visualization::VisualizationComponent;
 use crate::ui::components::working_animation_component::WorkingAnimationComponent;
 use super_stt_shared::validation::get_http_socket_path;
@@ -49,13 +49,8 @@ impl SuperSttApplet {
         core: cosmic::app::Core,
         visualization_side: VisualizationSide,
     ) -> (Self, cosmic_app::Task<Message>) {
-        let variant_name = AppletConfig::get_variant_name(&visualization_side).to_string();
-        let config = AppletConfig::load(&variant_name, visualization_side.clone());
-
-        let theme_config = ThemeConfig {
-            visualization_theme: config.visualization.theme.clone(),
-            visualization_color_config: config.visualization.colors.clone(),
-        };
+        let variant_name = AppletConfig::get_variant_name(&visualization_side);
+        let config = AppletConfig::load(variant_name, visualization_side.clone());
 
         let visualization = VisualizationComponent::new(
             0.0,
@@ -87,13 +82,11 @@ impl SuperSttApplet {
             audio_level: 0.0,
             is_speech_detected: false,
             is_open: IsOpen::None,
-            theme_config,
             udp_restart_counter: 0,
             visualization,
             working_animation,
             working_anim_start: None,
             config,
-            variant_name,
             icon_alignment_model,
             icon_alignment_start,
             icon_alignment_center,

--- a/super-stt-cosmic-applet/src/app/mod.rs
+++ b/super-stt-cosmic-applet/src/app/mod.rs
@@ -21,7 +21,7 @@ pub use messages::*;
 use crate::config::AppletConfig;
 use crate::daemon::RetryStrategy;
 use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
-use crate::models::theme::{ThemeConfig, VisualizationSide};
+use crate::models::theme::VisualizationSide;
 use crate::ui::components::sound_visualization::VisualizationComponent;
 use crate::ui::components::working_animation_component::WorkingAnimationComponent;
 use subscription::{PING_INTERVAL_SECS, UdpSubscriptionId, applet_events_subscription};
@@ -35,7 +35,6 @@ pub struct SuperSttApplet {
     audio_level: f32,
     is_speech_detected: bool,
     is_open: IsOpen,
-    theme_config: ThemeConfig,
     udp_restart_counter: u64,
     visualization: VisualizationComponent,
     working_animation: WorkingAnimationComponent,
@@ -43,7 +42,6 @@ pub struct SuperSttApplet {
     /// transcribing, used to derive the animation's elapsed time.
     working_anim_start: Option<Instant>,
     config: AppletConfig,
-    variant_name: String,
     icon_alignment_model: SingleSelectModel,
     icon_alignment_start: Entity,
     icon_alignment_center: Entity,

--- a/super-stt-cosmic-applet/src/app/subscription.rs
+++ b/super-stt-cosmic-applet/src/app/subscription.rs
@@ -5,9 +5,9 @@ use log::{info, warn};
 use std::pin::Pin;
 
 use crate::app::Message;
+use crate::daemon::identity;
 use crate::util::f64_to_f32;
 use super_stt_shared::daemon::http_client::WidgetEvent;
-use super_stt_shared::daemon::session::AppId;
 use super_stt_shared::daemon::widget_subscription::{
     WidgetSubscriptionConfig, WidgetSubscriptionUpdate, run_widget_subscription,
 };
@@ -19,19 +19,6 @@ pub(super) const PING_INTERVAL_SECS: u64 = 5;
 /// Wrapper for `Subscription::run_with` so the subscription restarts when the counter changes.
 #[derive(Hash)]
 pub(super) struct UdpSubscriptionId(pub(super) u64);
-
-/// Stable identity used to cache the applet's widget-scope session
-/// token under `(super-stt-session, super-stt-cosmic-applet)`. Mirrors
-/// the layout the CLI and settings app already use.
-pub(super) const APPLET_APP_ID: AppId = AppId("super-stt-cosmic-applet");
-const APPLET_APP_NAME: &str = "Super STT COSMIC Applet";
-const APPLET_SCOPES: &[&str] = &["recording_events", "audio_visualization"];
-const APPLET_TOPICS: &[&str] = &[
-    "recording_state",
-    "frequency_bands",
-    "transcribing_started",
-    "transcribing_stopped",
-];
 
 /// Subscribes to the daemon's `GET /events` SSE stream and forwards
 /// each event as a typed [`Message`]. The subscription is self-healing
@@ -45,10 +32,10 @@ pub(super) fn applet_events_subscription(
 ) -> Pin<Box<dyn Stream<Item = Message> + Send>> {
     Box::pin(cosmic::iced::stream::channel(100, async |mut channel| {
         let config = WidgetSubscriptionConfig::new(
-            APPLET_APP_ID,
-            APPLET_APP_NAME,
-            APPLET_SCOPES,
-            APPLET_TOPICS,
+            identity::APP_ID,
+            identity::APP_NAME,
+            identity::SCOPES,
+            identity::TOPICS,
         );
         let mut updates = Box::pin(run_widget_subscription(get_http_socket_path(), config));
         info!("Widget subscription starting");
@@ -157,14 +144,14 @@ mod widget_subscription_mapping_tests {
 
     #[test]
     fn applet_scopes_cover_subscribed_topics() {
-        // Guard the hand-maintained APPLET_SCOPES / APPLET_TOPICS lists: every
+        // Guard the hand-maintained identity SCOPES / TOPICS lists: every
         // subscribed topic must be granted by a requested scope, or the daemon
         // refuses the whole stream with `403 scope_denied`. The mapping lives
         // in super-stt-shared and is pinned to the daemon's `Topic::required_scope`.
         assert_eq!(
             super_stt_shared::daemon::widget_subscription::uncovered_topic(
-                APPLET_SCOPES,
-                APPLET_TOPICS,
+                identity::SCOPES,
+                identity::TOPICS,
             ),
             None,
         );

--- a/super-stt-cosmic-applet/src/app/update.rs
+++ b/super-stt-cosmic-applet/src/app/update.rs
@@ -12,8 +12,8 @@ use cosmic::{
 use log::{info, warn};
 
 use super::SuperSttApplet;
-use super::subscription::APPLET_APP_ID;
 use crate::app::Message;
+use crate::daemon::identity::APP_ID;
 use crate::daemon::{RetryStrategy, ping_daemon, ping_daemon_with_status};
 use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
 use crate::models::theme::{VisualizationColor, VisualizationTheme, WorkingAnimationTheme};
@@ -190,9 +190,8 @@ impl SuperSttApplet {
     }
 
     fn set_visualization_theme(&mut self, theme: VisualizationTheme) -> cosmic_app::Task<Message> {
-        self.theme_config.visualization_theme = theme.clone();
         self.config
-            .update_visualization_theme(theme.clone(), &self.variant_name);
+            .update(|c| c.visualization.theme = theme.clone());
         self.visualization.update_theme(theme);
         self.visualization
             .update_audio_level(self.audio_level, self.is_speech_detected);
@@ -202,7 +201,7 @@ impl SuperSttApplet {
 
     fn set_working_animation(&mut self, theme: WorkingAnimationTheme) -> cosmic_app::Task<Message> {
         self.config
-            .update_working_animation(theme, &self.variant_name);
+            .update(|c| c.visualization.working_animation = theme);
         self.working_animation.update_theme(theme);
         self.is_open = IsOpen::None;
         cosmic_app::Task::none()
@@ -275,7 +274,7 @@ impl SuperSttApplet {
         // Drop any cached token (in-memory + keyring) so the next
         // subscription cycle hits the daemon's /auth/request and spawns
         // a fresh consent prompt.
-        if let Err(e) = session::forget(APPLET_APP_ID) {
+        if let Err(e) = session::forget(APP_ID) {
             warn!("Failed to forget session before retry: {e}");
         }
         // Restart the iced subscription so the dropped helper task
@@ -382,7 +381,7 @@ impl SuperSttApplet {
     }
 
     fn set_applet_width(&mut self, width: u32) -> cosmic_app::Task<Message> {
-        self.config.update_applet_width(width, &self.variant_name);
+        self.config.update(|c| c.ui.applet_width = width);
         // Refresh the visualization so it adapts to the new size.
         self.visualization.clear();
         self.visualization
@@ -391,7 +390,7 @@ impl SuperSttApplet {
     }
 
     fn set_show_icon(&mut self, show_icon: bool) -> cosmic_app::Task<Message> {
-        self.config.update_show_icon(show_icon, &self.variant_name);
+        self.config.update(|c| c.ui.show_icon = show_icon);
         cosmic_app::Task::none()
     }
 
@@ -407,13 +406,12 @@ impl SuperSttApplet {
             "start"
         };
         self.config
-            .update_icon_alignment(alignment.to_string(), &self.variant_name);
+            .update(|c| c.ui.icon_alignment = alignment.to_string());
         cosmic_app::Task::none()
     }
 
     fn set_show_visualizations(&mut self, show: bool) -> cosmic_app::Task<Message> {
-        self.config
-            .update_show_visualizations(show, &self.variant_name);
+        self.config.update(|c| c.ui.show_visualization = show);
         cosmic_app::Task::none()
     }
 
@@ -422,12 +420,10 @@ impl SuperSttApplet {
         color: VisualizationColor,
         is_dark: bool,
     ) -> cosmic_app::Task<Message> {
-        self.theme_config
-            .visualization_color_config
-            .set_color(color, is_dark);
-        let updated_colors = self.theme_config.visualization_color_config.clone();
+        let mut updated_colors = self.config.visualization.colors.clone();
+        updated_colors.set_color(color, is_dark);
         self.config
-            .update_visualization_colors(updated_colors.clone(), &self.variant_name);
+            .update(|c| c.visualization.colors = updated_colors.clone());
         self.working_animation.update_colors(updated_colors.clone());
         self.visualization.update_colors(updated_colors);
         cosmic_app::Task::none()

--- a/super-stt-cosmic-applet/src/app/view.rs
+++ b/super-stt-cosmic-applet/src/app/view.rs
@@ -86,7 +86,6 @@ impl SuperSttApplet {
         let content = create_popup_content(&PopupContentParams {
             daemon_state: &self.daemon_state,
             is_open: &self.is_open,
-            theme_config: &self.theme_config,
             config: &self.config,
             icon_alignment_model: &self.icon_alignment_model,
             theme_selector_model: &self.theme_selector_model,

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -94,8 +94,11 @@ impl AppletConfig {
         config
     }
 
-    /// Save configuration to disk for a specific variant
-    pub fn save(&self, variant: &str) -> Result<(), Box<dyn std::error::Error>> {
+    /// Save configuration to disk. The variant (which file to write) is derived
+    /// from `visualization.side`, which `load` fixes to the binary-specific
+    /// value — so callers no longer thread a `variant` string around.
+    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let variant = Self::get_variant_name(&self.visualization.side);
         let config_path = Self::get_config_path(variant);
 
         // Create config directory if it doesn't exist
@@ -110,68 +113,22 @@ impl AppletConfig {
         Ok(())
     }
 
+    /// Apply an in-place mutation and persist it. Replaces the fan-out of
+    /// `update_*` setters (Applet Tier 3 #21): `config.update(|c| c.ui.show_icon
+    /// = v)` mutates then saves, logging (not propagating) a write failure.
+    pub fn update(&mut self, mutate: impl FnOnce(&mut Self)) {
+        mutate(self);
+        if let Err(e) = self.save() {
+            error!("Failed to save config: {e}");
+        }
+    }
+
     /// Get the variant name based on `VisualizationSide`
     pub fn get_variant_name(vis_side: &VisualizationSide) -> &'static str {
         match vis_side {
             VisualizationSide::Full => "full",
             VisualizationSide::Left => "left",
             VisualizationSide::Right => "right",
-        }
-    }
-
-    /// Update visualization theme and save to disk
-    pub fn update_visualization_theme(&mut self, theme: VisualizationTheme, variant: &str) {
-        self.visualization.theme = theme;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after visualization theme update: {e}");
-        }
-    }
-
-    /// Update the working animation theme and save to disk.
-    pub fn update_working_animation(&mut self, theme: WorkingAnimationTheme, variant: &str) {
-        self.visualization.working_animation = theme;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after working animation update: {e}");
-        }
-    }
-
-    /// Update just the applet width and save to disk
-    pub fn update_applet_width(&mut self, width: u32, variant: &str) {
-        self.ui.applet_width = width;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after applet width update: {e}");
-        }
-    }
-
-    /// Update just the icon visibility and save to disk
-    pub fn update_show_icon(&mut self, show_icon: bool, variant: &str) {
-        self.ui.show_icon = show_icon;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after icon visibility update: {e}");
-        }
-    }
-
-    /// Update just the icon alignment and save to disk
-    pub fn update_icon_alignment(&mut self, icon_alignment: String, variant: &str) {
-        self.ui.icon_alignment = icon_alignment;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after icon alignment update: {e}");
-        }
-    }
-
-    /// Update just the show visualization setting and save to disk
-    pub fn update_show_visualizations(&mut self, show_visualizations: bool, variant: &str) {
-        self.ui.show_visualization = show_visualizations;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after show visualization update: {e}");
-        }
-    }
-
-    /// Update visualization colors and save to disk
-    pub fn update_visualization_colors(&mut self, colors: VisualizationColorConfig, variant: &str) {
-        self.visualization.colors = colors;
-        if let Err(e) = self.save(variant) {
-            error!("Failed to save config after visualization colors update: {e}");
         }
     }
 }

--- a/super-stt-cosmic-applet/src/daemon/client.rs
+++ b/super-stt-cosmic-applet/src/daemon/client.rs
@@ -7,16 +7,10 @@
 //! subscription to `GET /events` is handled separately by
 //! `super_stt_shared::daemon::widget_subscription::run_widget_subscription`.
 
+use crate::daemon::identity::{APP_ID, APP_NAME, SCOPES};
 use std::path::PathBuf;
 use super_stt_shared::daemon::http_client;
-use super_stt_shared::daemon::session::{self, AppId};
-
-const APP_ID: AppId = AppId("super-stt-cosmic-applet");
-const APP_NAME: &str = "Super STT Applet";
-/// Scope set the applet requests. Shared with the `/events` subscription
-/// (same `AppId` token): `recording_events` for the recording indicator,
-/// `audio_visualization` for the frequency-band meter.
-const SCOPES: &[&str] = &["recording_events", "audio_visualization"];
+use super_stt_shared::daemon::session;
 
 /// What the applet's update loop expects from `ping_daemon_with_status`.
 /// In the legacy protocol the daemon could report

--- a/super-stt-cosmic-applet/src/daemon/identity.rs
+++ b/super-stt-cosmic-applet/src/daemon/identity.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! The applet's single daemon identity: the session `AppId`, the human-facing
+//! app name, the requested scopes, and the SSE topics. Both the `/ping`
+//! liveness client and the `/events` subscription must present the SAME
+//! `AppId` + scopes so they share one cached widget-scope token; keeping them
+//! here (instead of a copy in each) makes that invariant a fact rather than an
+//! eyeball check (App-let Tier 3 #19). The two copies previously even disagreed
+//! on the display name.
+
+use super_stt_shared::daemon::session::AppId;
+
+/// Stable identity caching the applet's widget-scope session token under
+/// `(super-stt-session, super-stt-cosmic-applet)`.
+pub const APP_ID: AppId = AppId("super-stt-cosmic-applet");
+
+/// Human-facing name shown in the daemon's consent prompt.
+pub const APP_NAME: &str = "Super STT COSMIC Applet";
+
+/// Scopes the applet requests: `recording_events` for the recording indicator,
+/// `audio_visualization` for the frequency-band meter.
+pub const SCOPES: &[&str] = &["recording_events", "audio_visualization"];
+
+/// `/events` SSE topics the applet subscribes to.
+pub const TOPICS: &[&str] = &[
+    "recording_state",
+    "frequency_bands",
+    "transcribing_started",
+    "transcribing_stopped",
+];

--- a/super-stt-cosmic-applet/src/daemon/mod.rs
+++ b/super-stt-cosmic-applet/src/daemon/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pub mod client;
+pub mod identity;
 
 pub use client::*;
 pub use super_stt_shared::daemon::retry::RetryStrategy;

--- a/super-stt-cosmic-applet/src/models/theme.rs
+++ b/super-stt-cosmic-applet/src/models/theme.rs
@@ -343,12 +343,6 @@ impl VisualizationColorConfig {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct ThemeConfig {
-    pub visualization_theme: VisualizationTheme,
-    pub visualization_color_config: VisualizationColorConfig,
-}
-
 #[cfg(test)]
 mod working_animation_theme_tests {
     use super::WorkingAnimationTheme;

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/centered_bars.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/centered_bars.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::config::FREQUENCY_NORMALIZATION_MAX;
-use crate::models::theme::VisualizationSide;
 use crate::ui::components::visualizations::{
-    DrawContext, VisualizationConfig, VisualizationRenderer,
+    BarAnchor, DrawContext, VisualizationConfig, VisualizationRenderer, render_bars,
 };
-use crate::util::usize_to_f32;
-use cosmic::iced::{
-    Padding, Point, Radius,
-    widget::canvas::{Fill, Frame, path, stroke},
-};
+use cosmic::iced::{Padding, Radius, widget::canvas::Frame};
 
+/// Bars that are centered vertically within the drawable bounds.
 pub struct CenteredBarsVisualization {
     config: VisualizationConfig,
 }
@@ -34,80 +29,6 @@ impl Default for CenteredBarsVisualization {
 
 impl VisualizationRenderer for CenteredBarsVisualization {
     fn draw(&self, frame: &mut Frame<cosmic::Renderer>, ctx: &DrawContext) {
-        let DrawContext {
-            bounds,
-            frequency_data,
-            side,
-            color_config,
-            is_dark,
-            cosmic_theme,
-        } = *ctx;
-        let effective_bounds = self.config.effective_bounds(bounds);
-
-        let total_bars = frequency_data.bands.len().min(32);
-        let (bars_to_show, bar_start_index) = match side {
-            VisualizationSide::Left => (total_bars / 2, 0),
-            VisualizationSide::Right => (total_bars / 2, total_bars / 2),
-            VisualizationSide::Full => (total_bars, 0),
-        };
-
-        // Nothing to draw (e.g. malformed/empty frequency data decoded to zero
-        // bands). Bail before dividing `bar_width`/`spacing` by zero and before
-        // `bars_to_show - 1` underflows the usize below (Tier 1 #21, same class
-        // as #268).
-        if bars_to_show == 0 {
-            return;
-        }
-
-        let bars_f32 = usize_to_f32(bars_to_show);
-        let bar_width = effective_bounds.width / bars_f32 * 0.8;
-        let spacing = effective_bounds.width / bars_f32 * 0.2;
-
-        // Center the bars in the available width.
-        let total_bars_width =
-            (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show.saturating_sub(1)));
-        let start_x = effective_bounds.x + (effective_bounds.width - total_bars_width) / 2.0;
-
-        let normalization_factor = 1.0 / FREQUENCY_NORMALIZATION_MAX;
-
-        for display_bar in 0..bars_to_show {
-            let x = start_x + (usize_to_f32(display_bar) * (bar_width + spacing));
-
-            let band_index = bar_start_index + display_bar;
-            let average_amplitude = if band_index < frequency_data.bands.len() {
-                frequency_data.bands[band_index]
-            } else {
-                0.0
-            };
-
-            let height_factor = average_amplitude * normalization_factor;
-            let max_height = self.config.max_element_height(effective_bounds.height);
-            let capped_height_factor = height_factor.min(1.0);
-            let bar_height = max_height * capped_height_factor;
-            let clamped_height = self
-                .config
-                .clamped_element_height(bar_height, effective_bounds.height);
-
-            let y = effective_bounds.y + (effective_bounds.height - clamped_height) / 2.0;
-
-            // Draw all bars
-            let mut path_builder = path::Builder::new();
-            path_builder.rounded_rectangle(
-                Point { x, y },
-                cosmic::iced::Size::new(bar_width, clamped_height),
-                self.config.corner_radius,
-            );
-
-            let base = color_config.get_color_with_theme(is_dark, cosmic_theme);
-
-            let path = path_builder.build();
-            frame.fill(
-                &path,
-                Fill {
-                    style: stroke::Style::Solid(base),
-                    ..Default::default()
-                },
-            );
-        }
+        render_bars(&self.config, BarAnchor::Center, frame, ctx);
     }
 }

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/equalizer.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/equalizer.rs
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::config::FREQUENCY_NORMALIZATION_MAX;
-use crate::models::theme::VisualizationSide;
 use crate::ui::components::visualizations::{
-    DrawContext, VisualizationConfig, VisualizationRenderer,
+    BarAnchor, DrawContext, VisualizationConfig, VisualizationRenderer, render_bars,
 };
-use crate::util::usize_to_f32;
-use cosmic::iced::{
-    Padding, Point, Radius,
-    widget::canvas::{Fill, Frame, path, stroke},
-};
+use cosmic::iced::{Padding, Radius, widget::canvas::Frame};
 
 /// Bars that are aligned to the bottom of the screen.
 pub struct EqualizerVisualization {
@@ -35,81 +29,6 @@ impl Default for EqualizerVisualization {
 
 impl VisualizationRenderer for EqualizerVisualization {
     fn draw(&self, frame: &mut Frame<cosmic::Renderer>, ctx: &DrawContext) {
-        let DrawContext {
-            bounds,
-            frequency_data,
-            side,
-            color_config,
-            is_dark,
-            cosmic_theme,
-        } = *ctx;
-        let effective_bounds = self.config.effective_bounds(bounds);
-        let total_bars = frequency_data.bands.len().min(32);
-
-        let (bars_to_show, bar_start_index) = match side {
-            VisualizationSide::Left => (total_bars / 2, 0),
-            VisualizationSide::Right => (total_bars / 2, total_bars / 2),
-            VisualizationSide::Full => (total_bars, 0),
-        };
-
-        // Nothing to draw (e.g. malformed/empty frequency data decoded to zero
-        // bands). Bail before dividing `bar_width`/`spacing` by zero and before
-        // `bars_to_show - 1` underflows the usize below (Tier 1 #21, same class
-        // as #268).
-        if bars_to_show == 0 {
-            return;
-        }
-
-        let bars_f32 = usize_to_f32(bars_to_show);
-        let bar_width = effective_bounds.width / bars_f32 * 0.8;
-        let spacing = effective_bounds.width / bars_f32 * 0.2;
-
-        // Center the bars in the available width.
-        let total_bars_width =
-            (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show.saturating_sub(1)));
-        let start_x = effective_bounds.x + (effective_bounds.width - total_bars_width) / 2.0;
-
-        let normalization_factor = 1.0 / FREQUENCY_NORMALIZATION_MAX;
-
-        for display_bar in 0..bars_to_show {
-            let x = start_x + (usize_to_f32(display_bar) * (bar_width + spacing));
-
-            let band_index = bar_start_index + display_bar;
-            let average_amplitude = if band_index < frequency_data.bands.len() {
-                frequency_data.bands[band_index]
-            } else {
-                0.0
-            };
-
-            let height_factor = average_amplitude * normalization_factor;
-            let max_height = self.config.max_element_height(effective_bounds.height);
-            let capped_height_factor = height_factor.min(1.0);
-            let bar_height = max_height * capped_height_factor;
-            let clamped_height = self
-                .config
-                .clamped_element_height(bar_height, effective_bounds.height);
-
-            // Bottom-aligned bars within effective bounds
-            let y = effective_bounds.y + effective_bounds.height - clamped_height;
-
-            // Draw all bars
-            let mut path_builder = path::Builder::new();
-            path_builder.rounded_rectangle(
-                Point { x, y },
-                cosmic::iced::Size::new(bar_width, clamped_height),
-                self.config.corner_radius,
-            );
-
-            let base = color_config.get_color_with_theme(is_dark, cosmic_theme);
-
-            let path = path_builder.build();
-            frame.fill(
-                &path,
-                Fill {
-                    style: stroke::Style::Solid(base),
-                    ..Default::default()
-                },
-            );
-        }
+        render_bars(&self.config, BarAnchor::Bottom, frame, ctx);
     }
 }

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/mod.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/mod.rs
@@ -11,11 +11,130 @@ pub use waveform::WaveformVisualization;
 
 use cosmic::{
     Renderer,
-    iced::{Padding, border, core::Rectangle, widget::canvas::Frame},
+    iced::{
+        Padding, Point, Size, border,
+        core::Rectangle,
+        widget::canvas::{Fill, Frame, path, stroke},
+    },
 };
 
+use crate::config::FREQUENCY_NORMALIZATION_MAX;
 use crate::models::theme::{VisualizationColorConfig, VisualizationSide};
+use crate::util::usize_to_f32;
 use super_stt_shared::FrequencyData;
+
+/// Maximum number of frequency bands any bar/waveform visualization renders.
+/// Frequency data may carry more; the extras are ignored so bar sizing stays
+/// stable across inputs. Previously a bare `32` copy-pasted into every renderer.
+pub const MAX_VISUALIZATION_BANDS: usize = 32;
+
+/// Vertical anchoring for a bar within the drawable bounds. The only thing that
+/// distinguishes the bottom equalizer from the centered equalizer.
+#[derive(Clone, Copy)]
+pub enum BarAnchor {
+    /// Bars grow upward from the bottom edge (bottom equalizer).
+    Bottom,
+    /// Bars are centered vertically (centered equalizer).
+    Center,
+}
+
+/// Split the frequency spectrum for the applet's rendered `side`, returning
+/// `(count, start_index)`: how many bands this instance draws and where its
+/// slice begins. `Left`/`Right` each render half the (capped) spectrum; `Full`
+/// renders all of it. Shared by every bar/waveform renderer so the
+/// [`MAX_VISUALIZATION_BANDS`] cap and the half-split live in one place.
+pub fn visible_band_range(side: &VisualizationSide, total_bands: usize) -> (usize, usize) {
+    let total = total_bands.min(MAX_VISUALIZATION_BANDS);
+    match side {
+        VisualizationSide::Left => (total / 2, 0),
+        VisualizationSide::Right => (total / 2, total / 2),
+        VisualizationSide::Full => (total, 0),
+    }
+}
+
+/// Render the vertical-bar family of visualizations (bottom equalizer and
+/// centered equalizer). The two differ only in their per-style
+/// [`VisualizationConfig`] and vertical [`BarAnchor`]; all band selection, bar
+/// sizing, spacing, centering, and drawing is identical and lives here.
+pub fn render_bars(
+    config: &VisualizationConfig,
+    anchor: BarAnchor,
+    frame: &mut Frame<Renderer>,
+    ctx: &DrawContext,
+) {
+    let DrawContext {
+        bounds,
+        frequency_data,
+        side,
+        color_config,
+        is_dark,
+        cosmic_theme,
+    } = *ctx;
+    let effective_bounds = config.effective_bounds(bounds);
+    let (bars_to_show, bar_start_index) = visible_band_range(side, frequency_data.bands.len());
+
+    // Nothing to draw (e.g. malformed/empty frequency data decoded to zero
+    // bands). Bail before dividing `bar_width`/`spacing` by zero and before
+    // `bars_to_show - 1` underflows the usize below (Tier 1 #21, same class
+    // as #268).
+    if bars_to_show == 0 {
+        return;
+    }
+
+    let bars_f32 = usize_to_f32(bars_to_show);
+    let bar_width = effective_bounds.width / bars_f32 * 0.8;
+    let spacing = effective_bounds.width / bars_f32 * 0.2;
+
+    // Center the bars in the available width.
+    let total_bars_width =
+        (bar_width * bars_f32) + (spacing * usize_to_f32(bars_to_show.saturating_sub(1)));
+    let start_x = effective_bounds.x + (effective_bounds.width - total_bars_width) / 2.0;
+
+    let normalization_factor = 1.0 / FREQUENCY_NORMALIZATION_MAX;
+
+    // Loop-invariant: neither the fill color nor the height ceiling depends on
+    // the per-bar amplitude, so resolve them once instead of per bar.
+    let base = color_config.get_color_with_theme(is_dark, cosmic_theme);
+    let max_height = config.max_element_height(effective_bounds.height);
+
+    for display_bar in 0..bars_to_show {
+        let x = start_x + (usize_to_f32(display_bar) * (bar_width + spacing));
+
+        let band_index = bar_start_index + display_bar;
+        let average_amplitude = if band_index < frequency_data.bands.len() {
+            frequency_data.bands[band_index]
+        } else {
+            0.0
+        };
+
+        let height_factor = average_amplitude * normalization_factor;
+        let capped_height_factor = height_factor.min(1.0);
+        let bar_height = max_height * capped_height_factor;
+        let clamped_height = config.clamped_element_height(bar_height, effective_bounds.height);
+
+        let y = match anchor {
+            BarAnchor::Bottom => effective_bounds.y + effective_bounds.height - clamped_height,
+            BarAnchor::Center => {
+                effective_bounds.y + (effective_bounds.height - clamped_height) / 2.0
+            }
+        };
+
+        let mut path_builder = path::Builder::new();
+        path_builder.rounded_rectangle(
+            Point { x, y },
+            Size::new(bar_width, clamped_height),
+            config.corner_radius,
+        );
+        let path = path_builder.build();
+        frame.fill(
+            &path,
+            Fill {
+                style: stroke::Style::Solid(base),
+                ..Default::default()
+            },
+        );
+    }
+}
 
 /// Shared configuration for visualization rendering with proper margin and height management
 #[derive(Debug, Clone)]
@@ -88,4 +207,42 @@ pub struct DrawContext<'a> {
 pub trait VisualizationRenderer {
     /// Draw the visualization using the per-frame [`DrawContext`].
     fn draw(&self, frame: &mut Frame<Renderer>, ctx: &DrawContext);
+}
+
+#[cfg(test)]
+mod visible_band_range_tests {
+    use super::{MAX_VISUALIZATION_BANDS, VisualizationSide, visible_band_range};
+
+    #[test]
+    fn full_takes_all_capped_bands_from_the_start() {
+        assert_eq!(visible_band_range(&VisualizationSide::Full, 32), (32, 0));
+        assert_eq!(visible_band_range(&VisualizationSide::Full, 8), (8, 0));
+    }
+
+    #[test]
+    fn left_and_right_split_the_spectrum_in_half() {
+        assert_eq!(visible_band_range(&VisualizationSide::Left, 32), (16, 0));
+        assert_eq!(visible_band_range(&VisualizationSide::Right, 32), (16, 16));
+    }
+
+    #[test]
+    fn caps_at_max_visualization_bands() {
+        // Frequency data can carry more than we render (e.g. 64 bands); the
+        // extras are ignored so bar sizing stays stable.
+        assert_eq!(
+            visible_band_range(&VisualizationSide::Full, 64),
+            (MAX_VISUALIZATION_BANDS, 0)
+        );
+        assert_eq!(
+            visible_band_range(&VisualizationSide::Right, 64),
+            (MAX_VISUALIZATION_BANDS / 2, MAX_VISUALIZATION_BANDS / 2)
+        );
+    }
+
+    #[test]
+    fn zero_bands_yields_zero_count() {
+        // Renderers rely on a zero count to bail before dividing by zero.
+        assert_eq!(visible_band_range(&VisualizationSide::Full, 0), (0, 0));
+        assert_eq!(visible_band_range(&VisualizationSide::Left, 0), (0, 0));
+    }
 }

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
@@ -2,7 +2,7 @@
 use crate::config::FREQUENCY_NORMALIZATION_MAX;
 use crate::models::theme::VisualizationSide;
 use crate::ui::components::visualizations::{
-    DrawContext, VisualizationConfig, VisualizationRenderer,
+    DrawContext, VisualizationConfig, VisualizationRenderer, visible_band_range,
 };
 use crate::util::{f32_to_usize, usize_to_f32};
 use cosmic::iced::{
@@ -99,12 +99,8 @@ impl WaveformVisualization {
         side: &VisualizationSide,
         effective_bounds: Rectangle,
     ) -> Vec<(f32, f32)> {
-        let total_bands = frequency_data.bands.len().min(32);
-        let (bands_to_show, band_start_index) = match side {
-            VisualizationSide::Left => (total_bands / 2, 0),
-            VisualizationSide::Right => (total_bands / 2, total_bands / 2),
-            VisualizationSide::Full => (total_bands, 0),
-        };
+        let (bands_to_show, band_start_index) =
+            visible_band_range(side, frequency_data.bands.len());
 
         let normalization_factor = 1.0 / FREQUENCY_NORMALIZATION_MAX;
         let max_height = self.config.max_element_height(effective_bounds.height);

--- a/super-stt-cosmic-applet/src/ui/sections/settings/section.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/settings/section.rs
@@ -16,7 +16,6 @@ use crate::{
     app::Message,
     config::AppletConfig,
     models::state::IsOpen,
-    models::theme::ThemeConfig,
     ui::sections::settings::components::visualization_theme::{
         create_visualization_color_selector, create_visualization_theme_selector,
         create_working_animation_selector,
@@ -25,7 +24,6 @@ use crate::{
 
 pub fn create_applet_settings_section<'a>(
     config: &AppletConfig,
-    theme_config: &ThemeConfig,
     is_open: &IsOpen,
     icon_alignment_model: &'a SingleSelectModel,
     theme_selector_model: &'a SingleSelectModel,
@@ -67,10 +65,10 @@ pub fn create_applet_settings_section<'a>(
                     .spacing(spacing.space_xxs)
                     .apply(Element::from)
                 ),
-                create_visualization_theme_selector(&theme_config.visualization_theme, is_open),
+                create_visualization_theme_selector(&config.visualization.theme, is_open),
                 create_working_animation_selector(config.visualization.working_animation, is_open),
                 create_visualization_color_selector(
-                    &theme_config.visualization_color_config,
+                    &config.visualization.colors,
                     is_open,
                     theme_selector_model,
                     selected_theme_for_config

--- a/super-stt-cosmic-applet/src/ui/views.rs
+++ b/super-stt-cosmic-applet/src/ui/views.rs
@@ -2,10 +2,7 @@
 use crate::{
     app::Message,
     config::AppletConfig,
-    models::{
-        state::{DaemonConnectionState, IsOpen},
-        theme::ThemeConfig,
-    },
+    models::state::{DaemonConnectionState, IsOpen},
     ui::sections::{
         app_info::create_app_info_section, launch::create_launch_section,
         settings::section::create_applet_settings_section, status::create_status_section,
@@ -23,7 +20,6 @@ use cosmic::{
 pub struct PopupContentParams<'a> {
     pub daemon_state: &'a DaemonConnectionState,
     pub is_open: &'a IsOpen,
-    pub theme_config: &'a ThemeConfig,
     pub config: &'a AppletConfig,
     pub icon_alignment_model: &'a SingleSelectModel,
     pub theme_selector_model: &'a SingleSelectModel,
@@ -44,7 +40,6 @@ pub fn create_popup_content<'a>(params: &PopupContentParams<'a>) -> Element<'a, 
         if matches!(params.daemon_state, DaemonConnectionState::Connected) {
             create_applet_settings_section(
                 params.config,
-                params.theme_config,
                 params.is_open,
                 params.icon_alignment_model,
                 params.theme_selector_model,


### PR DESCRIPTION
Applet-focused cleanup batch (Tier 3 #18-#21 from `docs/audits/2026-07-code-quality.md`).

## #18 — Merge the bar renderers
The bottom equalizer and centered equalizer differed only in their y-anchor and per-style config; the side-split band selection (`.min(32)` + `Left/Right/Full` match) was triplicated across `equalizer.rs`, `centered_bars.rs`, and `waveform.rs`.

- New shared `render_bars(config, anchor, frame, ctx)` + `BarAnchor { Bottom, Center }` in `visualizations/mod.rs`; `equalizer.rs`/`centered_bars.rs` are now thin wrappers holding their own config + anchor.
- Extracted `visible_band_range(side, total)` + `MAX_VISUALIZATION_BANDS` const, reused by all three renderers (waveform included).
- Hoisted the loop-invariant `get_color_with_theme` and `max_element_height` out of the per-bar loop (were recomputed 32×/frame).
- Added 4 unit tests pinning the split logic.

## #19 — Single daemon identity module
`APP_ID`/`APP_NAME`/`SCOPES`/`TOPICS` were defined in both `daemon/client.rs` and `app/subscription.rs` (display names had already drifted). New `daemon/identity.rs` owns them; the `/ping` liveness client and `/events` subscription both import it, so the shared-token-cache invariant is enforced by construction.

## #20 — One config source of truth
Deleted `ThemeConfig`, which mirrored `config.visualization.*` and had to be updated by hand. The settings UI and update handlers now read/write `config.visualization.*` directly.

## #21 — Collapse the seven `update_*` config methods
One closure-based `AppletConfig::update(|c| …)` replaces the seven `update_*` setters. `save()` derives the variant from `visualization.side` (fixed per binary at load) instead of threading a `variant` string, so the `variant_name` field drops entirely.

## Verification
- `cargo build -p super-stt-cosmic-applet` ✓
- workspace clippy pedantic (`-W clippy::pedantic -D warnings -D unused_must_use`) ✓
- all 22 applet tests pass ✓
- `just fmt` ✓
- `just check-features` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)