### PR TITLE
Audit Tier 3 #22-#26: type icon_alignment, drop applet+shared dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6795,14 +6795,9 @@ version = "0.1.4-beta.2"
 dependencies = [
  "anyhow",
  "async-stream",
- "chrono",
- "clap",
- "cpal",
- "dashmap",
  "dirs",
  "env_logger",
  "futures-util",
- "hound",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -6818,7 +6813,6 @@ dependencies = [
  "super-stt-registry-types",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "uuid",
 ]
 

--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -1062,32 +1062,36 @@ Tier 2 #4/#6/#8.
   `visualization.side` (fixed per binary at load) instead of threading a
   `variant` string, so the `variant_name` field drops entirely.
 
-### [ ] 22. 🟡 Applet: type `icon_alignment`
+### [x] 22. 🟡 Applet: type `icon_alignment`
 
 - **Where:** three hand-written string mappings (`init.rs:22-33`,
   `update.rs:405-419`, `view.rs:68-72`).
-- **Fix:** standardize the theme enums on one conversion idiom (currently inherent
-  `from_str` / `FromStr` / `From<String>` mixed, with `Display` meaning wire-id for
-  some and pretty-name for others).
+- **Fix:** introduced an `IconAlignment` enum (serde snake-case wire id +
+  `deserialize_or_default`) replacing the bare `String`, so the three mappings are
+  typed. Unified the from-wire idiom: `VisualizationTheme`/`WorkingAnimationTheme`
+  moved from inherent `from_str` to the `FromStr` trait (matching
+  `VisualizationSide` and `IconAlignment`); `VisualizationColor`'s pretty `Display`
+  became `pretty_name()` (the UI-label idiom) and its caller-less `From<String>`
+  was dropped, leaving Color a serde-only enum with no wire round-trip.
 
-### [ ] 23. 🟡 Applet: legacy-protocol vestiges (~100 lines)
+### [x] 23. 🟡 Applet: legacy-protocol vestiges (~100 lines)
 
 - Unsendable `RecordingStateChanged`/`AudioLevelUpdate` messages, `PingResponse`
   fields fully discarded, unused `sample_rate` decode, caller-less
   `From<String> for VisualizationColor`, never-constructed
   `IsOpen::AppletSettings`, write-only `UiConfig.last_popup_state`.
 
-### [ ] 24. 🟡 Applet: logging noise
+### [x] 24. 🟡 Applet: logging noise
 
 - **Where:** `info!` per successful 5 s ping forever (`update.rs:133`) with stale
   legacy phrasing; the retry path mixes info/warn.
 - **Fix:** log transitions at info, steady-state at debug.
 
-### [ ] 25. 🟡 Applet: double clone per frame + stale comment in the visualization `Element` conversion
+### [x] 25. 🟡 Applet: double clone per frame + stale comment in the visualization `Element` conversion
 
 - **Where:** `sound_visualization.rs:140-148`.
 
-### [ ] 26. 🟡 Shared: dead public API + unused deps
+### [x] 26. 🟡 Shared: dead public API + unused deps
 
 - **Where:** `get_secure_socket_path` + `generate_secure_client_id` (zero
   consumers; `get_http_socket_path` doc still claims dual listeners),

--- a/super-stt-app/Cargo.toml
+++ b/super-stt-app/Cargo.toml
@@ -32,7 +32,7 @@ rfd = { version = "0.17.2", default-features = false, features = ["xdg-portal"] 
     strum_macros.workspace = true
 super-stt-registry-types = { version = "0.1.4-beta.2", path = "../super-stt-registry-types" }
     # Workspace dependencies
-    super-stt-shared = { path = "../super-stt-shared", features = ["analysis"] }
+    super-stt-shared = { path = "../super-stt-shared" }
     tokio.workspace = true
     # Configuration
     toml.workspace = true

--- a/super-stt-cosmic-applet/src/app/init.rs
+++ b/super-stt-cosmic-applet/src/app/init.rs
@@ -10,23 +10,28 @@ use crate::app::Message;
 use crate::config::AppletConfig;
 use crate::daemon::{RetryStrategy, ping_daemon};
 use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
-use crate::models::theme::VisualizationSide;
+use crate::models::theme::{IconAlignment, VisualizationSide};
 use crate::ui::components::sound_visualization::VisualizationComponent;
 use crate::ui::components::working_animation_component::WorkingAnimationComponent;
 use super_stt_shared::validation::get_http_socket_path;
 
-/// Build the icon-alignment selector and activate the entry named by
-/// the stored `start`/`center`/`end` config value.
-fn build_icon_alignment_model(active: &str) -> (SingleSelectModel, Entity, Entity, Entity) {
+/// Build the icon-alignment selector and activate the entry for the stored
+/// [`IconAlignment`].
+fn build_icon_alignment_model(
+    active: IconAlignment,
+) -> (SingleSelectModel, Entity, Entity, Entity) {
     let mut model = SingleSelectModel::default();
-    let start = model.insert().text("Start").id();
-    let center = model.insert().text("Center").id();
-    let end = model.insert().text("End").id();
-    match active {
-        "center" => model.activate(center),
-        "end" => model.activate(end),
-        _ => model.activate(start),
-    }
+    let start = model.insert().text(IconAlignment::Start.pretty_name()).id();
+    let center = model
+        .insert()
+        .text(IconAlignment::Center.pretty_name())
+        .id();
+    let end = model.insert().text(IconAlignment::End.pretty_name()).id();
+    model.activate(match active {
+        IconAlignment::Start => start,
+        IconAlignment::Center => center,
+        IconAlignment::End => end,
+    });
     (model, start, center, end)
 }
 
@@ -67,7 +72,7 @@ impl SuperSttApplet {
         );
 
         let (icon_alignment_model, icon_alignment_start, icon_alignment_center, icon_alignment_end) =
-            build_icon_alignment_model(config.ui.icon_alignment.as_str());
+            build_icon_alignment_model(config.ui.icon_alignment);
 
         let is_dark = cosmic::theme::active().cosmic().is_dark;
         let (theme_selector_model, theme_selector_light, theme_selector_dark) =

--- a/super-stt-cosmic-applet/src/app/messages.rs
+++ b/super-stt-cosmic-applet/src/app/messages.rs
@@ -2,7 +2,7 @@
 use cosmic::{iced::window, widget::segmented_button::Entity};
 
 use crate::models::{
-    state::{IsOpen, RecordingState},
+    state::IsOpen,
     theme::{VisualizationColor, VisualizationTheme, WorkingAnimationTheme},
 };
 
@@ -12,17 +12,11 @@ pub enum Message {
     CloseRequested(window::Id),
     DaemonConnected,
     DaemonError(String),
-    RecordingStateChanged(RecordingState),
-    AudioLevelUpdate {
-        level: f32,
-        is_speech: bool,
-    },
     /// `recording_state` event from the daemon's `/events` SSE stream.
     WidgetRecordingState(bool),
     /// `frequency_bands` event — pre-computed visualization bands.
     WidgetFrequencyBands {
         bands: Vec<f32>,
-        sample_rate: f32,
         total_energy: f32,
     },
     /// `transcribing_started` event — the daemon began decoding captured audio.
@@ -49,10 +43,8 @@ pub enum Message {
     RetryConnection,
     ScheduleRetry,
     PingTimeout,
-    PingResponse {
-        message: String,
-        connection_active: bool,
-    },
+    /// A periodic liveness ping succeeded while already connected.
+    PingResponse,
     OpenGitHub,
     LaunchApp,
     RevealerToggle(IsOpen),

--- a/super-stt-cosmic-applet/src/app/subscription.rs
+++ b/super-stt-cosmic-applet/src/app/subscription.rs
@@ -104,7 +104,6 @@ fn widget_event_to_message(evt: WidgetEvent) -> Message {
         ),
         "frequency_bands" => Message::WidgetFrequencyBands {
             bands: b64_to_f32_vec(p.get("bands_b64").and_then(Value::as_str)),
-            sample_rate: f64_to_f32(p.get("sample_rate").and_then(Value::as_f64).unwrap_or(0.0)),
             total_energy: f64_to_f32(p.get("total_energy").and_then(Value::as_f64).unwrap_or(0.0)),
         },
         "revoked" => Message::WidgetRevoked(

--- a/super-stt-cosmic-applet/src/app/update.rs
+++ b/super-stt-cosmic-applet/src/app/update.rs
@@ -9,14 +9,16 @@ use cosmic::{
     },
     widget::segmented_button::Entity,
 };
-use log::{info, warn};
+use log::{debug, info, warn};
 
 use super::SuperSttApplet;
 use crate::app::Message;
 use crate::daemon::identity::APP_ID;
-use crate::daemon::{RetryStrategy, ping_daemon, ping_daemon_with_status};
+use crate::daemon::{RetryStrategy, ping_daemon};
 use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
-use crate::models::theme::{VisualizationColor, VisualizationTheme, WorkingAnimationTheme};
+use crate::models::theme::{
+    IconAlignment, VisualizationColor, VisualizationTheme, WorkingAnimationTheme,
+};
 use super_stt_shared::daemon::session;
 
 impl SuperSttApplet {
@@ -25,14 +27,10 @@ impl SuperSttApplet {
             Message::TogglePopup => self.toggle_popup(),
             Message::CloseRequested(id) => self.close_popup(id),
             Message::DaemonConnected => self.daemon_connected(),
-            Message::PingResponse { .. } => self.ping_response(),
+            Message::PingResponse => self.ping_response(),
             Message::DaemonError(err) => self.daemon_error(&err),
             Message::ScheduleRetry => self.schedule_retry(),
-            Message::RecordingStateChanged(state) => self.recording_state_changed(state),
             Message::RevealerToggle(src) => self.revealer_toggle(src),
-            Message::AudioLevelUpdate { level, is_speech } => {
-                self.audio_level_update(level, is_speech)
-            }
             Message::SetVisualizationTheme(theme) => self.set_visualization_theme(theme),
             Message::SetWorkingAnimation(theme) => self.set_working_animation(theme),
             Message::WidgetRecordingState(is_recording) => {
@@ -41,7 +39,6 @@ impl SuperSttApplet {
             Message::WidgetFrequencyBands {
                 bands,
                 total_energy,
-                ..
             } => self.widget_frequency_bands(&bands, total_energy),
             Message::WidgetTranscribingStarted => {
                 // Guard against out-of-order delivery: only enter Processing
@@ -112,6 +109,12 @@ impl SuperSttApplet {
     }
 
     fn daemon_connected(&mut self) -> cosmic_app::Task<Message> {
+        // Log the connect only on the actual transition — this fires from both
+        // a successful (re)connect ping and the subscription's `Connected`
+        // update, which would otherwise double-log at startup.
+        if self.daemon_state != DaemonConnectionState::Connected {
+            info!("Connected to daemon");
+        }
         self.daemon_state = DaemonConnectionState::Connected;
         self.retry_strategy.reset();
         // The widget /events subscription is self-healing
@@ -125,10 +128,10 @@ impl SuperSttApplet {
     }
 
     fn ping_response(&mut self) -> cosmic_app::Task<Message> {
-        // A successful `/v1/ping` always means the daemon is reachable —
-        // the HTTP protocol carries no separate "connection inactive"
-        // path (the legacy protocol did). Always flip to Connected.
-        info!("Daemon ping successful and connection is active - daemon may be idle");
+        // Fires on every periodic liveness ping (~5 s) while connected — pure
+        // steady state, so log at debug. A successful HTTP `/ping` means the
+        // daemon is reachable; keep the connection live and reset backoff.
+        debug!("Daemon ping OK");
         self.daemon_state = DaemonConnectionState::Connected;
         self.retry_strategy.reset();
         cosmic_app::Task::none()
@@ -149,7 +152,7 @@ impl SuperSttApplet {
     fn schedule_retry(&mut self) -> cosmic_app::Task<Message> {
         self.retry_strategy.should_retry(); // Always true; increments the attempt counter.
         let delay = self.retry_strategy.next_delay();
-        info!(
+        debug!(
             "Scheduling daemon connection retry {} in {:?}",
             self.retry_strategy.attempt, delay
         );
@@ -162,30 +165,12 @@ impl SuperSttApplet {
         )
     }
 
-    fn recording_state_changed(&mut self, state: RecordingState) -> cosmic_app::Task<Message> {
-        if matches!(
-            (&self.recording_state, &state),
-            (RecordingState::Processing, RecordingState::Idle)
-        ) {
-            info!("Transcription completed: Processing -> Idle");
-        }
-        self.set_recording_state(state);
-        cosmic_app::Task::none()
-    }
-
     fn revealer_toggle(&mut self, is_open_src: IsOpen) -> cosmic_app::Task<Message> {
         self.is_open = if self.is_open == is_open_src {
             IsOpen::None
         } else {
             is_open_src
         };
-        cosmic_app::Task::none()
-    }
-
-    fn audio_level_update(&mut self, level: f32, is_speech: bool) -> cosmic_app::Task<Message> {
-        self.audio_level = level;
-        self.is_speech_detected = is_speech;
-        self.visualization.update_audio_level(level, is_speech);
         cosmic_app::Task::none()
     }
 
@@ -292,7 +277,7 @@ impl SuperSttApplet {
             self.daemon_state = DaemonConnectionState::Connecting;
             info!("Manual retry initiated by user");
         }
-        info!(
+        debug!(
             "Retrying daemon connection (attempt {})...",
             self.retry_strategy.attempt
         );
@@ -300,7 +285,7 @@ impl SuperSttApplet {
             cosmic::Action::App(match result {
                 Ok(_) => Message::DaemonConnected,
                 Err(e) => {
-                    info!("Retry failed: {e}");
+                    debug!("Retry failed: {e}");
                     Message::ScheduleRetry
                 }
             })
@@ -309,27 +294,21 @@ impl SuperSttApplet {
 
     fn ping_timeout(&mut self) -> cosmic_app::Task<Message> {
         if self.daemon_state == DaemonConnectionState::Connected {
-            return cosmic_app::Task::perform(
-                ping_daemon_with_status(self.socket_path.clone()),
-                |result| {
-                    cosmic::Action::App(match result {
-                        Ok(response) => Message::PingResponse {
-                            message: response.message,
-                            connection_active: response.connection_active,
-                        },
-                        Err(e) => {
-                            warn!("Daemon ping failed: {e}");
-                            Message::DaemonError(format!("Connection lost: {e}"))
-                        }
-                    })
-                },
-            );
+            return cosmic_app::Task::perform(ping_daemon(self.socket_path.clone()), |result| {
+                cosmic::Action::App(match result {
+                    Ok(_) => Message::PingResponse,
+                    Err(e) => {
+                        warn!("Daemon ping failed: {e}");
+                        Message::DaemonError(format!("Connection lost: {e}"))
+                    }
+                })
+            });
         }
         if self.daemon_state == DaemonConnectionState::Connecting && self.retry_strategy.attempt > 5
         {
             // The retry strategy already drives reconnection during the
             // initial connect; just log occasionally.
-            info!(
+            debug!(
                 "Still attempting to connect (attempt {})...",
                 self.retry_strategy.attempt
             );
@@ -397,16 +376,15 @@ impl SuperSttApplet {
     fn set_icon_alignment(&mut self, entity: Entity) -> cosmic_app::Task<Message> {
         self.icon_alignment_model.activate(entity);
         let alignment = if entity == self.icon_alignment_start {
-            "start"
+            IconAlignment::Start
         } else if entity == self.icon_alignment_center {
-            "center"
+            IconAlignment::Center
         } else if entity == self.icon_alignment_end {
-            "end"
+            IconAlignment::End
         } else {
-            "start"
+            IconAlignment::Start
         };
-        self.config
-            .update(|c| c.ui.icon_alignment = alignment.to_string());
+        self.config.update(|c| c.ui.icon_alignment = alignment);
         cosmic_app::Task::none()
     }
 

--- a/super-stt-cosmic-applet/src/app/view.rs
+++ b/super-stt-cosmic-applet/src/app/view.rs
@@ -65,11 +65,7 @@ impl SuperSttApplet {
 
             let (applet_padding, _) = self.core.applet.suggested_padding(false);
 
-            let icon_alignment = match self.config.ui.icon_alignment.as_str() {
-                "center" => Alignment::Center,
-                "end" => Alignment::End,
-                _ => Alignment::Start,
-            };
+            let icon_alignment = self.config.ui.icon_alignment.to_alignment();
 
             let icon_button = transparent_icon_button(
                 icon_bytes,

--- a/super-stt-cosmic-applet/src/config/settings.rs
+++ b/super-stt-cosmic-applet/src/config/settings.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::VisualizationSide;
-use crate::models::theme::{VisualizationColorConfig, VisualizationTheme, WorkingAnimationTheme};
+use crate::models::theme::{
+    IconAlignment, VisualizationColorConfig, VisualizationTheme, WorkingAnimationTheme,
+};
 use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -35,9 +37,12 @@ pub struct VisualizationConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UiConfig {
-    pub last_popup_state: String, // Store as string for simplicity
     pub show_icon: bool,
-    pub icon_alignment: String,
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
+    pub icon_alignment: IconAlignment,
     pub applet_width: u32,        // Width in pixels
     pub show_visualization: bool, // Whether to show visualizations when recording
 }
@@ -52,9 +57,8 @@ impl Default for AppletConfig {
                 working_animation: WorkingAnimationTheme::default(),
             },
             ui: UiConfig {
-                last_popup_state: "None".to_string(),
                 show_icon: true,
-                icon_alignment: "end".to_string(),
+                icon_alignment: IconAlignment::End,
                 applet_width: 120,        // Default width in pixels
                 show_visualization: true, // Default to showing visualizations when recording
             },
@@ -185,7 +189,9 @@ mod working_animation_config_tests {
 #[cfg(test)]
 mod upgrade_compat_tests {
     use super::AppletConfig;
-    use crate::models::theme::{VisualizationColor, VisualizationTheme, WorkingAnimationTheme};
+    use crate::models::theme::{
+        IconAlignment, VisualizationColor, VisualizationTheme, WorkingAnimationTheme,
+    };
 
     /// The committed v0.1.3 `applet-full.toml` fixture. The canonical copy lives
     /// in the on-disk corpus so the release gate and these detailed assertions
@@ -209,7 +215,7 @@ mod upgrade_compat_tests {
             VisualizationColor::Blue
         );
         assert_eq!(cfg.ui.applet_width, 150);
-        assert_eq!(cfg.ui.icon_alignment, "end");
+        assert_eq!(cfg.ui.icon_alignment, IconAlignment::End);
         // New field materializes at its default.
         assert_eq!(
             cfg.visualization.working_animation,
@@ -257,6 +263,9 @@ mod upgrade_compat_tests {
 
     #[test]
     fn applet_bad_theme_falls_back_preserving_rest() {
+        // `last_popup_state` is an old, since-removed field; serde must ignore
+        // it (forward compat) rather than reject the whole config. `icon_alignment`
+        // carries a bad value and must fall back to its default without erroring.
         let toml_str = r#"
 [visualization]
 theme = "Nonexistent"
@@ -269,12 +278,13 @@ dark_colors = "PastelGreen"
 [ui]
 last_popup_state = "None"
 show_icon = true
-icon_alignment = "end"
+icon_alignment = "sideways"
 applet_width = 150
 show_visualization = true
 "#;
         let cfg: AppletConfig = toml::from_str(toml_str).expect("must parse, not error");
         assert_eq!(cfg.visualization.theme, VisualizationTheme::default()); // reset
+        assert_eq!(cfg.ui.icon_alignment, IconAlignment::default()); // bad value → default
         assert_eq!(
             cfg.visualization.colors.light_colors,
             VisualizationColor::Blue

--- a/super-stt-cosmic-applet/src/daemon/client.rs
+++ b/super-stt-cosmic-applet/src/daemon/client.rs
@@ -12,16 +12,6 @@ use std::path::PathBuf;
 use super_stt_shared::daemon::http_client;
 use super_stt_shared::daemon::session;
 
-/// What the applet's update loop expects from `ping_daemon_with_status`.
-/// In the legacy protocol the daemon could report
-/// `connection_active = false` separately from a successful ping; the
-/// HTTP `/ping` route is just 200-or-not, so a successful response
-/// always implies `connection_active = true`.
-pub struct PingResponse {
-    pub message: String,
-    pub connection_active: bool,
-}
-
 /// Run an HTTP-protocol operation with the cached widget-scope token.
 /// On `invalid_session` the cache is invalidated and the operation
 /// retries once with a fresh consent flow. Delegates the retry
@@ -54,19 +44,4 @@ pub async fn ping_daemon(socket_path: PathBuf) -> Result<String, String> {
         http_client::ping(sock, &token).await
     })
     .await
-}
-
-/// Ping the daemon and report whether the connection should be
-/// considered active. Mirrors the legacy two-field response; under
-/// HTTP, a successful ping always means `connection_active = true`.
-///
-/// # Errors
-///
-/// Same conditions as [`ping_daemon`].
-pub async fn ping_daemon_with_status(socket_path: PathBuf) -> Result<PingResponse, String> {
-    let message = ping_daemon(socket_path).await?;
-    Ok(PingResponse {
-        message,
-        connection_active: true,
-    })
 }

--- a/super-stt-cosmic-applet/src/models/state.rs
+++ b/super-stt-cosmic-applet/src/models/state.rs
@@ -25,5 +25,4 @@ pub enum IsOpen {
     VisualizationTheme,
     WorkingAnimation,
     VisualizationColors,
-    AppletSettings,
 }

--- a/super-stt-cosmic-applet/src/models/theme.rs
+++ b/super-stt-cosmic-applet/src/models/theme.rs
@@ -21,17 +21,21 @@ impl std::fmt::Display for VisualizationTheme {
     }
 }
 
-impl VisualizationTheme {
-    pub fn from_str(s: &str) -> Self {
+impl std::str::FromStr for VisualizationTheme {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "pulse" => VisualizationTheme::Pulse,
-            "b_equalizer" => VisualizationTheme::BottomEqualizer,
-            "c_equalizer" => VisualizationTheme::CenteredEqualizer,
-            "waveform" => VisualizationTheme::Waveform,
-            _ => VisualizationTheme::default(),
+            "pulse" => Ok(VisualizationTheme::Pulse),
+            "b_equalizer" => Ok(VisualizationTheme::BottomEqualizer),
+            "c_equalizer" => Ok(VisualizationTheme::CenteredEqualizer),
+            "waveform" => Ok(VisualizationTheme::Waveform),
+            _ => Err(()),
         }
     }
+}
 
+impl VisualizationTheme {
     pub fn pretty_name(&self) -> String {
         match self {
             VisualizationTheme::Pulse => "Pulse".to_string(),
@@ -64,16 +68,20 @@ impl std::fmt::Display for WorkingAnimationTheme {
     }
 }
 
-impl WorkingAnimationTheme {
-    pub fn from_str(s: &str) -> Self {
+impl std::str::FromStr for WorkingAnimationTheme {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "droplet" => WorkingAnimationTheme::Droplet,
-            "comet" => WorkingAnimationTheme::Comet,
-            "dots" => WorkingAnimationTheme::Dots,
-            _ => WorkingAnimationTheme::default(),
+            "droplet" => Ok(WorkingAnimationTheme::Droplet),
+            "comet" => Ok(WorkingAnimationTheme::Comet),
+            "dots" => Ok(WorkingAnimationTheme::Dots),
+            _ => Err(()),
         }
     }
+}
 
+impl WorkingAnimationTheme {
     pub fn pretty_name(self) -> String {
         match self {
             WorkingAnimationTheme::Droplet => "Droplet".to_string(),
@@ -125,6 +133,61 @@ impl VisualizationSide {
     }
 }
 
+/// Where the panel icon sits when visualizations are hidden. Persisted in the
+/// applet config as its snake-case wire id (`start`/`center`/`end`) and mapped
+/// to an iced [`Alignment`] at render time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum IconAlignment {
+    Start,
+    Center,
+    #[default]
+    End,
+}
+
+impl IconAlignment {
+    /// Human-facing label for the segmented selector.
+    pub fn pretty_name(self) -> &'static str {
+        match self {
+            IconAlignment::Start => "Start",
+            IconAlignment::Center => "Center",
+            IconAlignment::End => "End",
+        }
+    }
+
+    /// Map to the iced cross-axis alignment used when placing the panel icon.
+    pub fn to_alignment(self) -> cosmic::iced::Alignment {
+        match self {
+            IconAlignment::Start => cosmic::iced::Alignment::Start,
+            IconAlignment::Center => cosmic::iced::Alignment::Center,
+            IconAlignment::End => cosmic::iced::Alignment::End,
+        }
+    }
+}
+
+impl std::fmt::Display for IconAlignment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IconAlignment::Start => write!(f, "start"),
+            IconAlignment::Center => write!(f, "center"),
+            IconAlignment::End => write!(f, "end"),
+        }
+    }
+}
+
+impl std::str::FromStr for IconAlignment {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "start" => Ok(IconAlignment::Start),
+            "center" => Ok(IconAlignment::Center),
+            "end" => Ok(IconAlignment::End),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub enum VisualizationColor {
     #[default]
@@ -161,83 +224,46 @@ pub enum VisualizationColor {
     PastelLavender,
 }
 
-impl std::fmt::Display for VisualizationColor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            VisualizationColor::SystemAccent => write!(f, "System Accent"),
-            VisualizationColor::White => write!(f, "White"),
-            VisualizationColor::Black => write!(f, "Black"),
-            VisualizationColor::Gray => write!(f, "Light Gray"),
-            VisualizationColor::DarkGray => write!(f, "Dark Gray"),
-            VisualizationColor::Blue => write!(f, "Blue"),
-            VisualizationColor::DarkBlue => write!(f, "Dark Blue"),
-            VisualizationColor::Green => write!(f, "Green"),
-            VisualizationColor::DarkGreen => write!(f, "Dark Green"),
-            VisualizationColor::Orange => write!(f, "Orange"),
-            VisualizationColor::DarkOrange => write!(f, "Dark Orange"),
-            VisualizationColor::Purple => write!(f, "Purple"),
-            VisualizationColor::DarkPurple => write!(f, "Dark Purple"),
-            VisualizationColor::Red => write!(f, "Red"),
-            VisualizationColor::DarkRed => write!(f, "Dark Red"),
-            VisualizationColor::Cyan => write!(f, "Cyan"),
-            VisualizationColor::DarkCyan => write!(f, "Dark Cyan"),
-            VisualizationColor::Pink => write!(f, "Pink"),
-            VisualizationColor::DarkPink => write!(f, "Dark Pink"),
-            VisualizationColor::Violet => write!(f, "Violet"),
-            VisualizationColor::DarkViolet => write!(f, "Dark Violet"),
-            VisualizationColor::PastelBlue => write!(f, "Pastel Blue"),
-            VisualizationColor::PastelGreen => write!(f, "Pastel Green"),
-            VisualizationColor::PastelOrange => write!(f, "Pastel Orange"),
-            VisualizationColor::PastelPurple => write!(f, "Pastel Purple"),
-            VisualizationColor::PastelRed => write!(f, "Pastel Red"),
-            VisualizationColor::PastelCyan => write!(f, "Pastel Cyan"),
-            VisualizationColor::PastelPink => write!(f, "Pastel Pink"),
-            VisualizationColor::PastelYellow => write!(f, "Pastel Yellow"),
-            VisualizationColor::PastelMagenta => write!(f, "Pastel Magenta"),
-            VisualizationColor::PastelLavender => write!(f, "Pastel Lavender"),
-        }
-    }
-}
-
-impl From<std::string::String> for VisualizationColor {
-    fn from(input: String) -> Self {
-        match input.as_str() {
-            "white" => VisualizationColor::White,
-            "black" => VisualizationColor::Black,
-            "gray" => VisualizationColor::Gray,
-            "dark_gray" => VisualizationColor::DarkGray,
-            "blue" => VisualizationColor::Blue,
-            "dark_blue" => VisualizationColor::DarkBlue,
-            "green" => VisualizationColor::Green,
-            "dark_green" => VisualizationColor::DarkGreen,
-            "orange" => VisualizationColor::Orange,
-            "dark_orange" => VisualizationColor::DarkOrange,
-            "purple" => VisualizationColor::Purple,
-            "dark_purple" => VisualizationColor::DarkPurple,
-            "red" => VisualizationColor::Red,
-            "dark_red" => VisualizationColor::DarkRed,
-            "cyan" => VisualizationColor::Cyan,
-            "dark_cyan" => VisualizationColor::DarkCyan,
-            "pink" => VisualizationColor::Pink,
-            "dark_pink" => VisualizationColor::DarkPink,
-            "violet" => VisualizationColor::Violet,
-            "dark_violet" => VisualizationColor::DarkViolet,
-            "pastel_blue" => VisualizationColor::PastelBlue,
-            "pastel_green" => VisualizationColor::PastelGreen,
-            "pastel_orange" => VisualizationColor::PastelOrange,
-            "pastel_purple" => VisualizationColor::PastelPurple,
-            "pastel_red" => VisualizationColor::PastelRed,
-            "pastel_cyan" => VisualizationColor::PastelCyan,
-            "pastel_pink" => VisualizationColor::PastelPink,
-            "pastel_yellow" => VisualizationColor::PastelYellow,
-            "pastel_magenta" => VisualizationColor::PastelMagenta,
-            "pastel_lavender" => VisualizationColor::PastelLavender,
-            _ => VisualizationColor::SystemAccent,
-        }
-    }
-}
-
 impl VisualizationColor {
+    /// Human-facing label shown under each colour swatch. UI-only — the enum
+    /// persists via serde (variant name), so this is a pretty name, not a wire
+    /// id. Matches the `pretty_name()` idiom used by the other theme enums.
+    pub fn pretty_name(&self) -> &'static str {
+        match self {
+            VisualizationColor::SystemAccent => "System Accent",
+            VisualizationColor::White => "White",
+            VisualizationColor::Black => "Black",
+            VisualizationColor::Gray => "Light Gray",
+            VisualizationColor::DarkGray => "Dark Gray",
+            VisualizationColor::Blue => "Blue",
+            VisualizationColor::DarkBlue => "Dark Blue",
+            VisualizationColor::Green => "Green",
+            VisualizationColor::DarkGreen => "Dark Green",
+            VisualizationColor::Orange => "Orange",
+            VisualizationColor::DarkOrange => "Dark Orange",
+            VisualizationColor::Purple => "Purple",
+            VisualizationColor::DarkPurple => "Dark Purple",
+            VisualizationColor::Red => "Red",
+            VisualizationColor::DarkRed => "Dark Red",
+            VisualizationColor::Cyan => "Cyan",
+            VisualizationColor::DarkCyan => "Dark Cyan",
+            VisualizationColor::Pink => "Pink",
+            VisualizationColor::DarkPink => "Dark Pink",
+            VisualizationColor::Violet => "Violet",
+            VisualizationColor::DarkViolet => "Dark Violet",
+            VisualizationColor::PastelBlue => "Pastel Blue",
+            VisualizationColor::PastelGreen => "Pastel Green",
+            VisualizationColor::PastelOrange => "Pastel Orange",
+            VisualizationColor::PastelPurple => "Pastel Purple",
+            VisualizationColor::PastelRed => "Pastel Red",
+            VisualizationColor::PastelCyan => "Pastel Cyan",
+            VisualizationColor::PastelPink => "Pastel Pink",
+            VisualizationColor::PastelYellow => "Pastel Yellow",
+            VisualizationColor::PastelMagenta => "Pastel Magenta",
+            VisualizationColor::PastelLavender => "Pastel Lavender",
+        }
+    }
+
     pub fn to_rgb(&self) -> [f32; 3] {
         match self {
             VisualizationColor::SystemAccent => [0.5, 0.5, 0.5],
@@ -354,19 +380,54 @@ mod working_animation_theme_tests {
             WorkingAnimationTheme::Comet,
             WorkingAnimationTheme::Dots,
         ] {
-            assert_eq!(WorkingAnimationTheme::from_str(&t.to_string()), t);
+            assert_eq!(t.to_string().parse::<WorkingAnimationTheme>(), Ok(t));
         }
     }
 
     #[test]
-    fn unknown_falls_back_to_default() {
-        assert_eq!(
-            WorkingAnimationTheme::from_str("nope"),
-            WorkingAnimationTheme::default()
-        );
+    fn unknown_is_rejected() {
+        assert_eq!("nope".parse::<WorkingAnimationTheme>(), Err(()));
         assert_eq!(
             WorkingAnimationTheme::default(),
             WorkingAnimationTheme::Droplet
         );
+    }
+}
+
+#[cfg(test)]
+mod icon_alignment_tests {
+    use super::IconAlignment;
+
+    #[test]
+    fn display_from_str_round_trip() {
+        for a in [
+            IconAlignment::Start,
+            IconAlignment::Center,
+            IconAlignment::End,
+        ] {
+            assert_eq!(a.to_string().parse::<IconAlignment>(), Ok(a));
+        }
+    }
+
+    #[test]
+    fn wire_ids_are_snake_case_lowercase() {
+        assert_eq!(IconAlignment::Start.to_string(), "start");
+        assert_eq!(IconAlignment::Center.to_string(), "center");
+        assert_eq!(IconAlignment::End.to_string(), "end");
+    }
+
+    #[test]
+    fn unknown_is_rejected_and_default_is_end() {
+        assert_eq!("middle".parse::<IconAlignment>(), Err(()));
+        assert_eq!(IconAlignment::default(), IconAlignment::End);
+    }
+
+    #[test]
+    fn serde_uses_the_wire_id() {
+        // The config persists the lowercase wire id, not the PascalCase variant.
+        let json = serde_json::to_string(&IconAlignment::Center).expect("serialize");
+        assert_eq!(json, "\"center\"");
+        let back: IconAlignment = serde_json::from_str("\"end\"").expect("deserialize");
+        assert_eq!(back, IconAlignment::End);
     }
 }

--- a/super-stt-cosmic-applet/src/ui/components/color_buttons.rs
+++ b/super-stt-cosmic-applet/src/ui/components/color_buttons.rs
@@ -170,7 +170,7 @@ pub fn create_color_button(
         )
         .on_press(message)
         .interaction(cosmic::iced::mouse::Interaction::Pointer),
-        container(text(vis_color.to_string())).apply(Element::from),
+        container(text(vis_color.pretty_name())).apply(Element::from),
         cosmic::widget::tooltip::Position::Bottom,
     )
     .into()

--- a/super-stt-cosmic-applet/src/ui/components/sound_visualization.rs
+++ b/super-stt-cosmic-applet/src/ui/components/sound_visualization.rs
@@ -139,8 +139,9 @@ impl VisualizationComponent {
 
 impl<'a> From<VisualizationComponent> for Element<'a, Message> {
     fn from(visualization: VisualizationComponent) -> Element<'a, Message> {
-        // Use applet width as cache key to force redraw when size changes
-        Canvas::new(visualization.clone())
+        // `visualization` is already owned (the caller clones out of `&self`),
+        // so hand it straight to the canvas — no second clone.
+        Canvas::new(visualization)
             .width(cosmic::iced::Length::Fill)
             .height(cosmic::iced::Length::Fill)
             .into()

--- a/super-stt-cosmic-applet/src/ui/sections/settings/components/visualization_theme.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/settings/components/visualization_theme.rs
@@ -44,7 +44,7 @@ pub fn create_visualization_theme_selector<'a>(
         selected_theme.pretty_name(),
         &options,
         Message::RevealerToggle(IsOpen::VisualizationTheme),
-        |theme_str| Message::SetVisualizationTheme(VisualizationTheme::from_str(&theme_str)),
+        |theme_str| Message::SetVisualizationTheme(theme_str.parse().unwrap_or_default()),
     )
     .apply(Element::from)
 }
@@ -73,7 +73,7 @@ pub fn create_working_animation_selector<'a>(
         selected.pretty_name(),
         &options,
         Message::RevealerToggle(IsOpen::WorkingAnimation),
-        |anim_str| Message::SetWorkingAnimation(WorkingAnimationTheme::from_str(&anim_str)),
+        |anim_str| Message::SetWorkingAnimation(anim_str.parse().unwrap_or_default()),
     )
     .apply(Element::from)
 }

--- a/super-stt-shared/Cargo.toml
+++ b/super-stt-shared/Cargo.toml
@@ -12,16 +12,9 @@ workspace = true
     # Core shared dependencies
     anyhow.workspace = true
 async-stream = "0.3.6"
-    chrono.workspace = true
-    clap.workspace = true
-    cpal = { workspace = true, optional = true }
-    # Notification service dependencies
-    dashmap.workspace = true
 dirs.workspace = true
 env_logger.workspace = true
 futures-util.workspace = true
-    # Audio processing (optional feature)
-    hound = { workspace = true, optional = true }
 http-body-util = "0.1"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
@@ -43,10 +36,9 @@ super-stt-registry-types = { path = "../super-stt-registry-types" }
         "rt-multi-thread",
         "time",
     ] }
-tokio-stream = { version = "0.1.18", features = ["sync"] }
     uuid.workspace = true
 
 [features]
     default = []
     analysis = ["spectrum-analyzer"]
-    audio = ["cpal", "hound", "rubato"]
+    audio = ["rubato"]

--- a/super-stt-shared/src/lib.rs
+++ b/super-stt-shared/src/lib.rs
@@ -16,24 +16,3 @@ pub use models::*;
 pub use utils::audio as audio_utils;
 
 pub use audio::*;
-
-/// Macro to conditionally provide GPU device options based on CUDA feature availability
-#[macro_export]
-macro_rules! device_options {
-    () => {{
-        let mut devices = vec!["cpu".to_string()];
-        #[cfg(feature = "cuda")]
-        {
-            devices.push("cuda".to_string());
-        }
-        devices
-    }};
-}
-
-/// Check if CUDA support is available at compile time
-#[macro_export]
-macro_rules! has_cuda_support {
-    () => {
-        cfg!(feature = "cuda")
-    };
-}

--- a/super-stt-shared/src/validation/mod.rs
+++ b/super-stt-shared/src/validation/mod.rs
@@ -11,9 +11,7 @@ pub use inputs::{
     validate_limit, validate_optional_string, validate_required_string, validate_sample_rate,
     validate_string,
 };
-pub use paths::{
-    generate_secure_client_id, get_http_socket_path, get_secure_socket_path, secure_runtime_path,
-};
+pub use paths::{get_http_socket_path, secure_runtime_path};
 
 /// Validation errors for better error reporting
 #[derive(Debug, thiserror::Error)]

--- a/super-stt-shared/src/validation/paths.rs
+++ b/super-stt-shared/src/validation/paths.rs
@@ -1,27 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! Secure path helpers: client-ID generation and socket-path construction.
-
-/// Generate a cryptographically secure client ID
-///
-/// This function generates a unique client ID that prevents prediction and impersonation attacks.
-///
-/// Security features:
-/// - UUID v4 for cryptographic randomness
-/// - High-resolution timestamp for temporal uniqueness
-/// - Process ID for system-level uniqueness
-/// - Multi-factor composition for collision resistance
-///
-/// Format: `{component}-{pid}-{timestamp}-{uuid}`
-#[must_use]
-pub fn generate_secure_client_id(component: &str) -> String {
-    let pid = std::process::id();
-    let uuid = uuid::Uuid::new_v4();
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or(std::time::Duration::ZERO)
-        .as_nanos();
-    format!("{component}-{pid}-{timestamp}-{uuid}")
-}
+//! Secure path helpers: socket-path construction under `$XDG_RUNTIME_DIR/stt/`.
 
 /// Build a validated runtime path `$XDG_RUNTIME_DIR/stt/<relative>` with
 /// path-traversal / prefix / length checks on the runtime dir and a
@@ -63,28 +41,10 @@ pub fn secure_runtime_path(relative: &str) -> std::path::PathBuf {
     }
 }
 
-/// Get a secure socket path for the length-prefix protocol socket (`super-stt.sock`).
-///
-/// Validates the `XDG_RUNTIME_DIR` environment variable and constructs a secure
-/// socket path that prevents path injection attacks.
-///
-/// Security features:
-/// - Path length validation
-/// - Path traversal prevention
-/// - Directory whitelist enforcement
-/// - Canonical path verification
-/// - Secure fallback behavior
-/// - Security event logging
-#[must_use]
-pub fn get_secure_socket_path() -> std::path::PathBuf {
-    secure_runtime_path("super-stt.sock")
-}
-
-/// Get the path of the HTTP-protocol Unix socket (`super-stt-http.sock`).
-///
-/// This sits next to the legacy length-prefix socket from `get_secure_socket_path`,
-/// in the same `$XDG_RUNTIME_DIR/stt/` directory. The two listeners run
-/// side-by-side; clients pick whichever one matches their protocol.
+/// Get the path of the HTTP-protocol Unix socket (`super-stt-http.sock`) in
+/// `$XDG_RUNTIME_DIR/stt/`. This is the daemon's sole client-facing listener;
+/// all clients connect here. Path construction goes through
+/// [`secure_runtime_path`], which applies the traversal / prefix / length guards.
 #[must_use]
 pub fn get_http_socket_path() -> std::path::PathBuf {
     secure_runtime_path("super-stt-http.sock")
@@ -95,78 +55,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_generate_secure_client_id() {
-        // Test that client IDs are unique
-        let id1 = generate_secure_client_id("test-app");
-        let id2 = generate_secure_client_id("test-app");
-        assert_ne!(id1, id2, "Client IDs must be unique");
-
-        // Test that client IDs contain the component name
-        let app_id = generate_secure_client_id("super-stt-app");
-        assert!(
-            app_id.starts_with("super-stt-app-"),
-            "Client ID should start with component name"
-        );
-
-        let applet_id = generate_secure_client_id("super-stt-applet");
-        assert!(
-            applet_id.starts_with("super-stt-applet-"),
-            "Client ID should start with component name"
-        );
-
-        // Test that client IDs have expected format (component-pid-timestamp-uuid)
-        let parts: Vec<&str> = app_id.split('-').collect();
-        assert!(
-            parts.len() >= 6,
-            "Client ID should have at least 6 parts separated by hyphens"
-        );
-
-        // Test that the UUID part is valid (36 characters with hyphens)
-        let uuid_part = parts[parts.len() - 5..].join("-");
-        assert_eq!(uuid_part.len(), 36, "UUID part should be 36 characters");
-    }
-
-    #[test]
-    fn test_get_secure_socket_path() {
-        // Test with valid XDG_RUNTIME_DIR
+    fn secure_runtime_path_guards_xdg_runtime_dir() {
+        // Valid XDG_RUNTIME_DIR is honored.
         unsafe {
             std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
         }
-        let path = get_secure_socket_path();
-        assert!(path.to_string_lossy().contains("super-stt.sock"));
+        let path = secure_runtime_path("super-stt-http.sock");
+        assert!(path.to_string_lossy().contains("super-stt-http.sock"));
 
-        // Test with potentially malicious XDG_RUNTIME_DIR (path traversal)
+        // Path traversal falls back to /tmp/stt/.
         unsafe {
             std::env::set_var("XDG_RUNTIME_DIR", "../../../etc");
         }
-        let fallback_path = get_secure_socket_path();
         assert_eq!(
-            fallback_path,
-            std::path::PathBuf::from("/tmp/stt/super-stt.sock")
+            secure_runtime_path("super-stt-http.sock"),
+            std::path::PathBuf::from("/tmp/stt/super-stt-http.sock")
         );
 
-        // Test with invalid directory prefix
+        // Directory outside the whitelist falls back.
         unsafe {
             std::env::set_var("XDG_RUNTIME_DIR", "/etc/passwd");
         }
-        let fallback_path2 = get_secure_socket_path();
         assert_eq!(
-            fallback_path2,
-            std::path::PathBuf::from("/tmp/stt/super-stt.sock")
+            secure_runtime_path("super-stt-http.sock"),
+            std::path::PathBuf::from("/tmp/stt/super-stt-http.sock")
         );
 
-        // Test with extremely long path
+        // Over-long dir falls back.
         let long_path = "a".repeat(300);
         unsafe {
             std::env::set_var("XDG_RUNTIME_DIR", &long_path);
         }
-        let fallback_path3 = get_secure_socket_path();
         assert_eq!(
-            fallback_path3,
-            std::path::PathBuf::from("/tmp/stt/super-stt.sock")
+            secure_runtime_path("super-stt-http.sock"),
+            std::path::PathBuf::from("/tmp/stt/super-stt-http.sock")
         );
 
-        // Clean up environment
         unsafe {
             std::env::remove_var("XDG_RUNTIME_DIR");
         }


### PR DESCRIPTION
Applet + shared cleanup batch (Tier 3 #22-#26 from `docs/audits/2026-07-code-quality.md`).

## #22 — Type `icon_alignment`
The panel icon alignment was a stringly-typed `String` round-tripped through three hand-written mappings (`init.rs`, `update.rs`, `view.rs`). Introduced an `IconAlignment { Start, Center, End }` enum with a snake-case serde wire id (`deserialize_or_default`) so those mappings are typed.

While there, unified the mixed from-wire idiom the audit flagged:
- `VisualizationTheme` / `WorkingAnimationTheme` moved from inherent `from_str` to the `FromStr` trait (now matching `VisualizationSide` and the new `IconAlignment`).
- `VisualizationColor`'s pretty `Display` became `pretty_name()` (the UI-label idiom used by the other enums), and its caller-less `From<String>` was dropped — Color is now a serde-only enum with no wire round-trip.

## #23 — Legacy-protocol vestiges (~100 lines)
Removed: the unsendable `RecordingStateChanged`/`AudioLevelUpdate` messages + handlers; the fully-discarded `PingResponse` fields (collapsed to a unit variant; dropped the `PingResponse` struct and `ping_daemon_with_status`); the ignored `sample_rate` decode/field; the never-constructed `IsOpen::AppletSettings`; and the write-only `UiConfig.last_popup_state`. A forward-compat test proves old configs carrying the removed field still load.

## #24 — Logging noise
The connect is now logged once on the actual transition (`info`); the per-5s liveness ping and all per-attempt reconnect logs dropped to `debug`; fixed the stale "daemon may be idle" phrasing.

## #25 — Double clone per frame
`Canvas::new(visualization)` — the component is already owned (the caller clones out of `&self`), so the second clone is gone. Corrected the stale "cache key" comment.

## #26 — Shared: dead public API + unused deps
- Removed zero-consumer `get_secure_socket_path` and `generate_secure_client_id`, and the `device_options!`/`has_cuda_support!` macros (referenced a `cuda` feature that no longer exists). Repointed the SSRF/traversal guard test to the still-live `secure_runtime_path`.
- Fixed the `get_http_socket_path` doc (no longer claims dual side-by-side listeners).
- Dropped unused deps `clap`, `chrono`, `dashmap`, `tokio-stream`, and the dead optional `cpal`/`hound` — the `audio` feature is now just `["rubato"]`.
- The app no longer enables shared's `analysis` feature (it used nothing from it; the daemon, which does, still enables it).

## Verification
- `cargo build --workspace` ✓
- workspace clippy pedantic (`--all-features -W clippy::pedantic -D warnings -D unused_must_use`) ✓
- applet tests (26) ✓, shared lib tests (93) ✓
- `just check-features` ✓
- `just fmt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)