### PR TITLE
Audit 2 Tier 2: error_code envelopes, typed daemon_status, docs, CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ Controls how transcribed text is typed into the focused application. Auto-detect
 | **ydotool**                    | Uses ydotool virtual input (requires ydotoold running)                    |
 | **Wayland Protocol**           | Direct Wayland input simulation via the compositor                        |
 
-Both settings can be changed in the desktop app under Settings, or per-recording via CLI flags:
+Both settings can be changed in the desktop app under Settings. The stop mode
+can also be set per-recording on the CLI; the write method is configured only in
+the app or daemon config (it is not a per-recording flag):
 
 ```bash
-stt record --write --stop-mode manual --write-method ydotool
+stt record --write --stop-mode manual_only
 ```
 
 ## 🤖 Supported Models
@@ -110,11 +112,12 @@ If your computer does not have enough resources for local models, you can send y
 
 #### Enabling Online Models
 
+Online providers are installed as backends, then configured with an API key:
+
 1. Open the Super STT app
-2. Navigate to **Online Models** in the sidebar
-3. Enable the **Allow Online Models** toggle
-4. Enter your API key for the provider you want to use (keys are stored in your system keyring)
-5. Go to **Models**, open the model selector, and choose an online model
+2. Go to **Library → Browse** and install the provider's backend (Mistral, OpenAI, or Deepgram)
+3. On the **Installed** tab, open that backend's **Configure** sheet and enter your API key (stored in your system keyring)
+4. Go to **Models**, open the model selector, and choose an online model to load it
 
 API keys are stored securely in your system keyring (GNOME Keyring, KWallet, etc.) 
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -56,21 +56,21 @@ ls -la "$XDG_RUNTIME_DIR/stt/super-stt-http.sock"
 ## Security Features
 
 ### 1. Keyboard Input Protection
