### PR TITLE
Audit 2 #8: POST /transcribe response shapes (202 fire-and-forget, stream_realtime)

### DIFF
--- a/docs/audits/2026-07-code-quality-2.md
+++ b/docs/audits/2026-07-code-quality-2.md
@@ -405,7 +405,7 @@ Five clusters account for most of the findings:
   set with the doc (add `metal` or drop it); either produce `cuda_unavailable` or document
   the silent-CPU-fallback (the doc currently self-contradicts).
 
-### [ ] 8. 🟠 Protocol: `POST /transcribe` response shapes and the `stream_realtime` field diverge from the docs
+### [x] 8. 🟠 Protocol: `POST /transcribe` response shapes and the `stream_realtime` field diverge from the docs
 
 - **Where:** the handler unconditionally returns 200 `text/event-stream`
   (`http/v1/transcribe.rs:353-358`); `stream_realtime` is never read; preview is gated on
@@ -420,6 +420,23 @@ Five clusters account for most of the findings:
 - **Fix:** either read `stream_realtime` in `cmd_record` and honor the 202/200-JSON shapes,
   or rewrite the docs to the actual behavior (always 200 SSE; preview via `preview`) and drop
   `stream_realtime` + its error from the contract.
+- **Resolved (branch `refactor/audit2-cleanup`, chose "implement the documented contract"):**
+  `POST /transcribe` now honors all four cases. `wait:false` → `202
+  {message:"Recording started"}` with the recording **detached** from the connection (runs in
+  the background, stopped via `POST /transcribe/stop`; write-mode still types the result);
+  `wait:true` → `200` SSE ending in `done`, and `stream_realtime:true` additionally streams
+  `preview` frames. `stream_realtime` is decoupled from preview-typing at the handler by
+  claiming the shared preview slot only when set (`recording/preview.rs` runs the loop when a
+  slot is claimed **or** preview-typing is on, and types only when write-mode **and**
+  preview-typing are on). The `wait:true` SSE path keeps "client disconnect → stop the
+  recording" intact (Phase-2 `manual_stop_tx` signal). Client-side: `TranscribeOptions` gained
+  `stream_realtime`; the shared `transcribe()` parses the `202` JSON for `wait:false` (the CLI
+  already handled a `None` transcription); the app sends `stream_realtime:true` to keep its
+  live-preview panel. Two review-caught minors folded in: aligned the docs' request-body
+  example to the actual **flat** top-level option shape (`transcribe.md`/`transport.md` had
+  nested them under `data`, which the daemon never read for `write_mode`/`stop_mode`/`preview`),
+  and documented the fire-and-forget `202`'s optimistic (no-completion-guarantee) semantics on
+  the busy-race. The pre-existing busy-check TOCTOU is left as-is (Tier 3 #6).
 
 ### [ ] 9. 🟠 API design: `daemon_status_changed` payload is an untyped hand-matched contract whose keys have already drifted
 

--- a/docs/protocol/endpoints/v1/transcribe.md
+++ b/docs/protocol/endpoints/v1/transcribe.md
@@ -42,27 +42,31 @@ To stop an in-flight daemon-mic capture, see
   // value falls back to its primary_language.
   "language":    "en",
 
-  "data": {
-    // Stream incremental `event: preview` SSE frames before the
-    // final `event: done`. Default: false.
-    "stream_realtime": true,
+  // All remaining options are top-level fields of the request body.
+  //
+  // Default false. true = hold the response open until the transcription
+  // is delivered (`200 text/event-stream`); false = fire-and-forget
+  // (`202 { "message": "Recording started" }`, recording runs in the
+  // background — stop it with POST /transcribe/stop).
+  "wait":            true,
 
-    // Mic-capture options (ignored when audio_data is present).
-    // Default false. When true the final transcription is typed
-    // into the focused window via the configured WriteMethod.
-    "write_mode":      false,
+  // Stream incremental `event: preview` SSE frames before the final
+  // `event: done` (only with wait:true). Default: false. Independent of
+  // write-mode typing.
+  "stream_realtime": true,
 
-    // Per-request override for the configured stop mode. One of:
-    //   "silence_only" | "silence_and_manual" | "manual_only"
-    "stop_mode":       "manual_only",
+  // Mic-capture options (ignored when audio_data is present).
+  // Default false. When true the final transcription is typed into the
+  // focused window via the configured WriteMethod.
+  "write_mode":      false,
 
-    // Default false. true = hold the response open until the
-    // transcription is delivered.
-    "wait":            true,
+  // Per-request override for the configured stop mode. One of:
+  //   "silence_only" | "silence_and_manual" | "manual_only"
+  "stop_mode":       "manual_only",
 
-    // Per-request override for the preview_typing config flag.
-    "preview":         true
-  }
+  // Per-request override for the preview_typing config flag (on-screen
+  // typing of incremental preview text).
+  "preview":         true
 }
 ```
 

--- a/docs/protocol/transport.md
+++ b/docs/protocol/transport.md
@@ -53,8 +53,9 @@ Content-Length: 178
   "audio_data":  null,
   "sample_rate": null,
   "language":    "en",
-  "data":        { "wait": true, "stream_realtime": true,
-                   "stop_mode": "manual_only" }
+  "wait":        true,
+  "stream_realtime": true,
+  "stop_mode":   "manual_only"
 }
 ```
 

