### PR TITLE
Surface daemon errors instead of masking them as parse failures

### DIFF
--- a/super-stt-daemon/src/daemon/http/error_envelope_contract.rs
+++ b/super-stt-daemon/src/daemon/http/error_envelope_contract.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Contract: every error envelope the daemon emits must name its failure to
+//! the client.
+//!
+//! The daemon builds error bodies through several constructors, each with a
+//! slightly different shape (`error_code`, the registry's legacy `error`,
+//! `message`, `data.reason`). The client collapses all of them in one place —
+//! [`super_stt_shared::daemon::http_client::transport::daemon_error`] — into
+//! the text a user actually sees.
+//!
+//! Nothing structural keeps those two halves in agreement: they live in
+//! different crates, and neither crate's own tests exercise the pair. A new
+//! envelope that spells its identifier differently would parse as valid JSON,
+//! travel the wire intact, and reach the user as a bare `daemon returned HTTP
+//! 500` — losing the identifier without failing anything. This test asserts
+//! the round trip for every constructor in use, so that drift is a test
+//! failure rather than a degraded error message.
+//!
+//! Adding an error envelope? Add it here too.
+
+use super::internal::helpers::dispatch::json_response;
+use super::internal::helpers::responses::{
+    invalid_session, rate_limited, reason, recording_in_progress_response, scope_denied,
+};
+use super::v1::backends::{json_error, json_error_msg};
+use super::v1::registry::{registry_error, registry_error_msg};
+use axum::http::StatusCode;
+use axum::response::Response;
+use super_stt_shared::daemon::http_client::transport::error_for_status;
+use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
+
+async fn parts_of(resp: Response) -> (StatusCode, Vec<u8>) {
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("collect body");
+    (status, bytes.to_vec())
+}
+
+/// Run a daemon-built response through the client's mapping and return the
+/// string a user would see.
+async fn as_client_sees_it(resp: Response) -> String {
+    let (status, body) = parts_of(resp).await;
+    error_for_status(status, &body).to_string()
+}
+
+/// Each constructor, paired with the identifier that must survive the trip.
+/// Failures the user can act on are worth naming precisely, so the assertion
+/// is on the identifier itself rather than "some non-empty string".
+#[tokio::test]
+async fn every_error_envelope_reaches_the_client_naming_its_failure() {
+    let cases: Vec<(&str, Response, &str)> = vec![
+        (
+            "registry_error",
+            registry_error(StatusCode::NOT_FOUND, "not_found"),
+            "not_found",
+        ),
+        (
+            "registry_error_msg",
+            registry_error_msg(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "remove_failed",
+                "Permission denied (os error 13)",
+            ),
+            "remove_failed",
+        ),
+        (
+            "json_error",
+            json_error(StatusCode::NOT_FOUND, "unknown_backend"),
+            "unknown_backend",
+        ),
+        (
+            "json_error_msg",
+            json_error_msg(
+                StatusCode::BAD_REQUEST,
+                "invalid_option",
+                "value out of range",
+            ),
+            "invalid_option",
+        ),
+        ("scope_denied", scope_denied(), "scope_denied"),
+        ("rate_limited", rate_limited(), "rate_limited"),
+        (
+            "recording_in_progress",
+            recording_in_progress_response(),
+            "recording_in_progress",
+        ),
+    ];
+
+    for (name, resp, identifier) in cases {
+        let seen = as_client_sees_it(resp).await;
+        assert!(
+            seen.contains(identifier),
+            "`{name}` envelope reaches the client as {seen:?}, which does not name `{identifier}`"
+        );
+        assert!(
+            !seen.starts_with("daemon returned HTTP"),
+            "`{name}` envelope fell back to the bare status ({seen:?}) — the client cannot read \
+             the shape it emits"
+        );
+    }
+}
+
+/// `dispatch_command` answers on the `DaemonResponse` envelope, whose failures
+/// carry a typed `ErrorCode` and a human message. Both halves must arrive.
+#[tokio::test]
+async fn dispatch_error_reaches_the_client_with_code_and_message() {
+    let resp = DaemonResponse::error("No installed backend serves that model")
+        .with_error_code(ErrorCode::InvalidModel);
+    let (status, headers, body) = json_response(&resp);
+    let seen = error_for_status(status, body.as_bytes()).to_string();
+
+    assert_eq!(headers[0].1, "application/json");
+    assert!(
+        seen.contains("invalid_model"),
+        "the machine-readable code must survive: {seen:?}"
+    );
+    assert!(
+        seen.contains("No installed backend serves that model"),
+        "the human message must survive: {seen:?}"
+    );
+}
+
+/// A `401` is the one status the client must be able to route back to
+/// re-authentication, so it keeps a typed variant rather than collapsing into
+/// the operational-error text.
+#[tokio::test]
+async fn invalid_session_stays_routable_to_reauth() {
+    let (status, body) = parts_of(invalid_session(reason::UNKNOWN)).await;
+    let err = error_for_status(status, &body);
+
+    assert!(
+        err.is_invalid_session(),
+        "401 must stay typed for the re-auth path, got: {err}"
+    );
+    assert_eq!(err.to_string(), "invalid_session (unknown)");
+}