-- **Process authentication**: Write mode requires verification that the client is the legitimate stt binary
-- **Unix socket credentials**: Uses peer credential verification to authenticate processes
-- **Debug/release separation**: Authentication automatically disabled in debug builds for development
+- **Consent-gated authorization**: Auto-typing is the per-request `write_mode` flag on `POST /transcribe` (or the daemon's configured write mode). Reaching that endpoint at all requires a consent-minted session token with the `transcribe` scope — so a client can only type after the user approved it through the one-time consent prompt. There is no separate keyboard/write scope; it is the same `transcribe` scope dictation uses. See [Authorization](#authorization) and [`protocol/auth.md`](protocol/auth.md)
+- **Peer identity for the prompt**: `SO_PEERCRED` + `/proc/<pid>/exe` tell the consent prompt *which binary* is asking and reject cross-UID peers; this identifies the caller, it is not by itself the authorization
+- **Debug-only test bypass**: The consent auto-approval used by tests/CI (`SUPER_STT_AUTO_APPROVE`) is compiled out of release builds
 - **Limited scope**: Only types actual transcription results
 
-### 2. Network Isolation  
-- **UDP localhost-only**: Audio streaming bound to `127.0.0.1`
-- **No remote access**: Network connections impossible
-- **Read-only broadcast**: Only sends visualization data
+### 2. Network Isolation
+- **No inbound network surface**: The daemon listens only on a per-user Unix domain socket under `$XDG_RUNTIME_DIR/stt/` — there is no TCP or UDP listener, so no host on the network can connect to it
+- **Local visualization**: Audio-visualization frames are delivered as Server-Sent Events over that same Unix socket, not broadcast on the network
+- **Outbound only for backend installs**: The daemon reaches the network solely to fetch backends over HTTPS from the registry / GitHub — see [Daemon outbound network surface](#daemon-outbound-network-surface) below
 
-### 3. Process Authentication
-- **Unix peer credentials**: Verifies connecting process PID, UID, and executable path
-- **Binary verification**: Ensures only the legitimate stt binary can trigger write mode
-- **Compile-time security**: Uses `cfg!(debug_assertions)` to automatically disable in debug builds
-- **Fallback checks**: Validates process name if path verification fails
+### 3. Consent &amp; Peer Identity
+- **Session tokens + scopes**: Every request other than `/auth/request` requires a `Bearer` session token; each token carries the user-approved scopes that gate what it may do (`transcribe`, `settings`, `secrets`, `status`, and the event-topic scopes — see [`protocol/auth.md`](protocol/auth.md) for the full catalog)
+- **One-time consent**: Tokens are minted by the `super-stt-consent` helper — a popup naming the requesting binary (resolved via `SO_PEERCRED`) and the scopes it asks for, which the user approves or denies
+- **Same-UID only**: A peer whose UID differs from the daemon's is rejected before any prompt
+- See [`protocol/auth.md`](protocol/auth.md) for the full token, scope, and consent contract
 
 ### 4. Input Validation and DoS Protection
 - **Comprehensive validation**: All external inputs validated with strict limits
@@ -92,7 +92,7 @@ ls -la "$XDG_RUNTIME_DIR/stt/super-stt-http.sock"
 - **User service**: Runs under user account, not root
 - **Per-user socket**: Owner-only `$XDG_RUNTIME_DIR` plus a same-UID peer check — no cross-user access, no shared group
 - **Socket permissions**: Enforced at filesystem level
-- **Process authentication**: SO_PEERCRED verification for privileged operations
+- **Peer identity**: `SO_PEERCRED` resolves the peer UID (same-UID enforced) and exe path (shown in the consent prompt) — the authorization itself is the consent-minted session token and its scopes
 
 ## Daemon outbound network surface
 
@@ -146,9 +146,9 @@ cargo run --release --bin super-stt-daemon
 ## Threat Model
 
 ### Protected Against
-- ✅ Unauthorized local users accessing the daemon
-- ✅ Remote network attacks (localhost-only UDP binding)
-- ✅ Unauthorized keyboard injection (process authentication with SO_PEERCRED)
+- ✅ Unauthorized local users accessing the daemon (owner-only socket + same-UID peer check)
+- ✅ Remote network attacks (no inbound listener — Unix-socket only, no TCP/UDP port)
+- ✅ Unauthorized keyboard injection (reachable only with a consent-minted `transcribe`-scope token; auto-typing itself is the per-request `write_mode` flag)
 - ✅ Arbitrary command injection via keyboard
 - ✅ Privilege escalation (runs as an unprivileged user service)
 - ✅ Memory exhaustion attacks (comprehensive input validation)
@@ -156,7 +156,7 @@ cargo run --release --bin super-stt-daemon
 - ✅ JSON bomb attacks (size and depth validation)
 - ✅ Directory traversal attacks (path validation)
 - ✅ Audio data injection attacks (sample validation and pattern detection)
-- ✅ Process impersonation (binary path and name verification)
+- ✅ Cross-user access (same-UID peer check; the consent prompt names the caller's exe)
 
 ### Assumptions
 - Physical access to the machine is trusted
@@ -199,7 +199,7 @@ systemctl --user disable super-stt
 - ✅ Resource exhaustion protection testing
 - ✅ Path traversal attack testing
 - ✅ Memory safety analysis
-- ✅ Process authentication verification
+- ✅ Consent-token / scope authorization verification
 
 ### Continuous Security
 - Regular dependency security audits via `cargo audit`

--- a/docs/audits/2026-07-code-quality-2.md
+++ b/docs/audits/2026-07-code-quality-2.md
@@ -329,7 +329,7 @@ Five clusters account for most of the findings:
 
 ## Tier 2 — contract & documentation drift
 
-### [ ] 1. 🟠 Docs: `SECURITY.md` describes an obsolete SO_PEERCRED/binary-verification auth model and omits the actual token/scope/consent model
+### [x] 1. 🟠 Docs: `SECURITY.md` describes an obsolete SO_PEERCRED/binary-verification auth model and omits the actual token/scope/consent model
 
 - **Where:** `docs/SECURITY.md:59-72,159` ("Write mode requires verification that the
   client is the legitimate stt binary", "Unix peer credentials…", "Binary verification…",
@@ -345,6 +345,15 @@ Five clusters account for most of the findings:
 - **Fix:** rewrite the auth sections to describe the token/scope/consent model
   (cross-ref `auth.md`), keep SO_PEERCRED only in its real role (resolving the peer exe for
   the prompt + the uid-mismatch check), and reconcile the "No remote access" claim.
+- **Resolved (branch `refactor/audit2-tier2`):** rewrote the stale "Security Features"
+  sections (Keyboard Input Protection, Network Isolation, the former "Process Authentication"
+  → "Consent & Peer Identity", Process Isolation) and the Threat Model / testing bullets to
+  the real model: consent-minted per-request session tokens carrying user-approved scopes
+  (via `super-stt-consent`), with `SO_PEERCRED`/`/proc/<pid>/exe` in their true role
+  (identify the caller for the prompt + reject cross-UID peers), cross-referencing
+  `protocol/auth.md`. Replaced the self-contradicting "No remote access / Network connections
+  impossible" with "no inbound listener — Unix-socket only", reconciled against the documented
+  outbound-HTTPS backend-install surface.
 
 ### [x] 2. 🟠 Security/Install: the `stt`-group access-control model is documented and provisioned by installers but does not exist in the daemon
 
@@ -398,7 +407,7 @@ Five clusters account for most of the findings:
   which are incompatible with a `--user` service whose binary lives in `~/.local/bin` and whose
   socket lives in `/run/user/<uid>`; making that block actually startable is a separate fix.
 
-### [ ] 4. 🟠 Docs/CLI: README advertises a `--write-method` flag and `--stop-mode manual` value the CLI rejects
+### [x] 4. 🟠 Docs/CLI: README advertises a `--write-method` flag and `--stop-mode manual` value the CLI rejects
 
 - **Where:** `README.md:83` (`stt record --write --stop-mode manual --write-method
   ydotool`), `:61,80-84`.
@@ -413,8 +422,11 @@ Five clusters account for most of the findings:
 - **Fix:** `--stop-mode manual` → `manual_only`, delete `--write-method ydotool`, and state
   that write method is app/config-only (not a per-recording CLI flag) — or add it to
   `TranscribeOptions` + clap if per-recording override is intended.
+- **Resolved (branch `refactor/audit2-tier2`):** the README example is now `stt record --write
+  --stop-mode manual_only`; the `--write-method ydotool` flag is dropped and the surrounding
+  prose states the write method is set in the app or daemon config, not per-recording.
 
-### [ ] 5. 🟡 Docs: README "Enabling Online Models" references an "Online Models" sidebar page that no longer exists
+### [x] 5. 🟡 Docs: README "Enabling Online Models" references an "Online Models" sidebar page that no longer exists
 
 - **Where:** `README.md:111-117` ("Navigate to Online Models in the sidebar…").
 - **Problem:** the sidebar now has Models, Library, Customization (`init.rs:21-33`); online
@@ -422,8 +434,12 @@ Five clusters account for most of the findings:
   Configure-sheet secret flow (`ui/messages.rs:263-294`), not a dedicated page.
 - **Fix:** update the section to the current IA (install the provider from Library/Browse,
   open its Configure sheet for the API key) and correct the sidebar page names.
+- **Resolved (branch `refactor/audit2-tier2`):** the "Enabling Online Models" steps now read:
+  install the provider's backend from **Library → Browse**, open its **Configure** sheet (from
+  the Installed tab) to enter the API key, then pick the online model from **Models** — matching
+  the real backend-install + secret-flow IA (no "Online Models" sidebar page).
 
-### [ ] 6. 🟠 Protocol: `error_code` is absent from the registry, backend-option, secret, and model-language error envelopes
+### [x] 6. 🟠 Protocol: `error_code` is absent from the registry, backend-option, secret, and model-language error envelopes
 
 - **Where:** `backends/mod.rs:28-35` (`json_error` → `{status:"error", message:<code>}`,
   no `error_code`) covers option/secret/model-language; `registry/mod.rs:21-39`
@@ -438,8 +454,15 @@ Five clusters account for most of the findings:
   envelope unification is incomplete.
 - **Fix:** route these errors through the `error_code` envelope (or add `error_code` +
   `status:"error"` to `json_error`/`registry_error`); update the per-endpoint error tables.
+- **Resolved (branch `refactor/audit2-tier2`):** `json_error` now emits
+  `{status:"error", error_code, message}` (with a new `json_error_msg` sibling for the one
+  keyring-unavailable site that carries a distinct human message), and `registry_error`/
+  `registry_error_msg` now add `status:"error"` + `error_code` while retaining the legacy
+  `error` key for back-compat. So the backend option/secret/model-language and registry
+  surfaces all carry `error_code` per `transport.md`. The registry envelope test was updated
+  to field-level assertions.
 
-### [ ] 7. 🟠 Protocol: `active_device` error contract has drifted from the ErrorCode enum and the daemon
+### [x] 7. 🟠 Protocol: `active_device` error contract has drifted from the ErrorCode enum and the daemon
 
 - **Where:** `device_management.rs:131-135`; `active_device.md:66-69`.
 - **Problem:** (1) an unrecognized device is rejected with an uncoded error → 500, but the
@@ -453,6 +476,12 @@ Five clusters account for most of the findings:
 - **Fix:** add an `InvalidDevice` (400) variant and emit it; reconcile the accepted-device
   set with the doc (add `metal` or drop it); either produce `cuda_unavailable` or document
   the silent-CPU-fallback (the doc currently self-contradicts).
+- **Resolved (branch `refactor/audit2-tier2`):** added `ErrorCode::InvalidDevice` (400) and
+  emit it from `validate_device_switch_request` (was an uncoded 500). Dropped `metal` from
+  `active_device.md` (the daemon accepts only `cpu`/`cuda`), and replaced the never-emitted
+  `400 cuda_unavailable` row with an explicit note that requesting CUDA on a CUDA-less host is
+  **not** an error — the daemon silently falls back to CPU (surfaced via `actual_device`). The
+  `CudaUnavailable` variant is kept as reserved surface (documented as such).
 
 ### [x] 8. 🟠 Protocol: `POST /transcribe` response shapes and the `stream_realtime` field diverge from the docs
 
@@ -487,7 +516,7 @@ Five clusters account for most of the findings:
   and documented the fire-and-forget `202`'s optimistic (no-completion-guarantee) semantics on
   the busy-race. The pre-existing busy-check TOCTOU is left as-is (Tier 3 #6).
 
-### [ ] 9. 🟠 API design: `daemon_status_changed` payload is an untyped hand-matched contract whose keys have already drifted
+### [x] 9. 🟠 API design: `daemon_status_changed` payload is an untyped hand-matched contract whose keys have already drifted
 
 - **Where:** built inline with `serde_json::json!` string keys
   (`lifecycle.rs:108-124`, `device_management.rs:208-214,310-311`, `switch.rs:115-120`) and
@@ -505,8 +534,17 @@ Five clusters account for most of the findings:
 - **Fix:** define a `#[serde(tag="status")]` `DaemonStatusEvent` enum in shared with typed
   fields (`Provider`, `Device`); construct/deserialize it on both sides; normalize
   `to_device`/`target_device`; pin the schemas in `docs/protocol/scopes/daemon_status.md`.
+- **Resolved (branch `refactor/audit2-tier2`):** added a `#[serde(tag="status",
+  rename_all="snake_case")]` `DaemonStatusEvent` enum in shared (8 variants). All four daemon
+  producers (`lifecycle`, `device_management`, `switch`, `language_handlers`) now construct it
+  and publish via a typed `publish_daemon_status` (which injects `timestamp`, mirroring
+  `publish_download_progress`); the app consumer deserializes it with `from_value` and matches
+  the enum instead of hand-reading `.get("status")`/`.get("<field>")`. `to_device` is
+  normalized to `target_device` (matches `loading_model_for_device`). Pinned the per-variant
+  schema in `daemon_status.md`. Validated by unit tests + the
+  `language_change_broadcasts_settings_changed` integration test.
 
-### [ ] 10. 🟠 Duplication: `MAX_MANIFEST_BYTES` is triplicated across the indexer, install, and custom-repo paths
+### [x] 10. 🟠 Duplication: `MAX_MANIFEST_BYTES` is triplicated across the indexer, install, and custom-repo paths
 
 - **Where:** `super-stt-indexer/src/assets.rs:22` (`u64`, enforced at publish),
   `registry/install.rs:26` (`u64`, at install-time manifest download),
@@ -518,8 +556,12 @@ Five clusters account for most of the findings:
   cleanly yet fail every install at 256 KiB.
 - **Fix:** hoist a single `MAX_MANIFEST_BYTES` into `registry-types::verify` beside the
   tarball budgets; reference it from all three (casting to `usize` where needed).
+- **Resolved (branch `refactor/audit2-tier2`):** added `pub const MAX_MANIFEST_BYTES: u64` to
+  `registry-types::verify` (beside the tarball budgets); the indexer, `install.rs`, and
+  `custom_repo.rs` now import it and dropped their local copies — `custom_repo.rs`'s `usize`
+  copy became the shared `u64`, removing its `as u64` casts.
 
-### [ ] 11. 🟡 Duplication: install-time manifest verification uses raw `toml::from_str` instead of `Manifest::parse`
+### [x] 11. 🟡 Duplication: install-time manifest verification uses raw `toml::from_str` instead of `Manifest::parse`
 
 - **Where:** `verify_manifest_bytes` does `toml::from_str::<Manifest>(&text)`
   (`registry/install.rs:584`) then re-implements only the entrypoint-safety subset inline
@@ -532,8 +574,13 @@ Five clusters account for most of the findings:
   silently won't apply at install verification.
 - **Fix:** use `Manifest::parse(&text)` and drop the inline re-check, keeping only the
   install-specific index-consistency assertions.
+- **Resolved (branch `refactor/audit2-tier2`):** `verify_manifest_bytes` now calls
+  `Manifest::parse(&text)` (inheriting the entrypoint + per-file `destination` traversal
+  guards and the `file`-xor-`parts`/empty-`file` normalization) and dropped the redundant
+  inline `is_safe_relative_path` re-check; the install-only checks (`validate_runtime`, source
+  and entrypoint-vs-index consistency) are kept.
 
-### [ ] 12. 🟡 Protocol/Docs: undocumented endpoint `POST /v1/active_model/reload`
+### [x] 12. 🟡 Protocol/Docs: undocumented endpoint `POST /v1/active_model/reload`
 
 - **Where:** registered at `http/v1/settings/mod.rs:102-105` → `reload_active_model`
   (dispatches `Command::ReloadActiveModel`).
@@ -542,8 +589,13 @@ Five clusters account for most of the findings:
 - **Fix:** add a `reload.md` sibling (or a section in `active_model.md`) documenting scope,
   semantics, success response, and the recording/switch conflict errors; or remove the route
   if it isn't part of the external contract.
+- **Resolved (branch `refactor/audit2-tier2`):** added
+  `docs/protocol/endpoints/v1/active_model/reload.md` (sibling of `cancel.md`) documenting the
+  `settings` scope, the synchronous re-instantiate semantics, both 200 shapes (reloaded /
+  nothing-loaded), the `model_switched`+`ready` broadcast, and the errors
+  (401/403/409 `recording_in_progress`/500 reload-failed).
 
-### [ ] 13. 🟠 Tests/CI: subprocess transport orchestration is never compiled or run anywhere in CI
+### [x] 13. 🟠 Tests/CI: subprocess transport orchestration is never compiled or run anywhere in CI
 
 - **Where:** `super-stt-daemon/tests/subprocess_mock.rs` is gated by
   `#![cfg(all(feature="subprocess-backends", feature="test-fixtures"))]` **and** an
@@ -558,6 +610,12 @@ Five clusters account for most of the findings:
   step that compiles it (`cargo test --features test-fixtures --no-run --test subprocess_mock`
   or `just check --all-targets --all-features`); document that runtime coverage is
   systemd-gated.
+- **Resolved (branch `refactor/audit2-tier2`):** `just check-features` (run by `just ci` and
+  the GitHub CI Clippy job) now compiles the subprocess mock + its `mock_backend` fixture with
+  `cargo test --features test-fixtures --no-run --test subprocess_mock` under `-D warnings`, so
+  a `SubprocessBackend` refactor can no longer bit-rot undetected. A comment records that
+  *running* it is still systemd-gated (`SUPER_STT_TEST_SUBPROCESS=1`), which hosted runners
+  lack — so it can't run hermetically like the WASM mock.
 
 ---
 

--- a/docs/protocol/endpoints/v1/active_device.md
+++ b/docs/protocol/endpoints/v1/active_device.md
@@ -30,9 +30,9 @@ Content-Type: application/json
 }
 ```
 
-| Field    | Type   | Required | Notes                              |
-|----------|--------|----------|------------------------------------|
-| `device` | string | yes      | One of `"cpu"`, `"cuda"`, `"metal"` |
+| Field    | Type   | Required | Notes                        |
+|----------|--------|----------|------------------------------|
+| `device` | string | yes      | One of `"cpu"`, `"cuda"`     |
 
 **Response (200):**
 
@@ -61,14 +61,20 @@ but the load fell back). When no model is loaded the response
 returns synchronously and no `ready` event is emitted — the
 preference takes effect on the next model load.
 
-**Errors:**
+**Errors:** the device-validation failure carries its machine-readable
+identifier in `error_code` (see [transport.md](../../transport.md)); the standard
+auth failures carry theirs in `message`, as elsewhere.
 
-| HTTP | `message`             | Meaning                                                       |
-|------|-----------------------|---------------------------------------------------------------|
-| 400  | `cuda_unavailable`    | `device: "cuda"` requested on a host with no CUDA support      |
-| 400  | `invalid_device`      | `device` wasn't one of `cpu`, `cuda`, `metal`                  |
-| 401  | `invalid_session`     | Token unknown / expired / `exe_changed`                        |
-| 403  | `scope_denied`        | Token lacks the `settings` scope                               |
+| HTTP | Identifier        | Carried in   | Meaning                                 |
+|------|-------------------|--------------|-----------------------------------------|
+| 400  | `invalid_device`  | `error_code` | `device` wasn't one of `cpu`, `cuda`    |
+| 401  | `invalid_session` | `message`    | Token unknown / expired / `exe_changed` |
+| 403  | `scope_denied`    | `message`    | Token lacks the `settings` scope        |
+
+Requesting `device: "cuda"` on a host without CUDA is **not** an error — the
+daemon accepts it and silently falls back to CPU (surfaced by the resolved
+`actual_device` in the `ready` event and the next `GET /active_device`). It does
+not emit `cuda_unavailable`.
 
 ## `GET /active_device`
 

--- a/docs/protocol/endpoints/v1/active_model/reload.md
+++ b/docs/protocol/endpoints/v1/active_model/reload.md
@@ -1,0 +1,71 @@
+# `POST /active_model/reload`
+
+Re-instantiate the currently-loaded model **in place** (same identity) so a
+changed backend secret or option takes effect without picking a different model.
+It is a no-op when no model is loaded, and is rejected while a daemon-mic
+recording is active. A real-time (WebSocket) session holds the `model` read lock,
+so a reload requested during one serializes behind it rather than being rejected.
+
+Unlike [`POST /active_model`](../active_model.md#post-active_model) (which starts
+a possibly-long switch and returns `202`), reload is **synchronous** — the
+response is sent after the model has been re-instantiated.
+
+The active model state itself is read and written via
+[`/active_model`](../active_model.md).
+
+## Auth
+
+- **Required scope:** `settings`.
+- `Authorization: Bearer <session_token>` is required.
+- Tokens without the `settings` scope get `403 scope_denied`.
+
+## `POST /active_model/reload`
+
+**Request:**
+
+```http
+POST /active_model/reload HTTP/1.1
+Host: stt.local
+Authorization: Bearer stt_…64hex…
+```
+
+No request body.
+
+**Response (200) — reloaded:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status":  "success",
+  "message": "Successfully switched to model: whisper-tiny"
+}
+```
+
+On success the daemon re-instantiates the same `(model, provider, source)` on the
+current device preference and broadcasts `model_switched` then `ready` on
+[`/events?topics=daemon_status_changed`](../events.md) — identical to a completed
+switch, so subscribers converge on the same state.
+
+**Response (200) — nothing loaded:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status":  "success",
+  "message": "No active model to reload"
+}
+```
+
+**Errors:** `recording_in_progress` carries its identifier in `error_code`; the
+auth failures carry theirs in `message`, and the 500 is uncoded.
+
+| HTTP | Identifier              | Carried in   | Meaning                                              |
+|------|-------------------------|--------------|------------------------------------------------------|
+| 401  | `invalid_session`       | `message`    | Token unknown / expired / `exe_changed`              |
+| 403  | `scope_denied`          | `message`    | Token lacks the `settings` scope                     |
+| 409  | `recording_in_progress` | `error_code` | A daemon-mic recording is active — stop it and retry |
+| 500  | *(uncoded)*             | `message`    | Re-instantiation failed (`Model reload failed: …`); the previous model is unloaded |

--- a/docs/protocol/scopes/daemon_status.md
+++ b/docs/protocol/scopes/daemon_status.md
@@ -17,9 +17,31 @@ Settings UI also shows. Scopes are composable — see [auth.md](../auth.md).
 
 | Topic                   | Carries                                                                                                                                                                          |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `daemon_status_changed` | Heterogeneous; the `status` field discriminates (`loading_model`, `ready`, `model_switched`, `switching_device`, `device_switch_error`, …). Always includes `timestamp`.         |
+| `daemon_status_changed` | A discriminated union keyed on `status` (schema per variant [below](#daemon_status_changed-variants)). Every event also carries `timestamp` (RFC 3339).                          |
 | `download_progress`     | Per-file model-download tick — `{ model_name, current_file, file_index, total_files, percentage, status, eta_seconds, timestamp, error?, … }`. `error` carries the failure detail on the terminal `status` = `"error"` tick (omitted otherwise).                                            |
 | `registry_install`      | Backend-registry install / refresh progress — a serialized registry event (`install.progress` / `install.completed` / `install.failed` / `refresh.completed` / `refresh.failed`). |
+
+### `daemon_status_changed` variants
+
+Each event is a JSON object whose `status` field selects the variant. Every
+event also carries a `timestamp` (RFC 3339 string). Clients switch on `status`
+and read only the fields for that variant; unknown variants should be ignored.
+
+| `status`                   | Fields (besides `status` + `timestamp`)                                                     |
+|----------------------------|---------------------------------------------------------------------------------------------|
+| `loading_model`            | `new_model` (string)                                                                        |
+| `loading_model_for_device` | `model` (string), `target_device` (string)                                                  |
+| `model_switched`           | `model_name` (string), `provider` (string), `source` (string), `actual_device` (string)     |
+| `ready`                    | `model_loaded` (bool); optional `model_name`, `actual_device`, `preferred_device` (strings)  |
+| `switching_device`         | `from_device` (string), `target_device` (string), `model` (string)                          |
+| `device_switch_error`      | `error` (string), `failed_device` (string), `model` (string)                                |
+| `active_backend_changed`   | `source` (string, or `null` when the active backend was cleared)                            |
+| `settings_changed`         | `setting` (string — the name of what changed, e.g. `"language"`)                            |
+
+The destination device is named `target_device` on both `loading_model_for_device`
+and `switching_device` (previously `switching_device` used `to_device`). The
+daemon builds these from a single typed `DaemonStatusEvent` enum, so producer and
+consumer keys cannot drift.
 
 Full payload semantics and the SSE framing rules live on
 [`/events`](../endpoints/v1/events.md). A subscription that requests a topic

--- a/justfile
+++ b/justfile
@@ -101,6 +101,12 @@ check-features:
     RUSTFLAGS="-D warnings" cargo check -p super-stt-daemon --no-default-features --features subprocess-backends
     RUSTFLAGS="-D warnings" cargo check -p super-stt-daemon --no-default-features --features wasm-backends
     RUSTFLAGS="-D warnings" cargo check -p super-stt-daemon --no-default-features
+    # Compile (don't run) the subprocess transport integration test + its
+    # mock_backend fixture so a refactor breaking SubprocessBackend can't pass CI
+    # green. Running it needs a systemd --user session (SUPER_STT_TEST_SUBPROCESS=1)
+    # that hosted runners lack — unlike the WASM mock it can't run hermetically —
+    # but compiling it keeps it from bit-rotting (audit 2 Tier 2 #13).
+    RUSTFLAGS="-D warnings" cargo test -p super-stt-daemon --features test-fixtures --no-run --test subprocess_mock
 
 # Check formatting without modifying files
 fmt-check:

--- a/super-stt-app/src/core/app/handlers/daemon/events.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/events.rs
@@ -4,7 +4,7 @@ use crate::core::app::{AppModel, DeviceState, ModelOperationState};
 use crate::ui::messages::{DaemonMessage, DeviceMessage, DownloadMessage, Message};
 use cosmic::prelude::*;
 use log::{debug, info, warn};
-use super_stt_shared::models::protocol::NotificationEvent;
+use super_stt_shared::models::protocol::{DaemonStatusEvent, NotificationEvent};
 use super_stt_shared::models::provider::Provider;
 
 impl AppModel {
@@ -51,47 +51,64 @@ impl AppModel {
         event: &NotificationEvent,
     ) -> Option<Task<cosmic::Action<Message>>> {
         info!("Received daemon event: {:?}", event.data);
-        let status = event.data.get("status").and_then(|s| s.as_str())?;
-        match status {
-            "ready" => self.handle_daemon_ready_event(event),
-            "device_switch_error" | "error" => self.handle_daemon_device_error_event(event),
-            "model_switched" => self.handle_daemon_model_switched_event(event),
-            "switching_device" => {
-                info!("Received switching_device event: {:?}", event.data);
-                // Keep device_state as Switching and wait for "ready" event
-                // This event just confirms the switch is in progress
+        // Typed deserialize replaces the former hand-matched `.get("status")` /
+        // `.get("<field>")` reads: a field rename/typo is now a compile error, not
+        // a silent no-op (audit 2 Tier 2 #9). The injected `timestamp` key is
+        // ignored; an unrecognized or malformed event yields `None`.
+        let event = match serde_json::from_value::<DaemonStatusEvent>(event.data.clone()) {
+            Ok(ev) => ev,
+            Err(e) => {
+                info!("Unhandled/unparseable daemon status event: {e}");
+                return None;
+            }
+        };
+        match event {
+            DaemonStatusEvent::Ready {
+                model_loaded,
+                actual_device,
+                ..
+            } => {
+                self.handle_daemon_ready(actual_device.as_deref(), model_loaded);
+                None
+            }
+            DaemonStatusEvent::DeviceSwitchError { error, .. } => {
+                Some(self.handle_daemon_device_error(&error))
+            }
+            DaemonStatusEvent::ModelSwitched {
+                model_name,
+                provider,
+                source,
+                ..
+            } => Some(self.handle_daemon_model_switched(&model_name, &provider, &source)),
+            DaemonStatusEvent::SwitchingDevice { target_device, .. } => {
+                info!("Received switching_device event -> {target_device}");
+                // Keep device_state as Switching and wait for the `ready` event;
+                // this event just confirms the switch is in progress.
                 if !matches!(self.device_state, DeviceState::Switching { .. }) {
                     warn!("Received switching_device event but not in switching state");
-                    if let Some(to_device) = event.data.get("to_device").and_then(|d| d.as_str()) {
-                        self.set_device_switching(
-                            to_device.to_string(),
-                            "Switching device...".to_string(),
-                        );
-                    }
+                    self.set_device_switching(target_device, "Switching device...".to_string());
                 }
                 None
             }
-            "loading_model_for_device" => {
-                info!("Received loading_model_for_device event: {:?}", event.data);
-                if let (Some(target_device), Some(model)) = (
-                    event.data.get("target_device").and_then(|d| d.as_str()),
-                    event.data.get("model").and_then(|m| m.as_str()),
-                ) {
-                    let status_message = format!(
-                        "Loading {} on {}...",
-                        model,
-                        if target_device == "cpu" { "CPU" } else { "GPU" }
-                    );
-                    self.set_device_switching(target_device.to_string(), status_message);
-                }
+            DaemonStatusEvent::LoadingModelForDevice {
+                model,
+                target_device,
+            } => {
+                info!("Received loading_model_for_device event: {model} on {target_device}");
+                let status_message = format!(
+                    "Loading {} on {}...",
+                    model,
+                    if target_device == "cpu" { "CPU" } else { "GPU" }
+                );
+                self.set_device_switching(target_device, status_message);
                 None
             }
-            "settings_changed" => {
-                // A setting changed — possibly from another client, or the
-                // global Primary Language this very client just set. Re-fetch
-                // the language state so a per-model button that follows the
-                // global value, and the global card, reflect the new value.
-                if event.data.get("setting").and_then(|s| s.as_str()) != Some("language") {
+            DaemonStatusEvent::SettingsChanged { setting } => {
+                // A setting changed — possibly from another client, or the global
+                // Primary Language this very client just set. Re-fetch the language
+                // state so a per-model button that follows the global value, and
+                // the global card, reflect the new value.
+                if setting != "language" {
                     return None;
                 }
                 let mut tasks = vec![self.load_primary_language()];
@@ -100,19 +117,21 @@ impl AppModel {
                 }
                 Some(Task::batch(tasks))
             }
-            _ => {
-                info!("Received unhandled daemon status: {status}");
-                None
-            }
+            // No app-side effect today (matches the prior `_` fall-through): the
+            // load-start and active-backend-changed notifications don't drive UI
+            // state here.
+            DaemonStatusEvent::LoadingModel { .. }
+            | DaemonStatusEvent::ActiveBackendChanged { .. } => None,
         }
     }
 
-    pub(in crate::core::app) fn handle_daemon_ready_event(
+    pub(in crate::core::app) fn handle_daemon_ready(
         &mut self,
-        event: &NotificationEvent,
-    ) -> Option<Task<cosmic::Action<Message>>> {
+        actual_device: Option<&str>,
+        model_loaded: bool,
+    ) {
         // Handle device readiness
-        if let Some(actual_device) = event.data.get("actual_device").and_then(|d| d.as_str()) {
+        if let Some(actual_device) = actual_device {
             info!(
                 "Received ready event: current_device={} -> {}",
                 self.current_device, actual_device
@@ -127,12 +146,7 @@ impl AppModel {
         }
 
         // Handle model readiness - clear switching state
-        if event
-            .data
-            .get("model_loaded")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false)
-        {
+        if model_loaded {
             info!("Received ready event: model loading completed");
             info!(
                 "Model state before ready event: {:?}",
@@ -144,69 +158,57 @@ impl AppModel {
                 self.model_operation_state
             );
         }
-        None
     }
 
-    pub(in crate::core::app) fn handle_daemon_device_error_event(
+    pub(in crate::core::app) fn handle_daemon_device_error(
         &mut self,
-        event: &NotificationEvent,
-    ) -> Option<Task<cosmic::Action<Message>>> {
-        warn!("Received device switch error event: {:?}", event.data);
+        error: &str,
+    ) -> Task<cosmic::Action<Message>> {
+        warn!("Received device switch error event: {error}");
         // Reset device state from switching to ready
         if matches!(self.device_state, DeviceState::Switching { .. }) {
             info!("Device switch failed, reverting to ready state");
         }
         self.device_state = DeviceState::Ready;
-        if let Some(error_msg) = event.data.get("error").and_then(|e| e.as_str()) {
-            let error_message = error_msg.to_string();
-            // Show error to user
-            return Some(Task::perform(async move { error_message }, |msg| {
-                cosmic::Action::App(Message::Device(DeviceMessage::DeviceError(msg)))
-            }));
-        }
-        None
+        let error_message = error.to_string();
+        // Show error to user
+        Task::perform(async move { error_message }, |msg| {
+            cosmic::Action::App(Message::Device(DeviceMessage::DeviceError(msg)))
+        })
     }
 
-    pub(in crate::core::app) fn handle_daemon_model_switched_event(
+    pub(in crate::core::app) fn handle_daemon_model_switched(
         &mut self,
-        event: &NotificationEvent,
-    ) -> Option<Task<cosmic::Action<Message>>> {
-        if let Some(model_name) = event.data.get("model_name").and_then(|m| m.as_str()) {
-            let model = model_name.to_string();
-            let provider = event
-                .data
-                .get("provider")
-                .and_then(|p| p.as_str())
-                .and_then(|s| s.parse::<Provider>().ok())
-                .unwrap_or_else(|| self.current_provider.clone());
-            let source = event
-                .data
-                .get("source")
-                .and_then(|p| p.as_str())
-                .map_or_else(|| self.current_source.clone(), str::to_string);
-            info!(
-                "Received model_switched event: current_model={:?} -> {:?} via {provider} ({source})",
-                self.current_model, model
-            );
-            // A live identity change supersedes any in-flight reconnect
-            // snapshot: bump the epoch so a stale get_current_model response
-            // can't revert this.
-            self.current_model_epoch = self.current_model_epoch.wrapping_add(1);
-            self.current_model.clone_from(&model);
-            self.current_provider = provider;
-            self.current_source.clone_from(&source);
-            self.model_operation_state = ModelOperationState::Ready;
-            info!("Model state updated to Ready after model_switched event");
-            // Mirror CurrentModelLoaded/ModelChanged: fetch the per-model
-            // language block so the active-backend card's language button shows
-            // the model's resolved language instead of the neutral "Language"
-            // label. A client that learns the active model only via this
-            // broadcast — e.g. the settings app reconnecting after a daemon
-            // restart, where the startup load now emits model_switched — would
-            // otherwise leave model_language_for unset.
-            return Some(self.load_model_language(source, model));
-        }
-        None
+        model_name: &str,
+        provider: &str,
+        source: &str,
+    ) -> Task<cosmic::Action<Message>> {
+        let model = model_name.to_string();
+        // The wire carries the provider's `Display` form; fall back to the current
+        // provider if it doesn't parse (forward-compat with an unknown provider).
+        let provider = provider
+            .parse::<Provider>()
+            .unwrap_or_else(|_| self.current_provider.clone());
+        let source = source.to_string();
+        info!(
+            "Received model_switched event: current_model={:?} -> {:?} via {provider} ({source})",
+            self.current_model, model
+        );
+        // A live identity change supersedes any in-flight reconnect snapshot: bump
+        // the epoch so a stale get_current_model response can't revert this.
+        self.current_model_epoch = self.current_model_epoch.wrapping_add(1);
+        self.current_model.clone_from(&model);
+        self.current_provider = provider;
+        self.current_source.clone_from(&source);
+        self.model_operation_state = ModelOperationState::Ready;
+        info!("Model state updated to Ready after model_switched event");
+        // Mirror CurrentModelLoaded/ModelChanged: fetch the per-model language
+        // block so the active-backend card's language button shows the model's
+        // resolved language instead of the neutral "Language" label. A client that
+        // learns the active model only via this broadcast — e.g. the settings app
+        // reconnecting after a daemon restart, where the startup load now emits
+        // model_switched — would otherwise leave model_language_for unset.
+        self.load_model_language(source, model)
     }
 
     pub(in crate::core::app) fn process_download_progress_event(

--- a/super-stt-daemon/src/daemon/device_management.rs
+++ b/super-stt-daemon/src/daemon/device_management.rs
@@ -2,9 +2,8 @@
 
 use crate::daemon::types::SuperSTTDaemon;
 use crate::stt_models::transcribe::Transcribe;
-use chrono::Utc;
 use log::{error, info, warn};
-use super_stt_shared::models::protocol::DaemonResponse;
+use super_stt_shared::models::protocol::{DaemonResponse, DaemonStatusEvent, ErrorCode};
 
 impl SuperSTTDaemon {
     /// Handle set device command - switch between CPU and CUDA
@@ -127,12 +126,15 @@ impl SuperSTTDaemon {
 
     /// Validate device switch request and return early response if validation fails
     async fn validate_device_switch_request(&self, device: &str) -> Option<DaemonResponse> {
-        // Validate device parameter
+        // Validate device parameter. Emit the documented `400 invalid_device`
+        // code so clients can distinguish a bad request from a server failure
+        // (an uncoded error maps to 500) — audit 2 Tier 2 #7.
         if device != "cpu" && device != "cuda" {
             warn!("Invalid device specified: {device}");
-            return Some(DaemonResponse::error(&format!(
-                "Invalid device '{device}'. Must be 'cpu' or 'cuda'"
-            )));
+            return Some(DaemonResponse::error_with_code(
+                ErrorCode::InvalidDevice,
+                &format!("Invalid device '{device}'. Must be 'cpu' or 'cuda'"),
+            ));
         }
 
         // Check current preferred and actual devices
@@ -205,13 +207,11 @@ impl SuperSTTDaemon {
     async fn prepare_device_switch(&self, from_device: &str, to_device: &str, model: &str) {
         // Broadcast device switching status to settings subscribers
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "switching_device",
-                "from_device": from_device,
-                "to_device": to_device,
-                "model": model,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::SwitchingDevice {
+                from_device: from_device.to_string(),
+                target_device: to_device.to_string(),
+                model: model.to_string(),
+            });
 
         // Unload current model (free memory). Route through the shared graceful
         // path so the backend is `shutdown()` outside the write lock rather than
@@ -277,15 +277,12 @@ impl SuperSTTDaemon {
         info!("Device switch completed: {previous_device} -> {device} (actual: {actual_device})");
 
         // Broadcast ready status with new device
-        self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "ready",
-                "model_loaded": true,
-                "preferred_device": device,
-                "actual_device": actual_device,
-                "model_name": model_to_reload,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+        self.events.publish_daemon_status(DaemonStatusEvent::Ready {
+            model_loaded: true,
+            model_name: Some(model_to_reload.to_string()),
+            actual_device: Some(actual_device.clone()),
+            preferred_device: Some(device.to_string()),
+        });
 
         DaemonResponse::success()
             .with_device(actual_device)
@@ -306,13 +303,11 @@ impl SuperSTTDaemon {
 
         // Broadcast error status
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "device_switch_error",
-                "error": error.to_string(),
-                "failed_device": device,
-                "model": model_to_reload,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::DeviceSwitchError {
+                error: error.to_string(),
+                failed_device: device.to_string(),
+                model: model_to_reload.to_string(),
+            });
 
         // Check if shutdown is in progress before attempting recovery
         let mut shutdown_rx = self.shutdown_tx.subscribe();
@@ -368,15 +363,12 @@ impl SuperSTTDaemon {
                 );
 
                 // Broadcast ready status after successful recovery
-                self.events
-                    .publish_daemon_status_changed(serde_json::json!({
-                        "status": "ready",
-                        "model_loaded": true,
-                        "preferred_device": previous_device,
-                        "actual_device": recovery_actual_device,
-                        "model_name": model_to_reload,
-                        "timestamp": Utc::now().to_rfc3339(),
-                    }));
+                self.events.publish_daemon_status(DaemonStatusEvent::Ready {
+                    model_loaded: true,
+                    model_name: Some(model_to_reload.to_string()),
+                    actual_device: Some(recovery_actual_device.clone()),
+                    preferred_device: Some(previous_device.to_string()),
+                });
 
                 DaemonResponse::error(&format!(
                     "Failed to switch to device '{device}': {error}. Reverted to previous device '{recovery_actual_device}'."

--- a/super-stt-daemon/src/daemon/events.rs
+++ b/super-stt-daemon/src/daemon/events.rs
@@ -313,6 +313,24 @@ impl EventBus {
         let _ = self.daemon_status_changed.send(data);
     }
 
+    /// Publish a typed [`DaemonStatusEvent`], injecting the `timestamp` every
+    /// event carries (mirroring [`Self::publish_download_progress`]). Serializing
+    /// the enum is the single construction path, so producers no longer hand-build
+    /// `json!` maps whose keys can silently drift (audit 2 Tier 2 #9).
+    pub fn publish_daemon_status(
+        &self,
+        event: super_stt_shared::models::protocol::DaemonStatusEvent,
+    ) {
+        let mut payload = serde_json::to_value(event).unwrap_or_else(|_| serde_json::json!({}));
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert(
+                "timestamp".into(),
+                serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+            );
+        }
+        self.publish_daemon_status_changed(payload);
+    }
+
     /// Publish a `download_progress` event. Payload is the JSON shape
     /// the legacy `notification_manager.broadcast_event("download_progress",...)`
     /// used — the keys of `DownloadProgress` plus a `timestamp`. Requires

--- a/super-stt-daemon/src/daemon/http/v1/backends/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/mod.rs
@@ -24,12 +24,22 @@ pub(crate) async fn find_backend(s: &AppState, source: &str) -> Option<Discovere
         .cloned()
 }
 
-/// House-style JSON error envelope at a given status.
-pub(crate) fn json_error(code: StatusCode, message: &str) -> Response {
+/// House-style JSON error envelope at a given status. `error_code` is the stable
+/// machine-readable `snake_case` identifier clients switch on (per `transport.md`,
+/// "present on every error"); it is also mirrored into `message` since these
+/// backend endpoints carry no separate human-readable text (audit 2 Tier 2 #6).
+pub(crate) fn json_error(code: StatusCode, error_code: &str) -> Response {
+    json_error_msg(code, error_code, error_code)
+}
+
+/// [`json_error`] with a distinct human-readable `message` (the machine
+/// identifier still rides in `error_code`).
+pub(crate) fn json_error_msg(code: StatusCode, error_code: &str, message: &str) -> Response {
     (
         code,
         [("content-type", "application/json")],
-        serde_json::json!({ "status": "error", "message": message }).to_string(),
+        serde_json::json!({ "status": "error", "error_code": error_code, "message": message })
+            .to_string(),
     )
         .into_response()
 }

--- a/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use super::{decode_source, find_backend, json_error, ok};
+use super::{decode_source, find_backend, json_error, json_error_msg, ok};
 use crate::daemon::http::state::AppState;
 use axum::Router;
 use axum::extract::{Path, State};
@@ -127,9 +127,10 @@ fn secret_result(
     if resp.status == "success" {
         ok(&serde_json::json!({ "status": "success", "configured": configured }))
     } else {
-        json_error(
+        json_error_msg(
             StatusCode::SERVICE_UNAVAILABLE,
-            resp.message.as_deref().unwrap_or("keyring_unavailable"),
+            "keyring_unavailable",
+            resp.message.as_deref().unwrap_or("keyring is unavailable"),
         )
     }
 }

--- a/super-stt-daemon/src/daemon/http/v1/registry/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/mod.rs
@@ -11,29 +11,35 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 
-/// Registry error envelope: `{ "error": <code> }` at `status`.
+/// Registry error envelope: `{ "status": "error", "error_code": <code>, "error": <code> }`
+/// at `status`.
 ///
-/// The registry endpoints deliberately use a stable, machine-readable `error`
-/// code (see the failure-mode tables in
-/// `docs/protocol/endpoints/v1/registry/*.md`) rather than the
-/// `{ "status": "error", "message": … }` house style used elsewhere. This
-/// helper is the single place that shape is built.
+/// The registry endpoints historically used a bare `{ "error": <code> }` shape.
+/// `error_code` (and `status`) are now emitted alongside the retained `error`
+/// key so the whole surface honors `transport.md`'s "`error_code` present on
+/// every error" contract without breaking clients that read `error` (audit 2
+/// Tier 2 #6). This helper is the single place that shape is built.
 pub(crate) fn registry_error(status: StatusCode, code: &str) -> Response {
     (
         status,
         [("content-type", "application/json")],
-        serde_json::json!({ "error": code }).to_string(),
+        serde_json::json!({ "status": "error", "error_code": code, "error": code }).to_string(),
     )
         .into_response()
 }
 
-/// Registry error envelope with a human-readable `message`:
-/// `{ "error": <code>, "message": <message> }`.
+/// [`registry_error`] with a human-readable `message`.
 pub(crate) fn registry_error_msg(status: StatusCode, code: &str, message: &str) -> Response {
     (
         status,
         [("content-type", "application/json")],
-        serde_json::json!({ "error": code, "message": message }).to_string(),
+        serde_json::json!({
+            "status": "error",
+            "error_code": code,
+            "error": code,
+            "message": message,
+        })
+        .to_string(),
     )
         .into_response()
 }
@@ -51,14 +57,17 @@ mod tests {
         (status, String::from_utf8(bytes.to_vec()).expect("utf8"))
     }
 
-    /// The registry error envelope is the documented `{ "error": <code> }`
-    /// machine-readable shape (see docs/protocol/endpoints/v1/registry/*.md) —
-    /// distinct from the `{ "status": "error", "message": … }` house style.
+    /// The registry error envelope now carries the machine-readable `error_code`
+    /// (and `status`) per transport.md, while retaining the legacy `error` key so
+    /// existing clients keep working (audit 2 Tier 2 #6).
     #[tokio::test]
-    async fn registry_error_uses_documented_envelope() {
+    async fn registry_error_carries_error_code_and_legacy_key() {
         let (status, body) = body_of(registry_error(StatusCode::NOT_FOUND, "not_found")).await;
         assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(body, r#"{"error":"not_found"}"#);
+        let v: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["error_code"], "not_found");
+        assert_eq!(v["error"], "not_found"); // retained for back-compat
 
         let (status, body) = body_of(registry_error_msg(
             StatusCode::BAD_REQUEST,
@@ -67,9 +76,13 @@ mod tests {
         ))
         .await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["error_code"], "bad_request");
+        assert_eq!(v["error"], "bad_request");
         assert_eq!(
-            body,
-            r#"{"error":"bad_request","message":"provide exactly one of source, repo_url, local_path"}"#
+            v["message"],
+            "provide exactly one of source, repo_url, local_path"
         );
     }
 }

--- a/super-stt-daemon/src/daemon/language_handlers.rs
+++ b/super-stt-daemon/src/daemon/language_handlers.rs
@@ -6,12 +6,10 @@
 //! installed model whether or not it is currently loaded. See
 //! `docs/protocol/endpoints/v1/backends/model-language.md`.
 
-use chrono::Utc;
-
 use crate::daemon::language::resolve_language;
 use crate::daemon::types::SuperSTTDaemon;
 use crate::stt_models::ModelDefinition;
-use super_stt_shared::models::protocol::{Command, DaemonResponse, ErrorCode};
+use super_stt_shared::models::protocol::{Command, DaemonResponse, DaemonStatusEvent, ErrorCode};
 
 impl SuperSTTDaemon {
     /// Broadcast that a setting changed so subscribed clients re-resolve any
@@ -20,11 +18,9 @@ impl SuperSTTDaemon {
     /// topic clients already subscribe to; `setting` names what changed.
     fn publish_settings_changed(&self, setting: &str) {
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "settings_changed",
-                "setting": setting,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::SettingsChanged {
+                setting: setting.to_string(),
+            });
     }
 
     pub async fn handle_get_primary_language(&self) -> DaemonResponse {

--- a/super-stt-daemon/src/daemon/model_management/lifecycle.rs
+++ b/super-stt-daemon/src/daemon/model_management/lifecycle.rs
@@ -2,9 +2,8 @@
 use crate::daemon::types::{SuperSTTDaemon, normalize_device};
 use crate::stt_models::transcribe::Transcribe;
 use anyhow::Result;
-use chrono::Utc;
 use log::{error, info, warn};
-use super_stt_shared::models::protocol::DaemonResponse;
+use super_stt_shared::models::protocol::{DaemonResponse, DaemonStatusEvent};
 use super_stt_shared::models::provider::Provider;
 
 impl SuperSTTDaemon {
@@ -70,22 +69,18 @@ impl SuperSTTDaemon {
 
     pub fn broadcast_model_loading_status(&self, model: &str) {
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "loading_model",
-                "new_model": model,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::LoadingModel {
+                new_model: model.to_string(),
+            });
     }
 
     /// Broadcast model loading status specifically for device switching.
     pub fn broadcast_device_model_loading_status(&self, model: &str, target_device: &str) {
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "loading_model_for_device",
-                "model": model,
-                "target_device": target_device,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::LoadingModelForDevice {
+                model: model.to_string(),
+                target_device: target_device.to_string(),
+            });
     }
 
     /// Announce that `model` is now the active, loaded model. Emits the
@@ -104,24 +99,19 @@ impl SuperSTTDaemon {
         source: &str,
         actual_device: &str,
     ) {
-        let timestamp = Utc::now().to_rfc3339();
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "model_switched",
-                "model_name": name,
-                "provider": provider.to_string(),
-                "source": source,
-                "actual_device": actual_device,
-                "timestamp": timestamp,
-            }));
-        self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "ready",
-                "model_loaded": true,
-                "model_name": name,
-                "actual_device": actual_device,
-                "timestamp": timestamp,
-            }));
+            .publish_daemon_status(DaemonStatusEvent::ModelSwitched {
+                model_name: name.to_string(),
+                provider: provider.to_string(),
+                source: source.to_string(),
+                actual_device: actual_device.to_string(),
+            });
+        self.events.publish_daemon_status(DaemonStatusEvent::Ready {
+            model_loaded: true,
+            model_name: Some(name.to_string()),
+            actual_device: Some(actual_device.to_string()),
+            preferred_device: None,
+        });
     }
 
     // `pub(in crate::daemon)` so the device-switch paths (a sibling module)
@@ -204,12 +194,12 @@ impl SuperSTTDaemon {
         if let Err(e) = self.persist_config().await {
             warn!("Failed to persist config after unloading model: {e}");
         }
-        self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "ready",
-                "model_loaded": false,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+        self.events.publish_daemon_status(DaemonStatusEvent::Ready {
+            model_loaded: false,
+            model_name: None,
+            actual_device: None,
+            preferred_device: None,
+        });
         let msg = dropped.map_or_else(|| "Model unloaded".to_string(), |n| format!("Unloaded {n}"));
         info!("{msg}");
         DaemonResponse::success().with_message(msg)

--- a/super-stt-daemon/src/daemon/model_management/switch.rs
+++ b/super-stt-daemon/src/daemon/model_management/switch.rs
@@ -3,9 +3,8 @@ use crate::daemon::types::SuperSTTDaemon;
 use crate::stt_models::ModelDefinition;
 use crate::stt_models::backends;
 use crate::stt_models::transcribe::Transcribe;
-use chrono::Utc;
 use log::{error, info, warn};
-use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
+use super_stt_shared::models::protocol::{DaemonResponse, DaemonStatusEvent, ErrorCode};
 use super_stt_shared::models::provider::Provider;
 
 impl SuperSTTDaemon {
@@ -113,11 +112,9 @@ impl SuperSTTDaemon {
             warn!("Failed to persist config after active-backend set: {e}");
         }
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "active_backend_changed",
-                "source": source,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::ActiveBackendChanged {
+                source: Some(source.clone()),
+            });
         info!("Active backend set to {source}");
 
         let payload = self
@@ -151,11 +148,7 @@ impl SuperSTTDaemon {
             warn!("Failed to persist config after active-backend clear: {e}");
         }
         self.events
-            .publish_daemon_status_changed(serde_json::json!({
-                "status": "active_backend_changed",
-                "source": serde_json::Value::Null,
-                "timestamp": Utc::now().to_rfc3339(),
-            }));
+            .publish_daemon_status(DaemonStatusEvent::ActiveBackendChanged { source: None });
         info!("Active backend cleared (daemon idle)");
         DaemonResponse::success().with_message("Active backend cleared".to_string())
     }

--- a/super-stt-daemon/src/registry/custom_repo.rs
+++ b/super-stt-daemon/src/registry/custom_repo.rs
@@ -12,14 +12,13 @@
 //! `docs/protocol/endpoints/v1/registry/install.md`) reflects this.
 
 use super_stt_registry_types::manifest::{Kind, Manifest, ManifestError};
+use super_stt_registry_types::verify::MAX_MANIFEST_BYTES;
 use thiserror::Error;
 
 use crate::registry::index_schema::{
     IndexAsset, IndexAssets, IndexBackend, IndexSubprocessAsset, id_from_source,
 };
 use super_stt_forge::{ForgeClient, ReleaseAsset, RepoRef};
-
-const MAX_MANIFEST_BYTES: usize = 256 * 1024;
 
 #[derive(Debug, Error)]
 pub enum ResolveError {
@@ -70,7 +69,7 @@ pub async fn resolve(
         .iter()
         .find(|a| a.name == "backend.toml")
         .ok_or_else(|| ResolveError::AssetMissing("backend.toml".into()))?;
-    if manifest_asset.size > MAX_MANIFEST_BYTES as u64 {
+    if manifest_asset.size > MAX_MANIFEST_BYTES {
         return Err(ResolveError::ManifestTooLarge);
     }
     let manifest_url = manifest_asset.download_url.clone();
@@ -79,7 +78,7 @@ pub async fn resolve(
     // real cap during the transfer: `download` streams and aborts the moment the
     // body would exceed it, rather than buffering an unbounded body first.
     let manifest_bytes = client
-        .download(&manifest_url, MAX_MANIFEST_BYTES as u64)
+        .download(&manifest_url, MAX_MANIFEST_BYTES)
         .await
         .map_err(|e| match e {
             super_stt_forge::ForgeError::TooLarge { .. } => ResolveError::ManifestTooLarge,

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -15,15 +15,12 @@ use crate::download_stream::{StreamError, stream_body_to_writer};
 use crate::registry::compat::Selection;
 use crate::registry::index_schema::{IndexAsset, IndexBackend};
 use super_stt_registry_types::verify::{
-    sha256_matches, tar_budget_step, tar_entry_unsafe_reason, unpack_cap,
+    MAX_MANIFEST_BYTES, sha256_matches, tar_budget_step, tar_entry_unsafe_reason, unpack_cap,
 };
 
 /// Absolute ceiling on a single downloaded asset when its size is not declared
 /// in the index. Declared sizes are honored directly (plus a small margin).
 const MAX_DOWNLOAD_BYTES: u64 = 4 * 1024 * 1024 * 1024;
-/// Ceiling for the `backend.toml` manifest asset — manifests are tiny; this
-/// only bounds a hostile or mistaken upload.
-const MAX_MANIFEST_BYTES: u64 = 256 * 1024;
 /// Slack allowed over a declared asset size before a download is rejected.
 const DOWNLOAD_SIZE_MARGIN: u64 = 1024 * 1024;
 /// The byte ceiling for a download given the index-declared `expected_size`
@@ -581,7 +578,12 @@ fn verify_manifest_bytes(
     let text = std::str::from_utf8(bytes)
         .map_err(|_| reject("not valid UTF-8"))?
         .to_string();
-    let m: Manifest = toml::from_str(&text).map_err(|e| reject(&format!("parse: {e}")))?;
+    // `Manifest::parse` (not raw `toml::from_str`) so install-time verification
+    // shares the canonical parser's safety guards — entrypoint + per-file
+    // `destination` traversal rejection and the `file`-xor-`parts` / empty-`file`
+    // normalization — instead of hand-reimplementing only a subset here. A future
+    // guard added to `parse` then applies here automatically (audit 2 Tier 2 #11).
+    let m = Manifest::parse(&text).map_err(|e| reject(&format!("parse: {e}")))?;
     validate_runtime(&m).map_err(|e| reject(&format!("validation: {e}")))?;
     if m.backend.source != entry.source {
         return Err(reject(&format!(
@@ -589,10 +591,10 @@ fn verify_manifest_bytes(
             m.backend.source, entry.source
         )));
     }
-    if m.backend.entrypoint != entry.entrypoint
-        || !super_stt_shared::registry::is_safe_relative_path(&m.backend.entrypoint)
-    {
-        return Err(reject("entrypoint inconsistent or unsafe"));
+    // Index-consistency check only — the entrypoint's path safety is already
+    // enforced by `Manifest::parse` above.
+    if m.backend.entrypoint != entry.entrypoint {
+        return Err(reject("entrypoint inconsistent with index"));
     }
     Ok(text)
 }

--- a/super-stt-indexer/src/assets.rs
+++ b/super-stt-indexer/src/assets.rs
@@ -10,16 +10,15 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use ring::digest::{Context, SHA256};
-use super_stt_registry_types::verify::{tar_budget_step, tar_entry_unsafe_reason, unpack_cap};
+use super_stt_registry_types::verify::{
+    MAX_MANIFEST_BYTES, tar_budget_step, tar_entry_unsafe_reason, unpack_cap,
+};
 use thiserror::Error;
 
 /// Ceiling for a single release asset — a `file` or one part of a multi-part
 /// archive. Matches GitHub's 2 GiB per-asset release limit; a larger archive
 /// must be split into `parts`.
 pub const MAX_ASSET_BYTES: u64 = 2 * 1024 * 1024 * 1024;
-/// Ceiling for a `backend.toml` manifest asset — manifests are tiny; this only
-/// bounds a hostile or mistaken upload.
-pub const MAX_MANIFEST_BYTES: u64 = 256 * 1024;
 const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6d];
 
 #[derive(Debug, Error)]

--- a/super-stt-registry-types/src/verify.rs
+++ b/super-stt-registry-types/src/verify.rs
@@ -16,6 +16,12 @@ pub const MAX_TARBALL_TOTAL_FLOOR: u64 = 4 * 1024 * 1024 * 1024;
 /// ML libraries stays far below this; a zip-bomb is far above it.
 pub const MAX_DECOMP_RATIO: u64 = 5;
 
+/// Ceiling for a `backend.toml` manifest asset — manifests are tiny; this only
+/// bounds a hostile or mistaken upload. Enforced identically at publish (the
+/// indexer), install-time download, and custom-repo resolve, so a manifest that
+/// passes publishing also installs (mirrors the tarball budgets above).
+pub const MAX_MANIFEST_BYTES: u64 = 256 * 1024;
+
 /// The uncompressed-output ceiling for an archive of `archive_size` compressed
 /// bytes: scales with the input but never drops below the floor.
 #[must_use]

--- a/super-stt-shared/src/models/protocol/daemon_status.rs
+++ b/super-stt-shared/src/models/protocol/daemon_status.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Typed model of the `daemon_status_changed` SSE event (scope `daemon_status`).
+//!
+//! Historically this was a hand-built `serde_json::json!` on the daemon side and
+//! a hand-matched `.get("status")` / `.get("<field>")` read on the app side with
+//! no shared schema — so a field rename or a client typo was a silent runtime
+//! degradation with no compile/test signal (the keys had already drifted:
+//! `to_device` vs `target_device`). This enum is the single typed source of
+//! truth for the discriminated union — the daemon constructs a variant and
+//! serializes it, the app deserializes it and matches (audit 2 Tier 2 #9).
+//!
+//! Every event also carries a `timestamp` (RFC 3339); it is injected by the
+//! publish path (mirroring [`crate::models::protocol::DownloadProgress`]) and
+//! ignored on deserialize, so it is not modeled as a field here.
+
+use serde::{Deserialize, Serialize};
+
+/// A `daemon_status_changed` event. The wire `status` field is the discriminant;
+/// variant names map to it via `rename_all = "snake_case"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DaemonStatusEvent {
+    /// A model load has begun (name only, no device context).
+    LoadingModel { new_model: String },
+
+    /// A model is loading as part of a device switch.
+    LoadingModelForDevice {
+        model: String,
+        target_device: String,
+    },
+
+    /// A model finished loading and is now the active model.
+    ModelSwitched {
+        model_name: String,
+        /// The provider's `Display` form (e.g. `whisper`), parsed back on the
+        /// app side.
+        provider: String,
+        source: String,
+        actual_device: String,
+    },
+
+    /// The daemon settled into a ready state. `model_loaded` says whether a model
+    /// is loaded; the optional fields are present only on the emitters that have
+    /// them (a device switch carries device context; an unload carries none).
+    Ready {
+        model_loaded: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model_name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        actual_device: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        preferred_device: Option<String>,
+    },
+
+    /// A device switch has begun. `target_device` is the destination — normalized
+    /// from the former `to_device` so it matches [`Self::LoadingModelForDevice`].
+    SwitchingDevice {
+        from_device: String,
+        target_device: String,
+        model: String,
+    },
+
+    /// A device switch failed; the daemon is recovering to the previous device.
+    DeviceSwitchError {
+        error: String,
+        failed_device: String,
+        model: String,
+    },
+
+    /// The active backend changed. `source` is the backend's repo id, or `null`
+    /// when the active backend was cleared.
+    ActiveBackendChanged {
+        #[serde(default)]
+        source: Option<String>,
+    },
+
+    /// A settings value changed (the app refetches the affected block).
+    SettingsChanged { setting: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DaemonStatusEvent;
+
+    /// The wire discriminant is `status`, and variant/field names match the
+    /// hand-built JSON the daemon used to emit.
+    #[test]
+    fn model_switched_wire_shape() {
+        let json = serde_json::to_value(DaemonStatusEvent::ModelSwitched {
+            model_name: "whisper-tiny".into(),
+            provider: "whisper".into(),
+            source: "github.com/super-stt/whisper".into(),
+            actual_device: "cpu".into(),
+        })
+        .unwrap();
+        assert_eq!(json["status"], "model_switched");
+        assert_eq!(json["model_name"], "whisper-tiny");
+        assert_eq!(json["actual_device"], "cpu");
+    }
+
+    /// An extra `timestamp` key (injected by the publish path) is ignored on
+    /// deserialize, and `switching_device` reads back with the normalized
+    /// `target_device` key.
+    #[test]
+    fn deserialize_ignores_timestamp_and_reads_target_device() {
+        let v = serde_json::json!({
+            "status": "switching_device",
+            "from_device": "cpu",
+            "target_device": "cuda",
+            "model": "whisper-tiny",
+            "timestamp": "2026-07-16T00:00:00+00:00",
+        });
+        match serde_json::from_value::<DaemonStatusEvent>(v).unwrap() {
+            DaemonStatusEvent::SwitchingDevice { target_device, .. } => {
+                assert_eq!(target_device, "cuda");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    /// `ready` from an unload carries only `model_loaded`; the optional device
+    /// fields stay absent (not serialized).
+    #[test]
+    fn ready_omits_absent_optionals() {
+        let json = serde_json::to_value(DaemonStatusEvent::Ready {
+            model_loaded: false,
+            model_name: None,
+            actual_device: None,
+            preferred_device: None,
+        })
+        .unwrap();
+        assert_eq!(json["status"], "ready");
+        assert_eq!(json["model_loaded"], false);
+        assert!(json.get("actual_device").is_none());
+    }
+}

--- a/super-stt-shared/src/models/protocol/error_code.rs
+++ b/super-stt-shared/src/models/protocol/error_code.rs
@@ -30,8 +30,12 @@ pub enum ErrorCode {
     InvalidModel,
     /// No installed backend has the named source.
     InvalidBackend,
-    /// A CUDA device was requested but CUDA is unavailable.
+    /// A CUDA device was requested but CUDA is unavailable. Reserved: the daemon
+    /// currently falls back to CPU silently rather than emitting this (see
+    /// `active_device.md`).
     CudaUnavailable,
+    /// The requested `device` wasn't one the daemon accepts (`cpu`/`cuda`).
+    InvalidDevice,
     /// An online model was requested while online models are disabled.
     OnlineModelsDisabled,
     /// An unrecognized audio-theme name.
@@ -63,6 +67,7 @@ impl ErrorCode {
             Self::InvalidModel
             | Self::InvalidBackend
             | Self::CudaUnavailable
+            | Self::InvalidDevice
             | Self::OnlineModelsDisabled
             | Self::InvalidAudioTheme
             | Self::UnsupportedLanguage

--- a/super-stt-shared/src/models/protocol/mod.rs
+++ b/super-stt-shared/src/models/protocol/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 mod command;
+mod daemon_status;
 mod dispatch;
 mod error_code;
 mod request;
@@ -9,6 +10,7 @@ mod response;
 mod tests;
 
 pub use command::Command;
+pub use daemon_status::DaemonStatusEvent;
 pub use error_code::ErrorCode;
 pub use request::DaemonRequest;
 pub use response::{DaemonResponse, DownloadProgress, GpuInfo, NotificationEvent};


### PR DESCRIPTION
Resolves the **10 remaining Tier-2 findings** from the second code-quality audit (`docs/audits/2026-07-code-quality-2.md`) — contract & documentation drift — in one PR. (#2, #3, #8 were resolved earlier.)

| # | Sev | Fix |
|---|-----|-----|
| **1** | 🟠 | `SECURITY.md` still described an SO_PEERCRED/binary-verification auth model. Rewrote the auth/network/threat-model sections to the real per-request **token + scope + consent** model (via `super-stt-consent`), with `SO_PEERCRED`/`/proc/<pid>/exe` in their true role (identify the caller for the prompt + reject cross-UID peers). Reconciled the self-contradicting "No remote access" claim to "no inbound listener — Unix-socket only". |
| **4** | 🟠 | README advertised `--stop-mode manual` and a `--write-method` flag the CLI rejects → now `stt record --write --stop-mode manual_only`, with write-method noted as app/config-only. |
| **5** | 🟡 | README "Enabling Online Models" referenced a removed sidebar page → now the real **Library → Browse** install + **Configure** sheet flow. |
| **6** | 🟠 | `error_code` was absent from the backend option/secret/model-language and registry error envelopes despite `transport.md` promising it on every error. `json_error`/`registry_error` now emit `error_code` (+ a `json_error_msg` sibling; the legacy registry `error` key is kept for back-compat). |
| **7** | 🟠 | Invalid device was an uncoded 500 and the docs listed `metal` + a never-emitted `cuda_unavailable`. Added `ErrorCode::InvalidDevice` (400) and emit it; docs drop `metal` and document that CUDA-on-a-CUDA-less-host silently falls back to CPU (not an error). |
| **9** | 🟠 | `daemon_status_changed` was an untyped hand-matched `json!` contract whose keys had drifted (`to_device` vs `target_device`). Introduced a typed `#[serde(tag="status")] DaemonStatusEvent` enum in shared; all four daemon producers construct it (published via `publish_daemon_status`, which injects `timestamp`), and the app deserializes + matches it. Normalized `to_device` → `target_device`; pinned the per-variant schema in `daemon_status.md`. |
| **10** | 🟠 | `MAX_MANIFEST_BYTES` was triplicated (indexer/install/custom-repo). Hoisted a single `u64` const into `registry-types::verify`; removed the three copies (dropping `custom_repo`'s `usize`/`as u64` casts). |
| **11** | 🟡 | Install-time manifest verification used raw `toml::from_str`, skipping the parser's safety guards. Switched `verify_manifest_bytes` to `Manifest::parse` (inherits the entrypoint/destination traversal + `file`-xor-`parts` guards); kept the install-only index-consistency checks. |
| **12** | 🟡 | `POST /v1/active_model/reload` was undocumented → new `active_model/reload.md`. |
| **13** | 🟠 | The subprocess transport integration test was never compiled in CI. `just check-features` (run by `just ci` and the GitHub CI Clippy job) now compiles it + its `mock_backend` fixture under `-D warnings`; running it stays systemd-gated. |

## Verification
- `cargo check --workspace --all-features`, pedantic clippy (`-D warnings`), and `cargo fmt --check` all clean.
- Tests: shared **105** (+3 new `DaemonStatusEvent` tests), daemon lib **235**, app **43**, `http_smoke_events` **8/8** (incl. `language_change_broadcasts_settings_changed`, validating #9 end-to-end). The only failures — 3 registry loopback-HTTP tests — fail identically on clean `main` (environmental, not from this change).
- An adversarial multi-agent review (reviewer + refuter per finding) confirmed **2 doc-vs-code inaccuracies** I'd introduced — a nonexistent "keyboard-injection scope" in SECURITY.md and `invalid_session`/`scope_denied` mis-attributed to `error_code` in active_device.md — **both fixed**, plus the same class proactively corrected in the new `reload.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)