### PR TITLE
Audit 2 Tier 3 #1-5: offload blocking work + cut RT-thread allocations

### DIFF
--- a/docs/audits/2026-07-code-quality-2.md
+++ b/docs/audits/2026-07-code-quality-2.md
@@ -623,7 +623,7 @@ Five clusters account for most of the findings:
 
 ### Daemon — blocking work & performance
 
-### [ ] 1. 🟠 XDG portal typing backend rebuilds a fresh `zbus::Proxy` on every keysym press/release *(perf)*
+### [x] 1. 🟠 XDG portal typing backend rebuilds a fresh `zbus::Proxy` on every keysym press/release *(perf)*
 
 - **Where:** `notify_keysym` does `zbus::Proxy::new(…)` per call
   (`output/keyboard/xdg_portal_backend.rs:123-130`); `type_text` calls it 2–4× per char,
@@ -635,8 +635,13 @@ Five clusters account for most of the findings:
   interactive path.
 - **Fix:** build the `RemoteDesktop` proxy once in `XdgPortalBackend::new()` (or cache it in a
   field) and reuse it; it's immutable for the session.
+- **Resolved (branch `refactor/audit2-tier3-1-5`):** the `RemoteDesktop` proxy is now built
+  once in `new()` and stored as a `Proxy<'static>` field (the `&'static str` bus/path/interface
+  constants make the lifetime `'static`; the proxy holds its own clone of the async connection,
+  so the session stays alive and the separate `connection` field was dropped). `notify_keysym`
+  reuses it — no per-keysym proxy construct/drop or D-Bus match-rule churn on the typing path.
 
-### [ ] 2. 🟡 Preview loop resamples audio synchronously on the request's async worker every tick *(blocking)*
+### [x] 2. 🟡 Preview loop resamples audio synchronously on the request's async worker every tick *(blocking)*
 
 - **Where:** `resample_and_emit_preview` calls `utils::audio::resample(...)`
   (`recording/preview.rs:219`) on the async worker before handing the chunk to
@@ -645,16 +650,26 @@ Five clusters account for most of the findings:
   to 5s of capture on the worker, and the final drain resamples the whole recording.
 - **Fix:** fold the resample into the existing transcription `spawn_blocking`, or
   `spawn_blocking` the resample itself.
+- **Resolved (branch `refactor/audit2-tier3-1-5`):** `resample_and_emit_preview` now runs the
+  16kHz resample inside `tokio::task::spawn_blocking` (the audio Vec is moved in, the result
+  awaited). The skip-this-tick behavior is preserved on a resample error and now also on a task
+  panic; the already-16kHz fast path still returns the audio unchanged with no offload.
 
-### [ ] 3. 🟡 Registry index cache does blocking `std::fs` + JSON (de)serialization inside the async refresh path *(blocking)*
+### [x] 3. 🟡 Registry index cache does blocking `std::fs` + JSON (de)serialization inside the async refresh path *(blocking)*
 
 - **Where:** `Client::refresh` is async but `load_from_disk` (`std::fs::read`,
   `registry/client.rs:177`) + `serde_json`, `persist` (`:185-195`), and `from_env`'s
   `create_dir_all` (`:76`) are synchronous.
 - **Fix:** move the file IO + serialization behind `spawn_blocking`/`tokio::fs`, keeping only
   the in-memory `RwLock` swap on the async path.
+- **Resolved (branch `refactor/audit2-tier3-1-5`):** `load_from_disk` and `persist` became free
+  functions that `Client::refresh` runs inside `spawn_blocking` (only the in-memory `RwLock`
+  swap stays on the async path; join errors map to `ClientError::Io`). `from_env`'s eager
+  `create_dir_all` is gone — `persist_to_disk` now creates the parent dir (on the blocking
+  thread) before `write_atomic`, so the cache dir is created lazily on first successful fetch
+  rather than synchronously at construction.
 
-### [ ] 4. 🟡 SSE fan-out serializes every event twice (struct → Value → String) per subscriber *(perf)*
+### [x] 4. 🟡 SSE fan-out serializes every event twice (struct → Value → String) per subscriber *(perf)*
 
 - **Where:** `AnyReceiver::recv_json` does `serde_json::to_value(evt)` (`events.rs:350`); the
   forwarder then `serde_json::to_string`s that `Value` in `format_sse_frame`