--- a/super-stt-daemon/src/daemon/http/mod.rs
+++ b/super-stt-daemon/src/daemon/http/mod.rs
@@ -2,6 +2,8 @@
 //! HTTP server for the daemon protocol. See `server.rs` for the listener
 //! and `v1/` for the versioned endpoint tree.
 
+#[cfg(test)]
+mod error_envelope_contract;
 mod internal;
 mod server;
 mod state;

--- a/super-stt-shared/src/daemon/http_client/internal/transport.rs
+++ b/super-stt-shared/src/daemon/http_client/internal/transport.rs
@@ -69,17 +69,85 @@ pub(crate) fn build_delete(
         .map_err(|e| format!("Failed to build request: {e}"))
 }
 
-/// Extract the `data.reason` field from a 401 response body. Falls
-/// back to `"unknown"` if the body is malformed. Centralized so the
-/// three `invalid_session` sites stay consistent.
-pub(crate) fn parse_invalid_session_reason(body: &[u8]) -> String {
+/// Extract the `data.reason` field from an error body, falling back to
+/// `fallback` when the body is malformed or carries no reason.
+pub(crate) fn parse_reason(body: &[u8], fallback: &str) -> String {
     let parsed: serde_json::Value = serde_json::from_slice(body).unwrap_or(serde_json::Value::Null);
     parsed
         .get("data")
         .and_then(|d| d.get("reason"))
         .and_then(|r| r.as_str())
-        .unwrap_or("unknown")
+        .unwrap_or(fallback)
         .to_string()
+}
+
+/// The `data.reason` of a 401 body. Centralized so the `invalid_session`
+/// sites stay consistent.
+pub(crate) fn parse_invalid_session_reason(body: &[u8]) -> String {
+    parse_reason(body, "unknown")
+}
+
+/// **The** conversion from a non-success response to a typed [`HttpError`].
+///
+/// Every non-2xx path funnels through here so the rule lives in one place.
+/// It previously did not: four call sites each re-derived it, and the typed
+/// `send_request` path omitted the check entirely — handing error envelopes to
+/// the success-type deserializer, which then blamed whichever success field it
+/// found missing (a rate-limited uninstall surfaced as ``missing field
+/// `uninstalled` at line 1 column 43``).
+///
+/// `401` keeps its own variant because callers re-authenticate on it; every
+/// other status is an operational failure described by [`daemon_error`].
+///
+/// Note `/auth/request` deliberately does *not* use this: a 4xx there means the
+/// user declined consent, which is [`HttpError::AuthDenied`], not a daemon
+/// error.
+#[must_use]
+pub fn error_for_status(status: hyper::StatusCode, body: &[u8]) -> HttpError {
+    if status == hyper::StatusCode::UNAUTHORIZED {
+        return HttpError::InvalidSession {
+            reason: parse_invalid_session_reason(body),
+        };
+    }
+    daemon_error(status, body)
+}
+
+/// Build an [`HttpError`] from a non-success, non-401 response body.
+///
+/// The daemon answers failures with one of several `{"status":"error", …}`
+/// envelopes, all of which name the failure in `error_code` (the stable
+/// machine identifier — `error` is the registry envelope's legacy spelling of
+/// the same value) and/or `message` (human text). None of them share a shape
+/// with any endpoint's success type, so a non-2xx body must be turned into an
+/// error rather than deserialized.
+///
+/// Prefer [`error_for_status`] — it adds the `401` case. This is separate only
+/// so the daemon's envelope-contract test can assert on the operational
+/// mapping directly.
+#[must_use]
+pub fn daemon_error(status: hyper::StatusCode, body: &[u8]) -> HttpError {
+    let parsed: serde_json::Value = serde_json::from_slice(body).unwrap_or(serde_json::Value::Null);
+    let field = |key: &str| {
+        parsed
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    };
+    let code = field("error_code").or_else(|| field("error"));
+    let detail = match (code, field("message")) {
+        // Envelopes that carry no human text set `message` to the code itself;
+        // don't say it twice.
+        (Some(code), Some(message)) if code == message => Some(code),
+        (Some(code), Some(message)) => Some(format!("{code}: {message}")),
+        (Some(text), None) | (None, Some(text)) => Some(text),
+        (None, None) => None,
+    };
+    let status = status.as_u16();
+    HttpError::Other(detail.map_or_else(
+        || format!("daemon returned HTTP {status}"),
+        |detail| format!("{detail} (HTTP {status})"),
+    ))
 }
 
 /// Map non-success statuses on the `/events` subscribe call to the
@@ -94,16 +162,7 @@ pub(crate) async fn check_subscribe_status(
         return Ok(response);
     }
     let body = collect_body(response).await?;
-    if status == hyper::StatusCode::UNAUTHORIZED {
-        return Err(HttpError::InvalidSession {
-            reason: parse_invalid_session_reason(&body),
-        });
-    }
-    let parsed: serde_json::Value =
-        serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
-    Err(HttpError::Other(format!(
-        "events subscribe failed (status {status}): {parsed}"
-    )))
+    Err(error_for_status(status, &body))
 }
 
 /// Upper bound on how long a **non-interactive** request waits for the
