### PR TITLE
Merge the two release build jobs into one per target

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -72,71 +72,9 @@ jobs:
       - name: Load old config fixtures
         run: just config-compat
 
-  build-apps:
-    name: Build App Binaries (Beta)
+  build:
+    name: Build Binaries (Beta)
     needs: config-compat
-    strategy:
-      matrix:
-        include:
-          # Pinned to 22.04 (glibc 2.35) for broad binary compatibility.
-          - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-22.04
-          - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-22.04-arm
-
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ matrix.target }}-apps-beta-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libxkbcommon-x11-dev \
-            libegl1-mesa-dev \
-            libxrandr-dev \
-            libxinerama-dev \
-            libxcursor-dev \
-            libxi-dev \
-            libxss-dev \
-            libasound2-dev \
-            libdbus-1-dev \
-            pkg-config
-
-      - name: Build app binary
-        run: cargo build --release --target ${{ matrix.target }} --bin super-stt-app
-
-      - name: Build applet binary
-        run: cargo build --release --target ${{ matrix.target }} --bin super-stt-cosmic-applet
-
-      - name: Upload app binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: apps-${{ matrix.target }}
-          path: |
-            target/${{ matrix.target }}/release/super-stt-app
-            target/${{ matrix.target }}/release/super-stt-cosmic-applet
-
-  build-linux:
-    name: Build Linux Binaries (Beta)
-    needs: build-apps
     strategy:
       matrix:
         include:
@@ -185,23 +123,18 @@ jobs:
             libdbus-1-dev \
             pkg-config
 
-      # Build the daemon, CLI, and consent helper in one cargo
-      # invocation. `--bin` filters keep the build narrow (apps were
-      # already built in `build-apps`).
-      - name: Build daemon + CLI + consent helper
+      # Build all five binaries in one cargo invocation so the shared
+      # dependency graph compiles once, then assemble the tarball.
+      - name: Build binaries
         env:
           BUILD_VARIANT: ${{ matrix.suffix }}
         run: |
           cargo build --release --target ${{ matrix.target }} \
             --bin super-stt-daemon \
             --bin super-stt-cli \
-            --bin super-stt-consent
-
-      - name: Download app binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: apps-${{ matrix.target }}
-          path: app-binaries
+            --bin super-stt-consent \
+            --bin super-stt-app \
+            --bin super-stt-cosmic-applet
 
       - name: Create tarball
         run: |
@@ -212,8 +145,8 @@ jobs:
           cp target/${{ matrix.target }}/release/super-stt-daemon dist/
           cp target/${{ matrix.target }}/release/super-stt-cli dist/
           cp target/${{ matrix.target }}/release/super-stt-consent dist/
-          cp app-binaries/super-stt-app dist/
-          cp app-binaries/super-stt-cosmic-applet dist/
+          cp target/${{ matrix.target }}/release/super-stt-app dist/
+          cp target/${{ matrix.target }}/release/super-stt-cosmic-applet dist/
 
           # Include systemd service files
           mkdir -p dist/systemd
@@ -243,7 +176,7 @@ jobs:
 
   create-release:
     name: Create Beta Release
-    needs: build-linux
+    needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,73 +62,9 @@ jobs:
       - name: Load old config fixtures
         run: just config-compat
 
-  build-apps:
-    name: Build App Binaries
+  build:
+    name: Build Binaries
     needs: config-compat
-    strategy:
-      matrix:
-        include:
-          # Pinned to 22.04 (glibc 2.35) for broad binary compatibility.
-          - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-22.04
-          - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-22.04-arm
-
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ matrix.target }}-apps-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libxkbcommon-x11-dev \
-            libegl1-mesa-dev \
-            libxrandr-dev \
-            libxinerama-dev \
-            libxcursor-dev \
-            libxi-dev \
-            libxss-dev \
-            libasound2-dev \
-            libdbus-1-dev \
-            pkg-config
-
-      - name: Build app binary
-        run: |
-          cargo build --release --target ${{ matrix.target }} --bin super-stt-app
-
-      - name: Build applet binary
-        run: |
-          cargo build --release --target ${{ matrix.target }} --bin super-stt-cosmic-applet
-
-      - name: Upload app binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: apps-${{ matrix.target }}
-          path: |
-            target/${{ matrix.target }}/release/super-stt-app
-            target/${{ matrix.target }}/release/super-stt-cosmic-applet
-
-  build-linux:
-    name: Build Linux Binaries
-    needs: build-apps
     strategy:
       matrix:
         include:
@@ -177,23 +113,18 @@ jobs:
             libdbus-1-dev \
             pkg-config
 
-      # Build the daemon, CLI, and consent helper in one cargo
-      # invocation. `--bin` filters keep the build narrow (apps were
-      # already built in `build-apps`).
-      - name: Build daemon + CLI + consent helper
+      # Build all five binaries in one cargo invocation so the shared
+      # dependency graph compiles once, then assemble the tarball.
+      - name: Build binaries
         env:
           BUILD_VARIANT: ${{ matrix.suffix }}
         run: |
           cargo build --release --target ${{ matrix.target }} \
             --bin super-stt-daemon \
             --bin super-stt-cli \
-            --bin super-stt-consent
-
-      - name: Download app binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: apps-${{ matrix.target }}
-          path: app-binaries
+            --bin super-stt-consent \
+            --bin super-stt-app \
+            --bin super-stt-cosmic-applet
 
       - name: Create tarball
         run: |
@@ -204,8 +135,8 @@ jobs:
           cp target/${{ matrix.target }}/release/super-stt-daemon dist/
           cp target/${{ matrix.target }}/release/super-stt-cli dist/
           cp target/${{ matrix.target }}/release/super-stt-consent dist/
-          cp app-binaries/super-stt-app dist/
-          cp app-binaries/super-stt-cosmic-applet dist/
+          cp target/${{ matrix.target }}/release/super-stt-app dist/
+          cp target/${{ matrix.target }}/release/super-stt-cosmic-applet dist/
 
           # Include systemd service files
           mkdir -p dist/systemd
@@ -233,7 +164,7 @@ jobs:
 
   create-release:
     name: Create Release
-    needs: build-linux
+    needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 


### PR DESCRIPTION
## Why

`build-apps` and `build-linux` were split for a CUDA-era reason: the app and applet have no CUDA features, so building them **once per target** and reusing the artifacts avoided recompiling the GUI apps across the 24 CUDA daemon variants.

With CUDA removed (#308) there is a single CPU build per target, so the two matrices became identical and the split only cost:
- a duplicate compile of the shared dependency graph on two separate runners,
- an app-binary artifact upload/download round-trip,
- a sequential job wait (`build-linux needs build-apps`),
- doubled setup (checkout + rust + cache + apt) per target.

## Change

Each workflow collapses to a single `build` job per target that compiles all five binaries in one `cargo build --bin … --bin …` (shared deps compiled once), then assembles the tarball straight from `target/`. The intermediate `apps-<target>` artifacts are gone — nothing else consumed them (`create-release` only globs `*.tar.gz`). `create-release` now `needs: build`.

Job graph: `config-compat → build → create-release` (was `config-compat → build-apps → build-linux → create-release`).

## Verification

- Both workflows parse (pyyaml); jobs are exactly `config-compat`, `build`, `create-release`; `create-release needs: build`.
- `build` matrix: x86_64→`ubuntu-22.04`, aarch64→`ubuntu-22.04-arm`, `suffix: cpu`.
- The single `Build binaries` step compiles all five bins; the tarball `cp`s all five from `target/<triple>/release/`; no `download-artifact` in `build` (only in `create-release`, for the finished tarballs).
- No `build-apps` / `build-linux` / `apps-<target>` / `app-binaries` references remain.

Net **−136 lines**. Builds on #308 (already merged). Same caveat: green CI on the native `ubuntu-22.04` runners is confirmed only by an actual tag build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)