--- a/super-stt-app/src/daemon/client/v1/transcribe.rs
+++ b/super-stt-app/src/daemon/client/v1/transcribe.rs
@@ -46,6 +46,9 @@ pub fn record_command_stream() -> impl futures_util::Stream<Item = RecordEvent> 
                     wait: true,
                     write_mode: false,
                     stop_mode: Some("manual_only".to_string()),
+                    // The test panel renders live preview text, so it asks the
+                    // daemon to stream incremental `preview` frames.
+                    stream_realtime: true,
                 };
 
                 // Try to open the stream with the cached token; on

--- a/super-stt-cli/src/main.rs
+++ b/super-stt-cli/src/main.rs
@@ -199,6 +199,9 @@ async fn cmd_record(
             write_mode,
             stop_mode,
             wait,
+            // The CLI prints the final result (or fire-and-forgets); it does not
+            // render incremental preview, so it never asks to stream it.
+            stream_realtime: false,
         },
     )
     .await?;

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -156,29 +156,6 @@ async fn run_realtime_session(socket: axum::extract::ws::WebSocket, daemon: Arc<
     let _ = relay_out.await;
 }
 
-/// `POST /transcribe` — start a daemon-mic recording, streaming named
-/// SSE events back as the recording progresses. Same pattern modern
-/// LLM streaming APIs (`OpenAI`, Anthropic, Mistral chat, Google Gemini)
-/// use: POST with options in the body, response is `text/event-stream`.
-///
-/// Wire shape:
-///
-/// ```text
-/// event: preview
-/// data: {"text":"hello"}
-///
-/// event: preview
-/// data: {"text":"hello world"}
-///
-/// event: done
-/// data: {"transcription":"hello world"}
-/// ```
-///
-/// On daemon-side error a single `event: error\ndata: {"message":"..."}`
-/// frame is emitted instead. The stream always ends with one of
-/// `done` / `error` and the connection closes. Closing the
-/// connection mid-stream cancels the recording (the daemon detects
-/// the disconnect on its next write attempt).
 /// Build the raw bytes of one SSE `event: <name>\ndata: <json>\n\n` frame.
 /// `serde_json::to_string` never embeds raw newlines, so the JSON fits on the
 /// single `data:` line by construction. Shared by the unbounded `/transcribe`
