### PR TITLE
Audit Tier 3 #32-#34: BTreeMap doc, workspace deps, rename ResolveError

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -1154,19 +1154,27 @@ Tier 2 #4/#6/#8.
   client (all funnel through it) agree; the daemon's `spawn_http_listener` dropped
   its private env read. `transport.md` updated to drop the "on the daemon" scoping.
 
-### [ ] 32. 🟡 Indexer: `registry_toml.rs:31-33` doc claims `BTreeMap` preserves file order (it sorts by key)
+### [x] 32. 🟡 Indexer: `registry_toml.rs:31-33` doc claims `BTreeMap` preserves file order (it sorts by key)
 
-### [ ] 33. 🟡 Tooling: Cargo convention drift
+- **Fix:** corrected the doc — a `BTreeMap` iterates in sorted id order, not file
+  declaration order.
+
+### [x] 33. 🟡 Tooling: Cargo convention drift
 
 - **Where:** the indexer redeclares loose versions (`anyhow = "1"`, `clap = "4"`);
   the CLI mixes `workspace = true` with loose pins.
-- **Fix:** use `[workspace.dependencies]` throughout.
+- **Fix:** every dep the workspace already centralizes now inherits via
+  `.workspace = true` (indexer: anyhow/chrono/clap/env_logger/log/reqwest/serde/
+  serde_json/thiserror/tokio/toml; CLI: clap). Genuinely indexer-only deps
+  (flate2/futures/hex/ring/semver/tar/url) stay local — they don't drift.
 
-### [ ] 34. 🟡 Indexer: rename the indexer's `ResolveError` for grep-ability
+### [x] 34. 🟡 Indexer: rename the indexer's `ResolveError` for grep-ability
 
 - The three same-named `ResolveError` enums (custom_repo / local_dir / indexer
   resolve) are distinct concepts, not duplication — at most rename the indexer's.
   Same verdict for `Host` ×2 and `VisualizationConfig` ×2: no action needed.
+- **Fix:** renamed the indexer's to `ReleaseResolveError` (contained to
+  `resolve.rs`).
 
 ### [ ] 35. 🟠 Daemon: remaining blocking work (split off Tier 3 #4)
 

--- a/super-stt-cli/Cargo.toml
+++ b/super-stt-cli/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-clap = "4"
+clap.workspace = true
 http-body-util = "0.1"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }

--- a/super-stt-indexer/Cargo.toml
+++ b/super-stt-indexer/Cargo.toml
@@ -10,24 +10,27 @@ description = "Cron-driven indexer that builds index.json from registry.toml"
 workspace = true
 
 [dependencies]
-anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive"] }
+# Shared version pins inherited from [workspace.dependencies].
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+log.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+# Indexer-only dependencies (not used elsewhere in the workspace).
 flate2 = "1"
 futures = "0.3"
 hex = "0.4"
-log = "0.4"
-env_logger = "0.11"
-reqwest = { workspace = true }
 ring = "0.17"
 semver = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 tar = "0.4"
-thiserror = "2"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util"] }
-toml = "1"
 url = "2"
+# Workspace path crates.
 super-stt-registry-types = { path = "../super-stt-registry-types" }
 super-stt-forge = { version = "0.1.4-beta.2", path = "../super-stt-forge" }
 

--- a/super-stt-indexer/src/registry_toml.rs
+++ b/super-stt-indexer/src/registry_toml.rs
@@ -28,7 +28,8 @@ pub enum ParseError {
     PrefixOverlap { a: String, b: String, repo: String },
 }
 
-/// Parsed registry file: id → entry, preserving the file's order.
+/// Parsed registry file: id → entry. Backed by a `BTreeMap`, so iteration is in
+/// sorted id order — not the file's declaration order.
 #[derive(Debug, Clone)]
 pub struct Registry(pub BTreeMap<String, Entry>);
 

--- a/super-stt-indexer/src/resolve.rs
+++ b/super-stt-indexer/src/resolve.rs
@@ -16,7 +16,7 @@ pub struct Resolved {
 }
 
 #[derive(Debug, Error)]
