### PR TITLE
Skip consent popup for first-party co-located clients

### DIFF
--- a/docs/protocol/auth.md
+++ b/docs/protocol/auth.md
@@ -158,6 +158,8 @@ sequenceDiagram
         D-->>App: 403 auth_denied<br/>{ reason: "invalid_scope" }
     else throttled
         D-->>App: 403 auth_denied<br/>{ reason: "throttled" }
+    else first-party client binary (see First-party clients)
+        D-->>App: 200 { session_token, scopes, expires_at }
     else previously denied for this binary
         D-->>App: 403 auth_denied<br/>{ reason: "user_denied_cached" }
     else ok
@@ -195,6 +197,38 @@ request.
 libsecret/KWallet, the OS credential manager). Plaintext on disk
 defeats the design — any other process running as the same user
 can read it and impersonate the app.
+
+## First-party clients
+
+Super STT's own client binaries — `super-stt-app`, `super-stt-cli`,
+and `super-stt-cosmic-applet` — skip the consent popup. When one of
+them calls `POST /auth/request`, the daemon mints the session token
+immediately; the response is indistinguishable from a user-approved
+grant.
+
+A peer qualifies as first-party only when **all** of the following
+hold for its kernel-resolved executable (`/proc/<pid>/exe`,
+canonicalized):
+
+- Its basename is one of the three names above.
+- It resides in the same directory as the daemon's own binary.
+- It is owned by the daemon's effective uid and is not
+  world-writable.
+
+Any binary that fails any check — a symlink whose target resolves
+outside the daemon's directory, a replaced-on-disk executable that
+no longer canonicalizes, a copy in another location — goes through
+the normal consent flow instead.
+
+Writing to the daemon's install directory is already sufficient to
+replace the daemon itself, so trusting exact-named sibling binaries
+does not lower the bar an attacker must clear.
+
+Everything besides the skipped popup is unchanged: the token carries
+exactly the requested scopes, expires after 30 days, is bound to the
+binary's path, and is revoked by the `/events` exe-watch like any
+other token. A first-party client re-authenticating after an
+upgrade (`exe_changed`) therefore does so silently.
 
 ## Per-request authorization
 
@@ -309,10 +343,12 @@ A few non-obvious facts about how tokens behave on the wire:
 
 - **Tokens survive daemon restarts.** Your cached token will still
   be valid after the daemon restarts, up to the 30-day expiry.
