### PR TITLE
Audit 2 Tier 3 #32/#33/#36/#37: CLI deps/scope + installer cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,11 +6635,6 @@ version = "0.1.4-beta.2"
 dependencies = [
  "anyhow",
  "clap",
- "http-body-util",
- "hyper",
- "hyper-util",
- "serde",
- "serde_json",
  "super-stt-shared",
  "tokio",
 ]

--- a/docs/audits/2026-07-code-quality-2.md
+++ b/docs/audits/2026-07-code-quality-2.md
@@ -1038,7 +1038,7 @@ Five clusters account for most of the findings:
 
 ### CLI
 
-### [ ] 32. 🟡 super-stt-cli declares 5 unused dependencies (hyper, hyper-util, http-body-util, serde, serde_json)
+### [x] 32. 🟡 super-stt-cli declares 5 unused dependencies (hyper, hyper-util, http-body-util, serde, serde_json)
 
 - **Where:** `super-stt-cli/Cargo.toml:20-24`; the single-file crate references none of them (all
   network calls go through `super_stt_shared::daemon::http_client`).
@@ -1046,14 +1046,19 @@ Five clusters account for most of the findings:
   CLI hand-rolls a transport, inviting the reimplementation the shared client prevents.
 - **Fix:** `cargo remove -p super-stt-cli hyper hyper-util http-body-util serde serde_json`
   (keep anyhow, clap, tokio, super-stt-shared).
+- **Resolved:** `cargo remove`d all five from `super-stt-cli/Cargo.toml`; only the CLI's
+  dependency edges dropped from `Cargo.lock` (daemon/shared still pull hyper). Crate builds clean.
 
-### [ ] 33. 🟡 CLI-requested SCOPES are hardcoded literals with no conformance guard against the shared catalog
+### [x] 33. 🟡 CLI-requested SCOPES are hardcoded literals with no conformance guard against the shared catalog
 
 - **Where:** `SCOPES: &[&str] = &["transcribe", "status"]` (`super-stt-cli/src/main.rs:27`) — the
   set is correct/least-privilege, but has no link to `scopes::KNOWN_SCOPES`.
 - **Problem:** Tier 2 #8 added a conformance test for the consent binary's scope list; the CLI's
   requested-scope list got no equivalent, so a wire-scope rename fails only at runtime.
 - **Fix:** add a `#[test]` (or debug_assert) asserting `SCOPES.iter().all(|s| scopes::is_known_scope(s))`.
+- **Resolved:** added `#[cfg(test)] mod tests::requested_scopes_are_known` in `main.rs` asserting every
+  entry of `SCOPES` passes `scopes::is_known_scope`, mirroring the consent binary's `scope_conformance`
+  guard. A wire-scope rename now breaks the CLI at `cargo test` instead of at runtime.
 
 ### i18n
 
@@ -1083,21 +1088,27 @@ Five clusters account for most of the findings:
 
 ### Install scripts
 
-### [ ] 36. 🟡 Shell installers leak their `mktemp` working dir (tarball + extracted binaries) on every run
+### [x] 36. 🟡 Shell installers leak their `mktemp` working dir (tarball + extracted binaries) on every run
 
 - **Where:** `install-stable.sh:27` creates `TEMP_DIR` but its cleanup trap is commented out
   (`:679`); `install-beta.sh:51` has no trap.
 - **Impact:** each install/update leaves a `/tmp/tmp.XXXX` holding the multi-hundred-MB tarball +
   binaries until reboot.
 - **Fix:** add `trap 'rm -rf "$TEMP_DIR"' EXIT` after `TEMP_DIR` is set in both.
+- **Resolved:** added `trap 'rm -rf "$TEMP_DIR"' EXIT` immediately after `mktemp -d` in both scripts
+  (fires on early `set -e` failures too); dropped the stale commented-out trap in `install-stable.sh`.
 
