### PR TITLE
Support frosted glass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_helpers"
+version = "0.14.0"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=32283d7#32283d76a8d0342da74c4cc022a533c52dcf378f"
 dependencies = [
  "bitflags 2.11.0",
  "cosmic-protocols",
@@ -1309,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1330,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "quote",
  "syn",
@@ -1339,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "cosmic-freedesktop-icons"
 version = "0.4.0"
-source = "git+https://github.com/pop-os/freedesktop-icons#7a61a704f6d1ec41f71cbe766e3cc484858523fa"
+source = "git+https://github.com/pop-os/freedesktop-icons#ab4c57b8e416c6af9297cb04d101889896fd9a92"
 dependencies = [
  "bstr",
  "btoi",
@@ -1353,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#d518c7d25ef96f1a9696aa8cce008656bf66ece4"
+source = "git+https://github.com/pop-os/cosmic-panel#f416dbbe72d8600d395d24bf9f96f6ba1299d13b"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1367,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=32283d7#32283d76a8d0342da74c4cc022a533c52dcf378f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -1381,15 +1389,16 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
 
 [[package]]
 name = "cosmic-text"
-version = "0.18.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#d5a972a2b63649fad11ea3a7e80f7dc4c592f01a"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
@@ -1412,13 +1421,14 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "almost",
  "configparser",
  "cosmic-config",
  "csscolorparser",
  "dirs",
+ "hex_color",
  "palette",
  "ron",
  "serde",
@@ -1668,7 +1678,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/glyphon.git?tag=cosmic-0.14#c49de15bce4d8254ac136d1be9911960cc85ce12"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=e429a025df36ab8145708acb309080ae3deec17a#e429a025df36ab8145708acb309080ae3deec17a"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -2013,7 +2023,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "dpi"
 version = "0.1.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 
 [[package]]
 name = "drm"
@@ -2742,34 +2752,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -2920,6 +2913,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex_color"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37f101bf4c633f7ca2e4b5e136050314503dd198e78e325ea602c327c484ef0"
+dependencies = [
+ "arrayvec",
+ "rand 0.8.6",
+ "serde",
+]
 
 [[package]]
 name = "hexf-parse"
@@ -3133,8 +3137,9 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
+ "build_helpers",
  "dnd",
  "iced_accessibility",
  "iced_core",
@@ -3154,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3163,9 +3168,10 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "bitflags 2.11.0",
+ "build_helpers",
  "bytes",
  "cosmic-client-toolkit",
  "dnd",
@@ -3181,6 +3187,7 @@ dependencies = [
  "serde",
  "smol_str",
  "thiserror 2.0.18",
+ "unicode-segmentation",
  "web-time",
  "window_clipboard",
 ]
@@ -3188,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3198,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "futures",
  "iced_core",
@@ -3212,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3233,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3242,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3254,8 +3261,9 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
+ "build_helpers",
  "bytes",
  "cosmic-client-toolkit",
  "dnd",
@@ -3270,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3287,10 +3295,11 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
+ "build_helpers",
  "bytemuck",
  "cosmic-client-toolkit",
  "cryoglyph",
@@ -3318,8 +3327,9 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
+ "build_helpers",
  "cosmic-client-toolkit",
  "dnd",
  "iced_accessibility",
@@ -3337,8 +3347,9 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
+ "build_helpers",
  "cosmic-client-toolkit",
  "cursor-icon",
  "dnd",
@@ -3941,11 +3952,12 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#adb3e341fc35282c0cee108b73740dcb28d4efe1"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
  "auto_enums",
+ "build_helpers",
  "cosmic-client-toolkit",
  "cosmic-config",
  "cosmic-freedesktop-icons",
@@ -3954,6 +3966,7 @@ dependencies = [
  "cosmic-theme",
  "css-color",
  "derive_setters",
+ "enumflags2",
  "float-cmp 0.10.0",
  "futures",
  "i18n-embed",
@@ -4014,14 +4027,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -4225,9 +4238,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
  "bitflags 2.11.0",
  "block",
@@ -4344,9 +4357,9 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -5460,6 +5473,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -5469,7 +5484,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -5482,6 +5497,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5499,6 +5524,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -5584,6 +5612,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_event"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5018d583d6d2f5499352aea8d177e9067d1eb03ab17c78169d5ba7a30001b15"
+dependencies = [
+ "bitflags 2.11.0",
+ "libredox",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5594,9 +5632,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -6482,7 +6520,7 @@ dependencies = [
 [[package]]
 name = "softbuffer"
 version = "0.4.1"
-source = "git+https://github.com/pop-os/softbuffer?tag=cosmic-4.0#a3f77e251e7422803f693df6e3fc313c010c4dcb"
+source = "git+https://github.com/pop-os/softbuffer?tag=cosmic-4.0#c2b2c19ddb38ff17495643699f97cb1f2064a1be"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
@@ -7476,9 +7514,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-vo"
@@ -8210,9 +8248,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -8224,9 +8262,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix 1.1.4",
@@ -8258,9 +8296,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.11"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -8310,9 +8348,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -8324,9 +8362,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml 0.39.2",
@@ -8335,9 +8373,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.12"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63736a4a73e781cf6a736aa32c5d6773c3eb5389197562742a8c611b49b5e359"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
  "bitflags 2.11.0",
  "downcast-rs",
@@ -8348,9 +8386,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -8413,12 +8451,13 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -8442,9 +8481,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "d23f4642f53f666adcfd2d3218ab174d1e6681101aef18696b90cbe64d1c10f9"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -8474,36 +8513,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "44d6cb474beb218824dcc9e1ce679d973f719262789bfb27407da560cac20eeb"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -8517,7 +8556,6 @@ dependencies = [
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -8544,21 +8582,20 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -8678,25 +8715,27 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -8709,16 +8748,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8727,11 +8762,24 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -8742,18 +8790,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -8761,17 +8809,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8812,12 +8849,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8830,13 +8868,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-strings"
-version = "0.1.0"
+name = "windows-result"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8846,6 +8883,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8972,6 +9018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9157,7 +9212,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "cfg_aliases",
@@ -9183,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "winit-android"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "android-activity",
  "bitflags 2.11.0",
@@ -9198,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "winit-appkit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
@@ -9220,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "winit-common"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "memmap2 0.9.10",
  "objc2 0.6.4",
@@ -9235,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "winit-core"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "cursor-icon",
@@ -9249,14 +9304,14 @@ dependencies = [
 [[package]]
 name = "winit-orbital"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "dpi",
  "libredox",
  "orbclient",
  "raw-window-handle",
- "redox_syscall 0.7.3",
+ "redox_event",
  "smol_str",
  "tracing",
  "winit-core",
@@ -9265,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "winit-uikit"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
@@ -9285,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "winit-wayland"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "ahash",
  "bitflags 2.11.0",
@@ -9311,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "winit-web"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "atomic-waker",
  "bitflags 2.11.0",
@@ -9333,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "winit-win32"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "cursor-icon",
@@ -9349,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "winit-x11"
 version = "0.31.0-beta.2"
-source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#a610ac9c7a72b39ff102ed4d946291618dc725b6"
+source = "git+https://github.com/pop-os/winit.git?tag=cosmic-0.14#71ce08c043814514a8fd92d9d0599f115ae854e8"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -9374,9 +9429,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -9615,7 +9667,7 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#d518c7d25ef96f1a9696aa8cce008656bf66ece4"
+source = "git+https://github.com/pop-os/cosmic-panel#f416dbbe72d8600d395d24bf9f96f6ba1299d13b"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",
@@ -9725,9 +9777,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -9753,7 +9805,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -9785,9 +9837,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9800,12 +9852,12 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "zvariant",
 ]
 
@@ -9988,24 +10040,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10016,13 +10068,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,14 @@ dependencies = [
 [[package]]
 name = "build_helpers"
 version = "0.14.0"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
+name = "build_helpers"
+version = "0.14.0"
 source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "cfg_aliases",
@@ -1317,14 +1325,14 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "atomicwrites",
- "cosmic-config-derive",
+ "cosmic-config-derive 1.0.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "cosmic-settings-daemon",
  "dirs",
  "futures-util",
- "iced_futures",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "known-folders",
  "notify",
  "ron",
@@ -1333,6 +1341,32 @@ dependencies = [
  "tracing",
  "xdg",
  "zbus",
+]
+
+[[package]]
+name = "cosmic-config"
+version = "1.0.0"
+source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+dependencies = [
+ "atomicwrites",
+ "cosmic-config-derive 1.0.0 (git+https://github.com/pop-os/libcosmic.git)",
+ "dirs",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git)",
+ "known-folders",
+ "notify",
+ "ron",
+ "serde",
+ "tracing",
+ "xdg",
+]
+
+[[package]]
+name = "cosmic-config-derive"
+version = "1.0.0"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1364,7 +1398,7 @@ version = "0.1.0"
 source = "git+https://github.com/pop-os/cosmic-panel#f416dbbe72d8600d395d24bf9f96f6ba1299d13b"
 dependencies = [
  "anyhow",
- "cosmic-config",
+ "cosmic-config 1.0.0 (git+https://github.com/pop-os/libcosmic.git)",
  "serde",
  "smithay-client-toolkit",
  "tracing",
@@ -1421,11 +1455,11 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "almost",
  "configparser",
- "cosmic-config",
+ "cosmic-config 1.0.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "csscolorparser",
  "dirs",
  "hex_color",
@@ -3137,14 +3171,14 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "dnd",
  "iced_accessibility",
- "iced_core",
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "iced_debug",
- "iced_futures",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "iced_program",
  "iced_renderer",
  "iced_runtime",
@@ -3159,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3168,10 +3202,10 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "bitflags 2.11.0",
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "bytes",
  "cosmic-client-toolkit",
  "dnd",
@@ -3193,22 +3227,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_debug"
+name = "iced_core"
 version = "0.14.0"
 source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
- "iced_core",
- "iced_futures",
+ "bitflags 2.11.0",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git)",
+ "bytes",
+ "dnd",
+ "glam",
+ "lilt",
+ "log",
+ "mime 0.1.0",
+ "num-traits",
+ "palette",
+ "raw-window-handle",
+ "rustc-hash 2.1.1",
+ "smol_str",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "web-time",
+ "window_clipboard",
+]
+
+[[package]]
+name = "iced_debug"
+version = "0.14.0"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+dependencies = [
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "log",
 ]
 
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "futures",
- "iced_core",
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "log",
  "rustc-hash 2.1.1",
  "tokio",
@@ -3217,16 +3275,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "iced_graphics"
+name = "iced_futures"
 version = "0.14.0"
 source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+dependencies = [
+ "futures",
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git)",
+ "log",
+ "rustc-hash 2.1.1",
+ "wasm-bindgen-futures",
+ "wasmtimer",
+]
+
+[[package]]
+name = "iced_graphics"
+version = "0.14.0"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "cosmic-text",
  "half",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "image",
  "kamadak-exif",
  "log",
@@ -3240,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3249,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3261,15 +3332,15 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "bytes",
  "cosmic-client-toolkit",
  "dnd",
  "iced_accessibility",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "raw-window-handle",
  "thiserror 2.0.18",
  "window_clipboard",
@@ -3278,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3295,11 +3366,11 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "bytemuck",
  "cosmic-client-toolkit",
  "cryoglyph",
@@ -3327,9 +3398,9 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "cosmic-client-toolkit",
  "dnd",
  "iced_accessibility",
@@ -3347,15 +3418,15 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "cosmic-client-toolkit",
  "cursor-icon",
  "dnd",
  "iced_accessibility",
  "iced_debug",
- "iced_futures",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "iced_graphics",
  "iced_program",
  "iced_runtime",
@@ -3952,14 +4023,14 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
+source = "git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5#ef162b8e16ba4493e05c169cd56c7b9f77f0fda5"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
  "auto_enums",
- "build_helpers",
+ "build_helpers 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "cosmic-client-toolkit",
- "cosmic-config",
+ "cosmic-config 1.0.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "cosmic-freedesktop-icons",
  "cosmic-panel-config",
  "cosmic-settings-daemon",
@@ -3973,8 +4044,8 @@ dependencies = [
  "i18n-embed-fl",
  "iced",
  "iced_accessibility",
- "iced_core",
- "iced_futures",
+ "iced_core 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
+ "iced_futures 0.14.0 (git+https://github.com/pop-os/libcosmic.git?rev=ef162b8e16ba4493e05c169cd56c7b9f77f0fda5)",
  "iced_renderer",
  "iced_runtime",
  "iced_tiny_skia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,20 +68,32 @@
         keyring = { version = "3", features = ["sync-secret-service"] }
         # System calls (for client singleton)
         libc = "0.2"
-        # Cosmic specific
+        # Cosmic specific. The lib target is `cosmic`, so this is `use cosmic::`
+        # in code despite the package being `libcosmic` — no rename needed.
+        #
+        # Pinned by rev: libcosmic has no releases, so an unpinned git dep
+        # silently drifts to whatever the default branch points at. That matters
+        # more than usual here — cosmic-theme versions its cosmic-config schema,
+        # so a revision far enough from the installed COSMIC reads a theme
+        # directory the desktop no longer writes and the UI quietly renders
+        # stock colors. Bump deliberately: change the rev, then
+        # `cargo update -p libcosmic`.
+        #
+        # Pinning costs a small duplication: cosmic-panel-config, which
+        # libcosmic pulls in for `applet`, depends on cosmic-config from this
+        # same repo *unpinned*, and cargo treats a pinned and unpinned source as
+        # two sources. So cosmic-config, cosmic-config-derive and build_helpers
+        # each compile twice, and `cargo tree -d` reports them. Harmless, and
+        # not ours to fix upstream.
+        #
+        # Features live on each member instead of here, since the consent helper
+        # wants a much smaller build than the app. `default-features` can only be
+        # turned off at the workspace level, so members opt into "default" by
+        # name rather than inheriting it.
         libcosmic = {
             git = "https://github.com/pop-os/libcosmic.git",
-            features = [
-                "a11y",
-                "applet",
-                "dbus-config",
-                "multi-window",
-                "single-instance",
-                "tokio",
-                "wayland",
-                "wgpu",
-                "winit",
-            ]
+            rev = "ef162b8e16ba4493e05c169cd56c7b9f77f0fda5",
+            default-features = false,
         }
         log = "0.4.29"
         open = "5.3.3"

--- a/justfile
+++ b/justfile
@@ -122,6 +122,16 @@ fmt:
 test *args:
     cargo test {{ args }}
 
+# Run the #[ignore]'d GUI smoke tests. These spawn real libcosmic surfaces
+# against the live compositor, so they need a desktop session and can't run in
+# CI — but they're the only thing that catches a surface the compositor
+# rejects (e.g. a corner radius wider than an autosized layer surface, which
+# kills the client mid-handshake and turns every consent prompt into a silent
+# denial). Run them after touching any surface setup. Usage: just test-gui
+[doc("Run the GUI smoke tests against the live compositor (needs a desktop session)")]
+test-gui *args:
+    cargo test -p super-stt-consent --test gui_smoke -- --ignored --nocapture {{ args }}
+
 # Load every committed old-config fixture against the current config types.
 config-compat *args:
     cargo test -p super-stt-daemon --lib config {{ args }}
@@ -173,6 +183,42 @@ run-daemon *args:
 # Usage: just run-cli [ping|status|record|stop|logout] [args]
 run-cli *args:
     env RUST_BACKTRACE=full RUST_LOG=super_stt_cli=debug,super_stt_shared=debug cargo run --bin {{ cli_name }} -- {{ args }}
+
+# Run the consent dialog on its own, without the daemon. The dialog is
+# env-driven rather than argument-driven, so this fills in a plausible request;
+# pass scope names to change which permission bullets render. The decision
+# (allow / deny / dismissed) goes to stdout, same as the daemon would read.
+#
+# Heads up: the dialog is an overlay layer surface with an exclusive keyboard
+# grab, so it holds the keyboard until you click Allow or Deny — the mouse
+# still works. For a hands-free run, set STT_AUTH_AUTO_APPROVE_AFTER_MS and it
+# approves itself after that many milliseconds. That env var is debug-only; a
+# release build can never self-approve.
+#
+# For the automated version of this, see `just test-gui`.
+#
+# Usage: just run-consent [scope...]
+#   just run-consent
+#   just run-consent transcribe settings secrets
+#   STT_AUTH_AUTO_APPROVE_AFTER_MS=4000 just run-consent
+[doc("Run the consent dialog standalone. Usage: just run-consent [scope...]")]
+run-consent *scopes:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    scopes="{{ scopes }}"
+    # A spread of scopes so the dialog renders a representative bullet list.
+    [ -n "$scopes" ] || scopes="transcribe status settings"
+
+    echo "Scopes: $scopes"
+    # Quiet RUST_LOG: the default pulls in thousands of wgpu/zbus/wayland lines
+    # at startup and buries the dialog's own output.
+    env RUST_BACKTRACE=full \
+        RUST_LOG=super_stt_consent=debug,super_stt_shared=debug \
+        STT_AUTH_APP_NAME="Test App" \
+        STT_AUTH_SCOPES="$scopes" \
+        STT_AUTH_EXE_PATH="/usr/bin/test-app" \
+        cargo run --bin {{ consent_name }}
 
 # Run security audit to check for vulnerabilities
 audit:

--- a/super-stt-app/Cargo.toml
+++ b/super-stt-app/Cargo.toml
@@ -15,7 +15,21 @@
     i18n-embed-fl.workspace = true
     libc.workspace = true
     # COSMIC dependencies
+    # Dotted keys, not an inline table: `fluent_language_loader!` parses this
+    # manifest with a TOML 1.0 parser, which rejects a multi-line inline table.
     libcosmic.workspace = true
+    libcosmic.features = [
+        "default",
+        "a11y",
+        "applet",
+        "dbus-config",
+        "multi-window",
+        "single-instance",
+        "tokio",
+        "wayland",
+        "wgpu",
+        "winit",
+    ]
     log.workspace = true
     open.workspace = true
     rfd = { version = "0.17.2", default-features = false, features = ["xdg-portal"] }

--- a/super-stt-app/src/ui/views/about.rs
+++ b/super-stt-app/src/ui/views/about.rs
@@ -2,7 +2,7 @@
 //! About page view for the Super STT application.
 
 use cosmic::iced::Alignment;
-use cosmic::iced_widget::column;
+use cosmic::iced::widget::column;
 use cosmic::widget::{self, button};
 use cosmic::{Element, cosmic_theme, theme};
 

--- a/super-stt-app/src/ui/views/common.rs
+++ b/super-stt-app/src/ui/views/common.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //! Common components and utilities shared across views.
 
+use cosmic::iced::widget::row;
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::row;
 use cosmic::widget::{self, text};
 use cosmic::{Apply, Element};
 

--- a/super-stt-app/src/ui/views/models/active.rs
+++ b/super-stt-app/src/ui/views/models/active.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::Element;
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::{column, row};
 use cosmic::widget::{self, button, text};
 use super_stt_shared::models::protocol::DownloadProgress;
 
@@ -34,7 +34,7 @@ pub(super) fn glyph_tile<'a>(tile: f32, glyph: f32, radius_medium: bool) -> Elem
         .center_y(Length::Fixed(tile))
         .class(cosmic::theme::Container::custom(move |theme| {
             let radii = theme.cosmic().corner_radii;
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(fill)),
                 border: cosmic::iced::Border {
                     radius: if radius_medium {
@@ -443,7 +443,7 @@ pub(super) fn card_download_progress<'a>(
     };
     column![
         text::body(line),
-        widget::progress_bar(0.0..=1.0, fraction.max(0.05)),
+        widget::determinate_linear(fraction.max(0.05)).width(Length::Fill),
         row![
             text::caption(bytes).width(Length::Fill),
             widget::button::destructive("Cancel")

--- a/super-stt-app/src/ui/views/models/add_sheet.rs
+++ b/super-stt-app/src/ui/views/models/add_sheet.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::{column, row};
 use cosmic::widget::{self, button, text};
 use cosmic::{Apply, Element};
 

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::iced::Alignment;
-use cosmic::iced_widget::row;
+use cosmic::iced::widget::row;
 use cosmic::widget::{self, text};
 use cosmic::{Apply, Element};
 
@@ -62,7 +62,7 @@ pub(super) fn capability_chip(
     .apply(widget::container)
     .padding([spacing.space_xxxs, spacing.space_xs])
     .class(cosmic::theme::Container::custom(move |_| {
-        cosmic::iced_widget::container::Style {
+        cosmic::iced::widget::container::Style {
             background: Some(cosmic::iced::Background::Color(fill)),
             border: cosmic::iced::Border {
                 radius: radius.into(),
@@ -95,7 +95,7 @@ pub(super) fn count_chip(label: String) -> Element<'static, Message> {
         .apply(widget::container)
         .padding([spacing.space_xxxs, spacing.space_xs])
         .class(cosmic::theme::Container::custom(move |_| {
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(fill)),
                 border: cosmic::iced::Border {
                     radius: radius.into(),
@@ -134,7 +134,7 @@ pub(super) fn model_tag(name: String) -> Element<'static, Message> {
         .apply(widget::container)
         .padding([spacing.space_xxxs, spacing.space_xs])
         .class(cosmic::theme::Container::custom(move |_| {
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 border: cosmic::iced::Border {
                     radius: radius.into(),
                     width: 1.0,

--- a/super-stt-app/src/ui/views/models/configure.rs
+++ b/super-stt-app/src/ui/views/models/configure.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::Element;
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::{column, row};
 use cosmic::widget::{self, settings, text};
 
 use crate::core::app::AppModel;

--- a/super-stt-app/src/ui/views/models/download.rs
+++ b/super-stt-app/src/ui/views/models/download.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::{column, row};
 use cosmic::widget::{self, button, space::horizontal as horizontal_space, text};
 use cosmic::{Apply, Element};
 

--- a/super-stt-app/src/ui/views/models/fmt.rs
+++ b/super-stt-app/src/ui/views/models/fmt.rs
@@ -70,7 +70,7 @@ pub(super) fn vram_meter<'a>(used: u64, total: u64) -> Element<'a, Message> {
             } else {
                 cosmic.success.base.into()
             };
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(color)),
                 border: cosmic::iced::Border {
                     radius: (height / 2.0).into(),
@@ -86,7 +86,7 @@ pub(super) fn vram_meter<'a>(used: u64, total: u64) -> Element<'a, Message> {
         .class(cosmic::theme::Container::custom(move |theme| {
             let mut bg: cosmic::iced::Color = theme.cosmic().palette.neutral_5.into();
             bg.a = 0.25;
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(bg)),
                 border: cosmic::iced::Border {
                     radius: (height / 2.0).into(),
@@ -104,7 +104,7 @@ pub(super) fn vram_meter<'a>(used: u64, total: u64) -> Element<'a, Message> {
 pub(super) fn vram_warning<'a>(needed: u64, available: u64) -> Element<'a, Message> {
     use crate::ui::icons;
     use cosmic::iced::Alignment;
-    use cosmic::iced_widget::row;
+    use cosmic::iced::widget::row;
     use cosmic::widget::text;
 
     row![

--- a/super-stt-app/src/ui/views/models/installed.rs
+++ b/super-stt-app/src/ui/views/models/installed.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::Element;
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::{column, row};
 use cosmic::widget::{self, button, text};
 
 use crate::core::app::AppModel;
@@ -170,7 +170,7 @@ pub(super) fn installed_overflow_menu(
         .class(cosmic::theme::Container::custom(|theme| {
             let cosmic = theme.cosmic();
             let component = &theme.current_container().component;
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(component.base.into())),
                 border: cosmic::iced::Border {
                     radius: cosmic.corner_radii.radius_s.into(),

--- a/super-stt-app/src/ui/views/models/load_sheet.rs
+++ b/super-stt-app/src/ui/views/models/load_sheet.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::Element;
+use cosmic::iced::widget::row;
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::row;
 use cosmic::widget::{self, button, text};
 
 use crate::core::app::AppModel;
@@ -126,7 +126,7 @@ fn load_backend_row(backend: &BackendInfo, is_active: bool) -> Element<'static, 
         .class(cosmic::theme::Container::custom(move |theme| {
             let cosmic = theme.cosmic();
             let component = &theme.current_container().component;
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(component.base.into())),
                 border: cosmic::iced::Border {
                     radius: cosmic.corner_radii.radius_s.into(),

--- a/super-stt-app/src/ui/views/models/mod.rs
+++ b/super-stt-app/src/ui/views/models/mod.rs
@@ -19,8 +19,8 @@ use surface::{bordered_scroll_view, muted_text_color, tab_bar_container, toolbar
 use tabs::models_tab_switcher;
 
 use cosmic::Element;
+use cosmic::iced::widget::row;
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::row;
 use cosmic::widget::{self, text};
 
 use super::common::page_container;
@@ -94,7 +94,7 @@ pub(crate) fn status_pill(app: &AppModel) -> Element<'_, Message> {
         .width(Length::Fixed(size))
         .height(Length::Fixed(size))
         .class(cosmic::theme::Container::custom(move |theme| {
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 background: Some(cosmic::iced::Background::Color(color_fn(theme))),
                 border: cosmic::iced::Border {
                     radius: (size / 2.0).into(),

--- a/super-stt-app/src/ui/views/models/surface.rs
+++ b/super-stt-app/src/ui/views/models/surface.rs
@@ -31,7 +31,7 @@ pub(super) fn bordered_scroll_view<'a>(
         .height(Length::Fill)
         .class(cosmic::theme::Container::custom(|theme| {
             let component = &theme.current_container().component;
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 border: cosmic::iced::Border {
                     radius: theme.cosmic().corner_radii.radius_m.into(),
                     width: 1.0,
@@ -96,10 +96,10 @@ pub(super) fn accent_border_color(theme: &cosmic::Theme, active: bool) -> cosmic
 /// The shared "pill" container style: list-container fill, a hairline divider
 /// border, and an extra-large corner radius (no shadow). Used by the header
 /// pills and the segmented-control track.
-pub(super) fn pill_surface(theme: &cosmic::Theme) -> cosmic::iced_widget::container::Style {
+pub(super) fn pill_surface(theme: &cosmic::Theme) -> cosmic::iced::widget::container::Style {
     let cosmic = theme.cosmic();
     let component = &theme.current_container().component;
-    cosmic::iced_widget::container::Style {
+    cosmic::iced::widget::container::Style {
         background: Some(cosmic::iced::Background::Color(component.base.into())),
         border: cosmic::iced::Border {
             radius: cosmic.corner_radii.radius_xl.into(),
@@ -125,7 +125,7 @@ pub(super) fn card_surface<'a>(
             let cosmic = theme.cosmic();
             let component = &theme.current_container().component;
             let border_color = accent_border_color(theme, active);
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 icon_color: Some(component.on.into()),
                 text_color: Some(component.on.into()),
                 background: Some(cosmic::iced::Background::Color(component.base.into())),
@@ -242,7 +242,7 @@ pub(super) fn rounded_tooltip<'a>(
     cosmic::widget::tooltip::Tooltip::new(content, popup, position)
         .class(cosmic::theme::Container::custom(|theme| {
             let cosmic = theme.cosmic();
-            cosmic::iced_widget::container::Style {
+            cosmic::iced::widget::container::Style {
                 icon_color: None,
                 text_color: None,
                 background: Some(cosmic::iced::Background::Color(

--- a/super-stt-app/src/ui/views/models/tabs.rs
+++ b/super-stt-app/src/ui/views/models/tabs.rs
@@ -61,7 +61,7 @@ pub(super) fn models_tab_switcher(app: &AppModel) -> Element<'_, Message> {
                     } else {
                         cosmic::iced::Color::TRANSPARENT
                     };
-                    cosmic::iced_widget::container::Style {
+                    cosmic::iced::widget::container::Style {
                         background: Some(cosmic::iced::Background::Color(bg)),
                         border: cosmic::iced::Border {
                             radius: [r[0], r[1], 0.0, 0.0].into(),

--- a/super-stt-app/src/ui/views/recording.rs
+++ b/super-stt-app/src/ui/views/recording.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::Element;
+use cosmic::iced::widget::row;
 use cosmic::iced::{Alignment, Length};
-use cosmic::iced_widget::row;
 use cosmic::widget::{self, button, settings, text};
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 
@@ -73,10 +73,8 @@ fn test_section<'a>(
 
     let audio_widget = row![
         record_button,
-        widget::progress_bar(
-            0.0..=1.0,
-            audio_level.max(if audio_level > 0.0 { 0.1 } else { 0.0 })
-        ),
+        widget::determinate_linear(audio_level.max(if audio_level > 0.0 { 0.1 } else { 0.0 }))
+            .width(Length::Fill),
     ]
     .align_y(Alignment::Center)
     .spacing(10);

--- a/super-stt-consent/Cargo.toml
+++ b/super-stt-consent/Cargo.toml
@@ -12,10 +12,10 @@
     path = "src/main.rs"
 
 [dependencies]
-    cosmic = {
-        package = "libcosmic",
-        git = "https://github.com/pop-os/libcosmic.git",
-        default-features = false,
+    # Deliberately lean: no "default", so the helper skips a11y, dbus-config
+    # and x11 that the app pulls in. It's a short-lived dialog.
+    libcosmic = {
+        workspace = true,
         features = [
             "autosize",
             "multi-window",

--- a/super-stt-consent/src/main.rs
+++ b/super-stt-consent/src/main.rs
@@ -28,13 +28,17 @@
 
 mod constants;
 
-use cosmic::iced::Limits;
+use cosmic::iced::event::{self, listen_with};
+use cosmic::iced::platform_specific::shell::commands::corner_radius::corner_radius;
 use cosmic::iced::platform_specific::shell::commands::layer_surface::{
-    Anchor, KeyboardInteractivity, Layer, destroy_layer_surface, get_layer_surface,
+    Anchor, KeyboardInteractivity, Layer,
 };
+use cosmic::iced::runtime::platform_specific::wayland::CornerRadius;
 use cosmic::iced::runtime::platform_specific::wayland::layer_surface::SctkLayerSurfaceSettings;
 use cosmic::iced::window::Id as SurfaceId;
+use cosmic::iced::{Limits, Size, Subscription};
 use cosmic::prelude::*;
+use cosmic::surface::{action as surface_action, surface_task};
 use cosmic::widget::{button, dialog, icon, text};
 use std::io::Write;
 use std::sync::LazyLock;
@@ -43,6 +47,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const APP_ID: &str = "ai.menjivar.super-stt-consent";
 
 const QUESTION_ICON: &[u8] = include_bytes!("../resources/icons/phosphor/question.svg");
+
+/// Floor for the autosized surface, in logical pixels. Only applies for the
+/// frames before `autosize` measures the dialog.
+const MIN_SURFACE_DIM: f32 = 1.0;
+
+/// No compositor-side corner clip. The state the surface starts in, and the
+/// only safe one until it has a size — see [`ConsentApp::sync_corner_radius`].
+const SQUARE_CORNERS: CornerRadius = CornerRadius {
+    top_left: 0,
+    top_right: 0,
+    bottom_left: 0,
+    bottom_right: 0,
+};
 
 /// Stable id for the autosize widget that wraps the dialog body.
 /// `widget::autosize::autosize` measures its child to size the parent
@@ -64,6 +81,9 @@ static DECIDED: AtomicBool = AtomicBool::new(false);
 enum Message {
     Allow,
     Deny,
+    /// The compositor configured our surface to `Size`. Carries the id so a
+    /// stray event for another surface can't drive our corner radius.
+    Resized(SurfaceId, Size),
 }
 
 struct ConsentApp {
@@ -90,26 +110,60 @@ impl cosmic::Application for ConsentApp {
     }
 
     fn init(
-        core: cosmic::Core,
+        mut core: cosmic::Core,
         flags: Self::Flags,
     ) -> (Self, cosmic::Task<cosmic::Action<Self::Message>>) {
         let surface_id = SurfaceId::unique();
+
+        // We draw a layer-shell overlay, not an application window, so the
+        // dialog belongs to the system interface: its translucency follows the
+        // theme's "frosted system interface" toggle rather than the one for
+        // regular windows.
+        core.set_app_type(cosmic::core::AppType::System);
 
         // Spawn a layer-shell overlay surface. Tiling compositors do
         // not tile layer-shell surfaces, so this is the protocol-level
         // way to guarantee the dialog floats. KeyboardInteractivity is
         // Exclusive so the dialog grabs all keyboard input until the
         // user makes a choice (matches cosmic-osd's polkit dialog).
-        let task = get_layer_surface(SctkLayerSurfaceSettings {
-            id: surface_id,
-            keyboard_interactivity: KeyboardInteractivity::Exclusive,
-            anchor: Anchor::empty(),
-            namespace: "stt-consent".into(),
-            layer: Layer::Overlay,
-            size: None,
-            size_limits: Limits::NONE.min_width(1.0).min_height(1.0),
-            ..Default::default()
-        });
+        //
+        // Routed through `cosmic::surface` rather than the raw
+        // `get_layer_surface` command so libcosmic tracks the surface and owns
+        // its frosted-glass blur, re-applying it when the theme changes. A
+        // surface spawned directly is invisible to that bookkeeping, which
+        // leaves it translucent with nothing blurred behind it whenever the
+        // theme has frosted glass on.
+        let task = surface_task(surface_action::app_layer_shell::<Self>(
+            |_| surface_action::LiveSettings {
+                // Inherit the theme's blur decision.
+                blur: None,
+                // Corners start square and are rounded once the surface has a
+                // size. libcosmic would otherwise round a tracked layer
+                // surface to the theme's radius the moment it's created —
+                // before the compositor has configured any size for it — and
+                // cosmic-comp answers a radius wider than the surface it's
+                // clipping with `cosmic_corner_radius_layer_v1: error 1:
+                // corner radius too large`, killing the client. Raising the
+                // surface's `size_limits` floor does not help; the request
+                // goes out ahead of the first configure either way.
+                corners: Some(SQUARE_CORNERS),
+                padding: None,
+            },
+            move |_: &mut Self| SctkLayerSurfaceSettings {
+                id: surface_id,
+                keyboard_interactivity: KeyboardInteractivity::Exclusive,
+                anchor: Anchor::empty(),
+                namespace: "stt-consent".into(),
+                layer: Layer::Overlay,
+                size: None,
+                size_limits: Limits::NONE
+                    .min_width(MIN_SURFACE_DIM)
+                    .min_height(MIN_SURFACE_DIM),
+                ..Default::default()
+            },
+            // No dedicated view: libcosmic falls back to `view_window`.
+            None,
+        ));
 
         (
             Self {
@@ -148,15 +202,16 @@ impl cosmic::Application for ConsentApp {
 
         let permission_lines = permissions_for_scopes(&self.scopes);
 
-        let mut bullet_column = cosmic::widget::column().spacing(6);
+        let mut bullet_column =
+            cosmic::widget::column::with_capacity(permission_lines.len()).spacing(6);
         for line in permission_lines {
             bullet_column = bullet_column.push(bullet_row(line));
         }
 
-        let control = cosmic::widget::column()
+        let control = cosmic::widget::column::with_capacity(2)
             .push(text::body(format!("Executable:  {}", self.exe_path)))
             .push(
-                cosmic::widget::column()
+                cosmic::widget::column::with_capacity(2)
                     .push(text::heading("This will allow it to:"))
                     .push(bullet_column)
                     .spacing(6),
@@ -164,6 +219,12 @@ impl cosmic::Application for ConsentApp {
             .spacing(12);
 
         let dialog_widget = dialog::dialog()
+            // `Container::Dialog` only honours the theme's translucency when
+            // the dialog is *not* an overlay — an overlay sits on a dimmed
+            // backdrop inside an app window, where a see-through panel would
+            // read as a rendering bug. Ours is a standalone surface with the
+            // desktop behind it, so it takes the frosted treatment instead.
+            .is_overlay(false)
             .title("Allow access to Super STT?")
             .body(body_text)
             .icon(
@@ -180,20 +241,77 @@ impl cosmic::Application for ConsentApp {
         // layer-shell surface to match. Without it the surface stays
         // 0×0 and the dialog is invisible.
         cosmic::widget::autosize::autosize(dialog_widget, AUTOSIZE_ID.clone())
-            .min_width(1.0)
-            .min_height(1.0)
+            .min_width(MIN_SURFACE_DIM)
+            .min_height(MIN_SURFACE_DIM)
             .into()
+    }
+
+    fn subscription(&self) -> Subscription<Self::Message> {
+        // `Opened` covers the compositor's first configure, `Resized` any
+        // later one — a font-scale change, say. Both feed the corner radius.
+        listen_with(|ev, _status, id| match ev {
+            event::Event::Window(
+                cosmic::iced::window::Event::Opened { size, .. }
+                | cosmic::iced::window::Event::Resized(size),
+            ) => Some(Message::Resized(id, size)),
+            _ => None,
+        })
     }
 
     fn update(&mut self, message: Self::Message) -> cosmic::Task<cosmic::Action<Self::Message>> {
         let decision = match message {
             Message::Allow => ALLOW,
             Message::Deny => DENY,
+            Message::Resized(id, size) => return self.sync_corner_radius(id, size),
         };
-        // Tear down the layer surface gracefully so the compositor sees
-        // a clean exit, then write the decision to stdout and exit.
-        let _ = destroy_layer_surface::<Self::Message>(self.surface_id);
+        // Write the decision to stdout and exit; the compositor tears the
+        // surface down when the process goes away. Returning a destroy task
+        // instead would never run — `emit_and_exit` diverges before the
+        // runtime gets a chance to execute it.
         emit_and_exit(decision);
+    }
+}
+
+impl ConsentApp {
+    /// Match the compositor's corner clip to the rounded border the dialog
+    /// widget draws, now that the surface has a size to measure against.
+    ///
+    /// Without this the surface stays a square the dialog is painted into, and
+    /// its background shows through outside the rounded border at each corner.
+    /// The radius is clamped to half the shorter side: cosmic-comp rejects
+    /// anything wider than the surface it's clipping, and rejection means a
+    /// protocol error that kills the process, not a clamp on its end. Same
+    /// shape as the cosmic-osd indicator, which rounds on `Msg::Size`.
+    fn sync_corner_radius(
+        &self,
+        id: SurfaceId,
+        size: Size,
+    ) -> cosmic::Task<cosmic::Action<Message>> {
+        if id != self.surface_id {
+            return cosmic::Task::none();
+        }
+        // Degenerate sizes are the pre-configure state; stay square. The
+        // finite check also rejects NaN, which would otherwise slip past the
+        // comparison and clamp to nothing.
+        let limit = size.width.min(size.height) / 2.0;
+        if !limit.is_finite() || limit < 1.0 {
+            return cosmic::Task::none();
+        }
+        // `radius_m` is what `Container::Dialog` rounds its own border to, so
+        // the clip lands exactly on the edge the user sees.
+        let radii = cosmic::theme::active().cosmic().corner_radii.radius_m;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let clamp = |r: f32| r.min(limit).max(0.0).round() as u32;
+        corner_radius(
+            self.surface_id,
+            Some(CornerRadius {
+                top_left: clamp(radii[0]),
+                top_right: clamp(radii[1]),
+                bottom_right: clamp(radii[2]),
+                bottom_left: clamp(radii[3]),
+            }),
+        )
+        .discard()
     }
 }
 
@@ -255,7 +373,7 @@ fn permissions_for_scopes(scopes: &[String]) -> Vec<&'static str> {
 /// Render one bullet line. Uses a Row so wrapped text hangs under
 /// itself instead of slipping behind the bullet character.
 fn bullet_row(line: &str) -> Element<'_, Message> {
-    cosmic::widget::row()
+    cosmic::widget::row::with_capacity(2)
         .push(text::body("•"))
         .push(text::body(line))
         .spacing(8)

--- a/super-stt-consent/tests/gui_smoke.rs
+++ b/super-stt-consent/tests/gui_smoke.rs
@@ -27,12 +27,24 @@
 //!       `STT_AUTH_EXE_PATH`) is wired up;
 //!     - all three decision paths (Allow / Deny / dismissed) write a
 //!       recognizable line to stdout.
+//!
+//! - **surface_survives_compositor_handshake**: the helper is still alive
+//!   after the surface is up, and the compositor never raised a Wayland
+//!   protocol error against it. See that test for why a dialog that dies
+//!   during the handshake is invisible in production.
 
+use std::fs::File;
 use std::io::Read;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 const HELPER_BIN: &str = env!("CARGO_BIN_EXE_super-stt-consent");
+
+/// How long to let the surface settle before judging it healthy. The
+/// corner-radius protocol violation this guards against killed the helper
+/// ~500 ms in, so this leaves generous headroom on a slow machine.
+const HANDSHAKE_GRACE: Duration = Duration::from_millis(2500);
 
 /// Returns Some(reason) if no display is available — caller should skip
 /// the test rather than fail.
@@ -128,4 +140,111 @@ fn renders_and_decides() {
          exit status: {exit_status}"
     );
     eprintln!("[smoke] consent helper decision: {decision:?}");
+}
+
+/// The dialog's layer surface must survive the compositor handshake.
+///
+/// Regression guard. libcosmic applies the active theme's corner radii to
+/// every surface it tracks, but this dialog is autosized — the surface exists
+/// at its 1x1 `size_limits` floor before the dialog is measured, and a radius
+/// wider than the surface is a protocol violation. cosmic-comp answers
+/// `cosmic_corner_radius_layer_v1: error 1: corner radius too large` by
+/// killing the client, so the helper died ~500 ms in without ever painting.
+///
+/// Nothing downstream reports that as a failure: the daemon reads the closed
+/// stdout as [`ConsentDecision::Dismissed`], every consent prompt silently
+/// denies, and the only user-visible symptom is a client stuck retrying
+/// against `auth_denied (user_dismissed)`. Hence a test that watches the
+/// process and the compositor's complaints rather than just the decision —
+/// `renders_and_decides` treats an early exit as "the human clicked a button"
+/// and sails straight past a crash this size.
+#[test]
+#[ignore = "spawns a real libcosmic window — run manually with cargo test -- --ignored"]
+fn surface_survives_compositor_handshake() {
+    if let Some(reason) = skip_if_no_display() {
+        eprintln!("{reason}");
+        return;
+    }
+
+    // Route stderr to a file rather than a pipe: libcosmic logs thousands of
+    // lines at startup, and an undrained pipe would fill and block the child
+    // — which looks exactly like the hang we're testing for.
+    let log_path: PathBuf =
+        std::env::temp_dir().join(format!("stt-consent-smoke-{}.log", std::process::id()));
+    let log = File::create(&log_path).expect("create stderr capture file");
+
+    let mut child = Command::new(HELPER_BIN)
+        .env("STT_AUTH_APP_NAME", "Handshake Test App")
+        .env("STT_AUTH_SCOPES", "transcribe status")
+        .env("STT_AUTH_EXE_PATH", "/usr/bin/smoke-test")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(log))
+        .spawn()
+        .expect("spawn super-stt-consent");
+
+    std::thread::sleep(HANDSHAKE_GRACE);
+
+    let early_exit = match child.try_wait() {
+        Ok(status) => status,
+        Err(e) => panic!("error waiting on child: {e}"),
+    };
+
+    if early_exit.is_none() {
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(child.id() as libc::pid_t, libc::SIGTERM);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = child.kill();
+        }
+    }
+
+    let status = match early_exit {
+        Some(status) => status,
+        None => child.wait().expect("wait on child"),
+    };
+
+    let mut stdout = String::new();
+    if let Some(mut s) = child.stdout.take() {
+        let _ = s.read_to_string(&mut stdout);
+    }
+    let stderr = std::fs::read_to_string(&log_path).unwrap_or_default();
+    let _ = std::fs::remove_file(&log_path);
+
+    // The compositor's verdict on our surface. Any protocol error means we
+    // sent something it refused to accept, and it hung up on us.
+    let protocol_error = stderr
+        .lines()
+        .find(|l| l.contains("Protocol error") || l.contains("corner radius too large"));
+    assert!(
+        protocol_error.is_none(),
+        "compositor raised a Wayland protocol error against the consent \
+         surface: {}\n(exit status: {status})",
+        protocol_error.unwrap_or_default()
+    );
+
+    // An early exit is only legitimate if the helper reached a decision — a
+    // human clicking Allow/Deny, or the debug auto-approve timer. Exiting
+    // without one means it died on the way up.
+    if early_exit.is_some() {
+        let decided = stdout
+            .lines()
+            .any(|l| matches!(l.trim(), "allow" | "deny" | "dismissed"));
+        assert!(
+            decided,
+            "consent helper exited within {HANDSHAKE_GRACE:?} without writing a \
+             decision — it never got its dialog on screen.\n\
+             exit status: {status}\n\
+             stderr tail:\n{}",
+            tail(&stderr, 20)
+        );
+    }
+}
+
+/// Last `n` lines of `text`, for assertion messages.
+fn tail(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    lines[lines.len().saturating_sub(n)..].join("\n")
 }

--- a/super-stt-cosmic-applet/Cargo.toml
+++ b/super-stt-cosmic-applet/Cargo.toml
@@ -15,10 +15,10 @@
 [dependencies]
     base64 = "0.22.1"
     clap = { version = "4.5", features = ["derive"] }
-    cosmic = {
-        package = "libcosmic",
-        git = "https://github.com/pop-os/libcosmic.git",
+    libcosmic = {
+        workspace = true,
         features = [
+            "default",
             "applet",
             "tokio",
         ]

--- a/super-stt-cosmic-applet/src/app/update.rs
+++ b/super-stt-cosmic-applet/src/app/update.rs
@@ -3,10 +3,8 @@ use std::time::Instant;
 
 use cosmic::{
     app as cosmic_app,
-    iced::{
-        platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup},
-        window,
-    },
+    iced::window,
+    surface::{action as surface_action, surface_task},
     widget::segmented_button::Entity,
 };
 use log::{debug, info, warn};
@@ -84,21 +82,36 @@ impl SuperSttApplet {
         }
     }
 
+    /// Open or close the panel popup.
+    ///
+    /// Routed through `cosmic::surface` rather than the raw `get_popup` /
+    /// `destroy_popup` wayland commands so libcosmic tracks the surface: it
+    /// owns the popup's corner radii and its frosted-glass blur, and re-applies
+    /// both when the theme changes. A popup spawned directly is invisible to
+    /// that bookkeeping, which leaves it translucent with nothing blurred
+    /// behind it whenever the theme has frosted applets on.
     fn toggle_popup(&mut self) -> cosmic_app::Task<Message> {
         if let Some(p) = self.popup.take() {
-            return destroy_popup(p);
+            return surface_task(surface_action::destroy_popup(p));
         }
-        if let Some(main_window_id) = self.core.main_window_id() {
-            let new_id = window::Id::unique();
-            self.popup.replace(new_id);
-            let popup_settings =
-                self.core
+        let Some(main_window_id) = self.core.main_window_id() else {
+            warn!("Cannot toggle popup: main window ID not available");
+            return cosmic_app::Task::none();
+        };
+        surface_task(surface_action::app_popup::<Self>(
+            // Defaults: inherit the blur and corner radii libcosmic derives
+            // from the theme for an applet popup.
+            |_| surface_action::LiveSettings::default(),
+            move |app: &mut Self| {
+                let new_id = window::Id::unique();
+                app.popup.replace(new_id);
+                app.core
                     .applet
-                    .get_popup_settings(main_window_id, new_id, None, None, None);
-            return get_popup(popup_settings);
-        }
-        warn!("Cannot toggle popup: main window ID not available");
-        cosmic_app::Task::none()
+                    .get_popup_settings(main_window_id, new_id, None, None, None)
+            },
+            // No dedicated view: libcosmic falls back to `view_window`.
+            None,
+        ))
     }
 
     fn close_popup(&mut self, id: window::Id) -> cosmic_app::Task<Message> {

--- a/super-stt-cosmic-applet/src/app/view.rs
+++ b/super-stt-cosmic-applet/src/app/view.rs
@@ -3,8 +3,7 @@ use std::rc::Rc;
 
 use cosmic::{
     Element,
-    iced::{Alignment, Length, Size},
-    iced_widget,
+    iced::{Alignment, Length, Size, widget as iced_widget},
     theme::{self, Button},
     widget::{self, button, container, layer_container, mouse_area},
 };
@@ -153,7 +152,7 @@ fn transparent_icon_button<'a>(
     if symbolic {
         icon = icon.class(theme::Svg::Custom(Rc::new(|theme| {
             iced_widget::svg::Style {
-                color: Some(theme.cosmic().background.on.into()),
+                color: Some(theme.cosmic().background(theme.transparent).on.into()),
             }
         })));
     }

--- a/super-stt-cosmic-applet/src/ui/sections/settings/components/visualization_theme.rs
+++ b/super-stt-cosmic-applet/src/ui/sections/settings/components/visualization_theme.rs
@@ -15,9 +15,8 @@ use cosmic::{
     applet::padded_control,
     iced::{
         Length,
-        widget::{column, row},
+        widget::{Row, column, row},
     },
-    iced_widget::Row,
     theme,
     widget::{Space, segmented_button::SingleSelectModel, segmented_control, text},
 };


### PR DESCRIPTION
Windows, the applet popup, and the consent dialog now honour COSMIC's frosted glass settings. There is no in-app toggle — each surface follows its own key in the theme (`frosted_windows`, `frosted_applets`, `frosted_system_interface`), so it tracks whatever Appearance is set to.

## Why nothing worked before

`libcosmic` was pinned to a revision that predated frosted-glass support, and old enough to read `CosmicTheme/v1` while the desktop writes `v2` — the app was rendering a stale theme, ignoring accent and frost alike. Bumping it delivers frost for the main window on its own.

The applet popup and consent dialog needed more. Both spawned their surfaces with the raw `get_popup` / `get_layer_surface` commands, which leaves them out of libcosmic's `surface_views` map — and that map is what drives blur, corner radii, and re-applying both on theme change. They went translucent from the theme with nothing blurred behind them. Both now go through `cosmic::surface`, the same idiom cosmic-applets and cosmic-osd use; neither of those repos mentions blur anywhere.

## Consent dialog

Two further fixes, both load-bearing:

- `Container::Dialog` deliberately ignores translucency for overlays, since an overlay sits on a dimmed backdrop inside an app window where a see-through panel reads as a rendering bug. This one is a standalone surface, so `.is_overlay(false)`.
- libcosmic rounds a tracked layer surface at creation, before the compositor has configured a size. cosmic-comp answers a radius wider than the surface it clips with `cosmic_corner_radius_layer_v1: error 1: corner radius too large` and kills the client. The helper died ~500 ms in, the daemon read the closed stdout as `Dismissed`, and **every consent prompt silently denied** — the only symptom being a client looping on `auth_denied (user_dismissed)`. Corners now start square and round on the first configure, clamped to half the shorter side, matching the cosmic-osd indicator.

Raising the surface's `size_limits` floor does not fix this; the radius request goes out ahead of the first configure regardless.

## Tests

`just test-gui` runs the `#[ignore]`d GUI smoke tests against the live compositor — they need a desktop session, so CI can't. The new `surface_survives_compositor_handshake` fails on any Wayland protocol error or on an exit without a decision, and reports the compositor's complaint plus the stderr tail. Verified by reverting the fix and watching it fail.

It captures stderr to a file rather than a pipe: libcosmic emits ~3800 startup lines, and an undrained pipe would fill and block the child — which looks exactly like the hang being tested for.

The pre-existing `renders_and_decides` would not have caught this. It treats an early exit as "the human clicked a button" and sails past a crash.

`just run-consent [scope...]` runs the dialog by hand. It holds an exclusive keyboard grab until you click, so `STT_AUTH_AUTO_APPROVE_AFTER_MS` is the hands-free escape hatch (debug builds only — a release build can never self-approve).

## Verification

`just check`, `just test-gui`, workspace check, and release builds are green. Frost confirmed on all three surfaces; transparency checked numerically as well as visually — dialog interior pixels vary with what is behind them instead of sitting at the opaque `primary.base`.

Three pre-existing daemon test failures (`registry::client`, `registry::install`) are localhost connect timeouts unrelated to this branch; confirmed failing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)