-- **`/auth/request` always shows the popup.** There's no shortcut
-  for "I had a token once, give me a fresh one without prompting."
-  Cache the token client-side; only call `/auth/request` when you
-  don't have a valid one.
+- **`/auth/request` shows the popup for every third-party client.**
+  There's no shortcut for "I had a token once, give me a fresh one
+  without prompting." Cache the token client-side; only call
+  `/auth/request` when you don't have a valid one. First-party
+  clients are the only exception — see
+  [First-party clients](#first-party-clients).
 - **Sticky deny clears on daemon restart.** If the user denied you
   and you want to offer a "retry after daemon restart" UX, hint
   that they need to actually restart the daemon — the daemon's

--- a/docs/protocol/endpoints/v1/auth/request.md
+++ b/docs/protocol/endpoints/v1/auth/request.md
@@ -1,7 +1,8 @@
 # `POST /auth/request`
 
-Trigger the consent popup and mint a fresh session token. This is
-the only endpoint a new client can call before it has a token.
+Mint a fresh session token, normally by triggering the consent
+popup. This is the only endpoint a new client can call before it
+has a token.
 
 See [auth.md](../../auth.md) for the broader handshake design and
 the full list of `auth_denied` reasons.
@@ -17,6 +18,10 @@ Spawn the consent popup. The user is shown the requesting binary's
 identity, the scopes being requested, and an Allow / Deny choice.
 The call blocks until the user chooses, dismisses, or the popup
 times out (60 s default).
+
+First-party client binaries are approved automatically, without a
+popup — see [First-party clients](../../../auth.md#first-party-clients)
+in auth.md.
 
 **Request:**
 

--- a/super-stt-daemon/src/daemon/http/internal/auth/consent.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/consent.rs
@@ -152,6 +152,54 @@ pub(crate) async fn ask_user_for_consent(
     result.unwrap_or(ConsentDecision::Dismissed)
 }
 
+/// Basenames of the first-party client binaries that skip the consent
+/// popup when co-located with the daemon binary. See
+/// [`is_official_client`] for the full trust check.
+const OFFICIAL_CLIENT_NAMES: [&str; 3] =
+    ["super-stt-app", "super-stt-cli", "super-stt-cosmic-applet"];
+
+/// First-party trust check: does `exe_path` denote one of our own
+/// client binaries, installed alongside the daemon binary itself?
+///
+/// Mirrors the [`locate_consent_helper`] security model — co-location
+/// with the daemon binary plus the same ownership/permission
+/// verification. Writing to the daemon's install directory is already
+/// sufficient to replace the daemon, so trusting exact-named sibling
+/// binaries adds no new attack surface. Returns a plain bool: failure
+/// is the common case (every third-party client) and is deliberately
+/// not logged here — the caller logs the rare success.
+pub(crate) fn is_official_client(exe_path: &Path) -> bool {
+    let Ok(daemon_exe) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(daemon_dir) = daemon_exe.parent() else {
+        return false;
+    };
+    is_official_client_in(daemon_dir, exe_path)
+}
+
+/// Testable core of [`is_official_client`] with the daemon's own
+/// directory injected. Fail-closed on every non-verifiable branch: a
+/// replaced-on-disk exe (`/proc/<pid>/exe` → "… (deleted)") or a
+/// symlink resolving outside `daemon_dir` fails canonicalization or
+/// the parent check and falls through to the normal consent flow.
+fn is_official_client_in(daemon_dir: &Path, exe_path: &Path) -> bool {
+    let (Ok(resolved), Ok(daemon_dir)) = (exe_path.canonicalize(), daemon_dir.canonicalize())
+    else {
+        return false;
+    };
+    let Some(name) = resolved.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !OFFICIAL_CLIENT_NAMES.contains(&name) {
+        return false;
+    }
+    if resolved.parent() != Some(daemon_dir.as_path()) {
+        return false;
+    }
+    verify_helper_metadata(&resolved).is_ok()
+}
+
 /// Find the consent helper.
 ///
 /// **Security model.** The helper is only ever looked for **alongside the
@@ -286,5 +334,81 @@ mod tests {
         let a = normalize_scopes(&["settings".to_string(), "status".to_string()]);
         let b = normalize_scopes(&["status".to_string(), "settings".to_string()]);
         assert_eq!(a, b, "request order must not change the consent key");
+    }
+
+    /// First-party trust check (`is_official_client_in`): exact-name
+    /// allowlist + co-location with the daemon dir + metadata
+    /// verification, fail-closed on every non-verifiable branch.
+    mod official_client {
+        use super::super::is_official_client_in;
+        use std::os::unix::fs::PermissionsExt;
+        use std::path::{Path, PathBuf};
+
+        fn write_executable(dir: &Path, name: &str, mode: u32) -> PathBuf {
+            let path = dir.join(name);
+            std::fs::write(&path, b"\x7fELF").unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).unwrap();
+            path
+        }
+
+        #[test]
+        fn official_name_co_located_is_trusted() {
+            let dir = tempfile::tempdir().unwrap();
+            let app = write_executable(dir.path(), "super-stt-app", 0o755);
+            assert!(is_official_client_in(dir.path(), &app));
+        }
+
+        #[test]
+        fn unlisted_name_co_located_is_rejected() {
+            let dir = tempfile::tempdir().unwrap();
+            let other = write_executable(dir.path(), "super-stt-extra", 0o755);
+            assert!(
+                !is_official_client_in(dir.path(), &other),
+                "co-location alone must not confer trust"
+            );
+        }
+
+        #[test]
+        fn official_name_in_foreign_dir_is_rejected() {
+            let daemon_dir = tempfile::tempdir().unwrap();
+            let foreign = tempfile::tempdir().unwrap();
+            let app = write_executable(foreign.path(), "super-stt-app", 0o755);
+            assert!(
+                !is_official_client_in(daemon_dir.path(), &app),
+                "an official name outside the daemon dir must not be trusted"
+            );
+        }
+
+        #[test]
+        fn world_writable_official_binary_is_rejected() {
+            let dir = tempfile::tempdir().unwrap();
+            let app = write_executable(dir.path(), "super-stt-cli", 0o757);
+            assert!(
+                !is_official_client_in(dir.path(), &app),
+                "a world-writable binary could be swapped by anyone"
+            );
+        }
+
+        #[test]
+        fn missing_exe_is_rejected() {
+            let dir = tempfile::tempdir().unwrap();
+            assert!(
+                !is_official_client_in(dir.path(), &dir.path().join("super-stt-app")),
+                "a nonexistent (e.g. replaced-on-disk) exe must fail closed"
+            );
+        }
+
+        #[test]
+        fn symlink_resolving_outside_daemon_dir_is_rejected() {
+            let daemon_dir = tempfile::tempdir().unwrap();
+            let foreign = tempfile::tempdir().unwrap();
+            let target = write_executable(foreign.path(), "super-stt-cli", 0o755);
+            let link = daemon_dir.path().join("super-stt-cli");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            assert!(
+                !is_official_client_in(daemon_dir.path(), &link),
+                "canonicalization must unmask a symlink escaping the daemon dir"
+            );
+        }
     }
 }