@@ -665,8 +680,17 @@ Five clusters account for most of the findings:
 - **Fix:** for the statically-typed topics, serialize the typed event directly to the SSE
   `data:` string and skip the `Value` hop; the three genuinely-heterogeneous topics
   (`daemon_status_changed`, `download_progress`, `registry_install`) keep the current path.
+- **Resolved (branch `refactor/audit2-tier3-1-5`):** `AnyReceiver::recv_json_str` serializes
+  each event straight to its JSON `data:` string (`serde_json::to_string`), dropping the
+  throwaway `Value` for the typed topics — `format_sse_frame_str` is the new canonical framer
+  and the `/events` forwarder uses the String path (the old `recv_json`/`format_sse_frame` are
+  kept: `recv_json` as a `#[cfg(test)]` wrapper, `format_sse_frame` delegating for the
+  `/transcribe` stream). The 3 heterogeneous topics still serialize their `Value` (identical
+  bytes). One deliberate change: a typed `f32` now renders in its own shortest form (`0.95`)
+  rather than the f64-widened `0.949999988079071` the `to_value` hop produced — both parse to
+  the same value, and no consumer/test string-matches the frames.
 
-### [ ] 5. 🟡 Audio input callback clones the mono buffer (i16: allocates a throwaway intermediate) on the RT thread every chunk *(perf)*
+### [x] 5. 🟡 Audio input callback clones the mono buffer (i16: allocates a throwaway intermediate) on the RT thread every chunk *(perf)*
 
 - **Where:** `process_audio_data_f32_with_streaming` does
   `samples_tx.send(mono_samples.clone())` (`audio/processing.rs:106`) before passing
@@ -676,6 +700,12 @@ Five clusters account for most of the findings:
   allocation there risks buffer overruns / dropped input.
 - **Fix:** compute what `process_audio_samples` needs first, then **move** `mono_samples` into
   the send; for i16, downmix directly from the `&[i16]` slice into a single mono Vec.
+- **Resolved (branch `refactor/audit2-tier3-1-5`):** both streaming callbacks now call
+  `process_audio_samples(&mono_samples, …)` first and then **move** `mono_samples` into
+  `samples_tx.send(…)` — no clone. The i16 path downmixes directly from the `&[i16]` slice into
+  one mono `Vec<f32>` (numerically identical: `f32::from(s)/32768.0` averaged per channel),
+  replacing the throwaway interleaved-f32 Vec + downmix Vec + clone (three allocations → one)
+  on the audio RT thread.
 
 ### [ ] 6. 🟡 `spawn_recorder` installs the manual-stop channel before the authoritative busy claim, so a losing race nulls the winner's stop channel *(concurrency)*
 

