### PR TITLE
Audit 2 Tier 1 #3-9: blocking, durability, env gating, realtime WS caps

### DIFF
--- a/docs/audits/2026-07-code-quality-2.md
+++ b/docs/audits/2026-07-code-quality-2.md
@@ -140,7 +140,7 @@ Five clusters account for most of the findings:
   mic-path response shapes (202 fire-and-forget, `stream_realtime`-gates-preview) are a
   separate finding and were left behavially unchanged.
 
-### [ ] 3. 🟠 Daemon: record-start parks a tokio worker on cpal enumeration + a `std::thread::sleep` verification spin
+### [x] 3. 🟠 Daemon: record-start parks a tokio worker on cpal enumeration + a `std::thread::sleep` verification spin
 
 - **Where:** `setup_recording_session` (async, awaited from the `POST /v1/transcribe`
   task) → `DaemonAudioRecorder::new_with_theme` (`recorder.rs:194`) →
@@ -158,8 +158,15 @@ Five clusters account for most of the findings:
 - **Fix:** wrap recorder construction and `detect_default_input_sample_rate` in
   `spawn_blocking` (mirror `handle_get_gpu_info`), or fold setup into the already-spawned
   blocking recorder task; replace the `std::thread::sleep` spin with an off-runtime wait.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** recorder construction
+  (`DaemonAudioRecorder::new_with_theme`, which runs the cpal warm-up and the
+  `std::thread::sleep` device-verification spin) now runs on `spawn_blocking` inside
+  `setup_recording_session`, and `detect_default_input_sample_rate` (made an associated fn —
+  it reads no instance state) runs on `spawn_blocking` in `spawn_recorder`. The busy-flag
+  lifecycle and the 16kHz detection fallback are unchanged; the spin now parks a dedicated
+  blocking thread instead of a runtime worker.
 
-### [ ] 4. 🟠 Daemon: `SessionPersister` submits snapshots after releasing the lock — a revoked token can resurrect across restart *(security)*
+### [x] 4. 🟠 Daemon: `SessionPersister` submits snapshots after releasing the lock — a revoked token can resurrect across restart *(security)*
 
 - **Where:** `mint` (`tokens.rs:315-319`), `validate`-eviction (`:329-342`), and `revoke`
   (`:354-362`) build the snapshot under the `inner` Mutex, then call
@@ -181,8 +188,15 @@ Five clusters account for most of the findings:
   have the persist task read the authoritative map under the same lock instead of
   accepting caller-captured snapshots. A monotonic seq stamped under the lock + keep-highest
   in the loop also works.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** `mint`/`validate`/`revoke` now call
+  `self.persist.submit(...)` *while holding* the `inner` Mutex. `submit` is a non-blocking
+  `UnboundedSender::send` (the keyring DBus write happens off-thread in the persist task, not
+  here), so it's safe under the std Mutex and makes the persist-channel order match lock
+  order — a mutation that serializes first on the Mutex now also reaches the channel first,
+  so the coalescer can no longer persist a stale subset snapshot and resurrect a revoked
+  token across restart.
 
-### [ ] 5. 🟠 Daemon: session-token persistence is never drained on shutdown (durability regression from the async rewrite)
+### [x] 5. 🟠 Daemon: session-token persistence is never drained on shutdown (durability regression from the async rewrite)
 
 - **Where:** `mint`/`validate`/`revoke` call `self.persist.submit(snapshot)` →
   `tx.send()` into an unbounded channel drained by `persist_loop` (`tokens.rs:96-103`).
@@ -199,8 +213,16 @@ Five clusters account for most of the findings:
 - **Fix:** give `SessionPersister` an explicit flush/close handshake (keep a `JoinHandle`
   or flush-sentinel + oneshot ack); in the shutdown path drop the submit handles and await
   the persist task (bounded by a timeout) before `process::exit`.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** the persist channel now carries a typed
+  `PersistMsg` (`Snapshot | Flush(oneshot)`); `persist_loop` coalesces a burst to the latest
+  snapshot, writes it, then acks any flush in the same batch — so the ack means "the latest
+  state is on disk". A process-global `PERSIST_FLUSH` handle is registered when the
+  production `TokenStore` is created, and the shutdown path calls
+  `flush_persisted_sessions(5s)` after `shutdown_unload` and before `process::exit`, bounded
+  so a locked keyring can't hang shutdown. Combined with #4's submit-under-lock ordering, a
+  token minted or revoked in the final moments is now durably written.
 
-### [ ] 6. 🟠 Daemon: runtime env bypasses (`SUPER_STT_AUTO_APPROVE`, `SUPER_STT_KEYRING_MOCK`) are honored in release builds *(security)*
+### [x] 6. 🟠 Daemon: runtime env bypasses (`SUPER_STT_AUTO_APPROVE`, `SUPER_STT_KEYRING_MOCK`) are honored in release builds *(security)*
 
 - **Where:** `auth_request` reads `AUTO_APPROVE_ENV` with a plain runtime
   `std::env::var(...)` (`http/v1/auth/request.rs:154`) and, when set, skips
@@ -216,8 +238,14 @@ Five clusters account for most of the findings:
   non-persistent plaintext in-process map with no encryption at rest.
 - **Fix:** gate both behind `#[cfg(debug_assertions)]` with release no-op stubs (as #30
   did), or behind a dedicated `test-hooks` cargo feature the integration tests enable.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** both bypasses are now behind
