### PR TITLE
Tell the user why a write-mode recording failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 [[package]]
 name = "gpu-probe"
 version = "0.1.0"
-source = "git+https://github.com/jorge-menjivar/gpu-probe#55a3e6fcafa0039cc1611c9bac91ff8d6d8d83c2"
+source = "git+https://github.com/jorge-menjivar/gpu-probe?rev=2912a8d8ca2d77aae511e60f824fcad1ab409892#2912a8d8ca2d77aae511e60f824fcad1ab409892"
 dependencies = [
  "nvml-wrapper",
 ]
@@ -6695,7 +6695,6 @@ dependencies = [
  "libc",
  "log",
  "mockito",
- "nvml-wrapper",
  "parking_lot",
  "reqwest",
  "ring",

--- a/docs/protocol/endpoints/v1/transcribe.md
+++ b/docs/protocol/endpoints/v1/transcribe.md
@@ -129,8 +129,10 @@ When the request set `write_mode: true`, a failure also types a short fixed
 notice into the focused window — for example `[Super STT: no model loaded]` —
 because a write-mode client is looking at a text field rather than at this
 response. The notice is a fixed daemon-authored string; backend-supplied error
-detail is never typed. The failure is still reported normally here and via the
-`error` SSE event, with an empty transcription.
+detail is never typed. The failure is still reported normally — as the direct
+error response (e.g. `409 model_not_loaded`, checked and answered before the
+`202`/SSE envelope for a daemon-mic capture commits) or, once an SSE stream has
+started, via the `error` event — with an empty transcription.
 
 Once an SSE response has started (`200 text/event-stream`), late
 errors arrive as an in-stream `event: error` block followed by the

--- a/docs/protocol/endpoints/v1/transcribe.md
+++ b/docs/protocol/endpoints/v1/transcribe.md
@@ -120,9 +120,17 @@ when a capture is already in progress.
 | 400  | `stream_realtime_with_audio_data`  | Request carried both `audio_data` and `stream_realtime: true`           |
 | 401  | `invalid_session`                  | Token unknown / expired / `exe_changed` — re-auth and retry             |
 | 403  | `scope_denied`                     | Token lacks the `transcribe` scope                                      |
+| 409  | `model_not_loaded`                 | No model is loaded, so no transcription is possible; load one via `POST /active_model` and retry |
 | 409  | `recording_in_progress`            | A daemon-mic capture was already running; check `busy` on `/status` and call `/transcribe/stop` instead |
 | 429  | `rate_limited`                     | Per-client rate limit hit; back off and retry                           |
 | 503  | `connection_rejected`              | Server refused the connection                                           |
+
+When the request set `write_mode: true`, a failure also types a short fixed
+notice into the focused window — for example `[Super STT: no model loaded]` —
+because a write-mode client is looking at a text field rather than at this
+response. The notice is a fixed daemon-authored string; backend-supplied error
+detail is never typed. The failure is still reported normally here and via the
+`error` SSE event, with an empty transcription.
 
 Once an SSE response has started (`200 text/event-stream`), late
 errors arrive as an in-stream `event: error` block followed by the

--- a/super-stt-daemon/Cargo.toml
+++ b/super-stt-daemon/Cargo.toml
@@ -67,9 +67,8 @@ wasmtime-wasi = { version = "45.0.0", optional = true }
 wasmtime-wasi-http = { version = "45.0.0", optional = true }
 bytes = { version = "1.11.1", optional = true }
 http-body = { version = "1.0.1", optional = true }
-gpu-probe = { git = "https://github.com/jorge-menjivar/gpu-probe", version = "0.1.0" }
+gpu-probe = { git = "https://github.com/jorge-menjivar/gpu-probe", rev = "2912a8d8ca2d77aae511e60f824fcad1ab409892" }
 semver = "1.0.28"
-nvml-wrapper = "0.12"
 thiserror.workspace = true
 tar = "0.4.46"
 flate2 = "1.1.9"

--- a/super-stt-daemon/Cargo.toml
+++ b/super-stt-daemon/Cargo.toml
@@ -106,6 +106,9 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 libc.workspace = true
 mockito = "1.7.2"
 tempfile = "3.27.0"
+# `test-util` enables `#[tokio::test(start_paused = true)]`, so tests covering
+# the notice key-release delay assert it without spending it in wall-clock time.
+tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6.5"
 
 [[bin]]

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -1317,7 +1317,9 @@ async fn handle_transcribe_errors_when_no_model_loaded() {
 
 /// The whole point of the preflight: no capture, no beeps, and the user is told
 /// in the field they are looking at.
-#[tokio::test]
+// `start_paused` so the notice's key-release delay is virtual — this asserts
+// what the preflight does, not how long the notice waits.
+#[tokio::test(start_paused = true)]
 async fn record_with_no_model_types_a_notice_in_write_mode() {
     let daemon = test_daemon().await;
     let (sim, buf) = crate::output::keyboard::Simulator::capture();

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -1298,8 +1298,10 @@ async fn handle_transcribe_reports_backend_failure_as_error() {
     );
 }
 
-/// With no model loaded, the one-shot path returns an error response naming
-/// the missing model.
+/// With no model loaded, the one-shot path returns a coded error response —
+/// `ErrorCode::ModelNotLoaded`, so an HTTP caller of the pre-captured
+/// `audio_data` path gets the same `409 model_not_loaded` as the daemon-mic
+/// paths (see docs/protocol/endpoints/v1/transcribe.md).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn handle_transcribe_errors_when_no_model_loaded() {
     let daemon = test_daemon().await;
@@ -1309,14 +1311,8 @@ async fn handle_transcribe_errors_when_no_model_loaded() {
         .await;
 
     assert_eq!(resp.status, "error");
-    assert!(
-        resp.message
-            .as_deref()
-            .unwrap_or_default()
-            .contains("Model not loaded"),
-        "error message should name the missing model, got: {:?}",
-        resp.message
-    );
+    assert_eq!(resp.error_code, Some(ErrorCode::ModelNotLoaded));
+    assert_eq!(resp.message.as_deref(), Some("model_not_loaded"));
 }
 
 /// The whole point of the preflight: no capture, no beeps, and the user is told

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -7,6 +7,8 @@ use crate::input::audio::AudioProcessor;
 use crate::resource_management::ResourceManager;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+use super_stt_shared::models::protocol::ErrorCode;
+use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::theme::AudioTheme;
 use tokio::sync::broadcast;
 use tokio::time::{Duration, timeout};
@@ -1314,5 +1316,47 @@ async fn handle_transcribe_errors_when_no_model_loaded() {
             .contains("Model not loaded"),
         "error message should name the missing model, got: {:?}",
         resp.message
+    );
+}
+
+/// The whole point of the preflight: no capture, no beeps, and the user is told
+/// in the field they are looking at.
+#[tokio::test]
+async fn record_with_no_model_types_a_notice_in_write_mode() {
+    let daemon = test_daemon().await;
+    let (sim, buf) = crate::output::keyboard::Simulator::capture();
+    let mut typer = crate::output::typer::Typer::new(sim);
+
+    let resp = daemon
+        .handle_record_internal(&mut typer, true, RecordingStopMode::ManualOnly, None)
+        .await;
+
+    assert_eq!(resp.status, "error");
+    assert_eq!(resp.error_code, Some(ErrorCode::ModelNotLoaded));
+    assert_eq!(*buf.lock().unwrap(), "[Super STT: no model loaded]");
+    // Capture must never have started.
+    assert!(
+        !*daemon.busy.read().await,
+        "preflight must not leave the daemon busy"
+    );
+}
+
+/// Without write mode there is no focused field to write into; the caller gets
+/// the error response and nothing is typed.
+#[tokio::test]
+async fn record_with_no_model_types_nothing_without_write_mode() {
+    let daemon = test_daemon().await;
+    let (sim, buf) = crate::output::keyboard::Simulator::capture();
+    let mut typer = crate::output::typer::Typer::new(sim);
+
+    let resp = daemon
+        .handle_record_internal(&mut typer, false, RecordingStopMode::ManualOnly, None)
+        .await;
+
+    assert_eq!(resp.error_code, Some(ErrorCode::ModelNotLoaded));
+    assert_eq!(
+        *buf.lock().unwrap(),
+        "",
+        "nothing may be typed outside write mode"
     );
 }

--- a/super-stt-daemon/src/daemon/http/error_envelope_contract.rs
+++ b/super-stt-daemon/src/daemon/http/error_envelope_contract.rs
@@ -20,7 +20,8 @@
 
 use super::internal::helpers::dispatch::json_response;
 use super::internal::helpers::responses::{
-    invalid_session, rate_limited, reason, recording_in_progress_response, scope_denied,
+    invalid_session, model_not_loaded_response, rate_limited, reason,
+    recording_in_progress_response, scope_denied,
 };
 use super::v1::backends::{json_error, json_error_msg};
 use super::v1::registry::{registry_error, registry_error_msg};
@@ -85,6 +86,11 @@ async fn every_error_envelope_reaches_the_client_naming_its_failure() {
             recording_in_progress_response(),
             "recording_in_progress",
         ),
+        (
+            "model_not_loaded",
+            model_not_loaded_response(),
+            "model_not_loaded",
+        ),
     ];
 
     for (name, resp, identifier) in cases {
@@ -119,6 +125,24 @@ async fn dispatch_error_reaches_the_client_with_code_and_message() {
         seen.contains("No installed backend serves that model"),
         "the human message must survive: {seen:?}"
     );
+}
+
+/// `model_not_loaded_response` (the mic-path `409` fired before the
+/// `202`/SSE envelope commits) must carry `error_code` — not just `message`
+/// — so it agrees with the pre-captured `audio_data` path's `409` for the
+/// same condition (`DaemonResponse::error_with_code(ErrorCode::ModelNotLoaded,
+/// ..)`, see `transcription.rs`). `error_for_status` collapsing both fields
+/// to the same string (asserted above) isn't enough to prove `error_code` is
+/// actually present, since `message` alone already spells the identifier —
+/// so this test reads the raw JSON body directly.
+#[tokio::test]
+async fn model_not_loaded_response_carries_error_code() {
+    let (status, body) = parts_of(model_not_loaded_response()).await;
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(parsed["error_code"], "model_not_loaded");
+    assert_eq!(parsed["message"], "model_not_loaded");
 }
 
 /// A `401` is the one status the client must be able to route back to

