### PR TITLE
Audit Tier 3 #35-#37: async Simulator, keyring cleanup, UI rollback

### DIFF
--- a/docs/audits/2026-07-code-quality.md
+++ b/docs/audits/2026-07-code-quality.md
@@ -1176,7 +1176,7 @@ Tier 2 #4/#6/#8.
 - **Fix:** renamed the indexer's to `ReleaseResolveError` (contained to
   `resolve.rs`).
 
-### [ ] 35. 🟠 Daemon: remaining blocking work (split off Tier 3 #4)
+### [x] 35. 🟠 Daemon: remaining blocking work (split off Tier 3 #4)
 
 - **Where:** the keyboard `Simulator` path — portal `notify_keysym` spins up an OS
   thread + a fresh current-thread tokio runtime per keysym
@@ -1192,10 +1192,19 @@ Tier 2 #4/#6/#8.
   `mint`/`revoke`; correctness wants a single-writer persist task (a detached
   `spawn_blocking` per call would race the on-disk ordering), and `load_persisted` is
   a one-time startup blocking read.
-- **Fix:** async `Simulator` (threads the `Typer`/preview loop off the `std::Mutex`
-  guard); a dedicated session-persist task fed over a channel.
+- **Fix:** async `Simulator` — the portal backend awaits `NotifyKeyboardKeysym` on
+  its owned zbus connection (no per-keysym thread/runtime); the sync, `!Send`
+  enigo/ydotool backends run under `block_in_place` in the enum so their handle
+  never crosses an await. `Typer::{update_preview,clear_preview,process_final_text}`
+  and the diff helpers are async; the two `std::Mutex<String>` sites take the mirror
+  string out (in a guard-dropping scope) before the async typing and write it back —
+  safe because both run under `&mut Typer` and never overlap. Session persistence
+  moved to a single-writer `SessionPersister` task fed over an `mpsc` channel:
+  `mint`/`revoke`/`validate` submit a snapshot (non-blocking), the task coalesces
+  bursts and writes via `spawn_blocking` sequentially (correct on-disk order, off the
+  request worker).
 
-### [ ] 36. 🟡 Daemon: keyring cleanup deferred from Tier 3 #9
+### [x] 36. 🟡 Daemon: keyring cleanup deferred from Tier 3 #9
 
 - **Where:** the sessions-blob accessors (`keyring.rs` `get_sessions_blob`/
   `set_sessions_blob`) build `keyring::Entry` directly and rely on