+  `#[cfg(debug_assertions)]` with `#[cfg(not(debug_assertions))]` no-op stubs (mirroring
+  #30) — `SUPER_STT_AUTO_APPROVE` via a gated `auto_approve` binding in `auth_request`, and
+  `SUPER_STT_KEYRING_MOCK` via a gated `keyring_mock_env_set()` helper feeding `mock_store()`.
+  A release binary ignores both env vars entirely; `cargo test` builds the daemon in the dev
+  profile (debug_assertions on), so the integration tests that rely on them are unaffected.
 
-### [ ] 7. 🟠 Daemon: realtime WebSocket bridge feeds the guest through an unbounded channel with no backpressure; sessions are unbounded
+### [x] 7. 🟠 Daemon: realtime WebSocket bridge feeds the guest through an unbounded channel with no backpressure; sessions are unbounded
 
 - **Where:** `run_realtime_session` creates the incoming bridge as
   `mpsc::unbounded_channel` (`http/v1/transcribe.rs:47`); `relay_in` (`:63-78`) forwards
@@ -232,8 +260,17 @@ Five clusters account for most of the findings:
   watchdog.
 - **Fix:** use a bounded mpsc and let `relay_in` apply backpressure (await send, or
   drop-oldest on `Full`); cap concurrent realtime sessions with a try-acquire semaphore.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** the consumer→guest `incoming` channel
+  is now bounded (`CONSUMER_INCOMING_CAPACITY = 256`) and `relay_in` awaits the send, so a
+  fast client applies TCP backpressure instead of growing an unbounded buffer; concurrent
+  realtime sessions are capped by a static `Semaphore` (`MAX_REALTIME_SESSIONS = 4`)
+  `try_acquire`d in the handler *before* the upgrade (over-cap → `503
+  realtime_sessions_busy`), with the permit held for the session's lifetime. The batch
+  `transcribe_via_realtime` pre-load (which fills the channel before the session drains it)
+  now feeds from a concurrent task so the bounded channel can't deadlock it. Both realtime
+  WASM mock tests pass.
 
-### [ ] 8. 🟠 App: `fetch_current_model` error path bypasses the epoch guard and destructively clears live model state
+### [x] 8. 🟠 App: `fetch_current_model` error path bypasses the epoch guard and destructively clears live model state
 
 - **Where:** `fetch_current_model` tags success with `current_model_epoch` and
   `CurrentModelLoaded` drops a stale snapshot (`handlers/model.rs:93`), but the **error**
@@ -247,8 +284,15 @@ Five clusters account for most of the findings:
   authoritative state.
 - **Fix:** thread the captured epoch into the error branch; drop (or only log) the failure
   when the epoch has advanced — never `clear_loaded_model()` on a stale-epoch fetch error.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** `fetch_current_model`'s error branch now
+  emits a new `CurrentModelFetchFailed { epoch, error }` (the epoch captured when the fetch
+  was issued) instead of the unguarded `ModelError`; the handler calls `set_model_error`
+  (which clears the loaded model) only when the epoch still matches, otherwise it
+  logs-and-drops — a transient `get_current_model` failure that resolves after a live
+  `model_switched` no longer wipes the fresh state. The genuine-error producers
+  (`list_available_models`, the models page) keep using `ModelError`.
 
-### [ ] 9. 🟠 Daemon: online-model rejection returns uncoded 500 instead of the documented `400 online_models_disabled`
+### [x] 9. 🟠 Daemon: online-model rejection returns uncoded 500 instead of the documented `400 online_models_disabled`
 
 - **Where:** the gate at `model_management/switch.rs:209-213` returns
   `DaemonResponse::error("Online models are disabled…")` with no `error_code`;
@@ -260,6 +304,11 @@ Five clusters account for most of the findings:
   Tier 2 #3 is dead.
 - **Fix:** emit `DaemonResponse::error_with_code(ErrorCode::OnlineModelsDisabled, …)` at
   `switch.rs:210`.
+- **Resolved (branch `refactor/audit2-tier1-3-9`):** the gate now returns
+  `DaemonResponse::error_with_code(ErrorCode::OnlineModelsDisabled, …)` — a 400 code matching
+  `active_model.md`. The message text is unchanged, so the existing `core_tests.rs`
+  assertions still hold. (`OnlineModelsDisabled` was the last remaining zero-producer of the
+  three 400 codes flagged across Tier 1 #9 / Tier 2 #7 → only this one is in scope here.)
 
 ### [x] 10. 🟠 Install: `just install-daemon --model X` silently drops the model (sed targets a nonexistent `--socket` flag)
 

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -22,7 +22,8 @@ impl AppModel {
             ModelMessage::AvailableModelsLoaded(_)
             | ModelMessage::CurrentModelLoaded { .. }
             | ModelMessage::ModelChanged { .. }
-            | ModelMessage::ModelError(_) => self.handle_model_results(message),
+            | ModelMessage::ModelError(_)
+            | ModelMessage::CurrentModelFetchFailed { .. } => self.handle_model_results(message),
         }
     }
 
@@ -125,6 +126,24 @@ impl AppModel {
                 Task::none()
             }
 
+            ModelMessage::CurrentModelFetchFailed { epoch, error } => {
+                // A stale snapshot fetch that failed must not clobber live state:
+                // if a `model_switched` advanced the epoch after this fetch was
+                // issued, the fresher truth already arrived — log and keep it,
+                // never `clear_loaded_model()` on a superseded fetch error
+                // (audit 2 Tier 1 #8).
+                if epoch != self.current_model_epoch {
+                    info!(
+                        "Ignoring stale get_current_model failure (epoch {epoch} != {}); \
+                         keeping live model state: {error}",
+                        self.current_model_epoch
+                    );
+                    return Task::none();
+                }
+                self.set_model_error(&error);
+                Task::none()
+            }
+
             // Startup load is driven by the sibling `handle_model_load_commands`
             // arm; nothing to do here.
             ModelMessage::LoadInitialData => Task::none(),
@@ -161,7 +180,10 @@ impl AppModel {
                     epoch,
                 }))
             }
