### PR TITLE
Audit 2 Tier 3 #6-10: concurrency + consent/output security hardening

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -59,6 +59,7 @@ ls -la "$XDG_RUNTIME_DIR/stt/super-stt-http.sock"
 - **Consent-gated authorization**: Auto-typing is the per-request `write_mode` flag on `POST /transcribe` (or the daemon's configured write mode). Reaching that endpoint at all requires a consent-minted session token with the `transcribe` scope — so a client can only type after the user approved it through the one-time consent prompt. There is no separate keyboard/write scope; it is the same `transcribe` scope dictation uses. See [Authorization](#authorization) and [`protocol/auth.md`](protocol/auth.md)
 - **Peer identity for the prompt**: `SO_PEERCRED` + `/proc/<pid>/exe` tell the consent prompt *which binary* is asking and reject cross-UID peers; this identifies the caller, it is not by itself the authorization
 - **Debug-only test bypass**: The consent auto-approval used by tests/CI (`SUPER_STT_AUTO_APPROVE`) is compiled out of release builds
+- **Output sanitization**: Backend transcription output is untrusted, so before it is typed the daemon strips non-whitespace control codes (ESC/BEL/NUL/backspace), Unicode bidi overrides, and zero-width characters — a terminal escape sequence or a bidi spoof in a transcript can't reach the focused window
 - **Limited scope**: Only types actual transcription results
 
 ### 2. Network Isolation

--- a/docs/audits/2026-07-code-quality-2.md
+++ b/docs/audits/2026-07-code-quality-2.md
@@ -707,7 +707,7 @@ Five clusters account for most of the findings:
   replacing the throwaway interleaved-f32 Vec + downmix Vec + clone (three allocations → one)
   on the audio RT thread.
 
-### [ ] 6. 🟡 `spawn_recorder` installs the manual-stop channel before the authoritative busy claim, so a losing race nulls the winner's stop channel *(concurrency)*
+### [x] 6. 🟡 `spawn_recorder` installs the manual-stop channel before the authoritative busy claim, so a losing race nulls the winner's stop channel *(concurrency)*
 
 - **Where:** `*self.manual_stop_tx = Some(stop_tx)` at `recording/preview.rs:24`, before
   `setup_recording_session`'s check-and-set of `busy` (`recording/mod.rs:182-188`); the loser's
@@ -717,8 +717,12 @@ Five clusters account for most of the findings:
   leaving it unstoppable (toggle reports "in progress", disconnect stop is a no-op, the 1-minute
   timeout finds `None`) until restart.
 - **Fix:** claim `busy` first and install `manual_stop_tx` only after the claim succeeds.
+- **Resolved (branch `refactor/audit2-tier3-6-10`):** `spawn_recorder` now calls
+  `setup_recording_session` (the atomic `busy` check-and-set) **first** and installs
+  `manual_stop_tx` only after that succeeds — a losing racer returns via `?` without ever
+  touching the channel, so it can no longer null the winner's stop channel.
 
-### [ ] 7. 🟡 Session-persist channel is unbounded and accumulates full-map snapshots while a keyring write is stalled *(resources)*
+### [x] 7. 🟡 Session-persist channel is unbounded and accumulates full-map snapshots while a keyring write is stalled *(resources)*
 
 - **Where:** `mpsc::unbounded_channel` (`tokens.rs:76`); `persist_loop` only coalesces after
   `persist_snapshot` returns (`:97-102`), which awaits `spawn_blocking(set_sessions_blob)`
@@ -728,10 +732,17 @@ Five clusters account for most of the findings:
   Tier 3 #8 bounded for the `/events` SSE channel, left unbounded here.
 - **Fix:** bound to a capacity-1 "latest wins" mailbox (older snapshots are strict subsets), or
   refuse to enqueue while a write is in cooldown/in-flight.
+- **Resolved (branch `refactor/audit2-tier3-6-10`):** the snapshot no longer rides in the
+  channel. `SessionPersister` holds a capacity-1 latest-wins mailbox
+  (`pending: Arc<Mutex<Option<HashMap>>>`); `submit` replaces it (older snapshots are strict
+  subsets) and sends a tiny `Wake` only on the empty→pending transition, so at most one wake is
+  in flight and a burst during a stalled keyring write can't queue full-map clones. The
+  `persist_loop` drains the wake/flush signals, `take()`s the mailbox, writes it, then acks any
+  flush — preserving the Tier 1 #5 shutdown-durability handshake.
 
 ### Daemon — security & correctness
 
-### [ ] 8. 🟡 Write-mode types untrusted backend output into the focused window with no control-character sanitization *(security)*
+### [x] 8. 🟡 Write-mode types untrusted backend output into the focused window with no control-character sanitization *(security)*
 
 - **Where:** `preprocess_text` only trims/collapses whitespace + capitalizes
   (`output/preview.rs:11-43`); `process_final_text` types the result directly
@@ -743,8 +754,16 @@ Five clusters account for most of the findings:
 - **Fix:** strip/reject control (and optionally bidi/zero-width) chars before the simulator in
   both `update_preview` and `process_final_text`; align the `SECURITY.md` claim with what's
   enforced.
+- **Resolved (branch `refactor/audit2-tier3-6-10`):** `preprocess_text` — the single choke point
+  both the preview (`update_preview`) and final (`process_final_text`) typing paths run through —
+  now strips, before any other processing, non-whitespace C0/C1 control codes (ESC/BEL/NUL/
+  backspace/…), Unicode bidi overrides + isolates (U+202A–202E, U+2066–2069), and zero-width
+  chars (U+200B/C/D, U+FEFF). Real whitespace (`\n`/`\r`/`\t`) is preserved so words aren't glued
+  and the existing normalization still collapses runs. Added a unit test; added an
+  output-sanitization bullet to `SECURITY.md` so the "control character filtering" claim holds
+  end-to-end.
 
-### [ ] 9. 🟠 Consent flow prompts with an unverifiable `<unknown>` binary instead of failing closed *(security)*
+### [x] 9. 🟠 Consent flow prompts with an unverifiable `<unknown>` binary instead of failing closed *(security)*
 
 - **Where:** `resolve_peer_exe()` falls back to `PathBuf::from("<unknown>")` when the pid is
   absent or the `/proc/<pid>/exe` readlink fails (`auth/consent.rs:223-238`); `request.rs:79`
@@ -760,8 +779,14 @@ Five clusters account for most of the findings:
 - **Fix:** treat an unresolved exe as fail-closed (return a deny/`PopupFailed`, or refuse to
   mint); represent it as `Option<PathBuf>`/an explicit enum so callers can't treat the sentinel
   as a real identity.
+- **Resolved (branch `refactor/audit2-tier3-6-10`):** `resolve_peer_exe` now returns
+  `Option<PathBuf>` — `None` (not `PathBuf("<unknown>")`) on a missing `PeerInfo`/pid or a
+  `/proc/<pid>/exe` readlink failure. `auth_request` fails closed on `None` with
+  `403 peer_unverifiable` before any popup, consent-key, or mint, so an unidentifiable peer can
+  no longer be prompted for or minted a token bound to a bogus identity. Also hardened the peer
+  pid coercion in `server.rs` (an out-of-range pid becomes `None`, not `0` → `/proc/0/exe`).
 
-### [ ] 10. 🟡 `/auth/request` has no rate limit and no popup concurrency cap *(security)*
+### [x] 10. 🟡 `/auth/request` has no rate limit and no popup concurrency cap *(security)*
 
 - **Where:** `ConsentLocks` dedups only on `(exe_path, normalized-scopes)`
   (`consent.rs:42-47`); `/auth/request` is mounted outside every `require_rate_limit` group
@@ -773,6 +798,13 @@ Five clusters account for most of the findings:
   trusted security UI; the deny-cache is no defense (every subset is a fresh key).
 - **Fix:** a global semaphore (capacity 1) around popup spawning so at most one dialog is on
   screen, and/or a per-peer rate limit returning a transient error instead of spawning.
+- **Resolved (branch `refactor/audit2-tier3-6-10`):** added a process-global
+  `static CONSENT_POPUP: Semaphore(1)` acquired at the top of `ask_user_for_consent` and held
+  (RAII) across the spawn + up-to-60s decision, so at most one consent dialog is ever on screen
+  regardless of how many distinct `(exe, scopes)` keys a client fires. Excess requests wait for
+  the permit (bounded by the per-popup timeout) instead of stacking exclusive-keyboard overlays,
+  so the desktop-lockout DoS is closed. (Kept the per-peer rate limit as the untaken "or"
+  alternative — `/auth/request` stays outside the request-quota limiter by design.)
 
 ### [ ] 11. 🟡 Consent dialog headlines the attacker-controlled `app_name` with no "unverified" framing *(security)*
 

--- a/super-stt-daemon/src/daemon/http/internal/auth/consent.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/consent.rs
@@ -5,6 +5,12 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+/// Global cap of one on-screen consent popup at a time. See
+/// [`ask_user_for_consent`] — without it a same-uid client could drive hundreds
+/// of concurrent exclusive-keyboard dialogs (255 distinct consent keys) and lock
+/// the desktop (audit 2 Tier 3 #10).
+static CONSENT_POPUP: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(1);
+
 /// Identifies the consent flow uniquely: (`exe_path`, normalized
 /// `scopes`). The user verifies a *binary*, not a self-reported display
 /// name, so the deny / dedup key is keyed on the kernel-resolved
@@ -74,6 +80,20 @@ pub(crate) enum ConsentDecision {
 /// Spawn the `super-stt-consent` helper binary, wait up to 60s for the
 /// user's decision. The helper writes one of `allow` / `deny` / `dismissed`
 /// to stdout and exits.
+/// Read the consent helper's single-line verdict from its stdout.
+async fn read_consent_decision(stdout: tokio::process::ChildStdout) -> ConsentDecision {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    let mut reader = BufReader::new(stdout).lines();
+    match reader.next_line().await {
+        Ok(Some(line)) => match line.trim() {
+            "allow" => ConsentDecision::Allow,
+            "deny" => ConsentDecision::Deny,
+            _ => ConsentDecision::Dismissed,
+        },
+        _ => ConsentDecision::Dismissed,
+    }
+}
+
 pub(crate) async fn ask_user_for_consent(
     app_name: &str,
     scopes: &[String],
@@ -84,6 +104,19 @@ pub(crate) async fn ask_user_for_consent(
     // so we don't emit a second, redundant warning here.
     let Some(helper) = locate_consent_helper() else {
         return ConsentDecision::PopupFailed;
+    };
+
+    // Serialize popups globally: at most one consent dialog on screen at a time
+    // (audit 2 Tier 3 #10). `/auth/request` is unauthenticated and outside the
+    // rate limiter, and the 8 scopes yield 255 distinct `(exe, scopes)` consent
+    // keys — each bypassing the per-key dedup — so without this cap a same-uid
+    // process could stack hundreds of concurrent exclusive-keyboard overlays and
+    // lock the desktop. Excess requests wait for the permit rather than opening
+    // in parallel. Acquired before the spawn and held while the dialog is on
+    // screen; released before the untimed reap below so a wedged helper can't
+    // wedge all consent.
+    let Ok(popup_permit) = CONSENT_POPUP.acquire().await else {
+        return ConsentDecision::PopupFailed; // semaphore closed (never in practice)
     };
 
     let mut cmd = tokio::process::Command::new(&helper);
@@ -106,21 +139,14 @@ pub(crate) async fn ask_user_for_consent(
         return ConsentDecision::PopupFailed;
     };
 
-    let read_decision = async move {
-        use tokio::io::{AsyncBufReadExt, BufReader};
-        let mut reader = BufReader::new(stdout).lines();
-        match reader.next_line().await {
-            Ok(Some(line)) => match line.trim() {
-                "allow" => ConsentDecision::Allow,
-                "deny" => ConsentDecision::Deny,
-                _ => ConsentDecision::Dismissed,
-            },
-            _ => ConsentDecision::Dismissed,
-        }
-    };
-
-    let result = tokio::time::timeout(Duration::from_mins(1), read_decision).await;
+    let result = tokio::time::timeout(Duration::from_mins(1), read_consent_decision(stdout)).await;
     let _ = child.start_kill();
+    // The dialog is being torn down, so release the global one-popup permit
+    // *before* the reap. `child.wait()` is untimed; holding the sole global
+    // permit across it would let a helper that somehow doesn't reap promptly
+    // (a pathological uninterruptible-sleep) wedge all consent daemon-wide.
+    // Releasing first keeps the popup cap intact while the reap still completes.
+    drop(popup_permit);
     let _ = child.wait().await;
 
     result.unwrap_or(ConsentDecision::Dismissed)
@@ -205,35 +231,38 @@ fn verify_helper_metadata(_: &Path) -> Result<(), &'static str> {
 }
 
 /// Resolve the calling process's executable path from the
-/// `axum::Extension<PeerInfo>` attached by the accept loop. Returns
-/// the canonical path on success, `PathBuf::from("<unknown>")` on any
-/// failure — and **logs the specific reason** so we can tell, from
-/// the journal, whether the issue is missing peer credentials
-/// (`SO_PEERCRED` not supported, peer process gone), a missing pid in
-/// the credential struct, or a kernel-level denial of the
-/// `/proc/<pid>/exe` readlink (Yama `ptrace_scope`, systemd
-/// `ProtectProc=`, sandboxed daemon, etc.).
-pub(crate) fn resolve_peer_exe(peer: Option<&axum::Extension<PeerInfo>>) -> PathBuf {
+/// `axum::Extension<PeerInfo>` attached by the accept loop. Returns `Some(path)`
+/// on success and `None` when the peer can't be identified — a missing
+/// `PeerInfo`/pid (`SO_PEERCRED` unsupported, peer process gone) or a
+/// kernel-denied `/proc/<pid>/exe` readlink (Yama `ptrace_scope`, systemd
+/// `ProtectProc=`, a sandboxed daemon, pid recycling).
+///
+/// The caller **must fail closed** on `None`: the consent model verifies a
+/// *binary*, so an unidentifiable peer must not be prompted for (a
+/// `<unknown>`-labelled dialog is meaningless to approve) nor minted a token
+/// bound to a bogus identity that the `/events` exe-watch would then spuriously
+/// revoke (audit 2 Tier 3 #9). Each failure is logged with its specific reason.
+pub(crate) fn resolve_peer_exe(peer: Option<&axum::Extension<PeerInfo>>) -> Option<PathBuf> {
     let Some(peer) = peer else {
         log::warn!(
-            "auth_request: no PeerInfo extension attached — daemon won't be able to identify the requesting binary"
+            "auth_request: no PeerInfo extension attached — cannot identify the requesting binary"
         );
-        return PathBuf::from("<unknown>");
+        return None;
     };
     let Some(pid) = peer.0.pid else {
         log::warn!(
             "auth_request: PeerInfo had no pid (SO_PEERCRED returned no credentials); cannot resolve exe"
         );
-        return PathBuf::from("<unknown>");
+        return None;
     };
     let path = format!("/proc/{pid}/exe");
     match std::fs::read_link(&path) {
-        Ok(p) => p,
+        Ok(p) => Some(p),
         Err(e) => {
             log::warn!(
                 "auth_request: read_link({path}) failed: {e}; cannot identify peer pid {pid}"
             );
-            PathBuf::from("<unknown>")
+            None
         }
     }
 }

--- a/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/tokens.rs
@@ -53,18 +53,20 @@ fn allow_no_keyring() -> bool {
     std::env::var(ALLOW_NO_KEYRING_ENV).is_ok_and(|v| v == "1")
 }
 
-/// A message to the single-writer persist task.
-// Both fields are only read in `persist_loop`, which is `#[cfg(not(test))]`; the
-// constructors compile in test builds too, so the fields read as dead code under
-// `cargo test`. They're live in production — suppress the test-only lint.
+/// A signal to the single-writer persist task. The sessions snapshot itself is
+/// NOT carried here — it lives in the [`SessionPersister`]'s capacity-1
+/// latest-wins mailbox, so a burst of mutations while a keyring write is stalled
+/// can't queue full-map clones (audit 2 Tier 3 #7). These messages are tiny.
+// `Flush`'s field is only read in `persist_loop` (`#[cfg(not(test))]`), but the
+// constructor compiles under test too, so it reads as dead code there.
 #[cfg_attr(test, allow(dead_code))]
 enum PersistMsg {
-    /// Persist this sessions snapshot (coalesced with any newer ones).
-    Snapshot(HashMap<String, TokenMeta>),
-    /// Drain the backlog, write the latest snapshot, then signal completion via
-    /// the oneshot. The shutdown path uses this so a token minted or revoked in
-    /// the final moments is durably written before `process::exit` skips the
-    /// task (audit 2 Tier 1 #5).
+    /// A snapshot is pending in the mailbox; drain and write it.
+    Wake,
+    /// Write the latest pending snapshot, then signal completion via the oneshot.
+    /// The shutdown path uses this so a token minted or revoked in the final
+    /// moments is durably written before `process::exit` skips the task (audit 2
+    /// Tier 1 #5).
     Flush(tokio::sync::oneshot::Sender<()>),
 }
 
@@ -109,9 +111,15 @@ pub(crate) async fn flush_persisted_sessions(timeout: Duration) {
 /// this channel keeps the blocking write off the request path *and* serializes
 /// the writes so the last submitted snapshot is the last one written (audit
 /// Tier 3 #35). Callers submit under the in-memory lock so channel order matches
-/// lock order (audit 2 Tier 1 #4).
+/// lock order (audit 2 Tier 1 #4). The snapshot rides in a capacity-1 latest-wins
+/// mailbox (`pending`) rather than the channel, so a stalled keyring write can't
+/// back up a queue of full-map clones (audit 2 Tier 3 #7).
 #[derive(Clone)]
 pub(crate) struct SessionPersister {
+    /// Capacity-1, latest-wins mailbox holding the not-yet-written snapshot.
+    /// Older snapshots are strict subsets of the newest, so replacing is safe.
+    pending: Arc<Mutex<Option<HashMap<String, TokenMeta>>>>,
+    /// Tiny wake/flush signals (no snapshot payload).
     tx: mpsc::UnboundedSender<PersistMsg>,
 }
 
@@ -122,9 +130,10 @@ impl SessionPersister {
     /// dropped.
     fn spawn() -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<PersistMsg>();
+        let pending: Arc<Mutex<Option<HashMap<String, TokenMeta>>>> = Arc::new(Mutex::new(None));
         #[cfg(not(test))]
         {
-            tokio::spawn(persist_loop(rx));
+            tokio::spawn(persist_loop(rx, Arc::clone(&pending)));
             // Register the first (production) persister so the shutdown path can
             // drain it. Production creates exactly one `TokenStore` (AppState's);
             // any later store keeps its own channel but won't be flushed.
@@ -132,35 +141,51 @@ impl SessionPersister {
         }
         #[cfg(test)]
         drop(rx);
-        Self { tx }
+        Self { pending, tx }
     }
 
-    /// Submit the latest sessions snapshot for persistence. Best-effort: a
-    /// closed channel (test builds) just means the write is skipped — the
-    /// in-memory map stays authoritative.
+    /// Submit the latest sessions snapshot for persistence. Replaces any
+    /// not-yet-written snapshot in the capacity-1 mailbox (latest wins) and
+    /// signals the task only on the empty→pending transition, so at most one wake
+    /// is ever in flight (audit 2 Tier 3 #7). Best-effort: a closed channel (test
+    /// builds) just means the write is skipped — the in-memory map stays
+    /// authoritative.
     fn submit(&self, snapshot: HashMap<String, TokenMeta>) {
-        let _ = self.tx.send(PersistMsg::Snapshot(snapshot));
+        let newly_pending = {
+            let mut slot = self.pending.lock().unwrap();
+            let was_empty = slot.is_none();
+            *slot = Some(snapshot);
+            was_empty
+        };
+        if newly_pending {
+            let _ = self.tx.send(PersistMsg::Wake);
+        }
     }
 }
 
-/// The persist task: receive messages, coalesce a burst of snapshots down to the
-/// newest (older snapshots are strict subsets of the state the newest
-/// represents), write it, then ack any flush request in the same batch — so a
-/// shutdown flush is acked only after the latest state is on disk.
+/// The persist task: on each wake, drain the signal backlog (collecting any flush
+/// request), take the latest snapshot from the capacity-1 mailbox, write it, then
+/// ack the flush — so a shutdown flush is acked only after the latest state is on
+/// disk.
 #[cfg(not(test))]
-async fn persist_loop(mut rx: mpsc::UnboundedReceiver<PersistMsg>) {
+async fn persist_loop(
+    mut rx: mpsc::UnboundedReceiver<PersistMsg>,
+    pending: Arc<Mutex<Option<HashMap<String, TokenMeta>>>>,
+) {
     while let Some(first) = rx.recv().await {
-        let mut latest: Option<HashMap<String, TokenMeta>> = None;
         let mut flush_ack: Option<tokio::sync::oneshot::Sender<()>> = None;
         let mut msg = Some(first);
         while let Some(m) = msg {
-            match m {
-                PersistMsg::Snapshot(s) => latest = Some(s),
-                PersistMsg::Flush(ack) => flush_ack = Some(ack),
+            if let PersistMsg::Flush(ack) = m {
+                flush_ack = Some(ack);
             }
             msg = rx.try_recv().ok();
         }
-        if let Some(snapshot) = latest {
+        // Take the latest pending snapshot (capacity-1, latest-wins). A new
+        // `submit` after this take re-arms `pending` and sends a fresh Wake, so
+        // nothing is lost.
+        let snapshot = pending.lock().unwrap().take();
+        if let Some(snapshot) = snapshot {
             persist_snapshot(snapshot).await;
         }
         if let Some(ack) = flush_ack {

--- a/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
+++ b/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
@@ -36,6 +36,11 @@ pub(crate) mod reason {
     pub(crate) const USER_DENIED: &str = "user_denied";
     pub(crate) const USER_DISMISSED: &str = "user_dismissed";
     pub(crate) const POPUP_FAILED: &str = "popup_failed";
+    /// The daemon could not resolve the peer's executable (`SO_PEERCRED`/pid
+    /// missing, or `/proc/<pid>/exe` unreadable), so it can't verify *which*
+    /// binary is asking — consent requires a verifiable binary, so it fails
+    /// closed (audit 2 Tier 3 #9).
+    pub(crate) const PEER_UNVERIFIABLE: &str = "peer_unverifiable";
 }
 
 pub(crate) fn invalid_session(reason: &'static str) -> Response {

--- a/super-stt-daemon/src/daemon/http/server.rs
+++ b/super-stt-daemon/src/daemon/http/server.rs
@@ -165,10 +165,13 @@ pub async fn start_http_server(
                     }
                 };
                 let peer_cred = stream.peer_cred().ok();
+                // An out-of-range pid becomes `None` (not `0`) so it fails closed
+                // in `resolve_peer_exe` rather than resolving `/proc/0/exe`
+                // (audit 2 Tier 3 #9).
                 let resolved_process_id = peer_cred
                     .as_ref()
                     .and_then(tokio::net::unix::UCred::pid)
-                    .map(|p| u32::try_from(p).unwrap_or(0));
+                    .and_then(|p| u32::try_from(p).ok());
                 let resolved_user_id = peer_cred.as_ref().map(tokio::net::unix::UCred::uid);
                 let peer = PeerInfo {
                     pid: resolved_process_id,

--- a/super-stt-daemon/src/daemon/http/v1/auth/request.rs
+++ b/super-stt-daemon/src/daemon/http/v1/auth/request.rs
@@ -28,6 +28,31 @@ pub(crate) struct AuthOk {
     pub(crate) expires_at: String,
 }
 
+/// `403 user_denied_cached` if the user previously clicked Deny for this exact
+/// `(exe_path, scopes)` pair in this daemon's lifetime, else `None`. Checked both
+/// up front and again under the consent lock (a concurrent caller may have been
+/// denied while we queued behind their popup); `context` labels which.
+fn cached_deny_response(
+    state: &AppState,
+    consent_key: &ConsentKey,
+    context: &str,
+) -> Option<Response> {
+    if !state.deny_cache.contains(consent_key) {
+        return None;
+    }
+    let (exe_path, scopes) = consent_key;
+    log::info!(
+        "auth_request denied from cache ({context}): exe={} scopes={}",
+        exe_path.display(),
+        scopes.join(" ")
+    );
+    Some(auth_err(
+        StatusCode::FORBIDDEN,
+        "auth_denied",
+        reason::USER_DENIED_CACHED,
+    ))
+}
+
 pub(crate) async fn auth_request(
     State(state): State<AppState>,
     peer: Option<axum::Extension<PeerInfo>>,
@@ -71,12 +96,19 @@ pub(crate) async fn auth_request(
         }
     }
 
-    // Resolve the calling binary via /proc/<pid>/exe. Log each
-    // failure mode separately so we can tell whether the issue is
-    // missing peer credentials, a missing pid, or a kernel/proc
-    // permission denial. Falls back to "<unknown>" so the popup still
-    // has something to display.
-    let exe_path = resolve_peer_exe(peer.as_ref());
+    // Resolve the calling binary via /proc/<pid>/exe. If it can't be resolved
+    // (missing peer credentials/pid, or a kernel/proc permission denial), fail
+    // closed: consent verifies a *binary*, so we refuse rather than prompt with
+    // an unverifiable `<unknown>` identity or mint a token bound to it (audit 2
+    // Tier 3 #9). Each failure mode is logged inside `resolve_peer_exe`.
+    let Some(exe_path) = resolve_peer_exe(peer.as_ref()) else {
+        log::warn!("auth_request rejected: could not verify the requesting binary (fail-closed)");
+        return auth_err(
+            StatusCode::FORBIDDEN,
+            "auth_denied",
+            reason::PEER_UNVERIFIABLE,
+        );
+    };
 
     // Helper to build the success response for a (token, expires_at)
     // pair. Used by both reuse-scan paths (fast and slow) and the
@@ -106,23 +138,13 @@ pub(crate) async fn auth_request(
 
     let consent_key: ConsentKey = (exe_path.clone(), scopes.clone());
 
-    // Sticky-deny short-circuit. If the user previously clicked Deny
-    // for this exact (exe_path, scope) pair in this daemon's
-    // lifetime, reject immediately without spawning another popup.
-    // The cache is cleared by daemon restart; there's no other reset
-    // path on purpose. `app_name` is not part of the key because a
-    // misbehaving client could otherwise rotate it to bypass deny.
-    if state.deny_cache.contains(&consent_key) {
-        log::info!(
-            "auth_request denied from cache (user previously denied): exe={} scopes={}",
-            exe_path.display(),
-            scopes.join(" ")
-        );
-        return auth_err(
-            StatusCode::FORBIDDEN,
-            "auth_denied",
-            reason::USER_DENIED_CACHED,
-        );
+    // Sticky-deny short-circuit. If the user previously clicked Deny for this
+    // exact (exe_path, scope) pair in this daemon's lifetime, reject immediately
+    // without spawning another popup. The cache is cleared by daemon restart;
+    // there's no other reset path on purpose. `app_name` is not part of the key
+    // because a misbehaving client could otherwise rotate it to bypass deny.
+    if let Some(resp) = cached_deny_response(&state, &consent_key, "user previously denied") {
+        return resp;
     }
 
     // Serialize concurrent first-time requests for the same identity
@@ -135,20 +157,10 @@ pub(crate) async fn auth_request(
     let response = {
         let _guard = lock.lock().await;
 
-        // Re-check the deny cache: a concurrent caller for the same
-        // pair may have been denied while we were queued behind
-        // their popup.
-        if state.deny_cache.contains(&consent_key) {
-            log::info!(
-                "auth_request denied from cache (concurrent caller denied): exe={} scopes={}",
-                exe_path.display(),
-                scopes.join(" ")
-            );
-            auth_err(
-                StatusCode::FORBIDDEN,
-                "auth_denied",
-                reason::USER_DENIED_CACHED,
-            )
+        // Re-check the deny cache: a concurrent caller for the same pair may
+        // have been denied while we were queued behind their popup.
+        if let Some(resp) = cached_deny_response(&state, &consent_key, "concurrent caller denied") {
+            resp
         } else {
             // Auto-approve if the daemon is in test/CI mode. Honored only in
             // debug builds: compiled out of release so a stray/injected env var

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -18,20 +18,20 @@ impl SuperSTTDaemon {
         stop_mode: super_stt_shared::models::recording_stop_mode::RecordingStopMode,
     ) -> Result<RecordingSession> {
         let silence_detection_disabled = !stop_mode.silence_detection_enabled();
-
-        // Create a broadcast channel so any recording can be stopped externally.
-        let (stop_tx, stop_rx) = tokio::sync::broadcast::channel(1);
-        *self.manual_stop_tx.write().await = Some(stop_tx);
         info!("🎛️ Recording mode: {stop_mode}");
 
-        // Set up recording state and create recorder
-        let mut recorder = match self.setup_recording_session(write_mode).await {
-            Ok(recorder) => recorder,
-            Err(e) => {
-                *self.manual_stop_tx.write().await = None;
-                return Err(e);
-            }
-        };
+        // Claim `busy` FIRST (setup_recording_session does the atomic
+        // check-and-set), and only then install the external stop channel.
+        // Installing `manual_stop_tx` before the claim let a losing racer
+        // overwrite it — and its cleanup then null it — leaving the *winning*
+        // recording with no stop channel (unstoppable until the 1-minute
+        // timeout) (audit 2 Tier 3 #6). A losing racer now returns here via `?`
+        // without ever touching `manual_stop_tx`.
+        let mut recorder = self.setup_recording_session(write_mode).await?;
+
+        // Create a broadcast channel so this recording can be stopped externally.
+        let (stop_tx, stop_rx) = tokio::sync::broadcast::channel(1);
+        *self.manual_stop_tx.write().await = Some(stop_tx);
 
         // Get model processing interval from current model
         let model_processing_interval = {

--- a/super-stt-daemon/src/output/preview.rs
+++ b/super-stt-daemon/src/output/preview.rs
@@ -6,11 +6,29 @@
 //! [`Typer`](crate::output::typer::Typer) state machine. Keeping them separate
 //! makes them exhaustively unit-testable without a keyboard `Simulator`.
 
-/// Preprocess text - normalize, remove ellipses, capitalize
+/// A character that must never reach the keyboard simulator. Backend
+/// transcription output is untrusted (audit 2 Tier 3 #8): a non-whitespace C0/C1
+/// control code (ESC, BEL, NUL, backspace, …) could drive a terminal escape
+/// sequence, and a Unicode bidi override or zero-width char could visually spoof
+/// or hide text in an editor. Ordinary whitespace (`\n`/`\r`/`\t`) is preserved
+/// here and folded into single spaces by [`preprocess_text`]'s normalization.
+fn is_unsafe_to_type(c: char) -> bool {
+    (c.is_control() && !c.is_whitespace())
+        // Bidi overrides + isolates (LRO/RLO/PDF, LRI/RLI/FSI/PDI).
+        || matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')
+        // Zero-width space/joiner/non-joiner + BOM.
+        || matches!(c, '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}')
+}
+
+/// Preprocess text - sanitize, normalize, remove ellipses, capitalize
 #[must_use]
 pub(crate) fn preprocess_text(text: &str, is_preview: bool) -> String {
+    // Strip characters that must never be typed into the focused window before
+    // any other processing (audit 2 Tier 3 #8).
+    let sanitized: String = text.chars().filter(|&c| !is_unsafe_to_type(c)).collect();
+
     // Remove leading whitespaces
-    let mut text = text.trim_start().to_string();
+    let mut text = sanitized.trim_start().to_string();
 
     // Remove starting ellipses if present
     if text.starts_with("...") {

--- a/super-stt-daemon/src/output/preview_tests.rs
+++ b/super-stt-daemon/src/output/preview_tests.rs
@@ -17,6 +17,21 @@ fn test_preprocess_text() {
 }
 
 #[test]
+fn preprocess_text_strips_unsafe_control_and_format_chars() {
+    // Non-whitespace C0/C1 controls (ESC, BEL, NUL, backspace) are removed.
+    assert_eq!(preprocess_text("he\u{1b}[31mllo\u{07}", true), "He[31mllo");
+    assert_eq!(preprocess_text("a\u{00}b\u{08}c", true), "Abc");
+    // Bidi overrides and zero-width chars are removed.
+    assert_eq!(preprocess_text("ab\u{202e}cd", true), "Abcd");
+    assert_eq!(preprocess_text("wor\u{200b}d", true), "Word");
+    // Real whitespace (newline/tab) is preserved as a word separator, not glued.
+    assert_eq!(
+        preprocess_text("hello\nworld\tfoo", true),
+        "Hello world foo"
+    );
+}
+
+#[test]
 fn test_is_simple_extension() {
     assert!(is_simple_extension("hello", "hello world"));
     assert!(is_simple_extension("", "hello"));


### PR DESCRIPTION
Tier 3 #6–#10 from the second code-quality audit (`docs/audits/2026-07-code-quality-2.md`) — the concurrency/resource + security-hardening cluster (#8/#9/#10 are security).

| # | Sev | Fix |
|---|-----|-----|
| **6** | 🟡 concurrency | `spawn_recorder` installed `manual_stop_tx` **before** `setup_recording_session`'s atomic `busy` claim, so a losing racer overwrote then nulled the winner's stop channel — leaving the winning recording unstoppable until the 1-minute timeout. Now it claims `busy` first and installs the stop channel only after; a losing racer returns via `?` without ever touching `manual_stop_tx`. |
| **7** | 🟡 resources | The session-persist channel was unbounded, so a burst of mint/revoke while a keyring write stalled on a D-Bus prompt queued full-map clones. The snapshot now lives in a **capacity-1 latest-wins mailbox** (`pending: Arc<Mutex<Option<HashMap>>>`); the channel carries only tiny `Wake`/`Flush` signals, and `submit` sends a wake only on the empty→pending transition. Preserves the Tier 1 #5 shutdown-flush handshake. |
| **8** | 🟡🔒 | Write-mode typed **untrusted** backend output verbatim — no control-char sanitization (an ESC sequence could hit a terminal; a bidi override could spoof an editor). `preprocess_text` — the single choke point both the preview and final typing paths run through — now strips non-whitespace C0/C1 controls, Unicode bidi overrides/isolates, and zero-width chars, while preserving real whitespace so words aren't glued. SECURITY.md's "control character filtering" claim now holds end-to-end. |
| **9** | 🟠🔒 | The consent flow fell **open**: `resolve_peer_exe` returned `PathBuf("<unknown>")` on a missing pid or a `/proc/<pid>/exe` readlink denial (Yama/`ProtectProc`), then used it as the consent key, popup "Executable" line, and minted token identity. It now returns `Option<PathBuf>` and `auth_request` **fails closed** (`403 peer_unverifiable`) before any popup/​mint. Also hardened the peer-pid coercion so an out-of-range pid is `None`, not `0` (→ `/proc/0/exe`). |
| **10** | 🟡🔒 | `/auth/request` is unauthenticated and outside the rate limiter, and the 8 scopes yield 255 distinct `(exe, scopes)` consent keys — each bypassing the per-key dedup — so a same-uid client could drive hundreds of concurrent exclusive-keyboard overlays and lock the desktop. A process-global `Semaphore(1)` now caps consent popups to **one on screen at a time**; excess requests wait for the permit rather than stacking. |

### Review-caught robustness fix
An adversarial reviewer noted the #10 permit was held across the untimed `child.wait()` reap (making a wedged helper a *global* consent chokepoint) and that the comment overstated the 60s bound. Not attacker-reachable (needs a trusted binary in a kernel D-state; the overlay DoS itself is fully closed), so it was refuted as a blocker — but I folded in the fix anyway: the permit is released **before** the untimed reap.

## Verification
- `cargo check --workspace --all-features`, pedantic clippy (`-D warnings`), and `cargo fmt --check` all clean.
- Daemon lib **239 passed** (incl. a new `preprocess_text` sanitization test); `http_smoke` **3/3** (auth_request + `resolve_peer_exe` resolve the test peer fine, so #9's fail-closed doesn't break real auth; plus the recording-race path), `http_smoke_events` **8/8** (exe-watch), `http_smoke_ratelimit` **1/1**.
- Adversarial multi-agent review (reviewer + refuter per finding, extra-rigorous prompts for the 3 security findings): **0 confirmed blockers**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)