-### [ ] 37. 🟡 `uninstall.sh` does not remove the PATH export the installers append to the shell rc
+### [x] 37. 🟡 `uninstall.sh` does not remove the PATH export the installers append to the shell rc
 
 - **Where:** `update_path` appends `export PATH="$HOME/.local/bin:$PATH"` to `.bashrc`/`.zshrc`
   (`install-stable.sh:360-365`, `install-beta.sh:381-386`); `uninstall.sh` never touches the rc.
 - **Impact:** install/uninstall asymmetry — a leftover `export PATH` line survives a full
   uninstall, unmentioned by the "What is PRESERVED" notice.
 - **Fix:** strip the exact appended line on uninstall, or list it under the preserved-state notice.
+- **Resolved (root cause):** fixed the write side instead — `update_path` in both installers no longer
+  edits `.bashrc`/`.zshrc` at all; it only warns the user to add `~/.local/bin` to PATH if it's missing.
+  With nothing appended, the install/uninstall asymmetry is gone and `uninstall.sh` needs no rc edits.
+  Per-user decision: installers must never touch the user's shell profile files.
 
 ---
 

--- a/scripts/install-beta.sh
+++ b/scripts/install-beta.sh
@@ -49,6 +49,10 @@ INSTALL_OPTION="all"
 INTERACTIVE=true
 
 TEMP_DIR=$(mktemp -d)
+# Clean up the tarball + extracted binaries on any exit, including early
+# failures under `set -e`; otherwise each run leaks a multi-hundred-MB
+# /tmp/tmp.XXXX until reboot.
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
 echo "Temp directory: $TEMP_DIR"
 
@@ -361,30 +365,17 @@ install_service() {
     fi
 }
 
-# Update PATH if needed
+# Warn if the install dir isn't on PATH. We deliberately do NOT edit the
+# user's shell profile: rc files are the user's to manage, and an auto-append
+# has no clean uninstall counterpart. Assume `~/.local/bin` is already on PATH
+# (the XDG default) and just tell the user how to add it if it isn't.
 update_path() {
     local bin_dir="$1"
 
     if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
-        print_warn "Add $bin_dir to your PATH:"
+        print_warn "$bin_dir is not on your PATH."
+        print_warn "Add this line to your shell profile (e.g. ~/.bashrc or ~/.zshrc):"
         print_warn "  export PATH=\"$bin_dir:\$PATH\""
-
-        # Try to add to shell config for user installations
-        if [[ "$bin_dir" == "$HOME"* ]]; then
-            SHELL_CONFIG=""
-            if [ -f "$HOME/.bashrc" ]; then
-                SHELL_CONFIG="$HOME/.bashrc"
-            elif [ -f "$HOME/.zshrc" ]; then
-                SHELL_CONFIG="$HOME/.zshrc"
-            fi
-
-            if [ -n "$SHELL_CONFIG" ]; then
-                if ! grep -q "$bin_dir" "$SHELL_CONFIG"; then
-                    echo "export PATH=\"$bin_dir:\$PATH\"" >> "$SHELL_CONFIG"
-                    print_info "Added PATH update to $SHELL_CONFIG"
-                fi
-            fi
-        fi
     fi
 }
 

--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -25,6 +25,10 @@ INSTALL_OPTION="all"
 INTERACTIVE=true
 
 TEMP_DIR=$(mktemp -d)
+# Clean up the tarball + extracted binaries on any exit, including early
+# failures under `set -e`; otherwise each run leaks a multi-hundred-MB
+# /tmp/tmp.XXXX until reboot.
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
 echo "Temp directory: $TEMP_DIR"
 
@@ -340,30 +344,17 @@ install_service() {
     fi
 }
 
-# Update PATH if needed
+# Warn if the install dir isn't on PATH. We deliberately do NOT edit the
+# user's shell profile: rc files are the user's to manage, and an auto-append
+# has no clean uninstall counterpart. Assume `~/.local/bin` is already on PATH
+# (the XDG default) and just tell the user how to add it if it isn't.
 update_path() {
     local bin_dir="$1"
 
     if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
-        print_warn "Add $bin_dir to your PATH:"
+        print_warn "$bin_dir is not on your PATH."
+        print_warn "Add this line to your shell profile (e.g. ~/.bashrc or ~/.zshrc):"
         print_warn "  export PATH=\"$bin_dir:\$PATH\""
-
-        # Try to add to shell config for user installations
-        if [[ "$bin_dir" == "$HOME"* ]]; then
-            SHELL_CONFIG=""
-            if [ -f "$HOME/.bashrc" ]; then
-                SHELL_CONFIG="$HOME/.bashrc"
-            elif [ -f "$HOME/.zshrc" ]; then
-                SHELL_CONFIG="$HOME/.zshrc"
-            fi
-
-            if [ -n "$SHELL_CONFIG" ]; then
-                if ! grep -q "$bin_dir" "$SHELL_CONFIG"; then
-                    echo "export PATH=\"$bin_dir:\$PATH\"" >> "$SHELL_CONFIG"
-                    print_info "Added PATH update to $SHELL_CONFIG"
-                fi
-            fi
-        fi
     fi
 }
 
