### PR TITLE
Raise production rate limits above first-party client baseline

### DIFF
--- a/super-stt-daemon/src/resource_management/mod.rs
+++ b/super-stt-daemon/src/resource_management/mod.rs
@@ -53,9 +53,16 @@ impl ResourceLimits {
     #[must_use]
     pub fn production() -> Self {
         Self {
-            max_connections: 20,             // More restrictive for production
-            max_requests_per_minute: 60,     // 1 request per second
-            max_requests_per_hour: 1800,     // 0.5 requests per second average
+            max_connections: 20, // More restrictive for production
+            // The first-party settings app's own background polling
+            // (5s keep-alive ping + 3s GPU refresh ≈ 32 req/min) plus the
+            // ~14-request batch every reconnect/page-load fires already
+            // approaches this ceiling; the limiter is a tight-loop backstop
+            // for a buggy local client, not a security boundary (the daemon
+            // binds a local Unix socket keyed per uid:pid), so it sits well
+            // above legitimate first-party peak rather than at 1 req/s.
+            max_requests_per_minute: 300,    // 5 requests per second
+            max_requests_per_hour: 7200,     // headroom above ~32 req/min baseline
             connection_timeout_seconds: 180, // 3 minutes
             rate_limit_window_seconds: 60,
         }


### PR DESCRIPTION
## Summary

The `production()` resource profile capped requests at 60/min and 1,800/hr — below the settings app's own legitimate traffic. Baseline polling alone (5s keep-alive ping + 3s GPU-info refresh for the top-bar readout) is ~32 req/min ≈ 1,920 req/hr, and every reconnect or page load adds a burst of ~14 GETs. Result: the daemon's rate limiter rejected its own client's requests during normal use (observed as repeated `rate-limit hit … 61-71 requests in 60s (max: 60)` warnings, including mid-download).

Raise `max_requests_per_minute` 60 → 300 and `max_requests_per_hour` 1,800 → 7,200, matching the development profile that has never tripped. The limiter keeps its real job — a tight-loop backstop against a buggy local client — while sitting well above first-party peak. It is not a security boundary: the daemon binds a local Unix socket and keys the limit per `uid:pid`, which any local process can rotate by forking. Connection caps and timeouts are unchanged.

## Test plan

- `cargo test -p super-stt-daemon --lib resource_management`: 6 passed
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use`: clean
- Manual: with the raised limits, the settings app's polling + reconnect bursts stay under both windows (~32/min steady, ~1.9k/hr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)