-            Err(e) => cosmic::Action::App(Message::Model(ModelMessage::ModelError(e.to_string()))),
+            Err(e) => cosmic::Action::App(Message::Model(ModelMessage::CurrentModelFetchFailed {
+                epoch,
+                error: e.to_string(),
+            })),
         })
     }
 }

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -106,6 +106,16 @@ pub enum ModelMessage {
         source: String,
     },
     ModelError(String),
+    /// A `fetch_current_model` snapshot query failed. Carries the
+    /// `current_model_epoch` captured when the fetch was issued: the handler
+    /// clears the loaded model only if the epoch is unchanged. If a live
+    /// `model_switched` advanced the epoch since, the failure is stale and is
+    /// logged-and-dropped rather than clobbering the fresher state — the same
+    /// guard `CurrentModelLoaded` applies to its success path (audit 2 Tier 1 #8).
+    CurrentModelFetchFailed {
+        epoch: u64,
+        error: String,
+    },
 }
 
 /// Models-page UI: tabs, active-backend card, GPU readout, backend

--- a/super-stt-daemon/src/audio/recorder.rs
+++ b/super-stt-daemon/src/audio/recorder.rs
@@ -479,7 +479,7 @@ impl DaemonAudioRecorder {
     /// # Errors
     ///
     /// Returns an error if no input device/config is available.
-    pub fn detect_default_input_sample_rate(&self) -> Result<u32> {
+    pub fn detect_default_input_sample_rate() -> Result<u32> {
         let host = cpal::default_host();
         let device = host
             .default_input_device()

--- a/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
@@ -53,6 +53,53 @@ fn allow_no_keyring() -> bool {
     std::env::var(ALLOW_NO_KEYRING_ENV).is_ok_and(|v| v == "1")
 }
 
+/// A message to the single-writer persist task.
+// Both fields are only read in `persist_loop`, which is `#[cfg(not(test))]`; the
+// constructors compile in test builds too, so the fields read as dead code under
+// `cargo test`. They're live in production — suppress the test-only lint.
+#[cfg_attr(test, allow(dead_code))]
+enum PersistMsg {
+    /// Persist this sessions snapshot (coalesced with any newer ones).
+    Snapshot(HashMap<String, TokenMeta>),
+    /// Drain the backlog, write the latest snapshot, then signal completion via
+    /// the oneshot. The shutdown path uses this so a token minted or revoked in
+    /// the final moments is durably written before `process::exit` skips the
+    /// task (audit 2 Tier 1 #5).
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
+/// Process-global handle to the live persist task's channel. Registered when the
+/// single production `TokenStore` is created ([`SessionPersister::spawn`], only
+/// in non-test builds). [`flush_persisted_sessions`] uses it to drain queued
+/// writes on shutdown. `None` in `cargo test` builds (no task is spawned) and
+/// until the production store exists.
+static PERSIST_FLUSH: std::sync::OnceLock<mpsc::UnboundedSender<PersistMsg>> =
+    std::sync::OnceLock::new();
+
+/// Drain any queued session snapshots to the keyring before the daemon exits.
+///
+/// The persist task is fire-and-forget; the shutdown path's `process::exit`
+/// would otherwise skip it, losing a token minted or revoked in the sub-second
+/// window before shutdown (audit 2 Tier 1 #5). Bounded by `timeout` so a stalled
+/// keyring (a D-Bus unlock prompt) can't hang shutdown indefinitely.
+pub(crate) async fn flush_persisted_sessions(timeout: Duration) {
+    let Some(tx) = PERSIST_FLUSH.get() else {
+        return; // no production persist task (test build, or store never created)
+    };
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    if tx.send(PersistMsg::Flush(ack_tx)).is_err() {
+        return; // persist task already ended
+    }
+    match tokio::time::timeout(timeout, ack_rx).await {
+        Ok(Ok(())) => info!("Session store flushed to keyring on shutdown"),
+        Ok(Err(_)) => {} // ack sender dropped: task ended without acking
+        Err(_) => warn!(
+            "Session-store flush timed out after {}s on shutdown; queued writes may be lost",
+            timeout.as_secs()
+        ),
+    }
+}
+
 /// Single-writer handle for persisting the sessions map to the keyring.
 ///
 /// `mint`/`revoke`/`validate` are sync fns called from async request handlers;
@@ -61,10 +108,11 @@ fn allow_no_keyring() -> bool {
 /// would race the on-disk order. Funnelling every snapshot through one task over
 /// this channel keeps the blocking write off the request path *and* serializes
 /// the writes so the last submitted snapshot is the last one written (audit
-/// Tier 3 #35).
+/// Tier 3 #35). Callers submit under the in-memory lock so channel order matches
+/// lock order (audit 2 Tier 1 #4).
 #[derive(Clone)]
 pub(crate) struct SessionPersister {
-    tx: mpsc::UnboundedSender<HashMap<String, TokenMeta>>,
+    tx: mpsc::UnboundedSender<PersistMsg>,
 }
 
 impl SessionPersister {
@@ -73,9 +121,15 @@ impl SessionPersister {
     /// developer's keyring); submissions become no-ops as the receiver is
     /// dropped.
     fn spawn() -> Self {
-        let (tx, rx) = mpsc::unbounded_channel::<HashMap<String, TokenMeta>>();
+        let (tx, rx) = mpsc::unbounded_channel::<PersistMsg>();
         #[cfg(not(test))]
-        tokio::spawn(persist_loop(rx));
+        {
+            tokio::spawn(persist_loop(rx));
+            // Register the first (production) persister so the shutdown path can
+            // drain it. Production creates exactly one `TokenStore` (AppState's);
+            // any later store keeps its own channel but won't be flushed.
+            let _ = PERSIST_FLUSH.set(tx.clone());
+        }
         #[cfg(test)]
         drop(rx);
         Self { tx }
@@ -85,20 +139,33 @@ impl SessionPersister {
     /// closed channel (test builds) just means the write is skipped — the
     /// in-memory map stays authoritative.
     fn submit(&self, snapshot: HashMap<String, TokenMeta>) {
-        let _ = self.tx.send(snapshot);
+        let _ = self.tx.send(PersistMsg::Snapshot(snapshot));
     }
 }
 
-/// The persist task: receive snapshots, coalesce a burst down to the newest
-/// (older snapshots are strict subsets of the state the newest represents), and
-/// write each sequentially so on-disk order matches submission order.
+/// The persist task: receive messages, coalesce a burst of snapshots down to the
+/// newest (older snapshots are strict subsets of the state the newest
+/// represents), write it, then ack any flush request in the same batch — so a
+/// shutdown flush is acked only after the latest state is on disk.
 #[cfg(not(test))]
-async fn persist_loop(mut rx: mpsc::UnboundedReceiver<HashMap<String, TokenMeta>>) {
-    while let Some(mut latest) = rx.recv().await {
-        while let Ok(newer) = rx.try_recv() {
-            latest = newer;
+async fn persist_loop(mut rx: mpsc::UnboundedReceiver<PersistMsg>) {
+    while let Some(first) = rx.recv().await {
+        let mut latest: Option<HashMap<String, TokenMeta>> = None;
+        let mut flush_ack: Option<tokio::sync::oneshot::Sender<()>> = None;
+        let mut msg = Some(first);
+        while let Some(m) = msg {
+            match m {
+                PersistMsg::Snapshot(s) => latest = Some(s),
+                PersistMsg::Flush(ack) => flush_ack = Some(ack),
+            }
+            msg = rx.try_recv().ok();
         }
-        persist_snapshot(latest).await;
+        if let Some(snapshot) = latest {
+            persist_snapshot(snapshot).await;
+        }
+        if let Some(ack) = flush_ack {
+            let _ = ack.send(());
+        }
     }
 }
 
@@ -275,11 +342,12 @@ impl TokenStore {
         Ok(store)
     }
 
-    /// Persist the current sessions map to the keyring. Callers must
-    /// pass the locked guard so we can flush under the same lock that
-    /// guards the in-memory map (no torn writes vs concurrent mints).
-    /// Failures are logged but not propagated — the in-memory state is
-    /// still authoritative for the lifetime of the daemon.
+    /// Mint a fresh 30-day session token for `(app_name, scopes, exe_path)`,
+    /// insert it into the in-memory map, and submit the updated snapshot to the
+    /// persist task. The submit happens under the lock so the persist channel's
+    /// order matches lock order (audit 2 Tier 1 #4). Persistence failures are
+    /// logged but not propagated — the in-memory map stays authoritative for the
+    /// lifetime of the daemon.
     ///
     /// **Failure suppression.** A locked or denied keyring will fail
     /// every write; without a cooldown, a busy session-mint loop would
@@ -311,37 +379,38 @@ impl TokenStore {
             issued_at: now,
             expires_at,
         };
-        let snapshot = {
+        {
             let mut tokens = self.inner.lock().unwrap();
             tokens.insert(token.clone(), meta);
-            tokens.clone()
-        };
-        self.persist.submit(snapshot);
+            // Submit under the lock so the persist channel's order matches lock
+            // order. An off-lock submit can invert (two mutations serialize on
+            // the Mutex yet reach the channel out of order) and the coalescer
+            // would then write a stale subset snapshot — resurrecting a revoked
+            // token across restart. `submit` is a non-blocking channel send (the
+            // keyring I/O happens off-thread in the persist task), so it's safe
+            // to hold the std Mutex across it (audit 2 Tier 1 #4).
+            self.persist.submit(tokens.clone());
+        }
         (token, expires_at)
     }
 
     pub(crate) fn validate(&self, token: &str) -> Result<TokenMeta, &'static str> {
-        // Two-phase: drop the lock before flushing to avoid holding it
-        // across keyring DBus I/O. The expired-removal flush is best-effort
-        // — if the keyring write fails, the in-memory state is already
-        // correct and the cooldown mechanism handles transient failures.
-        let (result, maybe_snapshot) = {
-            let mut tokens = self.inner.lock().unwrap();
-            let Some(meta) = tokens.get(token).cloned() else {
-                return Err("unknown");
-            };
-            if meta.expires_at < Utc::now() {
-                tokens.remove(token);
-                let snapshot = tokens.clone();
-                (Err("expired"), Some(snapshot))
-            } else {
-                (Ok(meta), None)
-            }
+        // Submit the expired-eviction snapshot under the lock so the persist
+        // channel's order matches lock order (audit 2 Tier 1 #4). `submit` is a
+        // non-blocking channel send — the keyring DBus I/O happens off-thread in
+        // the persist task, not here — so it's safe to hold the std Mutex across
+        // it. The write is best-effort: the in-memory state is already correct
+        // and the cooldown mechanism handles transient keyring failures.
+        let mut tokens = self.inner.lock().unwrap();
+        let Some(meta) = tokens.get(token).cloned() else {
+            return Err("unknown");
         };
-        if let Some(snapshot) = maybe_snapshot {
-            self.persist.submit(snapshot);
+        if meta.expires_at < Utc::now() {
+            tokens.remove(token);
+            self.persist.submit(tokens.clone());
+            return Err("expired");
         }
-        result
+        Ok(meta)
     }
 
     /// Drop a session token immediately and persist the change. Used by
@@ -350,16 +419,10 @@ impl TokenStore {
     /// the session, so the daemon revokes the token, emits a `revoked`
     /// SSE event, and closes the stream. Idempotent.
     pub(crate) fn revoke(&self, token: &str) {
-        let maybe_snapshot = {
-            let mut tokens = self.inner.lock().unwrap();
-            if tokens.remove(token).is_some() {
-                Some(tokens.clone())
-            } else {
-                None
-            }
-        };
-        if let Some(snapshot) = maybe_snapshot {
-            self.persist.submit(snapshot);
+        let mut tokens = self.inner.lock().unwrap();
+        if tokens.remove(token).is_some() {
+            // Submit under the lock — see `mint` (audit 2 Tier 1 #4).
+            self.persist.submit(tokens.clone());
         }
     }
 }

--- a/super-stt-daemon/src/daemon/http/mod.rs
+++ b/super-stt-daemon/src/daemon/http/mod.rs
@@ -7,5 +7,9 @@ mod server;
 mod state;
 mod v1;
 
+/// Re-exported so the daemon's shutdown path can drain queued session-store
+/// writes before `process::exit` (audit 2 Tier 1 #5) without reaching into the
+/// private `internal` module tree.
+pub(crate) use internal::auth::tokens::flush_persisted_sessions;
 pub use server::AUTO_APPROVE_ENV;
 pub use server::start_http_server;

--- a/super-stt-daemon/src/daemon/http/v1/auth/request.rs
+++ b/super-stt-daemon/src/daemon/http/v1/auth/request.rs
@@ -150,9 +150,15 @@ pub(crate) async fn auth_request(
                 reason::USER_DENIED_CACHED,
             )
         } else {
-            // Auto-approve if the daemon is in test/CI mode.
+            // Auto-approve if the daemon is in test/CI mode. Honored only in
+            // debug builds: compiled out of release so a stray/injected env var
+            // can't silently defeat the human consent gate in a shipped binary
+            // (audit 2 Tier 1 #6; mirrors the #30 consent-timer release gating).
+            #[cfg(debug_assertions)]
             let auto_approve = std::env::var(crate::daemon::http::server::AUTO_APPROVE_ENV)
                 .is_ok_and(|v| v == "1");
+            #[cfg(not(debug_assertions))]
+            let auto_approve = false;
 
             let decision = if auto_approve {
                 let auto_approve_env = crate::daemon::http::server::AUTO_APPROVE_ENV;

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -23,6 +23,19 @@ use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
 #[cfg(feature = "wasm-backends")]
 const REALTIME_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(1);
 
+/// Maximum concurrent realtime WS sessions. Each holds the model read lock and a
+/// bounded input buffer; without a cap, any authorized transcribe-scope client
+/// could open sessions without limit (memory + lock pressure). A new connection
+/// beyond this is rejected with `503` before the upgrade (audit 2 Tier 1 #7).
+#[cfg(feature = "wasm-backends")]
+const MAX_REALTIME_SESSIONS: usize = 4;
+
+/// Permits for [`MAX_REALTIME_SESSIONS`]. `try_acquire` in the handler rejects
+/// excess connections rather than queueing them.
+#[cfg(feature = "wasm-backends")]
+static REALTIME_SESSIONS: tokio::sync::Semaphore =
+    tokio::sync::Semaphore::const_new(MAX_REALTIME_SESSIONS);
+
 /// `GET /v1/transcribe/realtime` — upgrade the connection and bridge it to the
 /// active model's realtime session.
 #[cfg(feature = "wasm-backends")]
@@ -30,23 +43,42 @@ pub(crate) async fn realtime_ws_handler(
     ws: axum::extract::ws::WebSocketUpgrade,
     State(state): State<AppState>,
 ) -> Response {
+    // Claim a session permit before upgrading so an over-cap client gets a clean
+    // `503` instead of an upgraded socket that's immediately closed. The permit
+    // is moved into the session task and released when it ends (audit 2 Tier 1 #7).
+    let Ok(permit) = REALTIME_SESSIONS.try_acquire() else {
+        log::warn!(
+            "realtime WS rejected: {MAX_REALTIME_SESSIONS} concurrent sessions already active"
+        );
+        return (StatusCode::SERVICE_UNAVAILABLE, "realtime_sessions_busy").into_response();
+    };
     let daemon = Arc::clone(&state.daemon);
-    ws.on_upgrade(move |socket| run_realtime_session(socket, daemon))
+    ws.on_upgrade(move |socket| run_realtime_session(socket, daemon, permit))
 }
 
 /// Drive one realtime session: split the consumer socket, bridge each half to
 /// the guest's consumer-stream channels, and invoke `realtime_session` while
 /// holding the model read lock.
 #[cfg(feature = "wasm-backends")]
-async fn run_realtime_session(socket: axum::extract::ws::WebSocket, daemon: Arc<SuperSTTDaemon>) {
-    use crate::stt_models::wasm::ws_host::{ConsumerStreamTransport, WsFrame};
+async fn run_realtime_session(
+    socket: axum::extract::ws::WebSocket,
+    daemon: Arc<SuperSTTDaemon>,
+    // Held for the session's lifetime; dropping it frees a `REALTIME_SESSIONS`
+    // permit for the next connection (audit 2 Tier 1 #7).
+    _permit: tokio::sync::SemaphorePermit<'static>,
+) {
+    use crate::stt_models::wasm::ws_host::{
+        CONSUMER_INCOMING_CAPACITY, ConsumerStreamTransport, WsFrame,
+    };
     use axum::extract::ws::Message;
     use futures::{SinkExt, StreamExt};
     use tokio::sync::mpsc;
 
     // Channels bridging the consumer socket and the guest's consumer-stream.
-    // incoming: consumer -> guest ; outgoing: guest -> consumer.
-    let (incoming_tx, incoming_rx) = mpsc::unbounded_channel::<WsFrame>();
+    // incoming: consumer -> guest (bounded, so a fast client applies backpressure
+    // instead of growing memory) ; outgoing: guest -> consumer (unbounded — the
+    // guest produces bounded output and we never want to stall it).
+    let (incoming_tx, incoming_rx) = mpsc::channel::<WsFrame>(CONSUMER_INCOMING_CAPACITY);
     let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<WsFrame>();
     let transport = ConsumerStreamTransport {
         incoming: incoming_rx,
@@ -72,7 +104,10 @@ async fn run_realtime_session(socket: axum::extract::ws::WebSocket, daemon: Arc<
                 // Ping/Pong are answered by axum automatically; ignore them.
                 Message::Ping(_) | Message::Pong(_) => continue,
             };
-            if incoming_tx.send(frame).is_err() {
+            // Bounded send: awaits when the guest is behind, so we stop reading
+            // the socket and the client's TCP send blocks — backpressure instead
+            // of unbounded buffering (audit 2 Tier 1 #7).
+            if incoming_tx.send(frame).await.is_err() {
                 break;
             }
         }

--- a/super-stt-daemon/src/daemon/model_management/switch.rs
+++ b/super-stt-daemon/src/daemon/model_management/switch.rs
@@ -205,9 +205,13 @@ impl SuperSTTDaemon {
         };
 
         // Online models must be explicitly enabled — gated after resolution
-        // since online-ness is a property of the resolved model.
+        // since online-ness is a property of the resolved model. Emit the
+        // documented `400 online_models_disabled` code so clients can show the
+        // "enable online models" affordance instead of treating an uncoded 500
+        // as a crash (audit 2 Tier 1 #9).
         if is_online && !self.config.read().await.online.allow_online_models {
-            return DaemonResponse::error(
+            return DaemonResponse::error_with_code(
+                ErrorCode::OnlineModelsDisabled,
                 "Online models are disabled. Enable 'Allow Online Models' in settings first.",
             );
         }

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -194,11 +194,20 @@ impl SuperSTTDaemon {
             *busy_guard = true;
         }
 
-        // Create audio recorder with current theme and volume
+        // Create audio recorder with current theme and volume. Construction runs
+        // the cpal cold-start (default host/output device/config) and a
+        // `std::thread::sleep` device-verification spin — up to ~1.6s of real
+        // blocking on a cold start. Run it on a blocking thread so it doesn't
+        // park a runtime worker and stall concurrent SSE/event/status handling
+        // exactly when the user starts talking (audit 2 Tier 1 #3).
         let current_theme = self.get_audio_theme();
         let current_volume = self.get_volume_f32();
-        let mut recorder = DaemonAudioRecorder::new_with_theme(current_theme, current_volume)
-            .context("Failed to create audio recorder")?;
+        let mut recorder = tokio::task::spawn_blocking(move || {
+            DaemonAudioRecorder::new_with_theme(current_theme, current_volume)
+        })
+        .await
+        .context("Audio recorder construction task panicked")?
+        .context("Failed to create audio recorder")?;
 
         // Initialize the recorder for threaded operation
         recorder.prepare_for_threaded_recording();

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -48,8 +48,17 @@ impl SuperSTTDaemon {
         // Get a reference to the recorder's internal audio buffer for direct preview access
         let preview_buffer = recorder.get_audio_buffer_ref();
 
-        // Detect the actual device sample rate for correct buffer calculations
-        let device_sample_rate = recorder.detect_default_input_sample_rate().unwrap_or(16000); // fallback to 16kHz if detection fails
+        // Detect the actual device sample rate for correct buffer calculations.
+        // This opens the cpal default input device, so run it on a blocking
+        // thread rather than the async worker (audit 2 Tier 1 #3). Falls back to
+        // 16kHz if detection (or the task) fails.
+        let device_sample_rate = tokio::task::spawn_blocking(
+            crate::audio::recorder::DaemonAudioRecorder::detect_default_input_sample_rate,
+        )
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or(16000);
 
         // Start the recorder in its own thread
         let recorder_handle = tokio::spawn({

--- a/super-stt-daemon/src/daemon_main.rs
+++ b/super-stt-daemon/src/daemon_main.rs
@@ -182,6 +182,12 @@ pub async fn run() -> Result<()> {
     // the unit cleanly.
     daemon.shutdown_unload().await;
 
+    // Drain any queued session-store writes before `process::exit` skips the
+    // fire-and-forget persist task — otherwise a token minted or revoked in the
+    // final moments is lost (audit 2 Tier 1 #5). Bounded so a locked keyring
+    // (D-Bus unlock prompt) can't hang shutdown.
+    crate::daemon::http::flush_persisted_sessions(tokio::time::Duration::from_secs(5)).await;
+
     // Give a brief moment for any remaining cleanup, then force exit if needed
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 

--- a/super-stt-daemon/src/keyring.rs
+++ b/super-stt-daemon/src/keyring.rs
@@ -78,11 +78,27 @@ fn backend_secret_account(source: &str, name: &str) -> String {
 /// fall back to the system keyring.
 fn mock_store() -> Option<&'static Mutex<HashMap<String, String>>> {
     static STORE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
-    if cfg!(test) || std::env::var_os("SUPER_STT_KEYRING_MOCK").is_some() {
+    if cfg!(test) || keyring_mock_env_set() {
         Some(STORE.get_or_init(|| Mutex::new(HashMap::new())))
     } else {
         None
     }
+}
+
+/// Whether `SUPER_STT_KEYRING_MOCK` requests the in-memory store. Honored only
+/// in debug builds (tests / CI); a release binary ignores the env var entirely
+/// so a stray or injected variable can't reroute every backend API key and the
+/// session store into a non-persistent, unencrypted in-process map (audit 2
+/// Tier 1 #6). Mirrors the release gating of the consent-timer bypass
+/// (audit Tier 1 #30).
+#[cfg(debug_assertions)]
+fn keyring_mock_env_set() -> bool {
+    std::env::var_os("SUPER_STT_KEYRING_MOCK").is_some()
+}
+
+#[cfg(not(debug_assertions))]
+fn keyring_mock_env_set() -> bool {
+    false
 }
 
 /// Read one keyring account (mock store under test/mock, else the real keyring).

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -307,50 +307,64 @@ impl WasmBackend {
     }
 
     /// Serve a one-shot transcription for a realtime-only model by driving an
-    /// internal realtime session over the buffered audio. The consumer channel
-    /// is unbounded and the guest reads all audio, commits, then drains the
-    /// upstream — so we pre-load `start` + PCM16 frames + `stop` *before*
-    /// invoking the session and collect only the final `done` transcript
-    /// *after* it returns. No concurrent feeder, so this is safe even from the
-    /// synchronous (`block_on`) `transcribe_audio` call sites.
+    /// internal realtime session over the buffered audio. We pre-build `start` +
+    /// PCM16 frames + `stop` and feed them from a concurrent task into the
+    /// bounded consumer channel while the session drains it, then collect only
+    /// the final `done` transcript *after* it returns. The feeder captures no
+    /// `self`, so this stays valid even from the synchronous (`block_on`)
+    /// `transcribe_audio` call sites.
     #[cfg(feature = "wasm-backends")]
     #[allow(clippy::cast_possible_truncation)] // intentional f32 -> i16 PCM clamp
     async fn transcribe_via_realtime(&self, audio: &[f32], sample_rate: u32) -> Result<String> {
-        use ws_host::{ConsumerStreamTransport, WsFrame};
+        use ws_host::{CONSUMER_INCOMING_CAPACITY, ConsumerStreamTransport, WsFrame};
 
         // 16-bit PCM, mono, LE. Mistral's `input_audio_buffer.append` caps a
         // single message at 262144 raw bytes; 16384 samples (32768 bytes) per
         // frame stays well under it.
         const FRAME_SAMPLES: usize = 16384;
 
-        let (incoming_tx, incoming_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
+        let (incoming_tx, incoming_rx) =
+            tokio::sync::mpsc::channel::<WsFrame>(CONSUMER_INCOMING_CAPACITY);
         let (outgoing_tx, mut outgoing_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
 
-        // Pre-load the consumer side: start, the audio as PCM16 binary chunks,
+        // Pre-build the consumer frames: start, the audio as PCM16 binary chunks,
         // then stop. The guest breaks on `stop`, so no further consumer recv.
-        let send = |frame| {
-            incoming_tx
-                .send(frame)
-                .map_err(|_| anyhow!("realtime channel closed"))
-        };
-        send(WsFrame::Text(format!(
+        let mut frames = Vec::with_capacity(audio.len() / FRAME_SAMPLES + 2);
+        frames.push(WsFrame::Text(format!(
             "{{\"type\":\"start\",\"sample_rate\":{sample_rate}}}"
-        )))?;
+        )));
         for chunk in audio.chunks(FRAME_SAMPLES) {
             let mut pcm = Vec::with_capacity(chunk.len() * 2);
             for &s in chunk {
                 let v = (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
                 pcm.extend_from_slice(&v.to_le_bytes());
             }
-            send(WsFrame::Binary(pcm))?;
+            frames.push(WsFrame::Binary(pcm));
         }
-        send(WsFrame::Text("{\"type\":\"stop\"}".to_string()))?;
+        frames.push(WsFrame::Text("{\"type\":\"stop\"}".to_string()));
+
+        // `incoming` is now bounded (audit 2 Tier 1 #7), so feed it from a task
+        // that runs concurrently with the session draining it — a synchronous
+        // pre-load would deadlock once the frame count exceeds the capacity. The
+        // feeder captures no `self`, so it's valid even from the sync `block_on`
+        // `transcribe_audio` call sites. Errors still surface through the session
+        // result below, not the feeder.
+        let feeder = tokio::spawn(async move {
+            for frame in frames {
+                if incoming_tx.send(frame).await.is_err() {
+                    break; // session ended / dropped the receiver early
+                }
+            }
+        });
 
         let transport = ConsumerStreamTransport {
             incoming: incoming_rx,
             outgoing: outgoing_tx,
         };
         self.realtime_session(transport).await?;
+        // Session returned → the guest consumed every frame (or aborted); reap
+        // the feeder so it can't outlive this call.
+        let _ = feeder.await;
 
         // The session has returned, so every frame the guest emitted (previews
         // plus the terminal `done`/`error`) is buffered. Return only the final

--- a/super-stt-daemon/src/stt_models/wasm/ws_host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/ws_host.rs
@@ -67,14 +67,20 @@ impl WsStreamResource {
     }
 }
 
+/// Capacity of the consumer→guest `incoming` channel. Bounds per-session memory:
+/// a client streaming audio faster than the guest drains it applies TCP
+/// backpressure rather than growing an unbounded buffer (audit 2 Tier 1 #7).
+pub const CONSUMER_INCOMING_CAPACITY: usize = 256;
+
 /// The host-side bridge between the consumer-facing axum WebSocket and the
 /// guest's realtime session. The axum endpoint task owns the opposite ends of
 /// these channels: it forwards frames it reads off the consumer socket into
 /// `incoming`, and writes frames the guest emits on `outgoing` back to the
 /// consumer.
 pub struct ConsumerStreamTransport {
-    /// Frames arriving FROM the consumer (axum) TO the guest.
-    pub incoming: tokio::sync::mpsc::UnboundedReceiver<WsFrame>,
+    /// Frames arriving FROM the consumer (axum) TO the guest. Bounded
+    /// ([`CONSUMER_INCOMING_CAPACITY`]) so a fast producer can't exhaust memory.
+    pub incoming: tokio::sync::mpsc::Receiver<WsFrame>,
     /// Frames the guest sends OUT to the consumer (axum forwards them).
     pub outgoing: tokio::sync::mpsc::UnboundedSender<WsFrame>,
 }

--- a/super-stt-daemon/tests/wasm_mock_realtime.rs
+++ b/super-stt-daemon/tests/wasm_mock_realtime.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 
 use super_stt_daemon::stt_models::transcribe::Transcribe;
 use super_stt_daemon::stt_models::wasm::WasmBackend;
-use super_stt_daemon::stt_models::wasm::ws_host::{ConsumerStreamTransport, WsFrame};
+use super_stt_daemon::stt_models::wasm::ws_host::{
+    CONSUMER_INCOMING_CAPACITY, ConsumerStreamTransport, WsFrame,
+};
 
 /// Path to the prebuilt mock realtime component
 /// (`just build-mock-wasm-realtime-backend`).
@@ -54,7 +56,10 @@ async fn realtime_orchestration_against_mock() {
 
     // Realtime: drive one session. The mock emits a preview then a done frame
     // after reading the consumer's `start` frame, then closes — no upstream.
-    let (consumer_tx, consumer_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
+    // `incoming` is a bounded channel (audit 2 Tier 1 #7); the consumer side is
+    // now `mpsc::Sender::send(..).await`.
+    let (consumer_tx, consumer_rx) =
+        tokio::sync::mpsc::channel::<WsFrame>(CONSUMER_INCOMING_CAPACITY);
     let (guest_tx, mut guest_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
     let transport = ConsumerStreamTransport {
         incoming: consumer_rx,
@@ -66,9 +71,11 @@ async fn realtime_orchestration_against_mock() {
             .send(WsFrame::Text(
                 r#"{"type":"start","sample_rate":16000}"#.to_string(),
             ))
+            .await
             .unwrap();
         consumer_tx
             .send(WsFrame::Text(r#"{"type":"stop"}"#.to_string()))
+            .await
             .unwrap();
         // Keep the sender alive until the session ends so the guest's first recv
         // (the start frame) doesn't race an early channel close.


### PR DESCRIPTION
Fixes the remaining Tier-1 findings (#3–#9) from the second code-quality audit (`docs/audits/2026-07-code-quality-2.md`), all in one PR as requested.

| # | Sev | Fix |
|---|-----|-----|
| **3** | 🟠 | Record-start ran the cpal cold-start + a `std::thread::sleep` device-verification spin (~1.6s) on an async worker. Recorder construction and `detect_default_input_sample_rate` now run on `spawn_blocking`, so they no longer stall concurrent SSE/event/status handling. |
| **4** | 🟠🔒 | `SessionPersister` submitted snapshots *after* dropping the token lock, so channel order could invert lock order and the coalescer could persist a stale subset — resurrecting a revoked token across restart. `submit` now runs **under** the lock (it's a non-blocking channel send; the keyring I/O stays off-thread). |
| **5** | 🟠 | The fire-and-forget persist task was never drained on shutdown. Added a typed `PersistMsg` flush handshake + a process-global handle; the shutdown path now calls `flush_persisted_sessions(5s)` before `process::exit`, bounded so a locked keyring can't hang shutdown. |
| **6** | 🟠🔒 | `SUPER_STT_AUTO_APPROVE` (consent bypass) and `SUPER_STT_KEYRING_MOCK` (in-memory secret store) were live runtime checks in release. Both are now behind `#[cfg(debug_assertions)]` with release no-op stubs (mirroring audit #30); `cargo test` builds in dev profile, so the integration tests are unaffected. |
| **7** | 🟠🔒 | The realtime WS bridge fed the guest through an unbounded channel with unbounded sessions (memory-exhaustion DoS). The input channel is now bounded (256) with backpressure, and concurrent sessions are capped by a semaphore (`503 realtime_sessions_busy` when full). The batch realtime path feeds the bounded channel from a concurrent task. |
| **8** | 🟠 | `fetch_current_model`'s error path bypassed the epoch guard and unconditionally cleared live model state. It now emits `CurrentModelFetchFailed { epoch, error }`; the handler clears state only when the epoch still matches, so a transient reconnect failure can't clobber a live `model_switched`. |
| **9** | 🟠 | Online-model rejection returned an uncoded 500 instead of the documented `400 online_models_disabled`; now emits `error_with_code(ErrorCode::OnlineModelsDisabled, …)`. |

## Verification
- `cargo check --workspace --all-features`, pedantic clippy (`-D warnings`), and `cargo fmt --check` all clean.
- Daemon lib **235 passed**; shared **102**; app **43**. (The only failures — 3 registry loopback-HTTP tests — fail identically on clean `main`; environmental, not from this change.)
- Realtime WASM mock tests **2/2** — exercises #7's bounded transport and batch feeder end-to-end.
- An adversarial multi-agent review (one reviewer + refuter per finding) raised 2 minor non-blockers — a test-cfg `dead_code` warning and a stale doc comment — both folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)