@@ -675,8 +666,7 @@ DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/$VERSION/$TARBAL
 
 print_info "Downloading from: $DOWNLOAD_URL"
 
-# Create temporary directory
-# trap "rm -rf $TEMP_DIR" EXIT
+# (TEMP_DIR cleanup trap is installed up top, right after `mktemp -d`.)
 
 # Download the tarball with fallback support
 download_with_fallback() {

--- a/super-stt-cli/Cargo.toml
+++ b/super-stt-cli/Cargo.toml
@@ -17,10 +17,5 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-http-body-util = "0.1"
-hyper = { version = "1", features = ["client", "http1"] }
-hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
 super-stt-shared = { path = "../super-stt-shared" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util"] }

--- a/super-stt-cli/src/main.rs
+++ b/super-stt-cli/src/main.rs
@@ -247,3 +247,24 @@ fn cmd_logout() -> Result<()> {
     println!("Cached session token removed. Next invocation will trigger re-consent.");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SCOPES;
+    use super_stt_shared::daemon::scopes::is_known_scope;
+
+    /// The CLI's requested scope set must be a subset of the daemon's shared
+    /// catalog. Without this, a wire-scope rename in `scopes::KNOWN_SCOPES`
+    /// would leave `SCOPES` requesting a token the daemon rejects, and the
+    /// break would only surface at runtime as a failed `/auth/request`. Mirrors
+    /// the consent binary's `scope_conformance` guard (audit 2 Tier 3 #33).
+    #[test]
+    fn requested_scopes_are_known() {
+        for scope in SCOPES {
+            assert!(
+                is_known_scope(scope),
+                "CLI requests scope `{scope}` that is not in scopes::KNOWN_SCOPES"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes four Tier 3 findings from `docs/audits/2026-07-code-quality-2.md`. Each is self-contained; no runtime behavior change beyond installer output.

| # | Fix |
|---|-----|
| **#32** | `cargo remove`d 5 unused `super-stt-cli` deps (`hyper`, `hyper-util`, `http-body-util`, `serde`, `serde_json`) — all network calls already route through `super_stt_shared::daemon::http_client`. Only the CLI's dependency edges leave `Cargo.lock`; the daemon/shared crates still pull hyper. |
| **#33** | Added a `#[cfg(test)]` guard in `super-stt-cli/src/main.rs` asserting every entry of the CLI's requested `SCOPES` is in `scopes::KNOWN_SCOPES`. A wire-scope rename now breaks at `cargo test` instead of surfacing at runtime as a failed `/auth/request`. Mirrors the consent binary's `scope_conformance` guard. |
| **#36** | Added `trap 'rm -rf "$TEMP_DIR"' EXIT` right after `mktemp -d` in `install-stable.sh` and `install-beta.sh` (fires on early `set -e` failures too), so each install/update no longer leaks a multi-hundred-MB `/tmp/tmp.XXXX`. Dropped the stale commented-out trap in `install-stable.sh`. |
| **#37** | Fixed the *write* side: `update_path` in both installers no longer appends `export PATH=...` to `.bashrc`/`.zshrc`. It only warns the user to add `~/.local/bin` to PATH if it's missing. With nothing appended, the install/uninstall asymmetry disappears and `uninstall.sh` needs no rc edits. Installers must never touch the user's shell profile. |

## Verification
- `cargo test -p super-stt-cli` — new `requested_scopes_are_known` test passes; crate compiles clean without the removed deps.
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings` — clean.
- `just fmt` — clean.
- `bash -n` on all three scripts — clean.
- Adversarial 4-dimension review (one reviewer + refuter per finding) — **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)