@@ -207,18 +184,19 @@ fn next_preview_slot_id() -> u64 {
     COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Whether the request asks for streaming preview frames via `stream_realtime`.
-/// Per the contract it lives under `data`; a flat top-level form is also
-/// accepted so the check is robust to either body shape.
-fn wants_stream_realtime(body: &serde_json::Value) -> bool {
+/// Read an optional bool control field (`stream_realtime`, `wait`) from a
+/// request body. Per the contract these live under `data`; a flat top-level
+/// form is also accepted so the check is robust to either body shape. Absent →
+/// `default`.
+fn body_flag(body: &serde_json::Value, key: &str, default: bool) -> bool {
     let nested = body
         .get("data")
-        .and_then(|d| d.get("stream_realtime"))
+        .and_then(|d| d.get(key))
         .and_then(serde_json::Value::as_bool);
-    body.get("stream_realtime")
+    body.get(key)
         .and_then(serde_json::Value::as_bool)
         .or(nested)
-        .unwrap_or(false)
+        .unwrap_or(default)
 }
 
 /// Pre-captured one-shot: transcribe a supplied `audio_data` buffer without
@@ -226,7 +204,7 @@ fn wants_stream_realtime(body: &serde_json::Value) -> bool {
 /// coded error). Rejects `stream_realtime` combined with `audio_data` per the
 /// contract.
 async fn transcribe_precaptured(s: &AppState, body: serde_json::Value) -> axum::response::Response {
-    if wants_stream_realtime(&body) {
+    if body_flag(&body, "stream_realtime", false) {
         return json_response(&DaemonResponse::error_with_code(
             ErrorCode::InvalidValue,
             "stream_realtime_with_audio_data",
@@ -241,6 +219,16 @@ async fn transcribe_precaptured(s: &AppState, body: serde_json::Value) -> axum::
     json_response(&resp).into_response()
 }
 
+/// `POST /transcribe`. One endpoint, four use cases dispatched on the body
+/// (see `docs/protocol/endpoints/v1/transcribe.md`):
+/// - top-level `audio_data` → pre-captured one-shot, `200` JSON `{transcription}`;
+/// - mic `wait:false` → fire-and-forget, `202 {message:"Recording started"}`;
+/// - mic `wait:true`, `stream_realtime:false` → `200` SSE with a single `done`;
+/// - mic `wait:true`, `stream_realtime:true` → `200` SSE, `preview` frames then `done`.
+///
+/// On the SSE paths a daemon-side failure arrives as a single `error` frame and
+/// closing the connection stops the recording. A start while already recording
+/// returns `409 recording_in_progress`.
 pub(crate) async fn transcribe(
     State(s): State<AppState>,
     body: Option<axum::Json<serde_json::Value>>,
@@ -262,9 +250,20 @@ pub(crate) async fn transcribe(
     transcribe_mic(s, data).await
 }
 
-/// Daemon-mic capture path: start a fresh recording and stream named SSE events
-/// (`preview` / `done` / `error`) back as it progresses.
+/// Daemon-mic capture path. Response shape follows the `wait`/`stream_realtime`
+/// controls (see `docs/protocol/endpoints/v1/transcribe.md`):
+/// - `wait:false` → `202 {message:"Recording started"}`, recording detaches and
+///   runs in the background (stop via `POST /transcribe/stop`).
+/// - `wait:true` → `200 text/event-stream`, ending with `done`/`error`;
+///   `stream_realtime:true` additionally streams incremental `preview` frames.
+///   Closing the connection stops the recording.
 async fn transcribe_mic(s: AppState, data: Option<serde_json::Value>) -> axum::response::Response {
+    // Read the response-shape controls before `data` is moved into the request.
+    // Absent `wait` → fire-and-forget per the contract.
+    let wait = data.as_ref().is_some_and(|b| body_flag(b, "wait", false));
+    let stream_realtime = data
+        .as_ref()
+        .is_some_and(|b| body_flag(b, "stream_realtime", false));
     let req = build_request("record", data);
 
     // Reject with `409 recording_in_progress` if a cycle is already
@@ -277,6 +276,51 @@ async fn transcribe_mic(s: AppState, data: Option<serde_json::Value>) -> axum::r
         return recording_in_progress_response();
     }
 
+    // Fire-and-forget: detach the recording from this connection and return
+    // `202` immediately. The recording owns its busy/stop lifecycle (stopped via
+    // `POST /transcribe/stop`); write-mode still types the result on completion.
+    //
+    // The `202` is optimistic and carries no completion guarantee (by design):
+    // the busy check above is a plain read, and the authoritative claim is inside
+    // `setup_recording_session`. A request that loses that race after passing the
+    // read still gets `202`, but its detached task is rejected as busy and only
+    // logs — there is no open connection to report on, unlike the SSE path which
+    // emits an `error` frame. Acceptable for a fire-and-forget contract.
+    if !wait {
+        let daemon = Arc::clone(&s.daemon);
+        tokio::spawn(async move {
+            let resp = daemon.handle_command(req).await;
+            if resp.status != "success" {
+                log::warn!(
+                    "fire-and-forget recording ended with error: {:?}",
+                    resp.message
+                );
+            }
+        });
+        let ack = DaemonResponse::success().with_message("Recording started".to_string());
+        let body = serde_json::to_string(&ack)
+            .unwrap_or_else(|_| String::from("{\"status\":\"success\"}"));
+        return (
+            StatusCode::ACCEPTED,
+            [("content-type", "application/json")],
+            body,
+        )
+            .into_response();
+    }
+
+    transcribe_mic_sse(&s, req, stream_realtime)
+}
+
+/// `wait:true` mic capture: drive the recording while streaming SSE back on the
+/// response body. Ends with `done`/`error`; `stream_realtime` gates the
+/// incremental `preview` frames (via the shared preview slot). Closing the
+/// connection signals the recording to stop. Returns immediately; the recording
+/// is driven by the spawned task.
+fn transcribe_mic_sse(
+    s: &AppState,
+    req: super_stt_shared::models::protocol::DaemonRequest,
+    stream_realtime: bool,
+) -> axum::response::Response {
     // mpsc channel that produces SSE byte chunks into the HTTP response body.
     let (line_tx, line_rx) =
         tokio::sync::mpsc::unbounded_channel::<Result<axum::body::Bytes, std::io::Error>>();
@@ -300,7 +344,14 @@ async fn transcribe_mic(s: AppState, data: Option<serde_json::Value>) -> axum::r
         // frame rather than clobbering the winner's stream.
         let (preview_tx, mut preview_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let slot_id = next_preview_slot_id();
-        {
+        // Claim the shared preview slot only when the client asked to stream
+        // preview frames (`stream_realtime`). Otherwise the response carries just
+        // the terminal `done`/`error`. When we claim, do it atomically: if
+        // another `/transcribe` already holds it we lost the busy-check race
+        // (the check above is a plain read), so bail with an error frame rather
+        // than clobbering the winner's stream. When we don't claim, keep the
+        // sender alive so `preview_rx.recv()` pends (never yields `None`).
+        let _retained_tx = if stream_realtime {
             let mut slot = daemon.preview_text.write().await;
             if slot.is_some() {
                 let _ = emit_sse_event(
@@ -311,7 +362,10 @@ async fn transcribe_mic(s: AppState, data: Option<serde_json::Value>) -> axum::r
                 return;
             }
             *slot = Some((slot_id, preview_tx));
-        }
+            None
+        } else {
+            Some(preview_tx)
+        };
 
         let cmd_fut = daemon.handle_command(req);
         let mut cmd_fut = std::pin::pin!(cmd_fut);

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -132,13 +132,17 @@ impl SuperSTTDaemon {
             }
             last_preview = Instant::now();
 
-            // Skip the preview-transcription work entirely when the
-            // preview-typing setting is off.
-            if !self
+            // Run the preview-transcription work if a client is streaming
+            // preview frames (a preview slot is claimed via `stream_realtime`)
+            // OR preview-typing is on. Skip only when neither consumer wants
+            // incremental results — the two are decoupled (a client can stream
+            // preview without on-screen typing, and vice versa).
+            let streaming = self.preview_text.read().await.is_some();
+            let typing = self
                 .preview_typing_enabled
-                .load(std::sync::atomic::Ordering::Relaxed)
-            {
-                debug!("Preview typing is disabled, skipping audio processing and transcription");
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if !streaming && !typing {
+                debug!("No preview client and preview-typing off; skipping preview transcription");
                 continue;
             }
 
@@ -278,7 +282,15 @@ impl SuperSTTDaemon {
             // because `update_preview` and `clear_preview` both run under
             // `&mut Typer` and never overlap (audit Tier 3 #35). Skip on a
             // poisoned lock, as before.
-            let taken = if write_mode {
+            // Type on screen only when write-mode AND preview-typing are both
+            // active. The loop may be running purely to stream preview frames to
+            // a client (`stream_realtime`) with preview-typing off, in which case
+            // it must not type.
+            let type_on_screen = write_mode
+                && self
+                    .preview_typing_enabled
+                    .load(std::sync::atomic::Ordering::Relaxed);
+            let taken = if type_on_screen {
                 session
                     .actually_typed
                     .lock()

--- a/super-stt-daemon/tests/http_smoke.rs
+++ b/super-stt-daemon/tests/http_smoke.rs
@@ -193,6 +193,7 @@ async fn http_endpoints_respond() {
             wait: false,
             write_mode: false,
             stop_mode: Some("manual_only".to_string()),
+            stream_realtime: false,
         },
     )
     .await
@@ -312,6 +313,7 @@ async fn second_transcribe_during_active_recording_surfaces_recording_in_progres
         wait: true,
         write_mode: false,
         stop_mode: Some("manual_only".to_string()),
+        stream_realtime: false,
     };
 
     // Fire the two transcribe calls concurrently. When audio works

--- a/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
@@ -6,12 +6,34 @@ use crate::models::protocol::DaemonResponse;
 use std::path::PathBuf;
 
 /// Options for [`transcribe`]. v1 only wires the daemon-mic capture path
-/// (no `audio_data`); pre-captured audio is a follow-up.
+/// (no `audio_data`); pre-captured audio is handled by the daemon's
+/// `POST /transcribe` when a client sends a top-level `audio_data` array.
 #[derive(Debug, Default, Clone)]
 pub struct TranscribeOptions {
     pub write_mode: bool,
     pub stop_mode: Option<String>,
+    /// Hold the connection open for the result. `true` → the daemon streams
+    /// SSE and returns the final transcription; `false` → fire-and-forget, the
+    /// daemon returns `202 {message:"Recording started"}` and records in the
+    /// background (stop it via [`transcribe_stop`]).
     pub wait: bool,
+    /// Stream incremental `event: preview` SSE frames before the final `done`
+    /// (only meaningful with `wait: true`). Independent of write-mode typing.
+    pub stream_realtime: bool,
+}
+
+/// Build the `POST /transcribe` request body from options. Mic-capture options
+/// are sent at the top level (the daemon reads them from the request body).
+fn record_body(opts: &TranscribeOptions) -> serde_json::Value {
+    let mut data = serde_json::json!({
+        "write_mode":      opts.write_mode,
+        "wait":            opts.wait,
+        "stream_realtime": opts.stream_realtime,
+    });
+    if let Some(mode) = &opts.stop_mode {
+        data["stop_mode"] = serde_json::Value::String(mode.clone());
+    }
+    data
 }
 
 /// One event from the `/transcribe` Server-Sent Events stream.
@@ -44,6 +66,12 @@ pub async fn transcribe(
     opts: TranscribeOptions,
 ) -> HttpResult<DaemonResponse> {
     use futures_util::StreamExt;
+    // Fire-and-forget: the daemon returns a single `202` JSON ack, not an SSE
+    // stream, so parse the response directly instead of reading events.
+    if !opts.wait {
+        let req = transport::build_post_json("/transcribe", &record_body(&opts), Some(token))?;
+        return transport::send_request::<DaemonResponse>(&socket_path, req).await;
+    }
     let mut stream = Box::pin(transcribe_stream(socket_path, token, opts).await?);
     let mut last_preview = String::new();
     while let Some(event) = stream.next().await {
@@ -85,14 +113,7 @@ pub async fn transcribe_stream(
     token: &str,
     opts: TranscribeOptions,
 ) -> HttpResult<impl futures_util::Stream<Item = TranscribeEvent> + Send + 'static> {
-    let mut data = serde_json::json!({
-        "write_mode": opts.write_mode,
-        "wait":       opts.wait,
-    });
-    if let Some(mode) = opts.stop_mode {
-        data["stop_mode"] = serde_json::Value::String(mode);
-    }
-    let req = transport::build_post_json("/transcribe", &data, Some(token))?;
+    let req = transport::build_post_json("/transcribe", &record_body(&opts), Some(token))?;
 
     let response = transport::open(&socket_path, req, Some(transport::REQUEST_TIMEOUT)).await?;
 


### PR DESCRIPTION
Resolves **Tier 2 #8** from `docs/audits/2026-07-code-quality-2.md`: `POST /transcribe` unconditionally returned `200 text/event-stream`, `stream_realtime` was never read, and preview streaming was conflated with preview-typing — diverging from the documented 4-case contract. Chose to **implement the documented contract** (vs. rewriting the docs down).

## Behavior

`POST /transcribe` now dispatches on the body:

| Case | Response |
|------|----------|
| `audio_data` present (pre-captured) | `200` JSON `{transcription}` *(landed in #296)* |
| mic, `wait:false` | **`202 {message:"Recording started"}`** — recording **detaches** and runs in the background (stop via `POST /transcribe/stop`; write-mode still types the result) |
| mic, `wait:true`, `stream_realtime:false` | `200` SSE, single `done` |
| mic, `wait:true`, `stream_realtime:true` | `200` SSE, incremental `preview` frames then `done` |

`stream_realtime` is **decoupled** from preview-typing: the shared preview slot is claimed only when `stream_realtime:true`, so the loop runs when a client is streaming **or** preview-typing is on, and types on screen only when write-mode **and** preview-typing are both on.

**Client-disconnect still stops the recording** on the `wait:true` SSE path (Phase-2 `manual_stop_tx` signal preserved); only `wait:false` detaches (its connection closes by design).

## Clients

- `TranscribeOptions` gains `stream_realtime`; the shared `transcribe()` parses the `202` JSON for `wait:false` (the CLI already handled a `None` transcription). So `stt record` is now fire-and-forget and `stt record --write` (Super+Space) fires-and-forgets while the daemon types.
- The settings app sends `stream_realtime:true` to keep its live-preview panel working.

## Docs

The protocol docs already described this contract. Two review-caught fixes: aligned the request-body example to the actual **flat** top-level option shape (docs nested options under `data`, which the daemon never read for `write_mode`/`stop_mode`/`preview` — a pre-existing drift), and documented the fire-and-forget `202`'s optimistic (no-completion-guarantee) semantics on the busy race.

## Verification

- Workspace compiles; pedantic clippy (`-D warnings -D unused_must_use`) clean; `just fmt` clean.
- `super-stt-shared` lib (96) + `super-stt-daemon` lib (238) green.
- 3-lens adversarial multi-agent review (lifecycle / decoupling / client-compat) with per-finding verification; its two confirmed minors are addressed above. The pre-existing busy-check TOCTOU is left for Tier 3 #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)