@@ -1208,10 +1217,15 @@ Tier 2 #4/#6/#8.
   restart test exercises — a verified change, not a drive-by. Typed errors ripple
   through every keyring/download-progress caller (incl. the Tier 3 #4 async wrappers)
   for marginal benefit.
-- **Fix:** route sessions through `kv_get`/`kv_set` and delete
-  `install_mock_if_requested`; introduce a small keyring error enum.
+- **Fix:** `get_sessions_blob`/`set_sessions_blob` now route through
+  `kv_get`/`kv_set` (one mock mechanism), `install_mock_if_requested` is deleted, and
+  a `KeyringError` enum (Display-preserving) replaces the stringly `Result<_,String>`
+  across keyring + its async wrappers. The real-keyring storage key is unchanged
+  (`("super-stt","stt-sessions")`) and no non-ignored test restarts the daemon, so no
+  restart behavior changed. Download-progress's two single-message `Result<_,String>`
+  are left as-is (not keyring errors; typing them is churn for no benefit).
 
-### [ ] 37. 🟡 App: roll back optimistic UI state on save failure (split off Tier 3 #11)
+### [x] 37. 🟡 App: roll back optimistic UI state on save failure (split off Tier 3 #11)
 
 - **Where:** the optimistic-then-banner sites — audio theme / feedback
   (`handlers/recording.rs`), volume commit (same), `SelectBackend` /
@@ -1223,8 +1237,15 @@ Tier 2 #4/#6/#8.
   message (and volume needs a stored last-committed value, since the drag already
   overwrote `self.volume`). The drift also self-heals on the next reconnect refetch
   (`VolumeLoaded`/`CurrentAudioThemeLoaded`/`ActiveBackendLoaded`).
-- **Fix:** capture the prior value at the optimistic set and restore it in a
-  dedicated failure message that also raises the banner.
+- **Fix:** each site captures its prior value(s) at the optimistic set and threads
+  them through a dedicated per-site failure message that restores them and raises the
+  banner: audio theme/feedback → `AudioThemeSaveFailed`; volume → `VolumeSaveFailed`
+  plus a new `last_committed_volume` field (the drag clobbers `volume`, so the
+  rollback target is stored separately and kept in sync on `VolumeLoaded`);
+  `SelectBackend` → `BackendSelectFailed`; `LoadStagedModel` → `StagedModelLoadFailed`
+  (both restore via a shared `set_model_error` helper). Handler-level tests aren't
+  feasible without the cosmic `Core` harness (the app has none); the restores are
+  simple field assignments verified by the compiler.
 
 ---
 

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -217,6 +217,9 @@ impl AppModel {
 
             DaemonMessage::VolumeLoaded(vol) => {
                 self.volume = vol;
+                // Keep the rollback target aligned with the daemon's value so a
+                // later failed commit rolls back to what's actually persisted.
+                self.last_committed_volume = vol;
                 Task::none()
             }
 

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -121,13 +121,7 @@ impl AppModel {
             }
 
             ModelMessage::ModelError(err) => {
-                warn!("Model operation failed: {err}");
-                let home = std::env::var("HOME").unwrap_or_default();
-                let sanitized = sanitize_home(&err, &home);
-                self.model_operation_state = ModelOperationState::Error { message: sanitized };
-                // A failed switch leaves the daemon idle (no model) — the
-                // backend stays selected, but no model is loaded.
-                self.clear_loaded_model();
+                self.set_model_error(&err);
                 Task::none()
             }
 
@@ -135,6 +129,19 @@ impl AppModel {
             // arm; nothing to do here.
             ModelMessage::LoadInitialData => Task::none(),
         }
+    }
+
+    /// Surface a failed model operation on the Models card and drop the loaded
+    /// model, sanitizing any `$HOME` path out of the message. Shared by the
+    /// `ModelError` sink and the optimistic-rollback handlers (audit Tier 3 #37).
+    pub(in crate::core::app) fn set_model_error(&mut self, err: &str) {
+        warn!("Model operation failed: {err}");
+        let home = std::env::var("HOME").unwrap_or_default();
+        let sanitized = sanitize_home(err, &home);
+        self.model_operation_state = ModelOperationState::Error { message: sanitized };
+        // A failed switch leaves the daemon idle (no model) — the backend stays
+        // selected, but no model is loaded.
+        self.clear_loaded_model();
     }
 
     /// Snapshot the daemon's current model, tagging the result with the

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -30,6 +30,8 @@ impl AppModel {
             ModelsPageMessage::OpenBackendConfig(_)
             | ModelsPageMessage::CloseBackendConfig
             | ModelsPageMessage::SelectBackend(_)
+            | ModelsPageMessage::BackendSelectFailed { .. }
+            | ModelsPageMessage::StagedModelLoadFailed { .. }
             | ModelsPageMessage::DeselectBackend
             | ModelsPageMessage::ActiveBackendLoaded(_)
             | ModelsPageMessage::RefreshGpuInfo
@@ -186,6 +188,10 @@ impl AppModel {
                 .filter(|d| d != "none" && *d != self.current_device)
         };
 
+        // Capture the pre-switch device so a failed switch rolls it back rather
+        // than leaving the UI on a device the daemon never adopted (audit
+        // Tier 3 #37).
+        let prev_device = self.current_device.clone();
         self.set_model_loading(model.clone(), "Initiating model switch...".to_string());
         if let Some(dev) = &device_to_set {
             self.current_device.clone_from(dev);
@@ -208,9 +214,12 @@ impl AppModel {
                         provider: provider_label.clone(),
                         source: source_label.clone(),
                     })),
-                    Err(e) => {
-                        cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string())))
-                    }
+                    Err(e) => cosmic::Action::App(Message::ModelsPage(
+                        ModelsPageMessage::StagedModelLoadFailed {
+                            prev_device: prev_device.clone(),
+                            message: e.to_string(),
+                        },
+                    )),
                 },
             ),
             Task::perform(
@@ -279,18 +288,43 @@ impl AppModel {
                 if self.models_page.active_backend.as_deref() == Some(source.as_str()) {
                     return Task::none();
                 }
+                // Capture the prior selection so a failed activation rolls the
+                // card back instead of showing a backend the daemon rejected
+                // (audit Tier 3 #37).
+                let prev_active = self.models_page.active_backend.take();
                 self.models_page.active_backend = Some(source.clone());
                 self.clear_loaded_model();
                 self.model_operation_state = ModelOperationState::Ready;
                 // Activation comes from the Models page's "Load a backend" sheet;
                 // dismiss it now that a choice was made.
                 self.core.window.show_context = false;
-                Task::perform(set_active_backend(source), |result| match result {
+                Task::perform(set_active_backend(source), move |result| match result {
                     Ok(()) => cosmic::Action::None,
-                    Err(e) => {
-                        cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string())))
-                    }
+                    Err(e) => cosmic::Action::App(Message::ModelsPage(
+                        ModelsPageMessage::BackendSelectFailed {
+                            prev_active: prev_active.clone(),
+                            message: e.to_string(),
+                        },
+                    )),
                 })
+            }
+
+            ModelsPageMessage::BackendSelectFailed {
+                prev_active,
+                message,
+            } => {
+                self.models_page.active_backend = prev_active;
+                self.set_model_error(&message);
+                Task::none()
+            }
+
+            ModelsPageMessage::StagedModelLoadFailed {
+                prev_device,
+                message,
+            } => {
+                self.current_device = prev_device;
+                self.set_model_error(&message);
+                Task::none()
             }
 
             ModelsPageMessage::DeselectBackend => {

--- a/super-stt-app/src/core/app/handlers/recording.rs
+++ b/super-stt-app/src/core/app/handlers/recording.rs
@@ -11,12 +11,18 @@ use cosmic::prelude::*;
 use futures_util::StreamExt;
 use super_stt_shared::daemon::http_client::HttpError;
 
-/// Build a Customization-scoped banner message for a failed audio-settings save.
-fn customization_error(e: &HttpError) -> Message {
-    Message::SettingActionFailed {
-        scope: ErrorScope::Customization,
+/// Build the audio-theme rollback message: restore the captured pre-save theme
+/// fields and raise a Customization banner (audit Tier 3 #37).
+fn audio_theme_save_failed(
+    prev_selected: AudioTheme,
+    prev_non_silent: AudioTheme,
+    e: &HttpError,
+) -> Message {
+    Message::Recording(RecordingMessage::AudioThemeSaveFailed {
+        prev_selected,
+        prev_non_silent,
         message: e.to_string(),
-    }
+    })
 }
 
 impl AppModel {
@@ -33,9 +39,11 @@ impl AppModel {
 
             RecordingMessage::AudioFeedbackToggled(_)
             | RecordingMessage::AudioThemeSelected(_)
+            | RecordingMessage::AudioThemeSaveFailed { .. }
             | RecordingMessage::AudioThemesLoaded(_)
             | RecordingMessage::VolumeChanged(_)
             | RecordingMessage::VolumeCommit
+            | RecordingMessage::VolumeSaveFailed { .. }
             | RecordingMessage::WidgetAudioLevel { .. }
             | RecordingMessage::WidgetRecordingState(_) => self.handle_audio_messages(message),
         }
@@ -105,6 +113,11 @@ impl AppModel {
             RecordingMessage::AudioFeedbackToggled(enabled) => {
                 // Clear any stale Customization banner as the user retries.
                 self.clear_action_error(ErrorScope::Customization);
+                // Capture the pre-optimistic values so a failed save can roll
+                // the UI back instead of leaving it stuck on the value the
+                // daemon rejected (audit Tier 3 #37).
+                let prev_selected = self.selected_audio_theme;
+                let prev_non_silent = self.last_non_silent_theme;
                 let theme = if enabled {
                     self.last_non_silent_theme
                 } else {
@@ -112,26 +125,50 @@ impl AppModel {
                 };
                 self.selected_audio_theme = theme;
                 // Success is a no-op (the optimistic value already holds); a
-                // failure surfaces a scoped banner instead of flipping the whole
-                // app to the connection-error page (Tier 1 #13). Reusing
-                // `DaemonConnected` here also used to trigger a full settings
-                // refetch on every toggle (Tier 1 #14).
-                Task::perform(set_audio_theme(theme), |result| match result {
+                // failure restores the prior value and surfaces a scoped banner
+                // instead of flipping the whole app to the connection-error page
+                // (Tier 1 #13). Reusing `DaemonConnected` here also used to
+                // trigger a full settings refetch on every toggle (Tier 1 #14).
+                Task::perform(set_audio_theme(theme), move |result| match result {
                     Ok(_) => cosmic::Action::None,
-                    Err(e) => cosmic::Action::App(customization_error(&e)),
+                    Err(e) => cosmic::Action::App(audio_theme_save_failed(
+                        prev_selected,
+                        prev_non_silent,
+                        &e,
+                    )),
                 })
             }
 
             RecordingMessage::AudioThemeSelected(theme) => {
                 self.clear_action_error(ErrorScope::Customization);
+                let prev_selected = self.selected_audio_theme;
+                let prev_non_silent = self.last_non_silent_theme;
                 self.selected_audio_theme = theme;
                 if theme != AudioTheme::Silent {
                     self.last_non_silent_theme = theme;
                 }
-                Task::perform(set_and_test_audio_theme(theme), |result| match result {
-                    Ok(_) => cosmic::Action::None,
-                    Err(e) => cosmic::Action::App(customization_error(&e)),
-                })
+                Task::perform(
+                    set_and_test_audio_theme(theme),
+                    move |result| match result {
+                        Ok(_) => cosmic::Action::None,
+                        Err(e) => cosmic::Action::App(audio_theme_save_failed(
+                            prev_selected,
+                            prev_non_silent,
+                            &e,
+                        )),
+                    },
+                )
+            }
+
+            RecordingMessage::AudioThemeSaveFailed {
+                prev_selected,
+                prev_non_silent,
+                message,
+            } => {
+                self.selected_audio_theme = prev_selected;
+                self.last_non_silent_theme = prev_non_silent;
+                self.set_action_error(ErrorScope::Customization, message);
+                Task::none()
             }
 
             RecordingMessage::AudioThemesLoaded(themes) => {
@@ -149,10 +186,32 @@ impl AppModel {
 
             RecordingMessage::VolumeCommit => {
                 self.clear_action_error(ErrorScope::Customization);
-                Task::perform(set_volume(self.volume), |result| match result {
+                // The drag already clobbered `self.volume`, so the rollback
+                // target is the last committed value. Advance it optimistically
+                // and capture the prior committed value for a possible rollback
+                // (audit Tier 3 #37).
+                let prev_volume = self.last_committed_volume;
+                let new_volume = self.volume;
+                self.last_committed_volume = new_volume;
+                Task::perform(set_volume(new_volume), move |result| match result {
                     Ok(()) => cosmic::Action::None,
-                    Err(e) => cosmic::Action::App(customization_error(&e)),
+                    Err(e) => cosmic::Action::App(Message::Recording(
+                        RecordingMessage::VolumeSaveFailed {
+                            prev_volume,
+                            message: e.to_string(),
+                        },
+                    )),
                 })
+            }
+
+            RecordingMessage::VolumeSaveFailed {
+                prev_volume,
+                message,
+            } => {
+                self.volume = prev_volume;
+                self.last_committed_volume = prev_volume;
+                self.set_action_error(ErrorScope::Customization, message);
+                Task::none()
             }
 
             RecordingMessage::WidgetAudioLevel { level, is_speech } => {

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -130,6 +130,7 @@ impl AppModel {
                 super_stt_shared::models::recording_stop_mode::RecordingStopMode::default(),
             write_method: super_stt_shared::models::write_method::WriteMethod::default(),
             volume: 100,
+            last_committed_volume: 100,
 
             // Custom models directory
             custom_models_dir: None,

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -136,6 +136,10 @@ pub struct AppModel {
 
     // Master volume (0-100)
     pub volume: u8,
+    /// Last value successfully committed to (or loaded from) the daemon. The
+    /// rollback target when a `VolumeCommit` save fails, since the live drag has
+    /// already overwritten `volume` (audit Tier 3 #37).
+    pub last_committed_volume: u8,
 
     // Custom models directory
     pub custom_models_dir: Option<String>,

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -135,6 +135,18 @@ pub enum ModelsPageMessage {
     /// Select a backend as active without loading a model — the card moves to
     /// the top, any model from a different backend is unloaded.
     SelectBackend(String),
+    /// A `SelectBackend` activation POST failed: restore the previously-active
+    /// backend and surface the model-card error (audit Tier 3 #37).
+    BackendSelectFailed {
+        prev_active: Option<String>,
+        message: String,
+    },
+    /// A `LoadStagedModel` switch failed: restore the previously-current device
+    /// and surface the model-card error (audit Tier 3 #37).
+    StagedModelLoadFailed {
+        prev_device: String,
+        message: String,
+    },
     /// Deselect the active backend (unload its model → daemon idle).
     DeselectBackend,
     /// Active backend `source` loaded from the daemon (None = idle).
@@ -342,11 +354,25 @@ pub enum RecordingMessage {
     AudioFeedbackToggled(bool),
     AudioThemeSelected(AudioTheme),
     AudioThemesLoaded(Vec<AudioTheme>),
+    /// A theme/feedback save failed: restore the optimistically-set theme
+    /// fields to the captured pre-save values and raise a scoped banner
+    /// (audit Tier 3 #37).
+    AudioThemeSaveFailed {
+        prev_selected: AudioTheme,
+        prev_non_silent: AudioTheme,
+        message: String,
+    },
     /// A drag tick: updates the local slider value only (no daemon POST).
     VolumeChanged(u8),
     /// The slider was released: commit the current value to the daemon once,
     /// rather than one POST per drag tick (Tier 1 #19).
     VolumeCommit,
+    /// A volume commit failed: restore the slider to the last committed value
+    /// and raise a scoped banner (audit Tier 3 #37).
+    VolumeSaveFailed {
+        prev_volume: u8,
+        message: String,
+    },
     /// `frequency_bands` event from the daemon's `/events` SSE stream
     /// — already converted to (`display_level_percent`, `is_speech`) so
     /// the settings UI can drive its meter unchanged.

--- a/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::mpsc;
 
 /// Schema version for the persisted sessions blob. Bump on any breaking
 /// change to `TokenMeta`'s on-disk shape so an older daemon can refuse
@@ -52,13 +53,108 @@ fn allow_no_keyring() -> bool {
     std::env::var(ALLOW_NO_KEYRING_ENV).is_ok_and(|v| v == "1")
 }
 
+/// Single-writer handle for persisting the sessions map to the keyring.
+///
+/// `mint`/`revoke`/`validate` are sync fns called from async request handlers;
+/// writing the whole map to the keyring inline blocks a runtime worker on `DBus`
+/// I/O, and two concurrent mutations dropping their `Mutex` guard before writing
+/// would race the on-disk order. Funnelling every snapshot through one task over
+/// this channel keeps the blocking write off the request path *and* serializes
+/// the writes so the last submitted snapshot is the last one written (audit
+/// Tier 3 #35).
+#[derive(Clone)]
+pub(crate) struct SessionPersister {
+    tx: mpsc::UnboundedSender<HashMap<String, TokenMeta>>,
+}
+
+impl SessionPersister {
+    /// Spawn the single-writer persist task and return a submit handle. In
+    /// `cargo test` builds no task is spawned (unit tests must not touch the
+    /// developer's keyring); submissions become no-ops as the receiver is
+    /// dropped.
+    fn spawn() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel::<HashMap<String, TokenMeta>>();
+        #[cfg(not(test))]
+        tokio::spawn(persist_loop(rx));
+        #[cfg(test)]
+        drop(rx);
+        Self { tx }
+    }
+
+    /// Submit the latest sessions snapshot for persistence. Best-effort: a
+    /// closed channel (test builds) just means the write is skipped — the
+    /// in-memory map stays authoritative.
+    fn submit(&self, snapshot: HashMap<String, TokenMeta>) {
+        let _ = self.tx.send(snapshot);
+    }
+}
+
+/// The persist task: receive snapshots, coalesce a burst down to the newest
+/// (older snapshots are strict subsets of the state the newest represents), and
+/// write each sequentially so on-disk order matches submission order.
+#[cfg(not(test))]
+async fn persist_loop(mut rx: mpsc::UnboundedReceiver<HashMap<String, TokenMeta>>) {
+    while let Some(mut latest) = rx.recv().await {
+        while let Ok(newer) = rx.try_recv() {
+            latest = newer;
+        }
+        persist_snapshot(latest).await;
+    }
+}
+
+/// Serialize one snapshot and write it to the keyring on a blocking thread.
+/// Runs inside the single persist task, so writes are already serialized.
+///
+/// **Failure suppression.** A locked or denied keyring fails every write;
+/// without a cooldown a busy mint/revoke loop would re-prompt the user every
+/// few seconds. After one failure we suppress further writes for
+/// [`KEYRING_FAILURE_COOLDOWN`]; the in-memory map stays authoritative and a
+/// later success clears the flag.
+#[cfg(not(test))]
+async fn persist_snapshot(snapshot: HashMap<String, TokenMeta>) {
+    if keyring_writes_in_cooldown() {
+        return;
+    }
+    let payload = SessionsFile {
+        version: SESSIONS_SCHEMA_VERSION,
+        sessions: snapshot,
+    };
+    let json = match serde_json::to_string(&payload) {
+        Ok(j) => j,
+        Err(e) => {
+            warn!("Failed to serialize sessions blob: {e}");
+            return;
+        }
+    };
+    // The keyring write is blocking DBus I/O; keep it off the task's async
+    // executor. The task awaits it, so writes stay strictly ordered.
+    match tokio::task::spawn_blocking(move || crate::keyring::set_sessions_blob(&json)).await {
+        Ok(Ok(())) => clear_keyring_failure_flag(),
+        Ok(Err(e)) => {
+            warn!(
+                "Failed to persist sessions blob: {e}; suppressing further keyring writes for {}s",
+                KEYRING_FAILURE_COOLDOWN.as_secs()
+            );
+            mark_keyring_failure();
+        }
+        Err(e) => warn!("Session persist task panicked: {e}"),
+    }
+}
+
 /// Persistent store of issued session tokens. The in-memory `HashMap`
 /// is the hot lookup path; every mutation also writes the whole map
 /// back to the system keyring under `(super-stt, stt-sessions)` so a
 /// daemon restart re-hydrates the same set of valid tokens.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct TokenStore {
     pub(crate) inner: Arc<Mutex<HashMap<String, TokenMeta>>>,
+    persist: SessionPersister,
+}
+
+impl Default for TokenStore {
+    fn default() -> Self {
+        Self::empty()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -95,8 +191,17 @@ impl TokenStore {
     /// # Errors
     /// Returns an error when the system keyring is unavailable and
     /// [`ALLOW_NO_KEYRING_ENV`] is not set, so the daemon aborts startup.
+    /// An empty store with a live persist task (production) / no-op persister
+    /// (test builds).
+    fn empty() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            persist: SessionPersister::spawn(),
+        }
+    }
+
     pub(crate) fn load_persisted() -> anyhow::Result<Self> {
-        let store = Self::default();
+        let store = Self::empty();
 
         let blob = match crate::keyring::get_sessions_blob() {
             Ok(Some(b)) => b,
@@ -190,45 +295,6 @@ impl TokenStore {
     /// smoke test in `tests/http_smoke_full.rs` (which exercises this
     /// crate built without the `test` cfg flag).
     ///
-    /// Takes a snapshot by value so the caller can drop its `Mutex`
-    /// guard *before* calling — keyring writes go through `DBus` and
-    /// can stall for seconds when the keyring is locked, and holding
-    /// `TokenStore::inner` across that stall would serialize every
-    /// authenticated request behind it.
-    fn flush_snapshot(snapshot: HashMap<String, TokenMeta>) {
-        if cfg!(test) {
-            return;
-        }
-        if keyring_writes_in_cooldown() {
-            // Suppressed — last write failed within the cooldown
-            // window. In-memory state is still authoritative.
-            return;
-        }
-        let payload = SessionsFile {
-            version: SESSIONS_SCHEMA_VERSION,
-            sessions: snapshot,
-        };
-        let json = match serde_json::to_string(&payload) {
-            Ok(j) => j,
-            Err(e) => {
-                warn!("Failed to serialize sessions blob: {e}");
-                return;
-            }
-        };
-        match crate::keyring::set_sessions_blob(&json) {
-            Ok(()) => {
-                clear_keyring_failure_flag();
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to persist sessions blob: {e}; suppressing further keyring writes for {}s",
-                    KEYRING_FAILURE_COOLDOWN.as_secs()
-                );
-                mark_keyring_failure();
-            }
-        }
-    }
-
     pub(crate) fn mint(
         &self,
         app_name: &str,
@@ -250,7 +316,7 @@ impl TokenStore {
             tokens.insert(token.clone(), meta);
             tokens.clone()
         };
-        Self::flush_snapshot(snapshot);
+        self.persist.submit(snapshot);
         (token, expires_at)
     }
 
@@ -273,7 +339,7 @@ impl TokenStore {
             }
         };
         if let Some(snapshot) = maybe_snapshot {
-            Self::flush_snapshot(snapshot);
+            self.persist.submit(snapshot);
         }
         result
     }
@@ -293,7 +359,7 @@ impl TokenStore {
             }
         };
         if let Some(snapshot) = maybe_snapshot {
-            Self::flush_snapshot(snapshot);
+            self.persist.submit(snapshot);
         }
     }
 }
@@ -316,8 +382,9 @@ mod tests {
     //! unknown-token path, mint correctness, and revocation. `validate`
     //! and `revoke` are the gates every authenticated request and the
     //! `/events` exe-watch path rely on, so they're exercised directly
-    //! here. `flush_snapshot` is a no-op under `cfg!(test)` (see its
-    //! doc comment), so none of these touch the system keyring.
+    //! here. Under `cfg!(test)` no persist task is spawned and the
+    //! `SessionPersister` receiver is dropped, so mint/revoke submissions
+    //! are no-ops — none of these touch the system keyring.
     use super::{TokenMeta, TokenStore};
     use chrono::{Duration as ChronoDuration, Utc};
     use std::path::PathBuf;

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -162,7 +162,7 @@ impl SuperSTTDaemon {
         // Phase 5: type the final transcript.
         if write_mode {
             info!("Writing transcription via {}", typer.write_method_name());
-            typer.process_final_text(&transcription_result);
+            typer.process_final_text(&transcription_result).await;
         }
 
         // Phase 6: finalize the cycle.

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -261,9 +261,27 @@ impl SuperSTTDaemon {
                 let _ = tx.send(processed);
             }
 
-            // Type on screen if in write mode
-            if write_mode && let Ok(mut actually_typed_guard) = session.actually_typed.lock() {
-                typer.update_preview(&text, &mut actually_typed_guard);
+            // Type on screen if in write mode. The typing is now async, and the
+            // `actually_typed` guard is a `!Send` `std::Mutex` guard that cannot
+            // be held across an `.await`. Take the mirror string out in a scope
+            // that drops the guard before typing, then write it back — safe
+            // because `update_preview` and `clear_preview` both run under
+            // `&mut Typer` and never overlap (audit Tier 3 #35). Skip on a
+            // poisoned lock, as before.
+            let taken = if write_mode {
+                session
+                    .actually_typed
+                    .lock()
+                    .ok()
+                    .map(|mut g| std::mem::take(&mut *g))
+            } else {
+                None
+            };
+            if let Some(mut actually_typed) = taken {
+                typer.update_preview(&text, &mut actually_typed).await;
+                if let Ok(mut g) = session.actually_typed.lock() {
+                    *g = actually_typed;
+                }
             }
         }
 
@@ -302,15 +320,24 @@ impl SuperSTTDaemon {
                 .preview_typing_enabled
                 .load(std::sync::atomic::Ordering::Relaxed);
             if preview_enabled {
-                if let Ok(mut actually_typed_guard) = session.actually_typed.lock() {
-                    info!(
-                        "Clearing preview text: '{}'",
-                        actually_typed_guard.chars().take(50).collect::<String>()
-                    );
-                    typer.clear_preview(&mut actually_typed_guard);
-                    info!("Preview cleared, actually_typed is now: '{actually_typed_guard}'");
+                // Take the mirror out in a scope that drops the `!Send` guard
+                // before the async backspacing (audit Tier 3 #35).
+                let taken = if let Ok(mut g) = session.actually_typed.lock() {
+                    Some(std::mem::take(&mut *g))
                 } else {
                     warn!("Failed to acquire actually_typed lock for clearing preview");
+                    None
+                };
+                if let Some(mut actually_typed) = taken {
+                    info!(
+                        "Clearing preview text: '{}'",
+                        actually_typed.chars().take(50).collect::<String>()
+                    );
+                    typer.clear_preview(&mut actually_typed).await;
+                    info!("Preview cleared, actually_typed is now: '{actually_typed}'");
+                    if let Ok(mut g) = session.actually_typed.lock() {
+                        *g = actually_typed;
+                    }
                 }
             } else {
                 debug!("Preview typing was disabled, no preview to clear");

--- a/super-stt-daemon/src/keyring.rs
+++ b/super-stt-daemon/src/keyring.rs
@@ -16,22 +16,30 @@ use std::sync::{Mutex, OnceLock};
 
 const SERVICE_NAME: &str = "super-stt";
 
-/// When `SUPER_STT_KEYRING_MOCK` is set, route session-blob keyring access to
-/// an in-memory mock store instead of the system secret service.
-///
-/// The integration tests spawn the daemon as a subprocess and CI runs
-/// headless, where there is no unlocked system keyring — touching the real
-/// secret service there blocks on an unlock prompt or fails. This must be
-/// called once at daemon startup, before any keyring access, as it sets the
-/// process-wide default credential builder.
-///
-/// Backend-secret access uses `mock_store()` instead and does not go through
-/// this builder.
-pub fn install_mock_if_requested() {
-    if std::env::var_os("SUPER_STT_KEYRING_MOCK").is_some() {
-        keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
-        // Runs before the logger is initialized, so use stderr directly.
-        eprintln!("SUPER_STT_KEYRING_MOCK set — using an in-memory keyring (test/CI only)");
+/// Errors from keyring access. A small typed enum replacing the previous
+/// stringly `Result<_, String>`; every variant's `Display` preserves the
+/// account context and underlying cause so existing `{e}` interpolations read
+/// the same (audit Tier 3 #36).
+#[derive(Debug, thiserror::Error)]
+pub enum KeyringError {
+    /// Opening, reading, writing, or deleting a system-keyring entry failed.
+    #[error("keyring access failed for {account}: {source}")]
+    Backend {
+        account: String,
+        #[source]
+        source: keyring::Error,
+    },
+    /// The `spawn_blocking` keyring task panicked or was cancelled.
+    #[error("keyring task failed: {0}")]
+    Task(String),
+}
+
+impl KeyringError {
+    fn backend(account: &str, source: keyring::Error) -> Self {
+        Self::Backend {
+            account: account.to_string(),
+            source,
+        }
     }
 }
 
@@ -78,7 +86,7 @@ fn mock_store() -> Option<&'static Mutex<HashMap<String, String>>> {
 }
 
 /// Read one keyring account (mock store under test/mock, else the real keyring).
-fn kv_get(account: &str) -> Result<Option<String>, String> {
+fn kv_get(account: &str) -> Result<Option<String>, KeyringError> {
     if let Some(store) = mock_store() {
         return Ok(store
             .lock()
@@ -87,16 +95,16 @@ fn kv_get(account: &str) -> Result<Option<String>, String> {
             .cloned());
     }
     let entry = keyring::Entry::new(SERVICE_NAME, account)
-        .map_err(|e| format!("Failed to access keyring entry for {account}: {e}"))?;
+        .map_err(|e| KeyringError::backend(account, e))?;
     match entry.get_password() {
         Ok(p) => Ok(Some(p)),
         Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(format!("Failed to read keyring entry {account}: {e}")),
+        Err(e) => Err(KeyringError::backend(account, e)),
     }
 }
 
 /// Write one keyring account (mock store under test/mock, else the real keyring).
-fn kv_set(account: &str, value: &str) -> Result<(), String> {
+fn kv_set(account: &str, value: &str) -> Result<(), KeyringError> {
     if let Some(store) = mock_store() {
         store
             .lock()
@@ -105,15 +113,15 @@ fn kv_set(account: &str, value: &str) -> Result<(), String> {
         return Ok(());
     }
     let entry = keyring::Entry::new(SERVICE_NAME, account)
-        .map_err(|e| format!("Failed to access keyring entry for {account}: {e}"))?;
+        .map_err(|e| KeyringError::backend(account, e))?;
     entry
         .set_password(value)
-        .map_err(|e| format!("Failed to store keyring entry {account}: {e}"))
+        .map_err(|e| KeyringError::backend(account, e))
 }
 
 /// Delete one keyring account; absent is success (mock store under test/mock,
 /// else the real keyring).
-fn kv_delete(account: &str) -> Result<(), String> {
+fn kv_delete(account: &str) -> Result<(), KeyringError> {
     if let Some(store) = mock_store() {
         store
             .lock()
@@ -122,10 +130,10 @@ fn kv_delete(account: &str) -> Result<(), String> {
         return Ok(());
     }
     let entry = keyring::Entry::new(SERVICE_NAME, account)
-        .map_err(|e| format!("Failed to access keyring entry for {account}: {e}"))?;
+        .map_err(|e| KeyringError::backend(account, e))?;
     match entry.delete_credential() {
         Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(format!("Failed to delete keyring entry {account}: {e}")),
+        Err(e) => Err(KeyringError::backend(account, e)),
     }
 }
 
@@ -135,7 +143,7 @@ fn kv_delete(account: &str) -> Result<(), String> {
 /// # Errors
 ///
 /// Returns an error if the keyring is unavailable or access fails.
-pub fn get_backend_secret(source: &str, name: &str) -> Result<Option<String>, String> {
+pub fn get_backend_secret(source: &str, name: &str) -> Result<Option<String>, KeyringError> {
     kv_get(&backend_secret_account(source, name)).map_err(|e| {
         warn!(
             "Failed to read backend secret {} ({}): {e}",
@@ -154,10 +162,7 @@ pub fn get_backend_secret(source: &str, name: &str) -> Result<Option<String>, St
 /// # Errors
 ///
 /// Returns an error if the keyring is unavailable or access fails.
-pub fn get_sessions_blob() -> Result<Option<String>, String> {
-    let entry = keyring::Entry::new(SERVICE_NAME, SESSIONS_KEY)
-        .map_err(|e| format!("Failed to access keyring entry for sessions: {e}"))?;
-
+pub fn get_sessions_blob() -> Result<Option<String>, KeyringError> {
     // Surface the read before it happens: on a *locked* keyring this call
     // blocks on the secret-service unlock prompt, potentially for a long
     // time. Logging first means a stalled startup is explained in the
@@ -167,18 +172,21 @@ pub fn get_sessions_blob() -> Result<Option<String>, String> {
         "Reading the persisted session store from the system keyring; if the keyring \
          is locked, the daemon will wait here until it is unlocked"
     );
-    match entry.get_password() {
-        Ok(blob) => {
+    // The sessions blob is just another keyring account, so route it through
+    // `kv_get` — one mock mechanism (the process-global store), not a second
+    // one via the credential-builder mock (audit Tier 3 #36).
+    match kv_get(SESSIONS_KEY) {
+        Ok(Some(blob)) => {
             debug!("Loaded persisted session blob from keyring");
             Ok(Some(blob))
         }
-        Err(keyring::Error::NoEntry) => {
+        Ok(None) => {
             debug!("No persisted session blob in keyring (fresh install)");
             Ok(None)
         }
         Err(e) => {
             warn!("Failed to read session blob from keyring: {e}");
-            Err(format!("Failed to read session blob: {e}"))
+            Err(e)
         }
     }
 }
@@ -187,7 +195,7 @@ pub fn get_sessions_blob() -> Result<Option<String>, String> {
 ///
 /// # Errors
 /// Returns an error if the keyring is unavailable or the write fails.
-pub fn set_backend_secret(source: &str, name: &str, value: &str) -> Result<(), String> {
+pub fn set_backend_secret(source: &str, name: &str, value: &str) -> Result<(), KeyringError> {
     kv_set(&backend_secret_account(source, name), value)
 }
 
@@ -195,7 +203,7 @@ pub fn set_backend_secret(source: &str, name: &str, value: &str) -> Result<(), S
 ///
 /// # Errors
 /// Returns an error if the keyring is unavailable or the delete fails.
-pub fn delete_backend_secret(source: &str, name: &str) -> Result<(), String> {
+pub fn delete_backend_secret(source: &str, name: &str) -> Result<(), KeyringError> {
     kv_delete(&backend_secret_account(source, name))
 }
 
@@ -203,7 +211,7 @@ pub fn delete_backend_secret(source: &str, name: &str) -> Result<(), String> {
 ///
 /// # Errors
 /// Returns an error if the keyring is unavailable or access fails.
-pub fn has_backend_secret(source: &str, name: &str) -> Result<bool, String> {
+pub fn has_backend_secret(source: &str, name: &str) -> Result<bool, KeyringError> {
     Ok(kv_get(&backend_secret_account(source, name))?.is_some())
 }
 
@@ -219,10 +227,10 @@ pub fn has_backend_secret(source: &str, name: &str) -> Result<bool, String> {
 pub async fn get_backend_secret_async(
     source: String,
     name: String,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, KeyringError> {
     tokio::task::spawn_blocking(move || get_backend_secret(&source, &name))
         .await
-        .map_err(|e| format!("keyring task failed: {e}"))?
+        .map_err(|e| KeyringError::Task(e.to_string()))?
 }
 
 /// Async form of [`set_backend_secret`], run on a blocking thread.
@@ -233,30 +241,30 @@ pub async fn set_backend_secret_async(
     source: String,
     name: String,
     value: String,
-) -> Result<(), String> {
+) -> Result<(), KeyringError> {
     tokio::task::spawn_blocking(move || set_backend_secret(&source, &name, &value))
         .await
-        .map_err(|e| format!("keyring task failed: {e}"))?
+        .map_err(|e| KeyringError::Task(e.to_string()))?
 }
 
 /// Async form of [`delete_backend_secret`], run on a blocking thread.
 ///
 /// # Errors
 /// Returns an error if the keyring is unavailable or the delete fails.
-pub async fn delete_backend_secret_async(source: String, name: String) -> Result<(), String> {
+pub async fn delete_backend_secret_async(source: String, name: String) -> Result<(), KeyringError> {
     tokio::task::spawn_blocking(move || delete_backend_secret(&source, &name))
         .await
-        .map_err(|e| format!("keyring task failed: {e}"))?
+        .map_err(|e| KeyringError::Task(e.to_string()))?
 }
 
 /// Async form of [`has_backend_secret`], run on a blocking thread.
 ///
 /// # Errors
 /// Returns an error if the keyring is unavailable or access fails.
-pub async fn has_backend_secret_async(source: String, name: String) -> Result<bool, String> {
+pub async fn has_backend_secret_async(source: String, name: String) -> Result<bool, KeyringError> {
     tokio::task::spawn_blocking(move || has_backend_secret(&source, &name))
         .await
-        .map_err(|e| format!("keyring task failed: {e}"))?
+        .map_err(|e| KeyringError::Task(e.to_string()))?
 }
 
 #[cfg(test)]
@@ -277,6 +285,17 @@ mod tests {
         assert!(!has_backend_secret(src, name).unwrap());
         delete_backend_secret(src, name).unwrap(); // idempotent
     }
+
+    /// The sessions blob now routes through `kv_*`, so a set-then-get shares the
+    /// process-global mock store and round-trips in-process (audit Tier 3 #36).
+    /// Before, the two accessors built isolated `keyring::Entry` credentials
+    /// under the builder mock and could not share state.
+    #[test]
+    fn sessions_blob_roundtrips_through_kv() {
+        let blob = r#"{"version":2,"sessions":{}}"#;
+        set_sessions_blob(blob).unwrap();
+        assert_eq!(get_sessions_blob().unwrap().as_deref(), Some(blob));
+    }
 }
 
 /// Write the daemon's HTTP session blob to the keyring. The value is
@@ -286,14 +305,10 @@ mod tests {
 /// # Errors
 ///
 /// Returns an error if the keyring is unavailable or the write fails.
-pub fn set_sessions_blob(value: &str) -> Result<(), String> {
-    let entry = keyring::Entry::new(SERVICE_NAME, SESSIONS_KEY)
-        .map_err(|e| format!("Failed to access keyring entry for sessions: {e}"))?;
-
-    entry
-        .set_password(value)
-        .map_err(|e| format!("Failed to store session blob: {e}"))?;
-
+pub fn set_sessions_blob(value: &str) -> Result<(), KeyringError> {
+    // Route through `kv_set` for the same reason as `get_sessions_blob`: one
+    // mock mechanism, one entry-construction path (audit Tier 3 #36).
+    kv_set(SESSIONS_KEY, value)?;
     debug!("Persisted session blob to keyring");
     Ok(())
 }

--- a/super-stt-daemon/src/main.rs
+++ b/super-stt-daemon/src/main.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     super_stt_daemon::install_crypto_provider();
-    super_stt_daemon::keyring::install_mock_if_requested();
     super_stt_daemon::run().await?;
     Ok(())
 }

--- a/super-stt-daemon/src/output/keyboard/enigo_backend.rs
+++ b/super-stt-daemon/src/output/keyboard/enigo_backend.rs
@@ -21,6 +21,11 @@ impl EnigoBackend {
         })
     }
 
+    /// Synchronous: enigo's handle holds raw xkbcommon pointers (`!Send`) and
+    /// the work blocks (per-chunk sleeps between `text()` calls). The
+    /// [`Simulator`](super::Simulator) enum runs this under `block_in_place` so
+    /// the handle never crosses an `.await` point — no thread migration mid-type
+    /// (audit Tier 3 #35).
     pub fn type_text(&mut self, text: &str) -> Result<()> {
         let mut i = 0;
         let chars: Vec<char> = text.chars().collect();

--- a/super-stt-daemon/src/output/keyboard/mod.rs
+++ b/super-stt-daemon/src/output/keyboard/mod.rs
@@ -85,15 +85,21 @@ impl Simulator {
         }
     }
 
-    /// Type text using the active backend.
+    /// Type text using the active backend. Async so the portal backend awaits
+    /// its D-Bus calls directly and the blocking backends yield the worker
+    /// (audit Tier 3 #35).
     ///
     /// # Errors
     /// Returns an error if the backend fails to simulate key input.
-    pub fn type_text(&mut self, text: &str) -> Result<()> {
+    pub async fn type_text(&mut self, text: &str) -> Result<()> {
         match self {
-            Self::WaylandProtocol(b) => b.type_text(text),
-            Self::Ydotool(_) => YdotoolBackend::type_text(text),
-            Self::XdgPortal(b) => b.type_text(text),
+            // The enigo/ydotool backends are synchronous and `!Send`; run them
+            // under `block_in_place` so their handle never crosses an await and
+            // the runtime spins up a replacement worker rather than stalling. The
+            // portal backend is genuinely async — await it directly.
+            Self::WaylandProtocol(b) => tokio::task::block_in_place(|| b.type_text(text)),
+            Self::Ydotool(_) => tokio::task::block_in_place(|| YdotoolBackend::type_text(text)),
+            Self::XdgPortal(b) => b.type_text(text).await,
         }
     }
 
@@ -101,14 +107,14 @@ impl Simulator {
     ///
     /// # Errors
     /// Returns an error if the backend fails to simulate key input.
-    pub fn backspace_n(&mut self, n: usize) -> Result<()> {
+    pub async fn backspace_n(&mut self, n: usize) -> Result<()> {
         match self {
             Self::WaylandProtocol(b) => {
-                b.backspace_n(n);
+                tokio::task::block_in_place(|| b.backspace_n(n));
                 Ok(())
             }
-            Self::Ydotool(_) => YdotoolBackend::backspace_n(n),
-            Self::XdgPortal(b) => b.backspace_n(n),
+            Self::Ydotool(_) => tokio::task::block_in_place(|| YdotoolBackend::backspace_n(n)),
+            Self::XdgPortal(b) => b.backspace_n(n).await,
         }
     }
 }

--- a/super-stt-daemon/src/output/keyboard/xdg_portal_backend.rs
+++ b/super-stt-daemon/src/output/keyboard/xdg_portal_backend.rs
@@ -14,8 +14,8 @@ const REQUEST_IFACE: &str = "org.freedesktop.portal.Request";
 const XKB_KEY_BACKSPACE: i32 = 0xFF08;
 
 pub struct XdgPortalBackend {
-    /// The async zbus connection, used from sync context via a dedicated
-    /// single-threaded executor so we never block a tokio worker.
+    /// The async zbus connection. The typing path awaits keysym calls on it
+    /// directly (audit Tier 3 #35), so no per-keysym thread/runtime is needed.
     connection: zbus::Connection,
     session_path: OwnedObjectPath,
 }
@@ -116,61 +116,47 @@ impl XdgPortalBackend {
 
     /// Send a keysym press or release via the portal.
     ///
-    /// This is called from sync code running on a tokio worker thread, so we
-    /// cannot use `block_on`.  Instead we send via `call_noreply` on a
-    /// one-shot `std::thread` to avoid blocking the async runtime.
-    fn notify_keysym(&self, keysym: i32, state: u32) -> Result<()> {
-        let conn = self.connection.clone();
-        let session = self.session_path.clone();
-
-        // Run the async D-Bus call on a short-lived thread that is allowed
-        // to block.  The overhead is negligible compared to the key event
-        // latency itself.
-        std::thread::scope(|s| {
-            s.spawn(|| {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("mini runtime");
-                rt.block_on(async {
-                    let proxy =
-                        zbus::Proxy::new(&conn, PORTAL_BUS, PORTAL_PATH, REMOTE_DESKTOP_IFACE)
-                            .await?;
-                    let options: HashMap<&str, Value<'_>> = HashMap::new();
-                    proxy
-                        .call_noreply(
-                            "NotifyKeyboardKeysym",
-                            &(session.as_ref(), options, keysym, state),
-                        )
-                        .await?;
-                    Ok::<(), zbus::Error>(())
-                })
-            })
-            .join()
-            .expect("keysym thread panicked")
+    /// Issued directly on the backend's owned async `Connection`. The typing
+    /// path is async end-to-end (audit Tier 3 #35), so this no longer spins up a
+    /// one-shot thread + current-thread runtime per keysym just to escape a sync
+    /// caller — it simply awaits the D-Bus call on the runtime.
+    async fn notify_keysym(&self, keysym: i32, state: u32) -> Result<()> {
+        let proxy = zbus::Proxy::new(
+            &self.connection,
+            PORTAL_BUS,
+            PORTAL_PATH,
+            REMOTE_DESKTOP_IFACE,
+        )
+        .await?;
+        let options: HashMap<&str, Value<'_>> = HashMap::new();
+        proxy
+            .call_noreply(
+                "NotifyKeyboardKeysym",
+                &(self.session_path.as_ref(), options, keysym, state),
+            )
+            .await
             .map_err(|e| anyhow::anyhow!("NotifyKeyboardKeysym failed: {e}"))
-        })
     }
 
-    pub fn type_text(&mut self, text: &str) -> Result<()> {
+    pub async fn type_text(&mut self, text: &str) -> Result<()> {
         for ch in text.chars() {
             let (needs_shift, keysym) = char_to_keysym(ch);
             if needs_shift {
-                self.notify_keysym(XKB_KEY_SHIFT_L, 1)?;
+                self.notify_keysym(XKB_KEY_SHIFT_L, 1).await?;
             }
-            self.notify_keysym(keysym, 1)?;
-            self.notify_keysym(keysym, 0)?;
+            self.notify_keysym(keysym, 1).await?;
+            self.notify_keysym(keysym, 0).await?;
             if needs_shift {
-                self.notify_keysym(XKB_KEY_SHIFT_L, 0)?;
+                self.notify_keysym(XKB_KEY_SHIFT_L, 0).await?;
             }
         }
         Ok(())
     }
 
-    pub fn backspace_n(&mut self, n: usize) -> Result<()> {
+    pub async fn backspace_n(&mut self, n: usize) -> Result<()> {
         for _ in 0..n {
-            self.notify_keysym(XKB_KEY_BACKSPACE, 1)?;
-            self.notify_keysym(XKB_KEY_BACKSPACE, 0)?;
+            self.notify_keysym(XKB_KEY_BACKSPACE, 1).await?;
+            self.notify_keysym(XKB_KEY_BACKSPACE, 0).await?;
         }
         Ok(())
     }

--- a/super-stt-daemon/src/output/keyboard/ydotool_backend.rs
+++ b/super-stt-daemon/src/output/keyboard/ydotool_backend.rs
@@ -21,6 +21,9 @@ impl YdotoolBackend {
             .is_ok_and(|o| o.status.success())
     }
 
+    /// Synchronous: shells out to a blocking `ydotool` subprocess. The
+    /// [`Simulator`](super::Simulator) enum runs this under `block_in_place` so
+    /// it doesn't stall a runtime worker (audit Tier 3 #35).
     pub fn type_text(text: &str) -> Result<()> {
         if text.is_empty() {
             return Ok(());

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -180,14 +180,14 @@ impl Typer {
     /// characters** (chars typed minus chars deleted) so callers accounting in
     /// chars stay consistent — mixing this with a byte length would drift on any
     /// multibyte text.
-    pub fn apply_simple_diff(&mut self, old_text: &str, new_text: &str) -> isize {
+    pub async fn apply_simple_diff(&mut self, old_text: &str, new_text: &str) -> isize {
         // Safety checks
         if old_text == new_text {
             return 0;
         }
 
         if old_text.is_empty() && !new_text.is_empty() {
-            if let Err(e) = self.keyboard_simulator.type_text(new_text) {
+            if let Err(e) = self.keyboard_simulator.type_text(new_text).await {
                 debug!("Failed to type new text: {e}");
             }
             return isize::try_from(new_text.chars().count()).unwrap_or(isize::MAX);
@@ -217,10 +217,10 @@ impl Typer {
         );
 
         // Backspace to the first different position
-        let _ = self.keyboard_simulator.backspace_n(chars_to_delete);
+        let _ = self.keyboard_simulator.backspace_n(chars_to_delete).await;
 
         // Type the new part
-        let _ = self.keyboard_simulator.type_text(&text_to_type);
+        let _ = self.keyboard_simulator.type_text(&text_to_type).await;
 
         // Net screen delta in chars: what we added minus what we removed.
         isize::try_from(chars_to_type).unwrap_or(isize::MAX)
@@ -228,7 +228,7 @@ impl Typer {
     }
 
     /// Update preview text using two-phase approach
-    pub fn update_preview(&mut self, new_text: &str, actually_typed: &mut String) {
+    pub async fn update_preview(&mut self, new_text: &str, actually_typed: &mut String) {
         let processed_text = preprocess_text(new_text, true);
 
         info!(
@@ -272,16 +272,16 @@ impl Typer {
         );
 
         // Apply the update to screen
-        self.apply_text_update(&display_text, actually_typed);
+        self.apply_text_update(&display_text, actually_typed).await;
         self.state.prev_text = processed_text;
     }
 
     /// Process final text (completed sentence) - Uses full session audio
-    pub fn process_final_text(&mut self, transcription_result: &str) {
+    pub async fn process_final_text(&mut self, transcription_result: &str) {
         // No preview typing, type directly
         let processed_text = preprocess_text(transcription_result, false);
         let final_text = format!("{processed_text} ");
-        if let Err(e) = self.keyboard_simulator.type_text(&final_text) {
+        if let Err(e) = self.keyboard_simulator.type_text(&final_text).await {
             warn!("Failed to type final transcription: {e}");
         } else {
             info!("Step 6 complete: Final transcription typed directly");
@@ -306,7 +306,7 @@ impl Typer {
     }
 
     /// Apply text update to screen (common logic)
-    fn apply_text_update(&mut self, new_text: &str, actually_typed: &mut String) {
+    async fn apply_text_update(&mut self, new_text: &str, actually_typed: &mut String) {
         info!(
             "Typing logic: old_typed='{}', new_display='{}'",
             actually_typed.chars().take(30).collect::<String>(),
@@ -319,17 +319,23 @@ impl Typer {
                 "Screen empty, typing new text: '{}'",
                 new_text.chars().take(30).collect::<String>()
             );
-            let _ = self.keyboard_simulator.type_text(&format!("{new_text} "));
+            let _ = self
+                .keyboard_simulator
+                .type_text(&format!("{new_text} "))
+                .await;
         } else if new_text.starts_with(actually_typed.as_str())
             && new_text.len() > actually_typed.len()
         {
             // Perfect extension — append only the new suffix.
             let suffix = &new_text[actually_typed.len()..];
             info!("Perfect extension, adding suffix: '{suffix}'");
-            let _ = self.keyboard_simulator.type_text(&format!("{suffix} "));
+            let _ = self
+                .keyboard_simulator
+                .type_text(&format!("{suffix} "))
+                .await;
         } else {
             // Replacement — backspace to the first difference and retype.
-            let net_change = self.apply_simple_diff(actually_typed, new_text);
+            let net_change = self.apply_simple_diff(actually_typed, new_text).await;
             info!("Diff replacement: net {net_change} char(s)");
         }
 
@@ -345,7 +351,7 @@ impl Typer {
     }
 
     /// Clear all typed text and reset state
-    pub fn clear_preview(&mut self, actually_typed: &mut String) {
+    pub async fn clear_preview(&mut self, actually_typed: &mut String) {
         info!("clear_preview called with actually_typed: '{actually_typed}'");
 
         if actually_typed.is_empty() {
@@ -356,7 +362,7 @@ impl Typer {
         let chars_to_delete = actually_typed.chars().count();
         info!("Backspacing {chars_to_delete} characters");
 
-        if let Err(e) = self.keyboard_simulator.backspace_n(chars_to_delete) {
+        if let Err(e) = self.keyboard_simulator.backspace_n(chars_to_delete).await {
             warn!("Failed to backspace preview text: {e}");
         } else {
             info!("Successfully backspaced {chars_to_delete} characters");


### PR DESCRIPTION
The three deferred structural follow-ups from `docs/audits/2026-07-code-quality.md`. Closes the entire audit backlog (#1–#37).

## #35 — Remaining blocking work (daemon)
**Async Simulator.** The portal backend spun up an OS thread + a fresh current-thread tokio runtime *per keysym* just to escape a sync caller. The typing path is now async end-to-end:
- Portal: `notify_keysym` awaits `NotifyKeyboardKeysym` on the backend's owned zbus `Connection` — no thread, no per-call runtime.
- enigo/ydotool: these hold `!Send` handles (raw xkbcommon pointers) / shell out; they stay **synchronous** and the `Simulator` enum runs them under `tokio::task::block_in_place`, so the handle never crosses an `.await` (no cross-thread migration mid-type) while the runtime spins a replacement worker instead of stalling.
- `Typer::{update_preview, clear_preview, process_final_text}` + the diff helpers are async. The two `std::Mutex<String>` (`actually_typed`) sites take the mirror string out in a guard-dropping scope before the async typing and write it back — sound because `update_preview`/`clear_preview` both run under `&mut Typer` and never overlap (`run_preview_loop` fully completes before `collect_and_clear_preview`).

*Soundness note:* the recording future already held the `unsafe impl Send` enigo across many awaits before this change, so `block_in_place` (no internal await inside the sync backends) introduces no new migration risk.

**Session-persist task.** `mint`/`revoke`/`validate` did a blocking keyring write inline (parking a request worker), and two concurrent mutations racing the drop-then-write ordered the on-disk blob nondeterministically. Now a single-writer `SessionPersister` task, fed over an `mpsc` channel, coalesces bursts (only the newest snapshot matters) and writes via `spawn_blocking` sequentially — off the request path, strictly ordered. No task is spawned under `cfg(test)`.

## #36 — Keyring cleanup (daemon)
- `get_sessions_blob`/`set_sessions_blob` route through `kv_get`/`kv_set`, so there's **one** mock mechanism (the process-global `mock_store`) instead of a second one via the credential-builder mock. `install_mock_if_requested` is deleted (dead once sessions use `kv`).
- A Display-preserving `KeyringError` enum replaces the stringly `Result<_, String>` across keyring + its four async wrappers; every `{e}` interpolation reads the same.
- The real-keyring storage key is unchanged (`("super-stt","stt-sessions")`) and no non-ignored test restarts the daemon, so no restart behavior changed. Download-progress's two single-message `Result<_,String>` are intentionally left (not keyring errors). Added a sessions-blob roundtrip test.

## #37 — Optimistic-state rollback (app)
Each optimistic-then-banner site now captures its prior value(s) and threads them through a **dedicated per-site failure message** that restores them *and* raises the scoped banner (previously the failure only bannered and the drift self-healed on the next refetch):
- audio theme / feedback → `AudioThemeSaveFailed { prev_selected, prev_non_silent }`
- volume → `VolumeSaveFailed { prev_volume }` + a new `last_committed_volume` field (the drag clobbers `volume`, so the rollback target is stored separately and kept in sync on `VolumeLoaded`)
- `SelectBackend` → `BackendSelectFailed { prev_active }`; `LoadStagedModel` → `StagedModelLoadFailed { prev_device }` (both restore via a shared `set_model_error` helper extracted from `ModelError`)

Handler-level tests aren't feasible without the cosmic `Core` harness (the app has none); the restores are simple field assignments verified by the compiler.

## Verification
- `cargo build --workspace` ✓, all workspace tests compile ✓
- workspace clippy pedantic (`--all-features -W clippy::pedantic -D warnings -D unused_must_use`) ✓
- daemon `--lib` (235) ✓, shared lib (94) ✓, applet (26) ✓
- `just check-features` ✓, `just fmt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)