### PR TITLE
Fix install-all and complete install/uninstall coverage

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,6 +20,8 @@ run_dir := env('XDG_RUNTIME_DIR') / 'stt'
 log_dir := home_dir / '.local' / 'share' / 'stt' / 'logs'
 user_desktop_dir := home_dir / '.local' / 'share' / 'applications'
 user_icons_dir := home_dir / '.local' / 'share' / 'icons' / 'hicolor' / 'scalable' / 'apps'
+# Theme root, not the leaf dir: gtk-update-icon-cache indexes a whole theme.
+user_icon_theme_dir := home_dir / '.local' / 'share' / 'icons' / 'hicolor'
 
 # Binary paths
 app_src := 'target' / 'release' / app_name
@@ -351,7 +353,7 @@ install-app:
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache {{ user_icons_dir }} 2>/dev/null || true
+        gtk-update-icon-cache -f -t {{ user_icon_theme_dir }} 2>/dev/null || true
     fi
 
     echo "✓ Super STT app installed: {{ app_dst }}"
@@ -390,6 +392,16 @@ install-applet:
     mkdir -p {{ user_icons_dir }}
     echo "Installing applet icon..."
     install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
+
+    # Refresh the desktop/icon caches so the panel picks up the new applet
+    # entries without a relogin (mirrors install-app).
+    if command -v update-desktop-database &> /dev/null; then
+        update-desktop-database {{ user_desktop_dir }} 2>/dev/null || true
+    fi
+
+    if command -v gtk-update-icon-cache &> /dev/null; then
+        gtk-update-icon-cache -f -t {{ user_icon_theme_dir }} 2>/dev/null || true
+    fi
 
     echo "✓ COSMIC applet installed: {{ applet_dst }}"
     echo "✓ Desktop entries installed for panel integration:"
@@ -707,7 +719,7 @@ install-all *args:
         exit 1
     fi
 
-    if ! just install-cosmic-all; then
+    if ! just install-applet; then
         echo "❌ COSMIC applet installation failed"
         exit 1
     fi
@@ -735,7 +747,7 @@ uninstall-app:
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache {{ user_icons_dir }} 2>/dev/null || true
+        gtk-update-icon-cache -f -t {{ user_icon_theme_dir }} 2>/dev/null || true
     fi
 
     echo "✓ Super STT App uninstalled"
@@ -776,7 +788,7 @@ uninstall-daemon:
     # install contract.
     rm -f {{ consent_dst }}
 
-    rm -f "{{ user_bin_dir }}/stt"
+    rm -f {{ wrapper_dst }}
 
     # Remove directories (but preserve logs)
     rm -rf {{ run_dir }}
@@ -832,10 +844,15 @@ uninstall-cli:
     #!/usr/bin/env bash
     echo "Uninstalling Super STT CLI..."
     rm -f {{ cli_dst }}
+
+    # The `stt` wrapper is a thin exec of the CLI, so it is dead weight
+    # without it — left in place it stays on PATH and fails at exec time
+    # instead of reporting as uninstalled.
+    rm -f {{ wrapper_dst }}
     echo "✓ Super STT CLI uninstalled"
 
-# Uninstall daemon, app, applet, and CLI
-uninstall: uninstall-daemon uninstall-app uninstall-applet uninstall-cli
+# Uninstall daemon, app, applet, CLI, and consent helper
+uninstall: uninstall-daemon uninstall-app uninstall-applet uninstall-cli uninstall-consent
 
 # Start the daemon user service
 start-daemon:


### PR DESCRIPTION
## Summary

`just install-all` has been failing partway through: it calls `install-cosmic-all`, a recipe that **git history shows was never defined in any commit** — a dangling reference rather than a leftover rename. Because it aborts *after* the daemon and app install successfully, you get a silent partial install with no applet.

Since `install-all` was the only aggregate meant to install the applet, there was no working path to install it short of calling `just install-applet` by hand.

Fixing that surfaced four adjacent gaps in the install/uninstall recipes, all included here.

## Changes

| Recipe | Fix |
|---|---|
| `install-all` | Call `install-applet` instead of the nonexistent `install-cosmic-all` |
| `uninstall` | Add `uninstall-consent` — the consent helper was orphaned in `~/.local/bin` after a full uninstall |
| `uninstall-cli` | Also remove the `stt` wrapper. It's a thin `exec` of the CLI, so alone it stayed on `PATH` and died at exec time instead of reporting as uninstalled — breaking any shortcut bound to `stt record --write` |
| `install-applet` | Add the `update-desktop-database` + icon-cache refresh that `install-app` already had, so the panel picks up the new applet entries without a relogin |
| `uninstall-daemon` | Use the existing `{{ wrapper_dst }}` var instead of a hardcoded `"{{ user_bin_dir }}/stt"` |

Also adds a `user_icon_theme_dir` var and points every `gtk-update-icon-cache` call at the **theme root** with `-f -t`. The previous form passed the leaf dir (`…/hicolor/scalable/apps`) and printed `No theme index file`, doing nothing — masked by `2>/dev/null || true`.

## Verification

- `just --summary` parses; every internal `just <recipe>` reference resolves
- `install-applet`, `uninstall-cli`, `uninstall-daemon`, `uninstall` all dry-run clean
- `gtk-update-icon-cache -f -t <theme root>` confirmed to report `Cache file created successfully`, where the old invocation failed

Not run end-to-end: a real `just install-all` would rebuild and overwrite a live install, so validation is dry-run plus reference resolution only.

Both `uninstall-daemon` and `uninstall-cli` now remove the wrapper, so the `uninstall` aggregate deletes it twice — harmless (`rm -f` is idempotent), and the point is that each recipe is correct standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)