@@ -208,10 +267,11 @@ pub(crate) async fn send_request_with_timeout<T: DeserializeOwned>(
     let response = open(socket_path, req, timeout).await?;
     let status = response.status();
     let body = collect_body(response).await?;
-    if status == hyper::StatusCode::UNAUTHORIZED {
-        return Err(HttpError::InvalidSession {
-            reason: parse_invalid_session_reason(&body),
-        });
+    // Only a 2xx body is an instance of `T`. Deserializing an error envelope
+    // into the success type reports a missing success field instead of the
+    // failure the daemon actually named — see [`error_for_status`].
+    if !status.is_success() {
+        return Err(error_for_status(status, &body));
     }
     serde_json::from_slice::<T>(&body)
         .map_err(|e| HttpError::Other(format!("Failed to parse response: {e}")))
@@ -319,4 +379,90 @@ pub async fn delete_json<T: DeserializeOwned>(
 ) -> HttpResult<T> {
     let req = build_delete(path, Some(token))?;
     send_request::<T>(&socket_path, req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::daemon_error;
+    use hyper::StatusCode;
+
+    /// A non-2xx body must never reach the `T` deserializer. The daemon's
+    /// error envelopes don't share a shape with the endpoint's success type,
+    /// so parsing one as `T` reports whichever success field happened to be
+    /// missing — burying the actual cause. This is the regression that made a
+    /// rate-limited uninstall surface as
+    /// ``missing field `uninstalled` at line 1 column 43``.
+    #[test]
+    fn non_success_status_reports_the_daemon_identifier_not_a_parse_error() {
+        let e = daemon_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            br#"{"status":"error","message":"rate_limited"}"#,
+        );
+        assert_eq!(e.to_string(), "rate_limited (HTTP 429)");
+        assert!(
+            !e.to_string().contains("missing field"),
+            "the endpoint's success schema must not be blamed for a daemon error"
+        );
+    }
+
+    /// The registry envelope carries the identifier in `error_code`, plus the
+    /// legacy `error` spelling of the same value. One mention is enough.
+    #[test]
+    fn registry_envelope_uses_error_code_without_repeating_the_legacy_key() {
+        let e = daemon_error(
+            StatusCode::NOT_FOUND,
+            br#"{"status":"error","error_code":"not_found","error":"not_found"}"#,
+        );
+        assert_eq!(e.to_string(), "not_found (HTTP 404)");
+    }
+
+    /// When the daemon supplies both a stable code and a human message, keep
+    /// both: the code is what a maintainer greps for, the message is what tells
+    /// the user *why* (e.g. the underlying io error behind `remove_failed`).
+    #[test]
+    fn code_and_message_are_both_preserved() {
+        let e = daemon_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            br#"{"status":"error","error_code":"remove_failed","error":"remove_failed","message":"Permission denied (os error 13)"}"#,
+        );
+        assert_eq!(
+            e.to_string(),
+            "remove_failed: Permission denied (os error 13) (HTTP 500)"
+        );
+    }
+
+    /// `dispatch_command` answers with a `DaemonResponse` whose `message` is
+    /// the human text callers used to surface via `require_success`. That text
+    /// must survive the earlier status check.
+    #[test]
+    fn daemon_response_error_keeps_its_human_message() {
+        let e = daemon_error(
+            StatusCode::BAD_REQUEST,
+            br#"{"status":"error","message":"Model not loaded","error_code":"model_not_loaded"}"#,
+        );
+        assert_eq!(
+            e.to_string(),
+            "model_not_loaded: Model not loaded (HTTP 400)"
+        );
+    }
+
+    /// A body that isn't the expected envelope at all (empty, HTML from a
+    /// stray proxy, truncated JSON) still has to name the status rather than
+    /// invent a field-level complaint.
+    #[test]
+    fn unrecognized_body_falls_back_to_the_bare_status() {
+        assert_eq!(
+            daemon_error(StatusCode::BAD_GATEWAY, b"").to_string(),
+            "daemon returned HTTP 502"
+        );
+        assert_eq!(
+            daemon_error(StatusCode::FORBIDDEN, b"<html>nope</html>").to_string(),
+            "daemon returned HTTP 403"
+        );
+        // Present-but-empty strings are as useless as absent ones.
+        assert_eq!(
+            daemon_error(StatusCode::CONFLICT, br#"{"status":"error","message":""}"#).to_string(),
+            "daemon returned HTTP 409"
+        );
+    }
 }

--- a/super-stt-shared/src/daemon/http_client/mod.rs
+++ b/super-stt-shared/src/daemon/http_client/mod.rs
@@ -34,4 +34,9 @@ pub mod transport {
         delete_json, get_json, post_json, settings_delete, settings_get, settings_post,
         settings_post_no_timeout,
     };
+
+    /// The single non-2xx-to-[`HttpError`] mapping, exported so the daemon's
+    /// envelope-contract test can assert that every error shape it emits is
+    /// one this client can actually read.
+    pub use super::internal::transport::{daemon_error, error_for_status};
 }

--- a/super-stt-shared/src/daemon/http_client/v1/auth/request.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/auth/request.rs
@@ -44,16 +44,13 @@ pub async fn auth_request(
     let status = response.status();
     let body = transport::collect_body(response).await?;
 
+    // Deliberately not `transport::error_for_status`: a 4xx here means the user
+    // declined consent (or the daemon refused to ask), which callers handle as
+    // `AuthDenied` with a reason — not as an operational daemon error.
     if !status.is_success() {
-        let parsed: serde_json::Value =
-            serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
-        let reason = parsed
-            .get("data")
-            .and_then(|d| d.get("reason"))
-            .and_then(|r| r.as_str())
-            .unwrap_or("auth_denied")
-            .to_string();
-        return Err(HttpError::AuthDenied { reason });
+        return Err(HttpError::AuthDenied {
+            reason: transport::parse_reason(&body, "auth_denied"),
+        });
     }
 
     serde_json::from_slice::<AuthOk>(&body)

--- a/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
+++ b/super-stt-shared/src/daemon/http_client/v1/transcribe.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use super::super::internal::error::{HttpError, HttpResult};
+use super::super::internal::error::HttpResult;
 use super::super::internal::sse;
 use super::super::internal::transport;
 use crate::models::protocol::DaemonResponse;
@@ -118,25 +118,14 @@ pub async fn transcribe_stream(
     let response = transport::open(&socket_path, req, Some(transport::REQUEST_TIMEOUT)).await?;
 
     let status = response.status();
-    if status == hyper::StatusCode::UNAUTHORIZED {
-        let body = transport::collect_body(response).await?;
-        return Err(HttpError::InvalidSession {
-            reason: transport::parse_invalid_session_reason(&body),
-        });
-    }
     if !status.is_success() {
         // Non-2xx response (e.g. 409 `recording_in_progress`, 403
-        // `scope_denied`, 429 `rate_limited`). The body is JSON, not
-        // SSE — parse `{"message": "..."}` and surface it as
-        // `HttpError::Other` so the caller doesn't try to read it as
-        // an event stream and report "transcribe stream ended
-        // unexpectedly".
+        // `scope_denied`, 429 `rate_limited`). The body is the JSON error
+        // envelope, not SSE, so map it like every other non-2xx rather than
+        // letting the caller read it as an event stream and report
+        // "transcribe stream ended unexpectedly".
         let body = transport::collect_body(response).await?;
-        let message: String = serde_json::from_slice::<serde_json::Value>(&body)
-            .ok()
-            .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(str::to_owned))
-            .unwrap_or_else(|| format!("HTTP {status}"));
-        return Err(HttpError::Other(message));
+        return Err(transport::error_for_status(status, &body));
     }
 
     // Parse Server-Sent Events as they arrive: each event is a block of

--- a/super-stt-shared/tests/transport_error_status.rs
+++ b/super-stt-shared/tests/transport_error_status.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! A daemon error must reach the caller as that error.
+//!
+//! The typed transport helpers deserialize a response body into the endpoint's
+//! success type. That is only valid for a 2xx: every daemon failure answers
+//! with a `{"status":"error", …}` envelope which shares no fields with any
+//! success type, so feeding one to the success deserializer reports whichever
+//! success field was missing and buries the real cause. A rate-limited backend
+//! uninstall surfaced in the app as
+//! ``Uninstall failed: Failed to parse response: missing field `uninstalled` at
+//! line 1 column 43`` — "column 43" being the length of the 429 body, the only
+//! trace of what actually went wrong.
+//!
+//! These tests drive the real socket path rather than the status-to-message
+//! helper alone, because the defect was the missing status check in
+//! `send_request`, not the mapping.
+
+use serde::Deserialize;
+use super_stt_shared::daemon::http_client::transport;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Stands in for any endpoint's success type — the point is that none of its
+/// fields appear in an error envelope.
+#[derive(Debug, Deserialize)]
+struct UninstallResponse {
+    #[allow(dead_code)]
+    uninstalled: bool,
+    #[allow(dead_code)]
+    was_active: bool,
+}
+
+/// Serve exactly one request on `socket`, answering with `status` and `body`.
+/// Raw bytes rather than a server framework: the response shape under test is
+/// a fixed handful of bytes, and the daemon writes its own rejections the same
+/// way. Must be called from within a tokio runtime — `bind` registers with the
+/// reactor.
+fn serve_once(socket: &std::path::Path, status: &'static str, body: &'static str) {
+    let listener = tokio::net::UnixListener::bind(socket).expect("bind test socket");
+    tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        // Read the request head so the client's write completes; the body is
+        // irrelevant to what we answer.
+        let mut buf = [0u8; 2048];
+        let _ = stream.read(&mut buf).await;
+        let response = format!(
+            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        let _ = stream.shutdown().await;
+    });
+}
+
+fn socket_path(name: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!("super-stt-transport-test-{name}.sock"));
+    let _ = std::fs::remove_file(&path);
+    path
+}
+
+/// The exact regression: 429 `rate_limited`, the body that produced
+/// "missing field `uninstalled` at line 1 column 43".
+#[tokio::test]
+async fn rate_limited_uninstall_surfaces_rate_limited() {
+    let socket = socket_path("rate-limited");
+    serve_once(
+        &socket,
+        "429 Too Many Requests",
+        r#"{"status":"error","message":"rate_limited"}"#,
+    );
+
+    let err = transport::delete_json::<UninstallResponse>(socket.clone(), "token", "/backends/x")
+        .await
+        .expect_err("a 429 is not a successful uninstall");
+
+    let message = err.to_string();
+    assert_eq!(message, "rate_limited (HTTP 429)");
+    assert!(
+        !message.contains("uninstalled"),
+        "the success schema must not be blamed for a daemon error: {message}"
+    );
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// The same guard has to hold for the operational failures an uninstall can
+/// legitimately hit, so none of them regress into schema complaints.
+#[tokio::test]
+async fn registry_failures_surface_their_error_code() {
+    let socket = socket_path("not-found");
+    serve_once(
+        &socket,
+        "404 Not Found",
+        r#"{"status":"error","error_code":"not_found","error":"not_found"}"#,
+    );
+
+    let err = transport::delete_json::<UninstallResponse>(socket.clone(), "token", "/backends/x")
+        .await
+        .expect_err("a 404 is not a successful uninstall");
+
+    assert_eq!(err.to_string(), "not_found (HTTP 404)");
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// A 401 still takes the typed `InvalidSession` path — the status check added
+/// for other failures must not swallow the one callers re-authenticate on.
+#[tokio::test]
+async fn unauthorized_still_maps_to_invalid_session() {
+    let socket = socket_path("unauthorized");
+    serve_once(
+        &socket,
+        "401 Unauthorized",
+        r#"{"status":"error","message":"invalid_session","data":{"reason":"expired"}}"#,
+    );
+
+    let err = transport::delete_json::<UninstallResponse>(socket.clone(), "token", "/backends/x")
+        .await
+        .expect_err("a 401 is not a successful uninstall");
+
+    assert!(
+        err.is_invalid_session(),
+        "401 must stay routable to re-auth, got: {err}"
+    );
+    assert_eq!(err.to_string(), "invalid_session (expired)");
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// The streaming endpoints answer a rejected request with the same JSON
+/// envelope rather than an event stream. Both used to derive their own error
+/// text; they now share the one mapping, and this pins the wiring so neither
+/// can quietly drift back.
+#[tokio::test]
+async fn streaming_endpoints_share_the_same_mapping() {
+    let socket = socket_path("events-rejected");
+    serve_once(
+        &socket,
+        "429 Too Many Requests",
+        r#"{"status":"error","message":"rate_limited"}"#,
+    );
+    let err = super_stt_shared::daemon::http_client::events_stream(socket.clone(), "token", &["a"])
+        .await
+        .err()
+        .expect("a 429 is not a subscription");
+    assert_eq!(err.to_string(), "rate_limited (HTTP 429)");
+    let _ = std::fs::remove_file(&socket);
+
+    let socket = socket_path("transcribe-rejected");
+    serve_once(
+        &socket,
+        "409 Conflict",
+        r#"{"status":"error","message":"recording_in_progress"}"#,
+    );
+    let err = super_stt_shared::daemon::http_client::transcribe_stream(
+        socket.clone(),
+        "token",
+        super_stt_shared::daemon::http_client::TranscribeOptions::default(),
+    )
+    .await
+    .err()
+    .expect("a 409 is not a recording");
+    assert_eq!(err.to_string(), "recording_in_progress (HTTP 409)");
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// The success path is untouched: a 2xx body still deserializes into `T`.
+#[tokio::test]
+async fn successful_uninstall_still_parses() {
+    let socket = socket_path("success");
+    serve_once(
+        &socket,
+        "200 OK",
+        r#"{"uninstalled":true,"was_active":false}"#,
+    );
+
+    let resp = transport::delete_json::<UninstallResponse>(socket.clone(), "token", "/backends/x")
+        .await
+        .expect("a 200 with a well-formed body is a successful uninstall");
+
+    assert!(resp.uninstalled);
+    assert!(!resp.was_active);
+    let _ = std::fs::remove_file(&socket);
+}


### PR DESCRIPTION
Uninstalling a backend in the app failed with `Uninstall failed: Failed to parse response: missing field `"`"`uninstalled`"`"` at line 1 column 43`.

## Root cause

`send_request` special-cased only `401`, then handed **every** other response body to the success-type deserializer. The daemon had answered `429 {"status":"error","message":"rate_limited"}` — a 43-byte body, hence "column 43". serde reported the first missing success field, burying the real cause.

This was never uninstall-specific: it masked `not_found`, `backend_busy`, `remove_failed`, and `scope_denied` across every typed endpoint.

## Fix

`error_for_status()` is now the single non-2xx → `HttpError` conversion, reading the daemon`'s `error_code`/`error`/`message`. Three sites route through it — `send_request` (was missing the check entirely), `check_subscribe_status` (dropped its raw-JSON dump), and `transcribe_stream` (was blind to `error_code`).

`auth_request` stays separate on purpose: a 4xx there means the user declined consent (`AuthDenied`), not a daemon failure. It now shares the `parse_reason` helper instead of re-deriving `data.reason`.

## Tests (13)

- **Contract test** (`error_envelope_contract.rs`) — every envelope constructor the daemon has is built for real, run through the client mapper, and asserted to still name its failure. Catches the daemon emitting a shape the client can't read.
- **Integration** (`transport_error_status.rs`) — real Unix sockets: the regression, registry failures, 401 staying typed for re-auth, both streaming endpoints, and the untouched success path.
- **Unit** — the mapping table.

Both new suites were sabotage-tested rather than assumed: disabling the status guard reproduces the exact original string; making the mapper unable to read `error_code` fails the contract test.

Audit 1 #6's property is preserved and asserted — failures still return `DaemonResponse::error` with the `error` SSE event, never success.

`just ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)