--- a/super-stt-daemon/src/audio/processing.rs
+++ b/super-stt-daemon/src/audio/processing.rs
@@ -103,8 +103,11 @@ pub fn process_audio_data_f32_with_streaming(
         .chunks(channels)
         .map(|chunk| chunk.iter().sum::<f32>() / channels_f32)
         .collect();
-    let _ = samples_tx.send(mono_samples.clone());
+    // Process against the borrowed buffer first, then MOVE the mono buffer into
+    // the analysis channel — one allocation instead of an extra clone on the
+    // audio RT thread (audit 2 Tier 3 #5).
     process_audio_samples(&mono_samples, buffer, state, level_tx);
+    let _ = samples_tx.send(mono_samples);
 }
 
 pub fn process_audio_data_i16_with_streaming(
@@ -117,11 +120,13 @@ pub fn process_audio_data_i16_with_streaming(
 ) {
     // channels is typically 1–8; fits u16 and thus u32 and f32 exactly.
     let channels_f32 = f32::from(u16::try_from(channels).unwrap_or(u16::MAX));
-    let samples: Vec<f32> = data.iter().map(|&s| f32::from(s) / 32768.0).collect();
-    let mono_samples: Vec<f32> = samples
+    // Downmix straight from the `&[i16]` slice into a single mono `Vec<f32>` —
+    // no throwaway interleaved-f32 Vec and no extra clone (three allocations →
+    // one) on the audio RT thread (audit 2 Tier 3 #5).
+    let mono_samples: Vec<f32> = data
         .chunks(channels)
-        .map(|chunk| chunk.iter().sum::<f32>() / channels_f32)
+        .map(|chunk| chunk.iter().map(|&s| f32::from(s) / 32768.0).sum::<f32>() / channels_f32)
         .collect();
-    let _ = samples_tx.send(mono_samples.clone());
     process_audio_samples(&mono_samples, buffer, state, level_tx);
+    let _ = samples_tx.send(mono_samples);
 }

--- a/super-stt-daemon/src/daemon/events.rs
+++ b/super-stt-daemon/src/daemon/events.rs
@@ -348,24 +348,36 @@ impl EventBus {
 }
 
 impl AnyReceiver {
-    /// Receive the next event for this topic. Returns the wire topic
-    /// name and a `serde_json::Value` payload, ready for the SSE
-    /// formatter. Bubbles `RecvError` so the handler can decide whether
-    /// to log+continue (lag) or close (closed).
+    /// Receive the next event for this topic as `(wire_name, json_data)`, where
+    /// `json_data` is the serialized SSE `data:` payload ready for the frame
+    /// formatter. Bubbles `RecvError` so the handler can log+continue (lag) or
+    /// close (closed).
+    ///
+    /// The typed topics are serialized straight to their JSON string, skipping the
+    /// throwaway `serde_json::Value` the old path built (audit 2 Tier 3 #4) —
+    /// notably `frequency_bands`, emitted at the audio-callback rate, where every
+    /// visualization subscriber otherwise paid a discarded `Value` allocation plus
+    /// a second full serialization per frame. The 3 heterogeneous topics already
+    /// carry a `Value`; serializing it here is the same work the old
+    /// `format_sse_frame` did.
+    ///
+    /// Note: a typed `f32` now serializes in its own shortest round-trip form
+    /// (e.g. `0.95`) rather than the f64-widened form the `to_value` hop produced
+    /// (`0.949999988079071`); both parse back to the same value.
     ///
     /// # Errors
-    /// Returns `RecvError::Lagged(n)` when the receiver fell behind the
-    /// channel capacity (the SSE handler logs and resyncs). Returns
-    /// `RecvError::Closed` when all senders have been dropped.
-    pub async fn recv_json(
+    /// Returns `RecvError::Lagged(n)` when the receiver fell behind the channel
+    /// capacity (the SSE handler logs and resyncs). Returns `RecvError::Closed`
+    /// when all senders have been dropped.
+    pub async fn recv_json_str(
         &mut self,
-    ) -> Result<(&'static str, serde_json::Value), broadcast::error::RecvError> {
+    ) -> Result<(&'static str, String), broadcast::error::RecvError> {
         macro_rules! recv_arm {
             ($rx:ident, $topic:ident) => {{
                 let evt = $rx.recv().await?;
                 Ok((
                     Topic::$topic.as_str(),
-                    serde_json::to_value(evt).unwrap_or_default(),
+                    serde_json::to_string(&evt).unwrap_or_default(),
                 ))
             }};
         }
@@ -378,19 +390,23 @@ impl AnyReceiver {
             Self::FrequencyBands(rx) => recv_arm!(rx, FrequencyBands),
             Self::PartialStt(rx) => recv_arm!(rx, PartialStt),
             Self::FinalStt(rx) => recv_arm!(rx, FinalStt),
-            Self::DaemonStatusChanged(rx) => {
-                let value = rx.recv().await?;
-                Ok((Topic::DaemonStatusChanged.as_str(), value))
-            }
-            Self::DownloadProgress(rx) => {
-                let value = rx.recv().await?;
-                Ok((Topic::DownloadProgress.as_str(), value))
-            }
-            Self::RegistryInstall(rx) => {
-                let value = rx.recv().await?;
-                Ok((Topic::RegistryInstall.as_str(), value))
-            }
+            Self::DaemonStatusChanged(rx) => recv_arm!(rx, DaemonStatusChanged),
+            Self::DownloadProgress(rx) => recv_arm!(rx, DownloadProgress),
+            Self::RegistryInstall(rx) => recv_arm!(rx, RegistryInstall),
         }
+    }
+
+    /// [`recv_json_str`](Self::recv_json_str) parsed back into a
+    /// `serde_json::Value` — used by tests that assert on structured fields.
+    ///
+    /// # Errors
+    /// See [`recv_json_str`](Self::recv_json_str).
+    #[cfg(test)]
+    pub async fn recv_json(
+        &mut self,
+    ) -> Result<(&'static str, serde_json::Value), broadcast::error::RecvError> {
+        let (name, json) = self.recv_json_str().await?;
+        Ok((name, serde_json::from_str(&json).unwrap_or_default()))
     }
 }
 

--- a/super-stt-daemon/src/daemon/http/v1/events.rs
+++ b/super-stt-daemon/src/daemon/http/v1/events.rs
@@ -3,7 +3,7 @@ use crate::daemon::http::internal::auth::middleware::AuthContext;
 use crate::daemon::http::internal::auth::tokens::TokenStore;
 use crate::daemon::http::internal::helpers::responses::{invalid_session, reason, scope_denied};
 use crate::daemon::http::state::{AppState, PeerInfo};
-use crate::daemon::http::v1::transcribe::format_sse_frame;
+use crate::daemon::http::v1::transcribe::format_sse_frame_str;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -28,9 +28,9 @@ type SseSender = tokio::sync::mpsc::Sender<Result<axum::body::Bytes, std::io::Er
 /// `false` only when the receiver is gone (client disconnected), so the caller
 /// tears down. A full channel drops the frame — the reader is stalled, so shed
 /// it — and returns `true`.
-fn try_emit_sse_event(tx: &SseSender, event: &str, data: &serde_json::Value) -> bool {
+fn try_emit_sse_event(tx: &SseSender, event: &str, data: &str) -> bool {
     use tokio::sync::mpsc::error::TrySendError;
-    match tx.try_send(Ok(format_sse_frame(event, data))) {
+    match tx.try_send(Ok(format_sse_frame_str(event, data))) {
         Ok(()) => true,
         Err(TrySendError::Full(_)) => {
             log::warn!("widget SSE backpressured; dropped a {event} frame");
@@ -127,7 +127,8 @@ pub(crate) async fn events(
         &serde_json::json!({
             "client_id": uuid::Uuid::new_v4().to_string(),
             "subscribed_to": topic_names,
-        }),
+        })
+        .to_string(),
     );
 
     spawn_events_keepalive_and_exe_watch(
@@ -203,7 +204,7 @@ fn spawn_topic_forwarder(
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => break,
-                res = rx.recv_json() => {
+                res = rx.recv_json_str() => {
                     match res {
                         Ok((name, payload)) => {
                             if !try_emit_sse_event(&tx, name, &payload) {
@@ -275,7 +276,7 @@ fn spawn_events_keepalive_and_exe_watch(
                     let _ = try_emit_sse_event(
                         &tx,
                         "revoked",
-                        &serde_json::json!({ "reason": "exe_changed" }),
+                        &serde_json::json!({ "reason": "exe_changed" }).to_string(),
                     );
                     tokens.revoke(&token_str);
                     cancel.cancel();

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -191,15 +191,22 @@ async fn run_realtime_session(
     let _ = relay_out.await;
 }
 
-/// Build the raw bytes of one SSE `event: <name>\ndata: <json>\n\n` frame.
-/// `serde_json::to_string` never embeds raw newlines, so the JSON fits on the
-/// single `data:` line by construction. Shared by the unbounded `/transcribe`
-/// stream ([`emit_sse_event`]) and the bounded `/events` fan-out.
-pub(crate) fn format_sse_frame(event: &str, data: &serde_json::Value) -> axum::body::Bytes {
+/// Build the raw bytes of one SSE `event: <name>\ndata: <json>\n\n` frame from an
+/// already-serialized JSON `data:` string. `data` must be single-line (no raw
+/// newlines) — `serde_json::to_string` guarantees this. This is the canonical
+/// framer; the `/events` fan-out uses it directly with the string
+/// `AnyReceiver::recv_json_str` produces (audit 2 Tier 3 #4).
+pub(crate) fn format_sse_frame_str(event: &str, data: &str) -> axum::body::Bytes {
     let mut bytes = format!("event: {event}\ndata: ").into_bytes();
-    bytes.extend_from_slice(serde_json::to_string(data).unwrap_or_default().as_bytes());
+    bytes.extend_from_slice(data.as_bytes());
     bytes.extend_from_slice(b"\n\n");
     axum::body::Bytes::from(bytes)
+}
+
+/// [`format_sse_frame_str`] for a `serde_json::Value` payload — the unbounded
+/// `/transcribe` stream ([`emit_sse_event`]) still holds `Value`s.
+pub(crate) fn format_sse_frame(event: &str, data: &serde_json::Value) -> axum::body::Bytes {
+    format_sse_frame_str(event, &serde_json::to_string(data).unwrap_or_default())
 }
 
 /// Emit a single SSE frame onto the unbounded `/transcribe` stream. Returns

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -233,27 +233,37 @@ impl SuperSTTDaemon {
             debug!("No resampling needed, device already at 16kHz");
             audio_data
         } else {
-            debug!(
-                "Resampling from {}Hz to 16kHz for preview",
-                session.device_sample_rate
-            );
-            match super_stt_shared::utils::audio::resample(
-                &audio_data,
-                session.device_sample_rate,
-                16000,
-                super_stt_shared::audio_utils::ResampleQuality::Fast,
-            ) {
-                Ok(resampled) => {
+            let device_rate = session.device_sample_rate;
+            debug!("Resampling from {device_rate}Hz to 16kHz for preview");
+            // Resampling is synchronous CPU work over up to ~5s of capture each
+            // tick (and the whole recording on the final drain); run it on a
+            // blocking thread rather than parking the request's async worker
+            // (audit 2 Tier 3 #2).
+            let input_len = audio_data.len();
+            match tokio::task::spawn_blocking(move || {
+                super_stt_shared::utils::audio::resample(
+                    &audio_data,
+                    device_rate,
+                    16000,
+                    super_stt_shared::audio_utils::ResampleQuality::Fast,
+                )
+            })
+            .await
+            {
+                Ok(Ok(resampled)) => {
                     debug!(
-                        "Resampled {} samples to {} samples",
-                        audio_data.len(),
+                        "Resampled {input_len} samples to {} samples",
                         resampled.len()
                     );
                     resampled
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     warn!("Failed to resample preview audio: {e}");
                     return true; // Signal caller to `continue` to next iteration
+                }
+                Err(e) => {
+                    warn!("Preview resample task panicked: {e}");
+                    return true;
                 }
             }
         };

--- a/super-stt-daemon/src/output/keyboard/xdg_portal_backend.rs
+++ b/super-stt-daemon/src/output/keyboard/xdg_portal_backend.rs
@@ -14,9 +14,13 @@ const REQUEST_IFACE: &str = "org.freedesktop.portal.Request";
 const XKB_KEY_BACKSPACE: i32 = 0xFF08;
 
 pub struct XdgPortalBackend {
-    /// The async zbus connection. The typing path awaits keysym calls on it
-    /// directly (audit Tier 3 #35), so no per-keysym thread/runtime is needed.
-    connection: zbus::Connection,
+    /// The `RemoteDesktop` portal proxy, built once and reused for every keysym
+    /// press/release (audit 2 Tier 3 #1). `type_text` issues 2–4 keysym calls per
+    /// char and the preview loop re-types the growing transcript each tick, so
+    /// rebuilding the proxy per call meant constant D-Bus match-rule churn on the
+    /// interactive path. The proxy holds its own clone of the async connection, so
+    /// the portal session stays alive for the backend's lifetime.
+    proxy: zbus::Proxy<'static>,
     session_path: OwnedObjectPath,
 }
 
@@ -56,10 +60,17 @@ impl XdgPortalBackend {
 
         let session_path = Self::setup_session(&conn).await?;
 
+        // Build the RemoteDesktop proxy once and reuse it for every keysym
+        // (audit 2 Tier 3 #1). The `&'static str` bus/path/interface constants
+        // make this a `Proxy<'static>`, and it clones the connection internally.
+        let proxy = zbus::Proxy::new(&conn, PORTAL_BUS, PORTAL_PATH, REMOTE_DESKTOP_IFACE)
+            .await
+            .context("Failed to create RemoteDesktop proxy")?;
+
         info!("XDG Desktop Portal write method ready (session: {session_path})");
 
         Ok(Self {
-            connection: conn,
+            proxy,
             session_path,
         })
     }
@@ -121,15 +132,8 @@ impl XdgPortalBackend {
     /// one-shot thread + current-thread runtime per keysym just to escape a sync
     /// caller — it simply awaits the D-Bus call on the runtime.
     async fn notify_keysym(&self, keysym: i32, state: u32) -> Result<()> {
-        let proxy = zbus::Proxy::new(
-            &self.connection,
-            PORTAL_BUS,
-            PORTAL_PATH,
-            REMOTE_DESKTOP_IFACE,
-        )
-        .await?;
         let options: HashMap<&str, Value<'_>> = HashMap::new();
-        proxy
+        self.proxy
             .call_noreply(
                 "NotifyKeyboardKeysym",
                 &(self.session_path.as_ref(), options, keysym, state),

--- a/super-stt-daemon/src/registry/client.rs
+++ b/super-stt-daemon/src/registry/client.rs
@@ -73,7 +73,8 @@ impl Client {
             Err(_) => DEFAULT_URL.into(),
         };
         let cache_dir = super_stt_shared::paths::cache_dir();
-        let _ = std::fs::create_dir_all(&cache_dir);
+        // The cache dir is created lazily by `persist_to_disk` on the first
+        // successful fetch (on a blocking thread), not eagerly here (Tier 3 #3).
         Self::new(url, cache_dir.join("registry-index.json"), DEFAULT_TTL)
     }
 
@@ -116,7 +117,12 @@ impl Client {
         let etag = {
             let need_load = self.state.read().is_none();
             if need_load {
-                if let Some((idx, etag)) = self.load_from_disk()? {
+                // Read + parse the on-disk cache off the async worker (Tier 3 #3).
+                let cache_path = self.cache_path.clone();
+                let loaded = tokio::task::spawn_blocking(move || load_from_disk(&cache_path))
+                    .await
+                    .map_err(|e| ClientError::Io(std::io::Error::other(e)))??;
+                if let Some((idx, etag)) = loaded {
                     self.state.write().replace(Cached {
                         index: idx,
                         etag: etag.clone(),
@@ -166,35 +172,57 @@ impl Client {
             fetched_at: SystemTime::now(),
         };
         self.state.write().replace(cached.clone());
-        self.persist(&cached, &bytes)?;
+        // Serialize + atomic-write the cache off the async worker (Tier 3 #3).
+        let cache_path = self.cache_path.clone();
+        let etag = cached.etag.clone();
+        let fetched_at = cached.fetched_at;
+        tokio::task::spawn_blocking(move || persist_to_disk(&cache_path, etag, fetched_at, &bytes))
+            .await
+            .map_err(|e| ClientError::Io(std::io::Error::other(e)))??;
         Ok(index)
     }
+}
 
-    fn load_from_disk(&self) -> Result<Option<(Index, Option<String>)>, ClientError> {
-        if !self.cache_path.exists() {
-            return Ok(None);
-        }
-        let bytes = std::fs::read(&self.cache_path)?;
-        let file: CacheFile = serde_json::from_slice(&bytes)?;
-        let mut index: Index = serde_json::from_value(file.index)?;
-        retain_safe_backends(&mut index);
-        warn_if_client_too_old(&index);
-        Ok(Some((index, file.etag)))
+/// Read + parse the on-disk index cache. Synchronous `std::fs` + `serde_json`, so
+/// the async refresh path runs it on a blocking thread (audit 2 Tier 3 #3).
+fn load_from_disk(
+    cache_path: &std::path::Path,
+) -> Result<Option<(Index, Option<String>)>, ClientError> {
+    if !cache_path.exists() {
+        return Ok(None);
     }
+    let bytes = std::fs::read(cache_path)?;
+    let file: CacheFile = serde_json::from_slice(&bytes)?;
+    let mut index: Index = serde_json::from_value(file.index)?;
+    retain_safe_backends(&mut index);
+    warn_if_client_too_old(&index);
+    Ok(Some((index, file.etag)))
+}
 
-    fn persist(&self, c: &Cached, body: &[u8]) -> Result<(), ClientError> {
-        let file = CacheFile {
-            etag: c.etag.clone(),
-            fetched_at_secs: c
-                .fetched_at
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            index: serde_json::from_slice(body)?,
-        };
-        super_stt_registry_types::fs::write_atomic(&self.cache_path, &serde_json::to_vec(&file)?)?;
-        Ok(())
+/// Serialize + atomic-write the index cache. Synchronous, so the async refresh
+/// path runs it on a blocking thread (audit 2 Tier 3 #3).
+fn persist_to_disk(
+    cache_path: &std::path::Path,
+    etag: Option<String>,
+    fetched_at: SystemTime,
+    body: &[u8],
+) -> Result<(), ClientError> {
+    let file = CacheFile {
+        etag,
+        fetched_at_secs: fetched_at
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        index: serde_json::from_slice(body)?,
+    };
+    // `write_atomic` writes `<path>.tmp` beside the target, so the parent must
+    // exist. Creating it here (on the blocking thread) instead of eagerly in the
+    // sync `from_env` constructor keeps that I/O off the async path too (Tier 3 #3).
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent)?;
     }
+    super_stt_registry_types::fs::write_atomic(cache_path, &serde_json::to_vec(&file)?)?;
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The **daemon perf/blocking cluster** — Tier 3 #1–#5 from the second code-quality audit (`docs/audits/2026-07-code-quality-2.md`).

| # | Sev | Fix |
|---|-----|-----|
| **1** | 🟠 | The XDG-portal typing backend rebuilt a fresh `zbus::Proxy` on **every** keysym press/release (`type_text` issues 2–4/char; the preview loop re-types the growing transcript each tick), each a D-Bus match-rule construct/drop on the default typing path. The `RemoteDesktop` proxy is now built **once** in `new()` and stored as a `Proxy<'static>` field, reused by `notify_keysym`. It holds its own clone of the async connection, so the session stays alive and the separate `connection` field was dropped. |
| **2** | 🟡 | `resample_and_emit_preview` ran the 16 kHz resample **inline on the async worker** each tick (up to ~5 s of capture, and the whole recording on the final drain) — the offload boundary was one call too late. Now wrapped in `tokio::task::spawn_blocking`; the skip-this-tick behavior is preserved on resample error and task panic, and the already-16 kHz fast path is unchanged. |
| **3** | 🟡 | `Client::refresh` (async) called synchronous `std::fs` + `serde_json` for the on-disk index cache (`load_from_disk`, `persist`) plus `from_env`'s eager `create_dir_all`. Both became free functions run inside `spawn_blocking` (only the in-memory `RwLock` swap stays on the async path); `create_dir_all` moved into `persist_to_disk` (blocking thread, before `write_atomic`), so the cache dir is created lazily on first successful fetch rather than synchronously at construction. |
| **4** | 🟡 | The `/events` SSE fan-out serialized every event **twice** (struct → `Value` → `String`) per subscriber — the intermediate `Value` was built and discarded, once per event per subscriber, and `frequency_bands` is emitted at the cpal-callback rate. `AnyReceiver::recv_json_str` now serializes typed events straight to their JSON `data:` string via `serde_json::to_string`, skipping the `Value`; `format_sse_frame_str` is the new canonical framer. The 3 heterogeneous topics (`daemon_status_changed`/`download_progress`/`registry_install`) still serialize their `Value`. The old `recv_json` is kept as a `#[cfg(test)]` wrapper and `format_sse_frame` delegates for the `/transcribe` stream. |
| **5** | 🟡 | The two streaming audio callbacks cloned the mono buffer on the **audio RT thread** every chunk (the i16 path also built a throwaway interleaved-f32 Vec + a downmix Vec, then cloned — three allocations). They now `process_audio_samples(&mono)` first and then **move** the buffer into the analysis channel; the i16 path downmixes directly from the `&[i16]` slice into one mono `Vec<f32>` (numerically identical). |

### On #4's wire output
Serializing a typed `f32` directly renders its own shortest round-trip form (e.g. `0.95`) instead of the f64-widened form the `to_value` hop produced (`0.949999988079071`) — for `frequency_bands` (`sample_rate`/`total_energy`) and `partial_stt`/`final_stt` (`confidence`). Both parse back to the same value, and no consumer or test string-matches SSE frames. The 3 heterogeneous topics are byte-identical.

## Verification
- `cargo check --workspace --all-features`, pedantic clippy (`-D warnings`), and `cargo fmt --check` all clean.
- Daemon lib **235 passed** (only the 3 pre-existing registry loopback-HTTP tests fail — identical on clean `main`, environmental). `http_smoke_events` **8/8** validates the #4 SSE path end-to-end; `returns_cache_when_network_fails` exercises #3's `spawn_blocking` disk-load.
- An adversarial multi-agent review (reviewer + refuter per finding) returned **0 confirmed issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)