--- a/super-stt-daemon/src/daemon/http/v1/auth/request.rs
+++ b/super-stt-daemon/src/daemon/http/v1/auth/request.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::daemon::http::internal::auth::consent::{
-    ConsentDecision, ConsentKey, ask_user_for_consent, normalize_scopes, resolve_peer_exe,
+    ConsentDecision, ConsentKey, ask_user_for_consent, is_official_client, normalize_scopes,
+    resolve_peer_exe,
 };
 use crate::daemon::http::internal::helpers::responses::{auth_err, is_known_scope, reason};
 use crate::daemon::http::state::{AppState, PeerInfo};
@@ -50,6 +51,37 @@ fn cached_deny_response(
         StatusCode::FORBIDDEN,
         "auth_denied",
         reason::USER_DENIED_CACHED,
+    ))
+}
+
+/// First-party short-circuit for `auth_request`: a trusted co-located
+/// client binary skips the popup and mints immediately. `None` means
+/// the peer is not first-party and the normal consent flow proceeds.
+fn official_client_response(
+    state: &AppState,
+    body: &AuthRequestBody,
+    scopes: &[String],
+    exe_path: &Path,
+    consent_key: ConsentKey,
+    ok_response: &dyn Fn(String, DateTime<Utc>) -> Response,
+) -> Option<Response> {
+    if !is_official_client(exe_path) {
+        return None;
+    }
+    log::info!(
+        "auth_request auto-approved for first-party client: app={} exe={} scopes={}",
+        body.app_name,
+        exe_path.display(),
+        scopes.join(" ")
+    );
+    Some(finalize_consent_decision(
+        ConsentDecision::Allow,
+        state,
+        body,
+        scopes,
+        exe_path,
+        consent_key,
+        ok_response,
     ))
 }
 
@@ -137,6 +169,21 @@ pub(crate) async fn auth_request(
     // consistent semantic is "request fresh consent".
 
     let consent_key: ConsentKey = (exe_path.clone(), scopes.clone());
+
+    // First-party binaries co-located with the daemon skip the popup
+    // (docs/protocol/auth.md § First-party clients); downstream is
+    // identical to a popup-approved grant. See `is_official_client`
+    // for the trust rationale.
+    if let Some(resp) = official_client_response(
+        &state,
+        &body,
+        &scopes,
+        &exe_path,
+        consent_key.clone(),
+        &ok_response,
+    ) {
+        return resp;
+    }
 
     // Sticky-deny short-circuit. If the user previously clicked Deny for this
     // exact (exe_path, scope) pair in this daemon's lifetime, reject immediately


### PR DESCRIPTION
## Summary

First-party client binaries (`super-stt-app`, `super-stt-cli`, `super-stt-cosmic-applet`) are auto-approved on `POST /auth/request` — no consent popup. A peer qualifies only when its kernel-resolved, canonicalized executable has one of those exact basenames, resides in the same directory as the daemon binary, is owned by the daemon's effective uid, and is not world-writable; every non-verifiable branch fails closed into the normal consent flow.

The trust argument matches the existing consent-helper model: writing to the daemon's install directory is already sufficient to replace the daemon itself, so trusting exact-named sibling binaries adds no new attack surface.

Everything downstream of the approval is identical to a popup grant — scoped token, 30-day expiry, exe binding, `/events` exe-watch. Side benefit: re-auth after an upgrade (`exe_changed`) is now silent for official clients. Third-party flow unchanged, including the sticky deny cache. The contract is documented in `docs/protocol/auth.md` § First-party clients, and `endpoints/v1/auth/request.md` is reconciled to match.

## Test plan

- 6 new unit tests for the trust check (real tempdirs, permission bits, symlinks): trusted path, unlisted name, foreign dir, world-writable, missing exe, symlink escape
- `cargo test -p super-stt-daemon --lib`: 257 passed
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use`: clean
- Manual: reinstall, restart daemon, launch `super-stt-app` from the install dir → no popup; journal shows `auth_request auto-approved for first-party client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)