-pub enum ResolveError {
+pub enum ReleaseResolveError {
     #[error("no releases on `{repo}`")]
     NoReleases { repo: String },
     #[error("no release tag matches prefix `{prefix}`")]
@@ -31,7 +31,7 @@ pub async fn resolve(
     client: &dyn ForgeClient,
     repo: &RepoRef,
     entry: &Entry,
-) -> Result<Resolved, ResolveError> {
+) -> Result<Resolved, ReleaseResolveError> {
     let releases = if entry.tag_prefix.is_some() {
         client.list_releases(repo).await?
     } else {
@@ -40,13 +40,13 @@ pub async fn resolve(
     select_release(releases, entry)
 }
 
-fn select_release(releases: Vec<Release>, entry: &Entry) -> Result<Resolved, ResolveError> {
+fn select_release(releases: Vec<Release>, entry: &Entry) -> Result<Resolved, ReleaseResolveError> {
     let max_cap = entry
         .max_version
         .as_deref()
         .map(parse_semver)
         .transpose()
-        .map_err(|tag| ResolveError::BadSemver { tag, prefix: None })?;
+        .map_err(|tag| ReleaseResolveError::BadSemver { tag, prefix: None })?;
 
     let mut best: Option<(Version, Release)> = None;
     for r in releases {
@@ -81,8 +81,8 @@ fn select_release(releases: Vec<Release>, entry: &Entry) -> Result<Resolved, Res
         }
     }
     let (version, release) = best.ok_or_else(|| match &entry.tag_prefix {
-        Some(p) => ResolveError::NoMatchingPrefix { prefix: p.clone() },
-        None => ResolveError::NoReleases {
+        Some(p) => ReleaseResolveError::NoMatchingPrefix { prefix: p.clone() },
+        None => ReleaseResolveError::NoReleases {
             repo: entry.repo.clone(),
         },
     })?;
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn errors_when_no_match() {
         let err = select_release(vec![rel("v1.0.0")], &entry(Some("xyz-"), None)).unwrap_err();
-        assert!(matches!(err, ResolveError::NoMatchingPrefix { .. }));
+        assert!(matches!(err, ReleaseResolveError::NoMatchingPrefix { .. }));
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
     fn prefix_requires_digit_boundary() {
         // Prefix `a` must not match `a-1.0.0` (a separator, not a digit, follows).
         let err = select_release(vec![rel("a-1.0.0")], &entry(Some("a"), None)).unwrap_err();
-        assert!(matches!(err, ResolveError::NoMatchingPrefix { .. }));
+        assert!(matches!(err, ReleaseResolveError::NoMatchingPrefix { .. }));
         // But `a-` does match it.
         let r = select_release(vec![rel("a-1.0.0")], &entry(Some("a-"), None)).unwrap();
         assert_eq!(r.version, Version::new(1, 0, 0));


### PR DESCRIPTION
Indexer + tooling cleanup batch (Tier 3 #32-#34 from `docs/audits/2026-07-code-quality.md`). Closes out the Tier 3 backlog (#1–#34).

## #32 — Wrong `BTreeMap` order doc
`Registry`'s doc claimed it preserves the file's declaration order, but it's a `BTreeMap` — iteration is in sorted id order. Corrected the doc to say so.

## #33 — Cargo convention drift
The indexer redeclared loose versions (`anyhow = "1"`, `clap = "4"`, …) for deps the workspace already centralizes, and the CLI mixed `workspace = true` with a loose `clap = "4"`. Now every dep present in `[workspace.dependencies]` inherits via `.workspace = true`:
- **indexer**: `anyhow`, `chrono`, `clap`, `env_logger`, `log`, `reqwest`, `serde`, `serde_json`, `thiserror`, `tokio`, `toml`
- **CLI**: `clap`

Genuinely indexer-only deps (`flate2`, `futures`, `hex`, `ring`, `semver`, `tar`, `url`) stay local — they aren't in the workspace table and can't drift. Done via `cargo remove` + `cargo add` (no hand-edited versions); `Cargo.lock` is unchanged (versions resolve identically).

## #34 — Grep-able `ResolveError`
The workspace has three unrelated `ResolveError` enums (custom_repo / local_dir / indexer resolve). Renamed the indexer's to `ReleaseResolveError` — it resolves the release/version to publish for a registry entry. The rename is contained to `resolve.rs` (`main.rs` calls `resolve::resolve()` but never names the type). Per the audit, the `Host`×2 / `VisualizationConfig`×2 name collisions are distinct concepts and need no action.

## Verification
- `cargo build --workspace` ✓
- clippy pedantic (indexer + CLI, `--all-features -W clippy::pedantic -D warnings -D unused_must_use`) ✓
- indexer unit tests (42) ✓
- `just check-features` ✓, `just fmt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)