--- a/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
+++ b/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
@@ -90,6 +90,26 @@ pub(crate) fn recording_in_progress_response() -> Response {
         .into_response()
 }
 
+/// Pre-built `409 model_not_loaded` JSON response for the `/v1/transcribe`
+/// handler's daemon-mic paths. Mirrors [`recording_in_progress_response`]
+/// (same shape, same literal identifier as `message`): returned before the
+/// `202`/`200 text/event-stream` envelope below would otherwise commit, so
+/// the documented `409` is actually reachable
+/// (`docs/protocol/endpoints/v1/transcribe.md`). Load a model via
+/// `POST /active_model` and retry.
+pub(crate) fn model_not_loaded_response() -> Response {
+    let body = serde_json::json!({
+        "status":  "error",
+        "message": "model_not_loaded",
+    });
+    (
+        StatusCode::CONFLICT,
+        [("content-type", "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}
+
 pub(crate) fn auth_err(status: StatusCode, message: &str, reason: &str) -> Response {
     error_response(status, message, reason)
 }

--- a/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
+++ b/super-stt-daemon/src/daemon/http/internal/helpers/responses.rs
@@ -97,10 +97,17 @@ pub(crate) fn recording_in_progress_response() -> Response {
 /// the documented `409` is actually reachable
 /// (`docs/protocol/endpoints/v1/transcribe.md`). Load a model via
 /// `POST /active_model` and retry.
+///
+/// Carries `error_code: "model_not_loaded"` so this shape agrees with the
+/// pre-captured `audio_data` path's `409` for the same condition (built via
+/// `DaemonResponse::error_with_code(ErrorCode::ModelNotLoaded, ..)`) — both
+/// are the same documented error and must expose the same stable,
+/// machine-readable identifier (`docs/protocol/transport.md`).
 pub(crate) fn model_not_loaded_response() -> Response {
     let body = serde_json::json!({
-        "status":  "error",
-        "message": "model_not_loaded",
+        "status":     "error",
+        "error_code": "model_not_loaded",
+        "message":    "model_not_loaded",
     });
     (
         StatusCode::CONFLICT,

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -337,8 +337,25 @@ async fn transcribe_mic(s: AppState, data: Option<serde_json::Value>) -> axum::r
     // wire response is the established `409` shape below (mirroring
     // `recording_in_progress_response`) rather than whatever `handle_command`
     // itself produced.
+    //
+    // Re-check `busy` immediately before dispatching. `handle_command` routes
+    // a `record` command through `handle_record_command`, which treats an
+    // already-busy daemon as a TOGGLE and sends a stop signal to whatever
+    // recording is in flight (see `handle_record_command` in
+    // `daemon/core.rs`). The busy read above and the `model.is_none()` read
+    // just above this comment are two separate plain reads, so a legitimate
+    // recording can start (and the model can be unloaded out from under it)
+    // in the gap between them. If that happened, dispatching here would stop
+    // that unrelated in-flight recording — silently, and without telling its
+    // caller — merely because *this* request decided no model was loaded.
+    // Skip the dispatch in that case: no capture needs starting (one is
+    // already running), so nothing regresses by not calling
+    // `handle_record_internal` for this specific request; the `409` response
+    // below still stands.
     if s.daemon.model.read().await.is_none() {
-        let _ = s.daemon.handle_command(req).await;
+        if !*s.daemon.busy.read().await {
+            let _ = s.daemon.handle_command(req).await;
+        }
         return model_not_loaded_response();
     }
 

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -2,7 +2,9 @@
 use crate::daemon::http::internal::helpers::dispatch::{
     build_request, build_transcribe_request, dispatch, json_response,
 };
-use crate::daemon::http::internal::helpers::responses::recording_in_progress_response;
+use crate::daemon::http::internal::helpers::responses::{
+    model_not_loaded_response, recording_in_progress_response,
+};
 use crate::daemon::http::state::AppState;
 // Only the wasm-backends realtime handler references the daemon type / bare
 // `Response`; gated so the subprocess-only and no-backend builds stay warning-clean.
@@ -270,7 +272,9 @@ async fn transcribe_precaptured(s: &AppState, body: serde_json::Value) -> axum::
 ///
 /// On the SSE paths a daemon-side failure arrives as a single `error` frame and
 /// closing the connection stops the recording. A start while already recording
-/// returns `409 recording_in_progress`.
+/// returns `409 recording_in_progress`; a start with no model loaded returns
+/// `409 model_not_loaded` (both mic sub-paths, before the `202`/SSE envelope
+/// commits).
 pub(crate) async fn transcribe(
     State(s): State<AppState>,
     body: Option<axum::Json<serde_json::Value>>,
@@ -294,6 +298,9 @@ pub(crate) async fn transcribe(
 
 /// Daemon-mic capture path. Response shape follows the `wait`/`stream_realtime`
 /// controls (see `docs/protocol/endpoints/v1/transcribe.md`):
+/// - already busy → `409 recording_in_progress`; no model loaded → `409
+///   model_not_loaded` — both checked (in that order) before either shape
+///   below commits.
 /// - `wait:false` → `202 {message:"Recording started"}`, recording detaches and
 ///   runs in the background (stop via `POST /transcribe/stop`).
 /// - `wait:true` → `200 text/event-stream`, ending with `done`/`error`;
@@ -316,6 +323,23 @@ async fn transcribe_mic(s: AppState, data: Option<serde_json::Value>) -> axum::r
     // `/v1/transcribe/stop` to end an in-flight capture.
     if *s.daemon.busy.read().await {
         return recording_in_progress_response();
+    }
+
+    // Fail fast when no model is loaded: `handle_record_internal`'s own
+    // preflight (further down the stack) rejects this the same way
+    // regardless of `wait`, but only after the `202`/SSE envelope below has
+    // already committed — which is why `409 model_not_loaded` was previously
+    // unreachable here (see docs/protocol/endpoints/v1/transcribe.md). This is
+    // a plain read racing that authoritative preflight, same trade-off as the
+    // busy check above. Dispatch the real command anyway (cheap: no model
+    // means no capture starts) so a write-mode request's on-screen failure
+    // notice still fires exactly as it would deeper in the stack; only the
+    // wire response is the established `409` shape below (mirroring
+    // `recording_in_progress_response`) rather than whatever `handle_command`
+    // itself produced.
+    if s.daemon.model.read().await.is_none() {
+        let _ = s.daemon.handle_command(req).await;
+        return model_not_loaded_response();
     }
 
     // Fire-and-forget: detach the recording from this connection and return

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -4,6 +4,7 @@ mod preview;
 mod transcribe;
 
 use crate::daemon::types::SuperSTTDaemon;
+use crate::output::notice;
 use crate::services::dbus::ListeningEvent;
 use crate::{audio::recorder::DaemonAudioRecorder, output::typer::Typer};
 use anyhow::{Context, Result};
@@ -49,6 +50,21 @@ impl SuperSTTDaemon {
                     "Recording already in progress. Please wait for current recording to complete.",
                 );
             }
+        }
+
+        // Fail before capture. With no model loaded the cycle can only end in a
+        // discarded recording, so starting the mic would cost the user a full
+        // take — beeps, speech, and all — to learn nothing. In write mode the
+        // reason lands in the field they are actually looking at.
+        if self.model.read().await.is_none() {
+            warn!("Recording request rejected - no model loaded");
+            if write_mode {
+                typer.type_notice(notice::NO_MODEL_LOADED).await;
+            }
+            return DaemonResponse::error_with_code(
+                ErrorCode::ModelNotLoaded,
+                "No model is loaded. Load a model and try again.",
+            );
         }
 
         // Wait for recording to complete and return the transcription.

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -102,6 +102,9 @@ impl SuperSTTDaemon {
                     let mut guard = self.busy.write().await;
                     *guard = false;
                 }
+                if write_mode {
+                    typer.type_notice(notice::COULD_NOT_START_RECORDING).await;
+                }
                 DaemonResponse::error(&format!("Recording failed: {e}"))
             }
         }
@@ -158,6 +161,9 @@ impl SuperSTTDaemon {
                 warn!("Recording capture failed: {e}");
                 self.finalize_recording_session("", false, Some(e.to_string()))
                     .await;
+                if write_mode {
+                    typer.type_notice(notice::RECORDING_FAILED).await;
+                }
                 return Ok(Err(format!("recording error: {e}")));
             }
         };
@@ -177,6 +183,9 @@ impl SuperSTTDaemon {
                 warn!("Final transcription failed: {e}");
                 self.finalize_recording_session("", false, Some(e.to_string()))
                     .await;
+                if write_mode {
+                    typer.type_notice(notice::TRANSCRIPTION_FAILED).await;
+                }
                 return Ok(Err(format!("STT error: {e}")));
             }
         };

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -329,6 +329,47 @@ impl SuperSTTDaemon {
         false // Normal completion — do not skip the timeout check
     }
 
+    /// Erase preview text typed during Phase 2. Split out of
+    /// `collect_and_clear_preview` so the recorder-failure paths clear the field
+    /// too — otherwise a failed capture leaves half-typed preview text behind
+    /// for the failure notice to append to.
+    async fn clear_preview_text(
+        &self,
+        actually_typed: &Arc<std::sync::Mutex<String>>,
+        typer: &mut Typer,
+        write_mode: bool,
+    ) {
+        if !write_mode {
+            return;
+        }
+        if !self
+            .preview_typing_enabled
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            debug!("Preview typing was disabled, no preview to clear");
+            return;
+        }
+        // Take the mirror out in a scope that drops the `!Send` guard before the
+        // async backspacing (audit Tier 3 #35).
+        let taken = if let Ok(mut g) = actually_typed.lock() {
+            Some(std::mem::take(&mut *g))
+        } else {
+            warn!("Failed to acquire actually_typed lock for clearing preview");
+            None
+        };
+        if let Some(mut taken) = taken {
+            info!(
+                "Clearing preview text: '{}'",
+                taken.chars().take(50).collect::<String>()
+            );
+            typer.clear_preview(&mut taken).await;
+            info!("Preview cleared, actually_typed is now: '{taken}'");
+            if let Ok(mut g) = actually_typed.lock() {
+                *g = taken;
+            }
+        }
+    }
+
     /// Phase 3: await the recorder task to get the full audio data, clear the
     /// stop channel, and erase any preview text that was typed during Phase 2.
     pub(super) async fn collect_and_clear_preview(
@@ -342,10 +383,14 @@ impl SuperSTTDaemon {
             Ok(Ok(data)) => data,
             Ok(Err(e)) => {
                 *self.manual_stop_tx.write().await = None;
+                self.clear_preview_text(&session.actually_typed, typer, write_mode)
+                    .await;
                 return Err(e);
             }
             Err(e) => {
                 *self.manual_stop_tx.write().await = None;
+                self.clear_preview_text(&session.actually_typed, typer, write_mode)
+                    .await;
                 return Err(anyhow::anyhow!("Recorder task failed: {e}"));
             }
         };
@@ -356,34 +401,8 @@ impl SuperSTTDaemon {
         *self.manual_stop_tx.write().await = None;
 
         // Clear preview after recording is done (only if preview typing was enabled)
-        if write_mode {
-            let preview_enabled = self
-                .preview_typing_enabled
-                .load(std::sync::atomic::Ordering::Relaxed);
-            if preview_enabled {
-                // Take the mirror out in a scope that drops the `!Send` guard
-                // before the async backspacing (audit Tier 3 #35).
-                let taken = if let Ok(mut g) = session.actually_typed.lock() {
-                    Some(std::mem::take(&mut *g))
-                } else {
-                    warn!("Failed to acquire actually_typed lock for clearing preview");
-                    None
-                };
-                if let Some(mut actually_typed) = taken {
-                    info!(
-                        "Clearing preview text: '{}'",
-                        actually_typed.chars().take(50).collect::<String>()
-                    );
-                    typer.clear_preview(&mut actually_typed).await;
-                    info!("Preview cleared, actually_typed is now: '{actually_typed}'");
-                    if let Ok(mut g) = session.actually_typed.lock() {
-                        *g = actually_typed;
-                    }
-                }
-            } else {
-                debug!("Preview typing was disabled, no preview to clear");
-            }
-        }
+        self.clear_preview_text(&session.actually_typed, typer, write_mode)
+            .await;
 
         Ok(full_audio_data)
     }

--- a/super-stt-daemon/src/daemon/transcription.rs
+++ b/super-stt-daemon/src/daemon/transcription.rs
@@ -6,6 +6,18 @@ use log::{debug, error, info, warn};
 use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
 use super_stt_shared::utils::audio::validate_audio;
 
+/// Distinguishes a genuine backend failure from "no model is loaded" so
+/// [`SuperSTTDaemon::handle_transcribe`] can attach
+/// [`ErrorCode::ModelNotLoaded`] only to the latter — the former has no
+/// better code than the default uncoded (`500`) error.
+enum RunTranscriptionError {
+    /// The backend itself failed to produce a transcription.
+    Failed(anyhow::Error),
+    /// No model is loaded; the request is well-formed and will succeed once
+    /// one is (see `docs/protocol/endpoints/v1/transcribe.md`).
+    NotLoaded,
+}
+
 impl SuperSTTDaemon {
     /// Handle transcribe command
     pub async fn handle_transcribe(
@@ -58,7 +70,18 @@ impl SuperSTTDaemon {
                     .await;
                 DaemonResponse::success().with_transcription(transcription)
             }
-            Ok(Err(e)) => DaemonResponse::error(&format!("Transcription failed: {e}")),
+            // No model loaded: coded so this pre-captured path carries the
+            // same `error_code` as the daemon-mic paths (see
+            // docs/protocol/endpoints/v1/transcribe.md). `message` matches the
+            // literal identifier every other coded error on this endpoint uses
+            // (`recording_in_progress`, `stream_realtime_with_audio_data`, …);
+            // `error_code` — not `message` — is the field clients switch on.
+            Ok(Err(RunTranscriptionError::NotLoaded)) => {
+                DaemonResponse::error_with_code(ErrorCode::ModelNotLoaded, "model_not_loaded")
+            }
+            Ok(Err(RunTranscriptionError::Failed(e))) => {
+                DaemonResponse::error(&format!("Transcription failed: {e}"))
+            }
             Err(e) => {
                 error!("Transcription task failed: {e}");
                 DaemonResponse::error(&format!("Task execution failed: {e}"))
@@ -157,12 +180,15 @@ impl SuperSTTDaemon {
     /// (local) path based on whether the loaded model is an online API model.
     ///
     /// Returns `Ok(Ok((text, duration)))` on success, `Ok(Err(_))` when the
-    /// model is not loaded, or `Err(_)` if the blocking task itself panicked.
+    /// backend failed or no model is loaded (distinguished by
+    /// [`RunTranscriptionError`] so the caller can attach the right
+    /// [`ErrorCode`]), or `Err(_)` if the blocking task itself panicked.
     async fn run_transcription(
         &self,
         processed_audio: Vec<f32>,
         request_language: Option<&str>,
-    ) -> Result<Result<(String, std::time::Duration), anyhow::Error>, tokio::task::JoinError> {
+    ) -> Result<Result<(String, std::time::Duration), RunTranscriptionError>, tokio::task::JoinError>
+    {
         let language = self.resolve_active_language(request_language).await;
         let start_time = std::time::Instant::now();
 
@@ -177,11 +203,13 @@ impl SuperSTTDaemon {
             // genuine error the caller must report.
             Err(DispatchError::Failed(e)) => {
                 warn!("Transcription failed: {e}");
-                Ok(Err(anyhow::anyhow!("Transcription failed: {e}")))
+                Ok(Err(RunTranscriptionError::Failed(anyhow::anyhow!(
+                    "Transcription failed: {e}"
+                ))))
             }
             Err(DispatchError::NotLoaded) => {
                 error!("Model not loaded");
-                Ok(Err(anyhow::anyhow!("Model not loaded")))
+                Ok(Err(RunTranscriptionError::NotLoaded))
             }
             Err(DispatchError::Join(e)) => Err(e),
         }

--- a/super-stt-daemon/src/output/keyboard/mod.rs
+++ b/super-stt-daemon/src/output/keyboard/mod.rs
@@ -24,6 +24,11 @@ pub enum Simulator {
     WaylandProtocol(Box<EnigoBackend>),
     Ydotool(YdotoolBackend),
     XdgPortal(XdgPortalBackend),
+    /// Test-only backend that records what *would* have been typed. The three
+    /// real backends each need a live compositor or portal, so without this the
+    /// typing path cannot be asserted on at all.
+    #[cfg(test)]
+    Capture(std::sync::Arc<std::sync::Mutex<String>>),
 }
 
 // SAFETY: see Simulator doc comment — single-writer access enforced by daemon.
@@ -82,6 +87,8 @@ impl Simulator {
             Self::XdgPortal(_) => "XDG Desktop Portal",
             Self::Ydotool(_) => "ydotool",
             Self::WaylandProtocol(_) => "Wayland protocol",
+            #[cfg(test)]
+            Self::Capture(_) => "capture (test)",
         }
     }
 
@@ -100,6 +107,11 @@ impl Simulator {
             Self::WaylandProtocol(b) => tokio::task::block_in_place(|| b.type_text(text)),
             Self::Ydotool(_) => tokio::task::block_in_place(|| YdotoolBackend::type_text(text)),
             Self::XdgPortal(b) => b.type_text(text).await,
+            #[cfg(test)]
+            Self::Capture(buf) => {
+                buf.lock().expect("capture buffer poisoned").push_str(text);
+                Ok(())
+            }
         }
     }
 
@@ -115,6 +127,48 @@ impl Simulator {
             }
             Self::Ydotool(_) => tokio::task::block_in_place(|| YdotoolBackend::backspace_n(n)),
             Self::XdgPortal(b) => b.backspace_n(n).await,
+            #[cfg(test)]
+            Self::Capture(buf) => {
+                let mut guard = buf.lock().expect("capture buffer poisoned");
+                // Truncate by chars, not bytes — a real backspace removes one
+                // grapheme, and truncating mid-UTF-8 would panic.
+                let keep = guard.chars().count().saturating_sub(n);
+                *guard = guard.chars().take(keep).collect();
+                Ok(())
+            }
         }
+    }
+}
+
+#[cfg(test)]
+impl Simulator {
+    /// A simulator that accumulates typed text instead of driving a keyboard.
+    /// Returns the simulator and a handle to the accumulated text.
+    pub(crate) fn capture() -> (Self, std::sync::Arc<std::sync::Mutex<String>>) {
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        (Self::Capture(std::sync::Arc::clone(&buf)), buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Simulator;
+
+    /// The capture backend has to behave like a real one — text accumulates and
+    /// backspace removes trailing *characters* (not bytes) — or tests written
+    /// against it will not reflect what lands in a user's window.
+    #[tokio::test]
+    async fn capture_backend_accumulates_text_and_honors_backspace() {
+        let (mut sim, buf) = Simulator::capture();
+
+        sim.type_text("hello").await.expect("type");
+        sim.type_text(" wörld").await.expect("type");
+        assert_eq!(*buf.lock().unwrap(), "hello wörld");
+
+        // Multi-byte char must be removed whole.
+        sim.backspace_n(4).await.expect("backspace");
+        assert_eq!(*buf.lock().unwrap(), "hello w");
+
+        assert_eq!(sim.name(), "capture (test)");
     }
 }

--- a/super-stt-daemon/src/output/mod.rs
+++ b/super-stt-daemon/src/output/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 pub mod keyboard;
+pub(crate) mod notice;
 pub mod preview;
 pub mod typer;

--- a/super-stt-daemon/src/output/notice.rs
+++ b/super-stt-daemon/src/output/notice.rs
@@ -9,9 +9,6 @@
 //! goes to the log and the error response; only these fixed strings are typed.
 
 /// No model is loaded, so the cycle cannot produce text. Caught before capture.
-// Not yet passed to `Typer::type_notice` — the failure-site callers land in a
-// later task.
-#[allow(dead_code)]
 pub(crate) const NO_MODEL_LOADED: &str = "[Super STT: no model loaded]";
 
 /// The recorder could not be spawned; capture never began.

--- a/super-stt-daemon/src/output/notice.rs
+++ b/super-stt-daemon/src/output/notice.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Fixed notices typed into the focused window when a write-mode recording
+//! fails.
+//!
+//! These are compile-time constants rather than formatted error text on
+//! purpose. Backends are explicitly untrusted (audit 2 Tier 3 #8) and most
+//! failure detail originates in one, so typing it would put
+//! attacker-influencable text into whatever the user has focused. The detail
+//! goes to the log and the error response; only these fixed strings are typed.
+
+/// No model is loaded, so the cycle cannot produce text. Caught before capture.
+// Not yet passed to `Typer::type_notice` — the failure-site callers land in a
+// later task.
+#[allow(dead_code)]
+pub(crate) const NO_MODEL_LOADED: &str = "[Super STT: no model loaded]";
+
+/// The recorder could not be spawned; capture never began.
+#[allow(dead_code)]
+pub(crate) const COULD_NOT_START_RECORDING: &str = "[Super STT: could not start recording]";
+
+/// Capture began but failed partway through.
+#[allow(dead_code)]
+pub(crate) const RECORDING_FAILED: &str = "[Super STT: recording failed]";
+
+/// Audio was captured but the model failed to transcribe it.
+#[allow(dead_code)]
+pub(crate) const TRANSCRIPTION_FAILED: &str = "[Super STT: transcription failed]";
+
+#[cfg(test)]
+pub(crate) const ALL: &[&str] = &[
+    NO_MODEL_LOADED,
+    COULD_NOT_START_RECORDING,
+    RECORDING_FAILED,
+    TRANSCRIPTION_FAILED,
+];

--- a/super-stt-daemon/src/output/notice.rs
+++ b/super-stt-daemon/src/output/notice.rs
@@ -12,15 +12,12 @@
 pub(crate) const NO_MODEL_LOADED: &str = "[Super STT: no model loaded]";
 
 /// The recorder could not be spawned; capture never began.
-#[allow(dead_code)]
 pub(crate) const COULD_NOT_START_RECORDING: &str = "[Super STT: could not start recording]";
 
 /// Capture began but failed partway through.
-#[allow(dead_code)]
 pub(crate) const RECORDING_FAILED: &str = "[Super STT: recording failed]";
 
 /// Audio was captured but the model failed to transcribe it.
-#[allow(dead_code)]
 pub(crate) const TRANSCRIPTION_FAILED: &str = "[Super STT: transcription failed]";
 
 #[cfg(test)]

--- a/super-stt-daemon/src/output/preview.rs
+++ b/super-stt-daemon/src/output/preview.rs
@@ -20,12 +20,24 @@ pub(crate) fn is_unsafe_to_type(c: char) -> bool {
         || matches!(c, '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}')
 }
 
+/// Strip every character [`is_unsafe_to_type`] flags. The single choke point
+/// untrusted text must cross before it can reach the keyboard simulator
+/// (audit 2 Tier 3 #8): both backend preview/final text (via
+/// [`preprocess_text`]) and the fixed failure notices
+/// ([`Typer::type_notice`](crate::output::typer::Typer::type_notice)) route
+/// through this function rather than each re-implementing the filter, so the
+/// property holds structurally instead of by convention.
+#[must_use]
+pub(crate) fn sanitize_for_typing(text: &str) -> String {
+    text.chars().filter(|&c| !is_unsafe_to_type(c)).collect()
+}
+
 /// Preprocess text - sanitize, normalize, remove ellipses, capitalize
 #[must_use]
 pub(crate) fn preprocess_text(text: &str, is_preview: bool) -> String {
     // Strip characters that must never be typed into the focused window before
     // any other processing (audit 2 Tier 3 #8).
-    let sanitized: String = text.chars().filter(|&c| !is_unsafe_to_type(c)).collect();
+    let sanitized: String = sanitize_for_typing(text);
 
     // Remove leading whitespaces
     let mut text = sanitized.trim_start().to_string();

--- a/super-stt-daemon/src/output/preview.rs
+++ b/super-stt-daemon/src/output/preview.rs
@@ -12,7 +12,7 @@
 /// sequence, and a Unicode bidi override or zero-width char could visually spoof
 /// or hide text in an editor. Ordinary whitespace (`\n`/`\r`/`\t`) is preserved
 /// here and folded into single spaces by [`preprocess_text`]'s normalization.
-fn is_unsafe_to_type(c: char) -> bool {
+pub(crate) fn is_unsafe_to_type(c: char) -> bool {
     (c.is_control() && !c.is_whitespace())
         // Bidi overrides + isolates (LRO/RLO/PDF, LRI/RLI/FSI/PDI).
         || matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -151,6 +151,28 @@ impl State {
     }
 }
 
+/// How long [`Typer::type_notice`] waits before typing, so the user's shortcut
+/// keys can be fully released first.
+///
+/// A failure notice can be emitted within milliseconds of a keypress, at which
+/// point the shortcut's modifier keys (Ctrl/Alt/Super/Shift) are usually still
+/// physically held down. Simulated keystrokes sent during that window arrive
+/// *modified*, so the focused application interprets the notice as shortcuts
+/// rather than text.
+///
+/// Two distinct cases hit this window, which is why the wait applies to every
+/// notice rather than just the first:
+///
+/// - The no-model preflight rejects the request before capture even starts, so
+///   the notice follows the *start* keypress almost immediately.
+/// - In manual stop mode the user presses the hotkey to end the recording, and
+///   a failure that surfaces quickly after that — a model unloaded mid-cycle,
+///   say — puts the notice right behind the *stop* keypress.
+///
+/// This does not apply to transcription output: that is typed after speech has
+/// been captured and transcribed, long past any plausible key-release window.
+const NOTICE_KEY_RELEASE_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Unified, simplified preview typer that combines the best of both approaches
 pub struct Typer {
     keyboard_simulator: Simulator,
@@ -320,7 +342,18 @@ impl Typer {
     /// other write path (audit 2 Tier 3 #8). The callers pass constants, so
     /// this is a no-op today; it is here so the property holds by
     /// construction.
+    ///
+    /// Waits [`NOTICE_KEY_RELEASE_DELAY`] before typing — see that constant for
+    /// why.
     pub async fn type_notice(&mut self, notice: &str) {
+        // Let the user's hotkey come back up first. The no-model preflight
+        // rejects before capture starts, so this can run within milliseconds of
+        // the press, while the shortcut's modifiers are still physically held.
+        // Typing then delivers *modified* keystrokes to the focused window —
+        // the notice would fire shortcuts in the user's application instead of
+        // inserting text.
+        tokio::time::sleep(NOTICE_KEY_RELEASE_DELAY).await;
+
         let sanitized = sanitize_for_typing(notice);
         if let Err(e) = self.keyboard_simulator.type_text(&sanitized).await {
             warn!("Failed to type notice: {e}");

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -5,7 +5,9 @@
 //! live in [`crate::output::preview`].
 
 use crate::output::keyboard::Simulator;
-use crate::output::preview::{find_common_prefix, find_tail_match_in_text, preprocess_text};
+use crate::output::preview::{
+    find_common_prefix, find_tail_match_in_text, is_unsafe_to_type, preprocess_text,
+};
 use log::{debug, info, warn};
 
 /// State for tracking preview updates
@@ -303,6 +305,37 @@ impl Typer {
 
         // Clear session for next recording
         self.state.full_session_text.clear();
+    }
+
+    /// Type a fixed daemon-authored notice into the focused window.
+    ///
+    /// Deliberately **not** `process_final_text`. That method mutates
+    /// transcript state (`last_transcription`, `prev_text`, `full_session_text`)
+    /// which feeds preview tail-matching on the next recording, and applies
+    /// transcript semantics — capitalization, a trailing period, a trailing
+    /// space — that a fixed marker must not inherit. A notice is typed verbatim
+    /// and leaves session state alone.
+    ///
+    /// Routed through the same `is_unsafe_to_type` filter as every other write
+    /// path (audit 2 Tier 3 #8). The callers pass constants, so this is a no-op
+    /// today; it is here so the property holds by construction.
+    pub async fn type_notice(&mut self, notice: &str) {
+        let sanitized: String = notice.chars().filter(|&c| !is_unsafe_to_type(c)).collect();
+        if let Err(e) = self.keyboard_simulator.type_text(&sanitized).await {
+            warn!("Failed to type notice: {e}");
+        } else {
+            info!("Typed failure notice: {sanitized}");
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_transcription_for_test(&self) -> &str {
+        &self.state.last_transcription
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prev_text_for_test(&self) -> &str {
+        &self.state.prev_text
     }
 
     /// Apply text update to screen (common logic)

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -6,7 +6,7 @@
 
 use crate::output::keyboard::Simulator;
 use crate::output::preview::{
-    find_common_prefix, find_tail_match_in_text, is_unsafe_to_type, preprocess_text,
+    find_common_prefix, find_tail_match_in_text, preprocess_text, sanitize_for_typing,
 };
 use log::{debug, info, warn};
 
@@ -316,26 +316,17 @@ impl Typer {
     /// space — that a fixed marker must not inherit. A notice is typed verbatim
     /// and leaves session state alone.
     ///
-    /// Routed through the same `is_unsafe_to_type` filter as every other write
-    /// path (audit 2 Tier 3 #8). The callers pass constants, so this is a no-op
-    /// today; it is here so the property holds by construction.
+    /// Routed through the same [`sanitize_for_typing`] choke point as every
+    /// other write path (audit 2 Tier 3 #8). The callers pass constants, so
+    /// this is a no-op today; it is here so the property holds by
+    /// construction.
     pub async fn type_notice(&mut self, notice: &str) {
-        let sanitized: String = notice.chars().filter(|&c| !is_unsafe_to_type(c)).collect();
+        let sanitized = sanitize_for_typing(notice);
         if let Err(e) = self.keyboard_simulator.type_text(&sanitized).await {
             warn!("Failed to type notice: {e}");
         } else {
             info!("Typed failure notice: {sanitized}");
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn last_transcription_for_test(&self) -> &str {
-        &self.state.last_transcription
-    }
-
-    #[cfg(test)]
-    pub(crate) fn prev_text_for_test(&self) -> &str {
-        &self.state.prev_text
     }
 
     /// Apply text update to screen (common logic)

--- a/super-stt-daemon/src/output/typer_tests.rs
+++ b/super-stt-daemon/src/output/typer_tests.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use super::*;
+use crate::output::keyboard::Simulator;
+use crate::output::notice;
 
 // ---------------------------------------------------------------------------
 // State machine characterization (keyboard-free transitions)
@@ -70,4 +72,52 @@ fn update_with_stabilization_locks_common_prefix_across_two_texts() {
     assert_eq!(s.stabilized_text, "Hello ");
     // Session text was seeded by the first (longer) preview and not shrunk.
     assert_eq!(s.full_session_text, "Hello world");
+}
+
+// ---------------------------------------------------------------------------
+// type_notice (fixed failure markers)
+// ---------------------------------------------------------------------------
+
+/// The markers are constants we control, so the sanitizer is a no-op on them
+/// today. Assert it anyway: this is what keeps the property true by
+/// construction if someone edits the strings later.
+#[test]
+fn notice_constants_survive_the_sanitizer_unchanged() {
+    for n in notice::ALL {
+        let sanitized: String = n
+            .chars()
+            .filter(|&c| !crate::output::preview::is_unsafe_to_type(c))
+            .collect();
+        assert_eq!(
+            &sanitized, n,
+            "notice contains a character that must never be typed: {n:?}"
+        );
+    }
+}
+
+/// A notice is typed verbatim — no capitalization, no trailing period, no
+/// trailing space. `process_final_text` applies all three, which is exactly why
+/// a notice must not go through it.
+#[tokio::test]
+async fn type_notice_types_the_marker_verbatim() {
+    let (sim, buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+
+    typer.type_notice(notice::NO_MODEL_LOADED).await;
+
+    assert_eq!(*buf.lock().unwrap(), "[Super STT: no model loaded]");
+}
+
+/// Transcript state feeds preview tail-matching on the *next* recording. If a
+/// notice landed in it, the typer would try to extend "[Super STT: …]" into the
+/// following sentence.
+#[tokio::test]
+async fn type_notice_leaves_transcript_state_untouched() {
+    let (sim, _buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+
+    typer.type_notice(notice::TRANSCRIPTION_FAILED).await;
+
+    assert_eq!(typer.last_transcription_for_test(), "");
+    assert_eq!(typer.prev_text_for_test(), "");
 }

--- a/super-stt-daemon/src/output/typer_tests.rs
+++ b/super-stt-daemon/src/output/typer_tests.rs
@@ -98,7 +98,9 @@ fn notice_constants_survive_the_sanitizer_unchanged() {
 /// A notice is typed verbatim — no capitalization, no trailing period, no
 /// trailing space. `process_final_text` applies all three, which is exactly why
 /// a notice must not go through it.
-#[tokio::test]
+// `start_paused` so the notice's key-release delay is virtual — this test
+// asserts what gets typed, not how long it waits.
+#[tokio::test(start_paused = true)]
 async fn type_notice_types_the_marker_verbatim() {
     let (sim, buf) = Simulator::capture();
     let mut typer = Typer::new(sim);
@@ -111,7 +113,9 @@ async fn type_notice_types_the_marker_verbatim() {
 /// Transcript state feeds preview tail-matching on the *next* recording. If a
 /// notice landed in it, the typer would try to extend "[Super STT: …]" into the
 /// following sentence.
-#[tokio::test]
+// `start_paused` so the notice's key-release delay is virtual — this test
+// asserts what gets typed, not how long it waits.
+#[tokio::test(start_paused = true)]
 async fn type_notice_leaves_transcript_state_untouched() {
     let (sim, _buf) = Simulator::capture();
     let mut typer = Typer::new(sim);
@@ -121,4 +125,28 @@ async fn type_notice_leaves_transcript_state_untouched() {
     assert_eq!(typer.state.last_transcription, "");
     assert_eq!(typer.state.prev_text, "");
     assert_eq!(typer.state.full_session_text, "");
+}
+
+/// A notice can be typed within milliseconds of the hotkey press (the no-model
+/// preflight rejects before capture starts), so the shortcut's modifiers are
+/// often still held. Typing then would deliver modified keystrokes and fire
+/// shortcuts in the user's application instead of inserting text. The wait must
+/// therefore happen BEFORE the text reaches the simulator, not after.
+///
+/// `start_paused` auto-advances tokio's clock while the runtime is idle, so
+/// this asserts the full delay elapsed without spending it in wall-clock time.
+#[tokio::test(start_paused = true)]
+async fn type_notice_waits_for_shortcut_keys_to_be_released_before_typing() {
+    let (sim, buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+    let start = tokio::time::Instant::now();
+
+    typer.type_notice(notice::NO_MODEL_LOADED).await;
+
+    assert!(
+        start.elapsed() >= std::time::Duration::from_secs(1),
+        "notice was typed after only {:?} — modifiers may still be held",
+        start.elapsed()
+    );
+    assert_eq!(*buf.lock().unwrap(), "[Super STT: no model loaded]");
 }

--- a/super-stt-daemon/src/output/typer_tests.rs
+++ b/super-stt-daemon/src/output/typer_tests.rs
@@ -118,6 +118,7 @@ async fn type_notice_leaves_transcript_state_untouched() {
 
     typer.type_notice(notice::TRANSCRIPTION_FAILED).await;
 
-    assert_eq!(typer.last_transcription_for_test(), "");
-    assert_eq!(typer.prev_text_for_test(), "");
+    assert_eq!(typer.state.last_transcription, "");
+    assert_eq!(typer.state.prev_text, "");
+    assert_eq!(typer.state.full_session_text, "");
 }

--- a/super-stt-daemon/src/registry/host_detect.rs
+++ b/super-stt-daemon/src/registry/host_detect.rs
@@ -40,31 +40,31 @@ fn target_triple() -> &'static str {
     "aarch64-unknown-linux-gnu"
 }
 
+/// CUDA properties come from `gpu-probe`, which owns the single process-wide
+/// NVML handle. Initializing NVML per call leaks a file descriptor each time,
+/// so this must not open its own — that is why the daemon has no direct
+/// `nvml-wrapper` dependency.
+///
+/// `gpu-probe` reports the parts separately and rejects the negative values a
+/// misbehaving driver can return; the packed `sm_XX` form is this crate's
+/// contract with `compat::select`, so it is assembled here.
 fn detect_cuda() -> Option<CudaHost> {
-    let nvml = nvml_wrapper::Nvml::init().ok()?;
-    let dev = nvml.device_by_index(0).ok()?;
-
-    // nvml-wrapper 0.12 returns `CudaComputeCapability { major: i32, minor: i32 }`.
-    let cc = dev.cuda_compute_capability().ok()?;
-    // Guard against negative values from a misbehaving driver.
-    if cc.major < 0 || cc.minor < 0 {
-        return None;
-    }
-    let cc_packed = cc.major.cast_unsigned() * 10 + cc.minor.cast_unsigned();
-
-    // `sys_cuda_driver_version()` returns a packed `i32`, e.g. 12090 for CUDA 12.9.
-    let cuda_version = nvml.sys_cuda_driver_version().ok()?;
-    if cuda_version <= 0 {
-        return None;
-    }
-    let runtime_major = (cuda_version / 1000).cast_unsigned();
-
-    let cudnn_present = detect_cudnn();
+    let host = gpu_probe::cuda_host()?;
     Some(CudaHost {
-        compute_capability: cc_packed,
-        runtime_major,
-        cudnn_present,
+        compute_capability: pack_sm(host.compute_capability.major, host.compute_capability.minor),
+        runtime_major: host.driver_version.major,
+        cudnn_present: detect_cudnn(),
     })
+}
+
+/// Pack a major/minor compute capability into the `sm_XX` form
+/// [`compat::select`](super::compat::select) matches an asset's `cuda_sm`
+/// against — 8 and 6 become 86, the same integer `nvidia-smi` renders as `8.6`.
+///
+/// Its own function because a wrong packing here silently mis-selects every
+/// CUDA asset rather than failing loudly.
+const fn pack_sm(major: u32, minor: u32) -> u32 {
+    major * 10 + minor
 }
 
 fn detect_cudnn() -> bool {
@@ -84,4 +84,24 @@ fn detect_cudnn() -> bool {
         return true;
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pack_sm;
+
+    /// `compat::select` compares this packed integer against an asset's
+    /// `cuda_sm`, so the encoding is a contract with the registry metadata, not
+    /// an internal detail. A wrong packing mis-selects every CUDA asset
+    /// silently — nothing downstream would reject an implausible value.
+    #[test]
+    fn compute_capability_packs_to_the_sm_form_assets_declare() {
+        // An RTX 30-series host: nvidia-smi reports compute_cap 8.6, assets
+        // declare cuda_sm = 86.
+        assert_eq!(pack_sm(8, 6), 86);
+        // Two-digit minors do not occur in CUDA's scheme, but a single-digit
+        // minor must not lose its place: 9.0 is 90, never 9.
+        assert_eq!(pack_sm(9, 0), 90);
+        assert_eq!(pack_sm(12, 0), 120);
+    }
 }

--- a/super-stt-daemon/tests/http_smoke.rs
+++ b/super-stt-daemon/tests/http_smoke.rs
@@ -186,7 +186,12 @@ async fn http_endpoints_respond() {
     );
 
     // --- POST /transcribe (fire-and-forget) ---
-    let resp = http_client::transcribe(
+    // Hermetic test harness => no backend installed => no model loaded, so
+    // the daemon now fails fast with `409 model_not_loaded` before
+    // committing to `202` (see docs/protocol/endpoints/v1/transcribe.md).
+    // Tolerate either that typed error or (should a backend somehow be
+    // present) a normal `202`/`200` response.
+    let result = http_client::transcribe(
         http_socket.clone(),
         &token,
         TranscribeOptions {
@@ -196,13 +201,18 @@ async fn http_endpoints_respond() {
             stream_realtime: false,
         },
     )
-    .await
-    .expect("transcribe should respond");
-    assert!(
-        resp.status == "success" || resp.status == "error",
-        "transcribe returned unknown status: {:?}",
-        resp.status
-    );
+    .await;
+    match result {
+        Ok(resp) => assert!(
+            resp.status == "success" || resp.status == "error",
+            "transcribe returned unknown status: {:?}",
+            resp.status
+        ),
+        Err(e) => assert!(
+            e.to_string().contains("model_not_loaded"),
+            "expected model_not_loaded, got: {e}"
+        ),
+    }
 
     // --- POST /transcribe/stop ---
     let resp = http_client::transcribe_stop(http_socket.clone(), &token)

--- a/super-stt-shared/src/models/protocol/error_code.rs
+++ b/super-stt-shared/src/models/protocol/error_code.rs
@@ -23,6 +23,9 @@ pub enum ErrorCode {
     /// A cancel was requested but there is no switch/download to cancel
     /// (`POST /active_model/cancel`; see `active_model/cancel.md`).
     NoSwitchInProgress,
+    /// No model is loaded, so nothing can be transcribed. The request is
+    /// well-formed and succeeds once a model is loaded via `POST /active_model`.
+    ModelNotLoaded,
 
     // --- 400 Bad Request: the client gave the daemon something it couldn't
     // use. ---
@@ -63,7 +66,10 @@ impl ErrorCode {
     #[must_use]
     pub fn http_status(self) -> u16 {
         match self {
-            Self::RecordingInProgress | Self::DownloadInProgress | Self::NoSwitchInProgress => 409,
+            Self::RecordingInProgress
+            | Self::DownloadInProgress
+            | Self::NoSwitchInProgress
+            | Self::ModelNotLoaded => 409,
             Self::InvalidModel
             | Self::InvalidBackend
             | Self::CudaUnavailable
@@ -101,5 +107,17 @@ mod tests {
         assert_eq!(ErrorCode::InvalidAudioTheme.http_status(), 400);
         assert_eq!(ErrorCode::NotFound.http_status(), 404);
         assert_eq!(ErrorCode::Internal.http_status(), 500);
+    }
+
+    /// `model_not_loaded` is a state conflict, not bad input: the request is
+    /// well-formed and becomes valid once a model is loaded. It shares the 409
+    /// group with the other "daemon's current state forbids it" codes.
+    #[test]
+    fn model_not_loaded_is_a_state_conflict() {
+        assert_eq!(ErrorCode::ModelNotLoaded.http_status(), 409);
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::ModelNotLoaded).unwrap(),
+            r#""model_not_loaded""#
+        );
     }
 }


### PR DESCRIPTION
With no model loaded, the daemon started the mic, beeped, recorded a full sentence, beeped again, then failed transcription with `Model not loaded`. In write mode nothing appeared and nothing explained why — a whole take spoken into a cycle that could never produce text.

## What changes

**Fail before capture.** `handle_record_internal` now checks for a loaded model after the busy check and before `record_and_transcribe`. No mic, no beeps, no wasted take.

**Say why, where the user is looking.** Write-mode failures type a fixed marker into the focused window:

| Failure | Marker |
|---|---|
| No model loaded (preflight) | `[Super STT: no model loaded]` |
| Recorder setup failed | `[Super STT: could not start recording]` |
| Capture failed mid-recording | `[Super STT: recording failed]` |
| Transcription failed | `[Super STT: transcription failed]` |

"Recording already in progress" types nothing on purpose — a recording is live and preview text may be typing into the field at that moment.

**Wait for the hotkey to come up first.** A notice can land within milliseconds of a keypress (the preflight rejects immediately; manual stop mode puts a fast failure right behind the stop key). Modifiers still held at that point turn the notice into shortcuts in the focused app instead of text, so `type_notice` waits 1s.

## Honoring the prior audits

**Audit 1 #6** removed error text from the success channel — the old `Ok("[STT error: …]")` *was* the transcription, which is why it got typed and why HTTP emitted `done` instead of `error`. Typing is reintroduced here as a side effect only: every path still returns an error with an empty transcription.

**Audit 2 #8** established that backends are untrusted and everything typed passes the sanitizer. Most failure detail originates in a backend, so only fixed daemon-authored constants are ever typed; detail goes to the log and the error response. That filter is now extracted as `sanitize_for_typing`, making the choke point structural rather than conventional.

## Protocol

Adds `ErrorCode::ModelNotLoaded` (409), documented in `docs/protocol/` first. A final review caught that the documented 409 was unreachable on all three `POST /transcribe` paths, so the code was changed to match the doc rather than the reverse.

## Unrelated second change

The last commit is independent and can be split out on request: `host_detect` opened its own NVML handle per call, leaking an fd each time. `gpu-probe` now exposes `cuda_host()` backed by a single process-wide handle, so `nvml-wrapper` is dropped and gpu-probe is the only NVML owner. Verified flat at 15 fds across 300 calls (previously +1 per call — this exhausted the daemon's 1024-fd ceiling in ~50 minutes and stopped it accepting connections).

## Testing

`just ci` green (594 passed). New: a capture keyboard backend (the typing path had zero coverage), `type_notice` semantics, the delay asserted with a paused clock, the preflight end-to-end including the write-mode/non-write-mode split, and the `sm_XX` packing contract.

Not covered automatically: the three post-capture markers. Reaching them needs a loaded-model fixture plus a real record cycle, and the setup-failure path only triggers when the host has no audio device — on a dev box such a test would start a real recording inside the suite. Real coverage needs the recorder extracted behind a trait, which belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)