### PR TITLE
Install system-wide to /usr/local with root-owned systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd super-stt
 just install
 ```
 
-Either way you get the daemon, the `stt` CLI, a consent helper, the desktop app, and (on COSMIC) the panel applet, wired up as a `systemctl --user` service. On COSMIC the installer offers to bind Super+Space → `stt record --write` for you. GPU acceleration comes from the model you run (see [Models](#-models)).
+Either way you get the daemon, the `stt` CLI, a consent helper, the desktop app, and (on COSMIC) the panel applet, wired up as a `systemctl --user` service. Everything installs system-wide (root-owned, so the installer asks for sudo), while the daemon itself runs unprivileged in your user session. On COSMIC the installer offers to bind Super+Space → `stt record --write` for you. GPU acceleration comes from the model you run (see [Models](#-models)).
 
 ## ⌨️ Using it
 
@@ -50,7 +50,7 @@ Either way you get the daemon, the `stt` CLI, a consent helper, the desktop app,
 stt record --write # Record and transcribes. Types the result after silence is detected or you run the command again.
 ```
 
-Bind `stt record --write` to a key combo. Super+Space is the convention (the COSMIC installer does this for you; on other desktops add a custom shortcut for `~/.local/bin/stt record --write`). When you trigger it:
+Bind `stt record --write` to a key combo. Super+Space is the convention (the COSMIC installer does this for you; on other desktops add a custom shortcut for `stt record --write`). When you trigger it:
 
 1. `stt` asks the running daemon to start transcribing from your mic.
 2. You speak; the daemon transcribes your audio.
@@ -151,7 +151,7 @@ This is a snapshot. The app always shows the current catalog, published live at 
 
 ## 🩺 Troubleshooting
 
-- **`stt: command not found`**: restart your terminal or run `export PATH="$HOME/.local/bin:$PATH"`.
+- **`stt: command not found`**: binaries are installed system-wide and are on `PATH` by default — restart your terminal so it rehashes, and check the installer finished without errors.
 - **Daemon won't start / misbehaves**: check `journalctl --user -u super-stt -n 49`.
 - **A stale legacy build is interfering** (auth popup shows `Path: <unknown>`, or errors mention an `stt` group): remove the old binaries and reinstall: `just uninstall` (or `rm -f ~/.local/bin/super-stt*`), then `just install`.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,6 +14,7 @@ Based on comprehensive security reviews completed in August 2025, Super STT demo
 - ✅ **Network Security**: Localhost-only UDP binding prevents remote attacks
 - ✅ **Resource Management**: Connection limits and rate limiting prevent abuse
 - ✅ **Path Security**: Comprehensive validation prevents directory traversal attacks
+- ✅ **Tamper-Resistant Install**: Binaries and the systemd user unit are installed root-owned in system paths; the daemon itself runs unprivileged in the user session
 
 **Security Assessment**: Production-ready with excellent security controls implemented.
 
@@ -158,11 +159,13 @@ cargo run --release --bin super-stt-daemon
 - ✅ Directory traversal attacks (path validation)
 - ✅ Audio data injection attacks (sample validation and pattern detection)
 - ✅ Cross-user access (same-UID peer check; the consent prompt names the caller's exe)
+- ✅ Silent replacement of the daemon binary or unit file by user-level processes (both are root-owned in system paths; modifying them requires privilege escalation)
 
 ### Assumptions
 - Physical access to the machine is trusted
 - The user running the daemon is trusted (the socket is same-user only)
 - System has standard Unix permission enforcement
+- `~/.config/systemd/user/` is not silently populated: a unit placed there overrides the packaged one (systemd precedence), so unit tampering at user level is detectable (`systemd-delta --user`) rather than impossible
 - Development builds are only used in secure development environments
 
 ## Incident Response
@@ -238,7 +241,7 @@ After=sound.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/super-stt-daemon
+ExecStart=super-stt-daemon
 Restart=on-failure
 RestartSec=5
 

--- a/justfile
+++ b/justfile
@@ -12,16 +12,21 @@ applet_full_desktop_file_name := 'super-stt-cosmic-applet-full.desktop'
 applet_left_desktop_file_name := 'super-stt-cosmic-applet-left.desktop'
 applet_right_desktop_file_name := 'super-stt-cosmic-applet-right.desktop'
 
-# Installation paths
+# Installation paths — root-owned under /usr/local, matching the
+# release installers, so install/uninstall recipes escalate with sudo
+# for the copy/remove steps. `systemctl --user` calls stay unprivileged
+# (the daemon runs as the user; only the files are root-owned).
 home_dir := env('HOME')
-user_bin_dir := home_dir / '.local' / 'bin'
-user_systemd_dir := home_dir / '.config' / 'systemd' / 'user'
+install_prefix := '/usr/local'
+bin_dir := install_prefix / 'bin'
+# systemd *user* unit, but installed root-owned.
+systemd_unit_dir := '/usr/lib/systemd/user'
 run_dir := env('XDG_RUNTIME_DIR') / 'stt'
 log_dir := home_dir / '.local' / 'share' / 'stt' / 'logs'
-user_desktop_dir := home_dir / '.local' / 'share' / 'applications'
-user_icons_dir := home_dir / '.local' / 'share' / 'icons' / 'hicolor' / 'scalable' / 'apps'
+desktop_dir := install_prefix / 'share' / 'applications'
+icons_dir := install_prefix / 'share' / 'icons' / 'hicolor' / 'scalable' / 'apps'
 # Theme root, not the leaf dir: gtk-update-icon-cache indexes a whole theme.
-user_icon_theme_dir := home_dir / '.local' / 'share' / 'icons' / 'hicolor'
+icon_theme_dir := install_prefix / 'share' / 'icons' / 'hicolor'
 
 # Binary paths
 app_src := 'target' / 'release' / app_name
@@ -30,33 +35,33 @@ cli_src := 'target' / 'release' / cli_name
 consent_src := 'target' / 'release' / consent_name
 applet_src := 'target' / 'release' / applet_name
 debug_applet_src := 'target' / 'debug' / applet_name
-app_dst := user_bin_dir / app_name
-daemon_dst := user_bin_dir / daemon_bin_name
-cli_dst := user_bin_dir / cli_name
-consent_dst := user_bin_dir / consent_name
-applet_dst := user_bin_dir / applet_name
-wrapper_dst := user_bin_dir / wrapper_name
+app_dst := bin_dir / app_name
+daemon_dst := bin_dir / daemon_bin_name
+cli_dst := bin_dir / cli_name
+consent_dst := bin_dir / consent_name
+applet_dst := bin_dir / applet_name
+wrapper_dst := bin_dir / wrapper_name
 
 # App files
 app_desktop_file_name := 'super-stt-app.desktop'
 app_desktop_file_src := 'super-stt-app' / 'resources' / app_desktop_file_name
 app_icon_src := 'super-stt-app' / 'resources' / 'icons' / 'hicolor' / 'scalable' / 'apps' / 'super-stt-app.svg'
-app_desktop_file_dst := user_desktop_dir / app_desktop_file_name
-app_icon_dst := user_icons_dir / 'super-stt-app.svg'
+app_desktop_file_dst := desktop_dir / app_desktop_file_name
+app_icon_dst := icons_dir / 'super-stt-app.svg'
 
 # Applet files
 applet_full_desktop_file_src := 'super-stt-cosmic-applet' / 'resources' / applet_full_desktop_file_name
 applet_left_desktop_file_src := 'super-stt-cosmic-applet' / 'resources' / applet_left_desktop_file_name
 applet_right_desktop_file_src := 'super-stt-cosmic-applet' / 'resources' / applet_right_desktop_file_name
 applet_icon_src := 'super-stt-cosmic-applet' / 'resources' / 'icons' / 'hicolor' / 'scalable' / 'apps' / 'super-stt-cosmic-applet.svg'
-applet_full_desktop_file_dst := user_desktop_dir / applet_full_desktop_file_name
-applet_left_desktop_file_dst := user_desktop_dir / applet_left_desktop_file_name
-applet_right_desktop_file_dst := user_desktop_dir / applet_right_desktop_file_name
-applet_icon_dst := user_icons_dir / 'super-stt-cosmic-applet.svg'
+applet_full_desktop_file_dst := desktop_dir / applet_full_desktop_file_name
+applet_left_desktop_file_dst := desktop_dir / applet_left_desktop_file_name
+applet_right_desktop_file_dst := desktop_dir / applet_right_desktop_file_name
+applet_icon_dst := icons_dir / 'super-stt-cosmic-applet.svg'
 
 # Service file
 service_file := service_name + '.service'
-service_dst := user_systemd_dir / service_file
+service_dst := systemd_unit_dir / service_file
 
 # Default recipe which runs `just build-release`
 default: build-release
@@ -229,24 +234,33 @@ run-applet *args:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the build can outlast sudo's credential cache, and a
+    # password prompt buried in build output is easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     env RUST_BACKTRACE=full RUST_LOG=debug,super_stt_shared=debug,warn cargo build --bin {{ applet_name }} {{ args }}
 
     echo "Installing Debug Super STT COSMIC applet..."
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ debug_applet_src }} {{ applet_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ debug_applet_src }} {{ applet_dst }}
 
     # Install the debug desktop entries for panel integration
-    mkdir -p {{ user_desktop_dir }}
-
     echo "Installing desktop entries for COSMIC panel integration..."
-    install -Dm0644 {{ applet_full_desktop_file_src }} {{ applet_full_desktop_file_dst }}
-    install -Dm0644 {{ applet_left_desktop_file_src }} {{ applet_left_desktop_file_dst }}
-    install -Dm0644 {{ applet_right_desktop_file_src }} {{ applet_right_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_full_desktop_file_src }} {{ applet_full_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_left_desktop_file_src }} {{ applet_left_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_right_desktop_file_src }} {{ applet_right_desktop_file_dst }}
 
     # Install the applet icon
-    mkdir -p {{ user_icons_dir }}
     echo "Installing applet icon..."
-    install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
+    sudo install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
+
+    # Installs are done — don't keep the sudo timestamp fresh while the
+    # panel runs in the foreground.
+    kill "$sudo_keepalive" 2>/dev/null || true
 
     cosmic-panel
 
@@ -258,24 +272,33 @@ run-applet-kill *args:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the build can outlast sudo's credential cache, and a
+    # password prompt buried in build output is easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     env RUST_BACKTRACE=full RUST_LOG=debug,super_stt_shared=debug,warn cargo build --bin {{ applet_name }} {{ args }}
 
     echo "Installing Debug Super STT COSMIC applet..."
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ debug_applet_src }} {{ applet_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ debug_applet_src }} {{ applet_dst }}
 
     # Install the debug desktop entries for panel integration
-    mkdir -p {{ user_desktop_dir }}
-
     echo "Installing desktop entries for COSMIC panel integration..."
-    install -Dm0644 {{ applet_full_desktop_file_src }} {{ applet_full_desktop_file_dst }}
-    install -Dm0644 {{ applet_left_desktop_file_src }} {{ applet_left_desktop_file_dst }}
-    install -Dm0644 {{ applet_right_desktop_file_src }} {{ applet_right_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_full_desktop_file_src }} {{ applet_full_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_left_desktop_file_src }} {{ applet_left_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_right_desktop_file_src }} {{ applet_right_desktop_file_dst }}
 
     # Install the applet icon
-    mkdir -p {{ user_icons_dir }}
     echo "Installing applet icon..."
-    install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
+    sudo install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
+
+    # Installs are done — don't keep the sudo timestamp fresh while the
+    # panel runs in the foreground.
+    kill "$sudo_keepalive" 2>/dev/null || true
 
     # Restart cosmic panel for changes to take effect
     pkill -f cosmic-panel || true
@@ -361,9 +384,17 @@ check-wit-sync:
 gen-schemas:
     cargo run -p super-stt-registry-types --features schema --bin gen_schemas
 
-# Install the app (user-local installation)
+# Install the app (system installation under /usr/local)
 install-app:
     #!/usr/bin/env bash
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the build can outlast sudo's credential cache, and a
+    # password prompt buried in build output is easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     # Build the app first
     echo "Building app..."
     if ! just build-app; then
@@ -378,36 +409,42 @@ install-app:
     fi
 
     echo "Installing Super STT app to {{ app_dst }}"
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ app_src }} {{ app_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ app_src }} {{ app_dst }}
 
     # Install the desktop entry for application menu
-    mkdir -p {{ user_desktop_dir }}
     echo "Installing desktop entry..."
-    install -Dm0644 {{ app_desktop_file_src }} {{ app_desktop_file_dst }}
+    sudo install -Dm0644 {{ app_desktop_file_src }} {{ app_desktop_file_dst }}
 
     # Install the app icon
-    mkdir -p {{ user_icons_dir }}
     echo "Installing app icon..."
-    install -Dm0644 {{ app_icon_src }} {{ app_icon_dst }}
+    sudo install -Dm0644 {{ app_icon_src }} {{ app_icon_dst }}
 
     # Update desktop database
     if command -v update-desktop-database &> /dev/null; then
-        update-desktop-database {{ user_desktop_dir }} 2>/dev/null || true
+        sudo update-desktop-database {{ desktop_dir }} 2>/dev/null || true
     fi
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t {{ user_icon_theme_dir }} 2>/dev/null || true
+        sudo gtk-update-icon-cache -f -t {{ icon_theme_dir }} 2>/dev/null || true
     fi
 
     echo "✓ Super STT app installed: {{ app_dst }}"
     echo "✓ Desktop entry installed: {{ app_desktop_file_dst }}"
     echo "✓ App icon installed: {{ app_icon_dst }}"
 
-# Install the cosmic applet (user-local installation)
+# Install the cosmic applet (system installation under /usr/local)
 install-applet:
     #!/usr/bin/env bash
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the build can outlast sudo's credential cache, and a
+    # password prompt buried in build output is easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     # Build the cosmic applet first
     echo "Building COSMIC applet..."
     if ! just build-applet; then
@@ -422,30 +459,27 @@ install-applet:
     fi
 
     echo "Installing Super STT COSMIC applet..."
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ applet_src }} {{ applet_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ applet_src }} {{ applet_dst }}
 
     # Install the desktop entries for panel integration
-    mkdir -p {{ user_desktop_dir }}
-
     echo "Installing desktop entries for COSMIC panel integration..."
-    install -Dm0644 {{ applet_full_desktop_file_src }} {{ applet_full_desktop_file_dst }}
-    install -Dm0644 {{ applet_left_desktop_file_src }} {{ applet_left_desktop_file_dst }}
-    install -Dm0644 {{ applet_right_desktop_file_src }} {{ applet_right_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_full_desktop_file_src }} {{ applet_full_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_left_desktop_file_src }} {{ applet_left_desktop_file_dst }}
+    sudo install -Dm0644 {{ applet_right_desktop_file_src }} {{ applet_right_desktop_file_dst }}
 
     # Install the applet icon
-    mkdir -p {{ user_icons_dir }}
     echo "Installing applet icon..."
-    install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
+    sudo install -Dm0644 {{ applet_icon_src }} {{ applet_icon_dst }}
 
     # Refresh the desktop/icon caches so the panel picks up the new applet
     # entries without a relogin (mirrors install-app).
     if command -v update-desktop-database &> /dev/null; then
-        update-desktop-database {{ user_desktop_dir }} 2>/dev/null || true
+        sudo update-desktop-database {{ desktop_dir }} 2>/dev/null || true
     fi
 
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t {{ user_icon_theme_dir }} 2>/dev/null || true
+        sudo gtk-update-icon-cache -f -t {{ icon_theme_dir }} 2>/dev/null || true
     fi
 
     echo "✓ COSMIC applet installed: {{ applet_dst }}"
@@ -457,10 +491,20 @@ install-applet:
     echo "🚀 Ready to use! The applet can now be added to your COSMIC panel through:"
     echo "-- COSMIC Settings > Desktop > Panel > Configure panel applets > Add Applet"
 
-# Install the daemon (user installation)
+# Install the daemon (system installation under /usr/local; runs as a
+# systemd --user service)
 # Usage: just install-daemon [--model MODEL]
 install-daemon *args:
     #!/usr/bin/env bash
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the builds (daemon, consent, CLI) can outlast sudo's
+    # credential cache, and a password prompt buried in build output is
+    # easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     # Build the daemon first
     echo "Building daemon..."
 
@@ -495,8 +539,8 @@ install-daemon *args:
 
     # Install binary
     echo "Installing daemon binary to {{ daemon_dst }}"
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ daemon_src }} {{ daemon_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ daemon_src }} {{ daemon_dst }}
 
     # Build + install the consent helper alongside the daemon. The
     # daemon's `locate_consent_helper` only looks for it next to its
@@ -512,7 +556,7 @@ install-daemon *args:
         exit 1
     fi
     echo "Installing consent helper to {{ consent_dst }}"
-    install -m755 {{ consent_src }} {{ consent_dst }}
+    sudo install -m755 {{ consent_src }} {{ consent_dst }}
 
     # Install the CLI alongside the daemon. The `stt` wrapper created below
     # execs the CLI (client commands like `record`/`stop` live there, not in
@@ -526,16 +570,21 @@ install-daemon *args:
     echo "Creating user directories..."
     mkdir -p {{ run_dir }}
     mkdir -p {{ log_dir }}
-    mkdir -p {{ user_systemd_dir }}
 
-    # Copy the service file from the repo
-    echo "Installing user systemd service file..."
-    cp super-stt-daemon/systemd/{{ service_file }} {{ service_dst }}
+    # Install the unit root-owned. Its bare ExecStart name resolves via
+    # systemd's fixed search path, which covers {{ bin_dir }}.
+    echo "Installing systemd user unit..."
+    sudo install -Dm0644 super-stt-daemon/systemd/{{ service_file }} {{ service_dst }}
+
+    # A unit left in ~/.config/systemd/user by an older install takes
+    # precedence over the packaged one — remove it or systemd keeps
+    # launching the stale ~/.local/bin binary.
+    rm -f "$HOME/.config/systemd/user/{{ service_file }}"
 
     # Add model parameter to ExecStart if specified
     if [[ -n "$model" ]]; then
         echo "Configuring daemon to use model: $model"
-        sed -i "s|ExecStart=%h/.local/bin/super-stt-daemon|ExecStart=%h/.local/bin/super-stt-daemon --model $model|" {{ service_dst }}
+        sudo sed -i "s|^ExecStart={{ daemon_bin_name }}$|ExecStart={{ daemon_bin_name }} --model $model|" {{ service_dst }}
     fi
 
     # Create the `stt` convenience wrapper (for keyboard shortcuts like
@@ -549,12 +598,14 @@ install-daemon *args:
     # socket file is owned `user:user-primary-group` with 0660, so the
     # owner (same user) can access regardless of group membership.
     echo "Creating wrapper script at {{ wrapper_dst }}"
-    echo '#!/bin/bash' > {{ wrapper_dst }}
-    echo '# Super STT convenience wrapper — invokes super-stt-cli directly.' >> {{ wrapper_dst }}
-    echo '# Used by keyboard shortcuts (e.g. Super+Space → "stt record --write").' >> {{ wrapper_dst }}
-    echo '' >> {{ wrapper_dst }}
-    echo 'exec {{ cli_dst }} "$@"' >> {{ wrapper_dst }}
-    chmod +x {{ wrapper_dst }}
+    wrapper_tmp=$(mktemp)
+    echo '#!/bin/bash' > "$wrapper_tmp"
+    echo '# Super STT convenience wrapper — invokes super-stt-cli directly.' >> "$wrapper_tmp"
+    echo '# Used by keyboard shortcuts (e.g. Super+Space → "stt record --write").' >> "$wrapper_tmp"
+    echo '' >> "$wrapper_tmp"
+    echo 'exec {{ cli_dst }} "$@"' >> "$wrapper_tmp"
+    sudo install -m755 "$wrapper_tmp" {{ wrapper_dst }}
+    rm -f "$wrapper_tmp"
 
     # Setup COSMIC keyboard shortcut if available
     # Setup COSMIC keyboard shortcut
@@ -567,7 +618,7 @@ install-daemon *args:
 
         if [[ ! "$add_shortcut" =~ ^[Nn]$ ]]; then
             mkdir -p "$COSMIC_SHORTCUTS_DIR"
-            stt_command="{{ user_bin_dir }}/stt record --write"
+            stt_command="{{ bin_dir }}/stt record --write"
 
             if [ -f "$COSMIC_SHORTCUTS_FILE" ] && [ -s "$COSMIC_SHORTCUTS_FILE" ]; then
                 if ! grep -q "Super STT" "$COSMIC_SHORTCUTS_FILE"; then
@@ -589,7 +640,6 @@ install-daemon *args:
                         echo '}' >> "$temp_file"
                         mv "$temp_file" "$COSMIC_SHORTCUTS_FILE"
                         rm -f "$COSMIC_SHORTCUTS_FILE.backup"
-                        rm -f "$COSMIC_SHORTCUTS_FILE.backup"
                     fi
                 fi
             else
@@ -606,18 +656,6 @@ install-daemon *args:
         fi
     fi || true
 
-    # Update PATH in user's shell config
-    shell_config="$HOME/.bashrc"
-    if [[ "$SHELL" == *"zsh"* ]]; then
-        shell_config="$HOME/.zshrc"
-    fi
-
-    if ! grep -q "{{ user_bin_dir }}" "$shell_config" 2>/dev/null; then
-        echo "Adding {{ user_bin_dir }} to PATH in $shell_config"
-        echo 'export PATH="{{ user_bin_dir }}:$PATH"' >> "$shell_config"
-        echo "⚠️  Restart your shell or run: source $shell_config"
-    fi
-
     echo "✓ Super STT installed to {{ daemon_dst }}"
     echo "✓ Wrapper script created at {{ wrapper_dst }}"
     echo "✓ Convenience shortcut 'stt' created"
@@ -631,7 +669,10 @@ install-daemon *args:
 
     echo "✓ Daemon installed successfully as user service!"
     echo ""
-    systemctl --user start {{ service_name }}
+    # `restart`, not `start`: start is a no-op on an already-running
+    # unit, which would leave a freshly installed binary unused (the old
+    # process keeps running from the deleted inode).
+    systemctl --user restart {{ service_name }}
     systemctl --user enable {{ service_name }}
 
 # Install daemon, settings app, and CLI
@@ -672,7 +713,7 @@ setup-cosmic-shortcut:
     mkdir -p "$COSMIC_SHORTCUTS_DIR"
 
     # Use the full path to the stt wrapper for reliability
-    stt_command="{{ user_bin_dir }}/stt record --write"
+    stt_command="{{ bin_dir }}/stt record --write"
 
     # Check if shortcuts file exists and has content
     if [ -f "$COSMIC_SHORTCUTS_FILE" ] && [ -s "$COSMIC_SHORTCUTS_FILE" ]; then
@@ -768,18 +809,18 @@ install-all *args:
 uninstall-app:
     #!/usr/bin/env bash
     echo "Uninstalling Super STT App..."
-    rm -f {{ app_dst }}
-    rm -f {{ app_desktop_file_dst }}
-    rm -f {{ app_icon_dst }}
+    sudo rm -f {{ app_dst }}
+    sudo rm -f {{ app_desktop_file_dst }}
+    sudo rm -f {{ app_icon_dst }}
 
     # Update desktop database
     if command -v update-desktop-database &> /dev/null; then
-        update-desktop-database {{ user_desktop_dir }} 2>/dev/null || true
+        sudo update-desktop-database {{ desktop_dir }} 2>/dev/null || true
     fi
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t {{ user_icon_theme_dir }} 2>/dev/null || true
+        sudo gtk-update-icon-cache -f -t {{ icon_theme_dir }} 2>/dev/null || true
     fi
 
     echo "✓ Super STT App uninstalled"
@@ -790,12 +831,12 @@ uninstall-app:
 uninstall-applet:
     #!/usr/bin/env bash
     echo "Uninstalling Super STT COSMIC applet..."
-    rm -f {{ applet_dst }}
-    rm -f {{ applet_full_desktop_file_dst }}
-    rm -f {{ applet_left_desktop_file_dst }}
-    rm -f {{ applet_right_desktop_file_dst }}
+    sudo rm -f {{ applet_dst }}
+    sudo rm -f {{ applet_full_desktop_file_dst }}
+    sudo rm -f {{ applet_left_desktop_file_dst }}
+    sudo rm -f {{ applet_right_desktop_file_dst }}
     # Remove the applet icon
-    rm -f {{ applet_icon_dst }}
+    sudo rm -f {{ applet_icon_dst }}
     echo "✓ COSMIC applet uninstalled"
     echo "✓ Desktop entries removed"
     echo "✓ Applet icon removed"
@@ -809,18 +850,19 @@ uninstall-daemon:
     systemctl --user stop {{ service_name }} || true
     systemctl --user disable {{ service_name }} || true
 
-    # Remove service file
-    rm -f {{ service_dst }}
+    # Remove service file (also any legacy user-local copy)
+    sudo rm -f {{ service_dst }}
+    rm -f "$HOME/.config/systemd/user/{{ service_file }}"
 
     # Remove binary
-    rm -f {{ daemon_dst }}
+    sudo rm -f {{ daemon_dst }}
 
     # Remove the co-located consent helper — without it the daemon
     # would deny every auth_request, so it's part of the daemon's
     # install contract.
-    rm -f {{ consent_dst }}
+    sudo rm -f {{ consent_dst }}
 
-    rm -f {{ wrapper_dst }}
+    sudo rm -f {{ wrapper_dst }}
 
     # Remove directories (but preserve logs)
     rm -rf {{ run_dir }}
@@ -834,6 +876,14 @@ uninstall-daemon:
 # Install just the consent helper (normally bundled with install-daemon)
 install-consent:
     #!/usr/bin/env bash
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the build can outlast sudo's credential cache, and a
+    # password prompt buried in build output is easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     if ! just build-consent; then
         echo "❌ Consent helper build failed"
         exit 1
@@ -842,20 +892,28 @@ install-consent:
         echo "❌ Consent helper binary not found at {{ consent_src }}"
         exit 1
     fi
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ consent_src }} {{ consent_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ consent_src }} {{ consent_dst }}
     echo "✓ Consent helper installed: {{ consent_dst }}"
 
 # Uninstall the consent helper.
 uninstall-consent:
     #!/usr/bin/env bash
     echo "Uninstalling Super STT consent helper..."
-    rm -f {{ consent_dst }}
+    sudo rm -f {{ consent_dst }}
     echo "✓ Consent helper uninstalled"
 
-# Install the CLI binary (user-local installation)
+# Install the CLI binary (system installation under /usr/local)
 install-cli:
     #!/usr/bin/env bash
+    # Ask for sudo up front and keep the timestamp alive in the
+    # background: the build can outlast sudo's credential cache, and a
+    # password prompt buried in build output is easy to miss.
+    sudo -v
+    ( while sudo -n -v 2>/dev/null; do sleep 60; done ) &
+    sudo_keepalive=$!
+    trap 'kill "$sudo_keepalive" 2>/dev/null' EXIT
+
     echo "Building CLI..."
     if ! just build-cli; then
         echo "❌ CLI build failed or was interrupted"
@@ -867,20 +925,20 @@ install-cli:
         exit 1
     fi
 
-    mkdir -p {{ user_bin_dir }}
-    install -m755 {{ cli_src }} {{ cli_dst }}
+    sudo mkdir -p {{ bin_dir }}
+    sudo install -m755 {{ cli_src }} {{ cli_dst }}
     echo "✓ Super STT CLI installed: {{ cli_dst }}"
 
 # Uninstall the CLI binary
 uninstall-cli:
     #!/usr/bin/env bash
     echo "Uninstalling Super STT CLI..."
-    rm -f {{ cli_dst }}
+    sudo rm -f {{ cli_dst }}
 
     # The `stt` wrapper is a thin exec of the CLI, so it is dead weight
     # without it — left in place it stays on PATH and fails at exec time
     # instead of reporting as uninstalled.
-    rm -f {{ wrapper_dst }}
+    sudo rm -f {{ wrapper_dst }}
     echo "✓ Super STT CLI uninstalled"
 
 # Uninstall daemon, app, applet, CLI, and consent helper

--- a/scripts/install-beta.sh
+++ b/scripts/install-beta.sh
@@ -39,8 +39,10 @@ BG_YELLOW='\033[43m'
 BG_RED='\033[41m'
 NC='\033[0m'
 
-# Default values
-INSTALL_PREFIX="$HOME/.local"
+# Default values. Everything installs to root-owned system paths so a
+# user-level process can't tamper with the binaries or the unit file,
+# and /usr/local/bin is on PATH everywhere — no shell-profile edits.
+INSTALL_PREFIX="/usr/local"
 GITHUB_REPO="jorge-menjivar/super-stt"
 VERSION="latest"
 INSTALL_OPTION="all"
@@ -56,15 +58,38 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 
 echo "Temp directory: $TEMP_DIR"
 
-DESKTOP_DIR="$HOME/.local/share/applications"
-ICON_DIR="$HOME/.local/share/icons"
-METAINFO_DIR="$HOME/.local/share/metainfo"
-USER_SYSTEMD_DIR="$HOME/.config/systemd/user"
+DESKTOP_DIR="$INSTALL_PREFIX/share/applications"
+ICON_DIR="$INSTALL_PREFIX/share/icons/hicolor/scalable/apps"
+ICON_THEME_DIR="$INSTALL_PREFIX/share/icons/hicolor"
+METAINFO_DIR="$INSTALL_PREFIX/share/metainfo"
+# systemd *user* units, installed root-owned so a user-level process
+# can't rewrite ExecStart to point at its own binary.
+SYSTEMD_UNIT_DIR="/usr/lib/systemd/user"
+
+# Legacy (pre-/usr/local) per-user install locations. Cleaned up on
+# upgrade: ~/.local/bin usually precedes /usr/local/bin on PATH and a
+# stale copy would shadow the fresh install.
+LEGACY_BIN_DIR="$HOME/.local/bin"
+LEGACY_DESKTOP_DIR="$HOME/.local/share/applications"
+LEGACY_METAINFO_DIR="$HOME/.local/share/metainfo"
+LEGACY_SYSTEMD_DIR="$HOME/.config/systemd/user"
 
 # Print functions
 print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Root is needed to write into /usr/local and /usr/lib/systemd/user.
+# The daemon itself still runs as your user via `systemctl --user`.
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+elif command -v sudo &> /dev/null; then
+    SUDO="sudo"
+else
+    print_error "This installer writes to $INSTALL_PREFIX and needs root privileges, but sudo is not available."
+    print_error "Re-run this script as root."
+    exit 1
+fi
 
 # Detect system architecture
 detect_arch() {
@@ -86,14 +111,13 @@ detect_arch() {
 install_daemon() {
     mkdir -p "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/stt"
     mkdir -p "$HOME/.local/share/stt/logs"
-    mkdir -p "$HOME/.config/systemd/user"
 
     print_info "Installing daemon, CLI, and consent helper..."
-    mkdir -p "$INSTALL_PREFIX/bin"
+    $SUDO mkdir -p "$INSTALL_PREFIX/bin"
 
-    install -m 755 "$TEMP_DIR/super-stt-daemon" "$INSTALL_PREFIX/bin/"
-    install -m 755 "$TEMP_DIR/super-stt-cli" "$INSTALL_PREFIX/bin/"
-    install -m 755 "$TEMP_DIR/super-stt-consent" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-daemon" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-cli" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-consent" "$INSTALL_PREFIX/bin/"
 
     # The `stt` convenience wrapper used by keyboard shortcuts (e.g.
     # Super+Space → `stt record --write`). Invokes the daemon binary
@@ -101,43 +125,56 @@ install_daemon() {
     # daemon's CLI peers breaks `/proc/<pid>/exe` readlinks across
     # the daemon ↔ client boundary because the kernel's
     # __ptrace_may_access check requires both UID AND GID to match.
-    cat > "$INSTALL_PREFIX/bin/stt" << EOF
+    cat > "$TEMP_DIR/stt-wrapper" << EOF
 #!/bin/bash
 # Super STT convenience wrapper — invokes super-stt-cli directly.
 # Used by keyboard shortcuts (e.g. Super+Space → "stt record --write").
 exec "$INSTALL_PREFIX/bin/super-stt-cli" "\$@"
 EOF
-    chmod 755 "$INSTALL_PREFIX/bin/stt"
+    $SUDO install -m 755 "$TEMP_DIR/stt-wrapper" "$INSTALL_PREFIX/bin/stt"
+
+    # Clear stale copies from the old per-user layout so they don't
+    # shadow the fresh install.
+    for bin in super-stt super-stt-daemon super-stt-cli super-stt-consent stt; do
+        if [ -e "$LEGACY_BIN_DIR/$bin" ]; then
+            rm -f "$LEGACY_BIN_DIR/$bin"
+            print_info "  removed legacy $LEGACY_BIN_DIR/$bin"
+        fi
+    done
 }
 
 # Install desktop app
 install_app() {
     print_info "Installing desktop app..."
-    mkdir -p "$INSTALL_PREFIX/bin"
+    $SUDO mkdir -p "$INSTALL_PREFIX/bin"
 
     # Install binary
-    install -m 755 "$TEMP_DIR/super-stt-app" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-app" "$INSTALL_PREFIX/bin/"
 
     print_info "Installing desktop integration files..."
 
     # Install desktop file
-    mkdir -p "$DESKTOP_DIR"
-    install -m 644 "$TEMP_DIR/resources/super-stt-app.desktop" "$DESKTOP_DIR/super-stt-app.desktop"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/super-stt-app.desktop" "$DESKTOP_DIR/super-stt-app.desktop"
 
     # Install icon
-    mkdir -p "$ICON_DIR"
-    cp -r "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-app.svg" "$ICON_DIR/"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-app.svg" "$ICON_DIR/super-stt-app.svg"
 
     # Install metainfo
-    mkdir -p "$METAINFO_DIR"
     if [ -f "$TEMP_DIR/resources/super-stt-app.metainfo.xml" ]; then
-        install -m 644 "$TEMP_DIR/resources/super-stt-app.metainfo.xml" "$METAINFO_DIR/super-stt-app.metainfo.xml"
+        $SUDO install -Dm644 "$TEMP_DIR/resources/super-stt-app.metainfo.xml" "$METAINFO_DIR/super-stt-app.metainfo.xml"
     fi
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t "$ICON_DIR" 2>/dev/null || true
+        $SUDO gtk-update-icon-cache -f -t "$ICON_THEME_DIR" 2>/dev/null || true
     fi
+
+    # Clear the old per-user copies so launchers don't show duplicates.
+    rm -f "$LEGACY_BIN_DIR/super-stt-app"
+    rm -f "$LEGACY_DESKTOP_DIR/super-stt-app.desktop"
+    rm -f "$HOME/.local/share/icons/super-stt-app.svg" \
+        "$HOME/.local/share/icons/hicolor/scalable/apps/super-stt-app.svg"
+    rm -f "$LEGACY_METAINFO_DIR/super-stt-app.metainfo.xml"
 }
 
 # Install COSMIC applet
@@ -148,34 +185,44 @@ install_applet() {
     fi
 
     print_info "Installing COSMIC applet..."
-    mkdir -p "$INSTALL_PREFIX/bin"
+    $SUDO mkdir -p "$INSTALL_PREFIX/bin"
 
-    # Check if this is an update (binary already exists)
+    # Check if this is an update (binary already exists in either layout)
     local is_update=false
-    if [ -f "$INSTALL_PREFIX/bin/super-stt-cosmic-applet" ]; then
+    if [ -f "$INSTALL_PREFIX/bin/super-stt-cosmic-applet" ] || [ -f "$LEGACY_BIN_DIR/super-stt-cosmic-applet" ]; then
         is_update=true
     fi
 
     # Install binary
-    install -m 755 "$TEMP_DIR/super-stt-cosmic-applet" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-cosmic-applet" "$INSTALL_PREFIX/bin/"
 
     print_info "Installing COSMIC applet integration files..."
 
     # Install desktop files
-    mkdir -p "$DESKTOP_DIR"
     for desktop_file in "$TEMP_DIR/resources/super-stt-cosmic-applet-"*.desktop; do
         local filename=$(basename "$desktop_file")
-        install -m 644 "$desktop_file" "$DESKTOP_DIR/$filename"
+        $SUDO install -Dm644 "$desktop_file" "$DESKTOP_DIR/$filename"
     done
 
     # Install icon
-    mkdir -p "$ICON_DIR"
-    cp -r "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-cosmic-applet.svg" "$ICON_DIR/"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-cosmic-applet.svg" "$ICON_DIR/super-stt-cosmic-applet.svg"
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t "$ICON_DIR" 2>/dev/null || true
+        $SUDO gtk-update-icon-cache -f -t "$ICON_THEME_DIR" 2>/dev/null || true
     fi
+
+    # Clear the old per-user copies so they don't shadow this install
+    # (super-stt-applet-{full,left,right} are the pre-rewrite applet names).
+    rm -f "$LEGACY_BIN_DIR/super-stt-cosmic-applet" \
+        "$LEGACY_BIN_DIR/super-stt-applet-full" \
+        "$LEGACY_BIN_DIR/super-stt-applet-left" \
+        "$LEGACY_BIN_DIR/super-stt-applet-right"
+    rm -f "$LEGACY_DESKTOP_DIR/super-stt-cosmic-applet-full.desktop" \
+        "$LEGACY_DESKTOP_DIR/super-stt-cosmic-applet-left.desktop" \
+        "$LEGACY_DESKTOP_DIR/super-stt-cosmic-applet-right.desktop"
+    rm -f "$HOME/.local/share/icons/super-stt-cosmic-applet.svg" \
+        "$HOME/.local/share/icons/hicolor/scalable/apps/super-stt-cosmic-applet.svg"
 
     # Restart COSMIC panel so the updated applet binary is loaded
     if [ "$is_update" = true ] && pgrep -f cosmic-panel > /dev/null 2>&1; then
@@ -193,8 +240,17 @@ install_service() {
 
     print_info "Installing systemd service..."
 
-    mkdir -p "$USER_SYSTEMD_DIR"
-    cp "$TEMP_DIR/systemd/super-stt.service" "$USER_SYSTEMD_DIR/"
+    # Root-owned unit dir: a user-level process can't rewrite ExecStart.
+    $SUDO install -Dm644 "$TEMP_DIR/systemd/super-stt.service" "$SYSTEMD_UNIT_DIR/super-stt.service"
+
+    # A unit left in ~/.config/systemd/user by an older install takes
+    # precedence over the packaged one — remove it or systemd keeps
+    # launching the (now deleted) legacy ~/.local/bin binary.
+    if [ -f "$LEGACY_SYSTEMD_DIR/super-stt.service" ]; then
+        print_info "Removing legacy user-local systemd unit..."
+        rm -f "$LEGACY_SYSTEMD_DIR/super-stt.service"
+    fi
+
     systemctl --user daemon-reload
 
     # Enable and start (or restart) the service
@@ -218,20 +274,6 @@ install_service() {
     fi
 }
 
-# Warn if the install dir isn't on PATH. We deliberately do NOT edit the
-# user's shell profile: rc files are the user's to manage, and an auto-append
-# has no clean uninstall counterpart. Assume `~/.local/bin` is already on PATH
-# (the XDG default) and just tell the user how to add it if it isn't.
-update_path() {
-    local bin_dir="$1"
-
-    if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
-        print_warn "$bin_dir is not on your PATH."
-        print_warn "Add this line to your shell profile (e.g. ~/.bashrc or ~/.zshrc):"
-        print_warn "  export PATH=\"$bin_dir:\$PATH\""
-    fi
-}
-
 # Configure COSMIC keyboard shortcut
 configure_cosmic_shortcut() {
     # Check if we're on COSMIC desktop
@@ -241,6 +283,13 @@ configure_cosmic_shortcut() {
 
     COSMIC_SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1"
     COSMIC_SHORTCUTS_FILE="$COSMIC_SHORTCUTS_DIR/custom"
+
+    # Migrate a legacy shortcut that points at the removed
+    # ~/.local/bin wrapper.
+    if [ -f "$COSMIC_SHORTCUTS_FILE" ] && grep -q "$HOME/.local/bin/stt " "$COSMIC_SHORTCUTS_FILE"; then
+        sed -i "s|$HOME/.local/bin/stt |$INSTALL_PREFIX/bin/stt |g" "$COSMIC_SHORTCUTS_FILE"
+        print_info "Updated COSMIC shortcut to use $INSTALL_PREFIX/bin/stt"
+    fi
 
     # Ask user if they want to add the shortcut
     echo -n "Add COSMIC keyboard shortcut (Super+Space)? [Y/n]: "
@@ -516,6 +565,13 @@ print_info "Successfully downloaded: $DOWNLOADED_TARBALL"
 print_info "Extracting binaries..."
 tar -xzf "$TEMP_DIR/$DOWNLOADED_TARBALL" -C "$TEMP_DIR"
 
+# Make sure we can escalate before touching the system dirs; on a
+# fresh shell this prompts for the password once.
+if [ -n "$SUDO" ]; then
+    print_info "Root privileges are required to install into $INSTALL_PREFIX (the daemon still runs as your user)."
+    $SUDO -v
+fi
+
 # Install components based on selection
 case $INSTALL_OPTION in
     "all")
@@ -541,11 +597,6 @@ case $INSTALL_OPTION in
         install_applet
         ;;
 esac
-
-# Add to PATH if installing to non-standard location
-if [ "$INSTALL_PREFIX" != "/usr/local" ] && [ "$INSTALL_PREFIX" != "/usr" ]; then
-    update_path "$INSTALL_PREFIX/bin"
-fi
 
 # Configure COSMIC shortcut if daemon was installed and in interactive mode
 if [ "$INTERACTIVE" = true ] && ([ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]); then

--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -15,8 +15,10 @@ BG_YELLOW='\033[43m'
 BG_RED='\033[41m'
 NC='\033[0m'
 
-# Default values
-INSTALL_PREFIX="$HOME/.local"
+# Default values. Everything installs to root-owned system paths so a
+# user-level process can't tamper with the binaries or the unit file,
+# and /usr/local/bin is on PATH everywhere — no shell-profile edits.
+INSTALL_PREFIX="/usr/local"
 GITHUB_REPO="jorge-menjivar/super-stt"
 VERSION="latest"
 INSTALL_OPTION="all"
@@ -32,15 +34,38 @@ trap 'rm -rf "$TEMP_DIR"' EXIT
 
 echo "Temp directory: $TEMP_DIR"
 
-DESKTOP_DIR="$HOME/.local/share/applications"
-ICON_DIR="$HOME/.local/share/icons"
-METAINFO_DIR="$HOME/.local/share/metainfo"
-USER_SYSTEMD_DIR="$HOME/.config/systemd/user"
+DESKTOP_DIR="$INSTALL_PREFIX/share/applications"
+ICON_DIR="$INSTALL_PREFIX/share/icons/hicolor/scalable/apps"
+ICON_THEME_DIR="$INSTALL_PREFIX/share/icons/hicolor"
+METAINFO_DIR="$INSTALL_PREFIX/share/metainfo"
+# systemd *user* units, installed root-owned so a user-level process
+# can't rewrite ExecStart to point at its own binary.
+SYSTEMD_UNIT_DIR="/usr/lib/systemd/user"
+
+# Legacy (pre-/usr/local) per-user install locations. Cleaned up on
+# upgrade: ~/.local/bin usually precedes /usr/local/bin on PATH and a
+# stale copy would shadow the fresh install.
+LEGACY_BIN_DIR="$HOME/.local/bin"
+LEGACY_DESKTOP_DIR="$HOME/.local/share/applications"
+LEGACY_METAINFO_DIR="$HOME/.local/share/metainfo"
+LEGACY_SYSTEMD_DIR="$HOME/.config/systemd/user"
 
 # Print functions
 print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Root is needed to write into /usr/local and /usr/lib/systemd/user.
+# The daemon itself still runs as your user via `systemctl --user`.
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+elif command -v sudo &> /dev/null; then
+    SUDO="sudo"
+else
+    print_error "This installer writes to $INSTALL_PREFIX and needs root privileges, but sudo is not available."
+    print_error "Re-run this script as root."
+    exit 1
+fi
 
 # Detect system architecture
 detect_arch() {
@@ -62,14 +87,13 @@ detect_arch() {
 install_daemon() {
     mkdir -p "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/stt"
     mkdir -p "$HOME/.local/share/stt/logs"
-    mkdir -p "$HOME/.config/systemd/user"
 
     print_info "Installing daemon, CLI, and consent helper..."
-    mkdir -p "$INSTALL_PREFIX/bin"
+    $SUDO mkdir -p "$INSTALL_PREFIX/bin"
 
-    install -m 755 "$TEMP_DIR/super-stt-daemon" "$INSTALL_PREFIX/bin/"
-    install -m 755 "$TEMP_DIR/super-stt-cli" "$INSTALL_PREFIX/bin/"
-    install -m 755 "$TEMP_DIR/super-stt-consent" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-daemon" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-cli" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-consent" "$INSTALL_PREFIX/bin/"
 
     # The `stt` convenience wrapper used by keyboard shortcuts (e.g.
     # Super+Space -> `stt record --write`). Invokes super-stt-cli
@@ -77,41 +101,54 @@ install_daemon() {
     # daemon's CLI peers would break `/proc/<pid>/exe` readlinks across
     # the daemon <-> client boundary, because the kernel's
     # __ptrace_may_access check requires both UID AND GID to match.
-    cat > "$INSTALL_PREFIX/bin/stt" << EOF
+    cat > "$TEMP_DIR/stt-wrapper" << EOF
 #!/bin/bash
 # Super STT convenience wrapper -- invokes super-stt-cli directly.
 # Used by keyboard shortcuts (e.g. Super+Space -> "stt record --write").
 exec "$INSTALL_PREFIX/bin/super-stt-cli" "\$@"
 EOF
-    chmod 755 "$INSTALL_PREFIX/bin/stt"
+    $SUDO install -m 755 "$TEMP_DIR/stt-wrapper" "$INSTALL_PREFIX/bin/stt"
+
+    # Clear stale copies from the old per-user layout so they don't
+    # shadow the fresh install.
+    for bin in super-stt super-stt-daemon super-stt-cli super-stt-consent stt; do
+        if [ -e "$LEGACY_BIN_DIR/$bin" ]; then
+            rm -f "$LEGACY_BIN_DIR/$bin"
+            print_info "  removed legacy $LEGACY_BIN_DIR/$bin"
+        fi
+    done
 }
 
 # Install desktop app
 install_app() {
     print_info "Installing desktop app..."
-    mkdir -p "$INSTALL_PREFIX/bin"
+    $SUDO mkdir -p "$INSTALL_PREFIX/bin"
 
     # Install binary
-    install -m 755 "$TEMP_DIR/super-stt-app" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-app" "$INSTALL_PREFIX/bin/"
 
     print_info "Installing desktop integration files..."
 
     # Install desktop file
-    mkdir -p "$DESKTOP_DIR"
-    install -m 644 "$TEMP_DIR/resources/super-stt-app.desktop" "$DESKTOP_DIR/super-stt-app.desktop"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/super-stt-app.desktop" "$DESKTOP_DIR/super-stt-app.desktop"
 
     # Install icon
-    mkdir -p "$ICON_DIR"
-    cp -r "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-app.svg" "$ICON_DIR/"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-app.svg" "$ICON_DIR/super-stt-app.svg"
 
     # Install metainfo
-    mkdir -p "$METAINFO_DIR"
-    install -m 644 "$TEMP_DIR/resources/super-stt-app.metainfo.xml" "$METAINFO_DIR/super-stt-app.metainfo.xml"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/super-stt-app.metainfo.xml" "$METAINFO_DIR/super-stt-app.metainfo.xml"
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t "$ICON_DIR" 2>/dev/null || true
+        $SUDO gtk-update-icon-cache -f -t "$ICON_THEME_DIR" 2>/dev/null || true
     fi
+
+    # Clear the old per-user copies so launchers don't show duplicates.
+    rm -f "$LEGACY_BIN_DIR/super-stt-app"
+    rm -f "$LEGACY_DESKTOP_DIR/super-stt-app.desktop"
+    rm -f "$HOME/.local/share/icons/super-stt-app.svg" \
+        "$HOME/.local/share/icons/hicolor/scalable/apps/super-stt-app.svg"
+    rm -f "$LEGACY_METAINFO_DIR/super-stt-app.metainfo.xml"
 }
 
 # Install COSMIC applet
@@ -122,34 +159,44 @@ install_applet() {
     fi
 
     print_info "Installing COSMIC applet..."
-    mkdir -p "$INSTALL_PREFIX/bin"
+    $SUDO mkdir -p "$INSTALL_PREFIX/bin"
 
-    # Check if this is an update (binary already exists)
+    # Check if this is an update (binary already exists in either layout)
     local is_update=false
-    if [ -f "$INSTALL_PREFIX/bin/super-stt-cosmic-applet" ]; then
+    if [ -f "$INSTALL_PREFIX/bin/super-stt-cosmic-applet" ] || [ -f "$LEGACY_BIN_DIR/super-stt-cosmic-applet" ]; then
         is_update=true
     fi
 
     # Install binary
-    install -m 755 "$TEMP_DIR/super-stt-cosmic-applet" "$INSTALL_PREFIX/bin/"
+    $SUDO install -m 755 "$TEMP_DIR/super-stt-cosmic-applet" "$INSTALL_PREFIX/bin/"
 
     print_info "Installing COSMIC applet integration files..."
 
     # Install desktop files
-    mkdir -p "$DESKTOP_DIR"
     for desktop_file in "$TEMP_DIR/resources/super-stt-cosmic-applet-"*.desktop; do
         local filename=$(basename "$desktop_file")
-        install -m 644 "$desktop_file" "$DESKTOP_DIR/$filename"
+        $SUDO install -Dm644 "$desktop_file" "$DESKTOP_DIR/$filename"
     done
 
     # Install icon
-    mkdir -p "$ICON_DIR"
-    cp -r "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-cosmic-applet.svg" "$ICON_DIR/"
+    $SUDO install -Dm644 "$TEMP_DIR/resources/icons/hicolor/scalable/apps/super-stt-cosmic-applet.svg" "$ICON_DIR/super-stt-cosmic-applet.svg"
 
     # Update icon cache
     if command -v gtk-update-icon-cache &> /dev/null; then
-        gtk-update-icon-cache -f -t "$ICON_DIR" 2>/dev/null || true
+        $SUDO gtk-update-icon-cache -f -t "$ICON_THEME_DIR" 2>/dev/null || true
     fi
+
+    # Clear the old per-user copies so they don't shadow this install
+    # (super-stt-applet-{full,left,right} are the pre-rewrite applet names).
+    rm -f "$LEGACY_BIN_DIR/super-stt-cosmic-applet" \
+        "$LEGACY_BIN_DIR/super-stt-applet-full" \
+        "$LEGACY_BIN_DIR/super-stt-applet-left" \
+        "$LEGACY_BIN_DIR/super-stt-applet-right"
+    rm -f "$LEGACY_DESKTOP_DIR/super-stt-cosmic-applet-full.desktop" \
+        "$LEGACY_DESKTOP_DIR/super-stt-cosmic-applet-left.desktop" \
+        "$LEGACY_DESKTOP_DIR/super-stt-cosmic-applet-right.desktop"
+    rm -f "$HOME/.local/share/icons/super-stt-cosmic-applet.svg" \
+        "$HOME/.local/share/icons/hicolor/scalable/apps/super-stt-cosmic-applet.svg"
 
     # Restart COSMIC panel so the updated applet binary is loaded
     if [ "$is_update" = true ] && pgrep -f cosmic-panel > /dev/null 2>&1; then
@@ -167,8 +214,17 @@ install_service() {
 
     print_info "Installing systemd service..."
 
-    mkdir -p "$USER_SYSTEMD_DIR"
-    cp "$TEMP_DIR/systemd/super-stt.service" "$USER_SYSTEMD_DIR/"
+    # Root-owned unit dir: a user-level process can't rewrite ExecStart.
+    $SUDO install -Dm644 "$TEMP_DIR/systemd/super-stt.service" "$SYSTEMD_UNIT_DIR/super-stt.service"
+
+    # A unit left in ~/.config/systemd/user by an older install takes
+    # precedence over the packaged one — remove it or systemd keeps
+    # launching the (now deleted) legacy ~/.local/bin binary.
+    if [ -f "$LEGACY_SYSTEMD_DIR/super-stt.service" ]; then
+        print_info "Removing legacy user-local systemd unit..."
+        rm -f "$LEGACY_SYSTEMD_DIR/super-stt.service"
+    fi
+
     systemctl --user daemon-reload
 
     # Enable and start (or restart) the service
@@ -192,20 +248,6 @@ install_service() {
     fi
 }
 
-# Warn if the install dir isn't on PATH. We deliberately do NOT edit the
-# user's shell profile: rc files are the user's to manage, and an auto-append
-# has no clean uninstall counterpart. Assume `~/.local/bin` is already on PATH
-# (the XDG default) and just tell the user how to add it if it isn't.
-update_path() {
-    local bin_dir="$1"
-
-    if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
-        print_warn "$bin_dir is not on your PATH."
-        print_warn "Add this line to your shell profile (e.g. ~/.bashrc or ~/.zshrc):"
-        print_warn "  export PATH=\"$bin_dir:\$PATH\""
-    fi
-}
-
 # Configure COSMIC keyboard shortcut
 configure_cosmic_shortcut() {
     # Check if we're on COSMIC desktop
@@ -215,6 +257,13 @@ configure_cosmic_shortcut() {
 
     COSMIC_SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1"
     COSMIC_SHORTCUTS_FILE="$COSMIC_SHORTCUTS_DIR/custom"
+
+    # Migrate a legacy shortcut that points at the removed
+    # ~/.local/bin wrapper.
+    if [ -f "$COSMIC_SHORTCUTS_FILE" ] && grep -q "$HOME/.local/bin/stt " "$COSMIC_SHORTCUTS_FILE"; then
+        sed -i "s|$HOME/.local/bin/stt |$INSTALL_PREFIX/bin/stt |g" "$COSMIC_SHORTCUTS_FILE"
+        print_info "Updated COSMIC shortcut to use $INSTALL_PREFIX/bin/stt"
+    fi
 
     # Ask user if they want to add the shortcut
     echo -n "Add COSMIC keyboard shortcut (Super+Space)? [Y/n]: "
@@ -465,6 +514,13 @@ print_info "Successfully downloaded: $DOWNLOADED_TARBALL"
 print_info "Extracting binaries..."
 tar -xzf "$TEMP_DIR/$DOWNLOADED_TARBALL" -C "$TEMP_DIR"
 
+# Make sure we can escalate before touching the system dirs; on a
+# fresh shell this prompts for the password once.
+if [ -n "$SUDO" ]; then
+    print_info "Root privileges are required to install into $INSTALL_PREFIX (the daemon still runs as your user)."
+    $SUDO -v
+fi
+
 # Install components based on selection
 case $INSTALL_OPTION in
     "all")
@@ -490,11 +546,6 @@ case $INSTALL_OPTION in
         install_applet
         ;;
 esac
-
-# Add to PATH if installing to non-standard location
-if [ "$INSTALL_PREFIX" != "/usr/local" ] && [ "$INSTALL_PREFIX" != "/usr" ]; then
-    update_path "$INSTALL_PREFIX/bin"
-fi
 
 # Configure COSMIC shortcut if daemon was installed and in interactive mode
 if [ "$INTERACTIVE" = true ] && ([ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]); then

--- a/super-stt-daemon/src/daemon/http/internal/auth/consent.rs
+++ b/super-stt-daemon/src/daemon/http/internal/auth/consent.rs
@@ -214,8 +214,9 @@ fn is_official_client_in(daemon_dir: &Path, exe_path: &Path) -> bool {
 ///
 /// On top of that, before returning the path:
 /// - We `canonicalize()` it, so symlink-swap shenanigans don't help.
-/// - We verify the resolved file is owned by the daemon's effective uid
-///   (catches "someone dropped a helper they own into the install dir").
+/// - We verify the resolved file is owned by root or the daemon's
+///   effective uid (catches "another local user dropped a helper they
+///   own into the install dir").
 /// - We verify it isn't world-writable.
 pub(crate) fn locate_consent_helper() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
@@ -259,15 +260,22 @@ pub(crate) fn locate_consent_helper() -> Option<PathBuf> {
 fn verify_helper_metadata(path: &Path) -> Result<(), &'static str> {
     use std::os::unix::fs::MetadataExt;
     let metadata = std::fs::metadata(path).map_err(|_| "cannot stat helper")?;
-    // Require the helper to be owned by the same uid the daemon runs
-    // as. This catches the case of another local user (or root)
-    // dropping a binary into the install dir.
     let our_uid = unsafe { libc::geteuid() };
-    if metadata.uid() != our_uid {
-        return Err("helper not owned by daemon's effective uid");
+    check_helper_metadata(metadata.uid(), our_uid, metadata.mode())
+}
+
+/// Testable core of [`verify_helper_metadata`]. Trust binaries owned by
+/// the daemon's own uid (source/dev installs) or by root (the packaged
+/// /usr/local/bin // /usr/bin install) — whoever controls root already
+/// controls the daemon binary itself, so root ownership adds no new
+/// attack surface. Anything else is another local user's drop-in.
+#[cfg(unix)]
+fn check_helper_metadata(owner_uid: u32, our_uid: u32, mode: u32) -> Result<(), &'static str> {
+    if owner_uid != our_uid && owner_uid != 0 {
+        return Err("helper not owned by root or the daemon's effective uid");
     }
     // Reject world-writable helpers — anyone could swap them out.
-    if metadata.mode() & 0o002 != 0 {
+    if mode & 0o002 != 0 {
         return Err("helper is world-writable");
     }
     Ok(())
@@ -318,6 +326,35 @@ pub(crate) fn resolve_peer_exe(peer: Option<&axum::Extension<PeerInfo>>) -> Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `check_helper_metadata`: the ownership/permission gate shared by
+    /// the consent-helper lookup and the official-client trust check.
+    mod helper_metadata {
+        use super::super::check_helper_metadata;
+
+        #[test]
+        fn owned_by_daemon_uid_is_trusted() {
+            assert!(check_helper_metadata(1000, 1000, 0o755).is_ok());
+        }
+
+        #[test]
+        fn root_owned_is_trusted() {
+            // The packaged install (/usr/local/bin, /usr/bin) is
+            // root-owned; root could already replace the daemon binary
+            // itself, so this adds no new attack surface.
+            assert!(check_helper_metadata(0, 1000, 0o755).is_ok());
+        }
+
+        #[test]
+        fn other_local_user_is_rejected() {
+            assert!(check_helper_metadata(1001, 1000, 0o755).is_err());
+        }
+
+        #[test]
+        fn world_writable_is_rejected_even_when_root_owned() {
+            assert!(check_helper_metadata(0, 1000, 0o757).is_err());
+        }
+    }
 
     #[test]
     fn normalize_sorts_and_dedups() {

--- a/super-stt-daemon/systemd/super-stt.service
+++ b/super-stt-daemon/systemd/super-stt.service
@@ -7,7 +7,10 @@ Requires=graphical-session.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sh -c 'while [ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; do sleep 0.1; done'
-ExecStart=%h/.local/bin/super-stt-daemon
+# Bare name: systemd resolves it against its fixed search path, so the
+# same unit works for /usr/local/bin (script install) and /usr/bin
+# (distro package) without editing.
+ExecStart=super-stt-daemon
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,11 +13,15 @@
 #   bash uninstall.sh
 #
 # What gets removed:
-#   - All Super STT binaries in ~/.local/bin (both layouts)
-#   - Desktop entries, icons, metainfo
+#   - All Super STT binaries in /usr/local/bin and ~/.local/bin
+#     (current system layout plus both legacy per-user layouts)
+#   - Desktop entries, icons, metainfo (system + per-user)
 #   - Runtime socket dir under $XDG_RUNTIME_DIR/stt
-#   - systemd user unit
+#   - systemd user unit (/usr/lib/systemd/user + ~/.config/systemd/user)
 #   - COSMIC keyboard shortcut (only if it's the lone entry)
+#
+# Root-owned files are removed via sudo; it is only invoked when such
+# files are actually present.
 #
 # What is PRESERVED:
 #   - ~/.local/share/stt/logs/ (in case you need to inspect history)
@@ -40,17 +44,57 @@ print_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-INSTALL_PREFIX="${INSTALL_PREFIX:-$HOME/.local}"
+# Current (system) install locations.
+SYSTEM_PREFIX="${INSTALL_PREFIX:-/usr/local}"
+SYSTEM_BIN_DIR="$SYSTEM_PREFIX/bin"
+SYSTEM_DESKTOP_DIR="$SYSTEM_PREFIX/share/applications"
+SYSTEM_ICON_DIR="$SYSTEM_PREFIX/share/icons/hicolor/scalable/apps"
+SYSTEM_ICON_THEME_DIR="$SYSTEM_PREFIX/share/icons/hicolor"
+SYSTEM_METAINFO_DIR="$SYSTEM_PREFIX/share/metainfo"
+SYSTEM_SYSTEMD_DIR="/usr/lib/systemd/user"
+
+# Legacy per-user install locations.
+LEGACY_BIN_DIR="$HOME/.local/bin"
 DESKTOP_DIR="$HOME/.local/share/applications"
 ICON_DIR_HICOLOR="$HOME/.local/share/icons/hicolor/scalable/apps"
 ICON_DIR_FLAT="$HOME/.local/share/icons"
 METAINFO_DIR="$HOME/.local/share/metainfo"
 USER_SYSTEMD_DIR="$HOME/.config/systemd/user"
+
 RUN_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/stt"
 LOG_DIR="$HOME/.local/share/stt/logs"
 CONFIG_DIR="$HOME/.config/super-stt"
 COSMIC_SHORTCUTS="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom"
 SERVICE_NAME="super-stt"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+# Remove a path that may be root-owned. Tries a plain rm first so sudo
+# is only invoked when actually needed. Returns 1 if the path did not
+# exist (so callers can skip their "removed" message).
+remove_path() {
+    local target="$1"
+    if [ ! -e "$target" ] && [ ! -L "$target" ]; then
+        return 1
+    fi
+    rm -f "$target" 2>/dev/null || $SUDO rm -f "$target"
+}
+
+# Detect whether a system install is present at all, so legacy-only
+# setups never see a sudo prompt.
+SYSTEM_INSTALL_PRESENT=false
+for probe in \
+    "$SYSTEM_BIN_DIR/super-stt-daemon" \
+    "$SYSTEM_BIN_DIR/super-stt-app" \
+    "$SYSTEM_BIN_DIR/super-stt-cosmic-applet" \
+    "$SYSTEM_BIN_DIR/stt" \
+    "$SYSTEM_SYSTEMD_DIR/$SERVICE_NAME.service"
+do
+    [ -e "$probe" ] && SYSTEM_INSTALL_PRESENT=true
+done
 
 print_info "Uninstalling Super STT..."
 
@@ -64,9 +108,9 @@ if command -v systemctl &> /dev/null; then
     fi
 fi
 
-# 2. Remove binaries — both layouts. Missing files are not an error
-#    (the user may have only installed a subset).
-print_info "Removing binaries from $INSTALL_PREFIX/bin..."
+# 2. Remove binaries — system layout plus both legacy layouts. Missing
+#    files are not an error (the user may have only installed a subset).
+print_info "Removing binaries from $SYSTEM_BIN_DIR and $LEGACY_BIN_DIR..."
 for bin in \
     super-stt \
     super-stt-daemon \
@@ -74,49 +118,55 @@ for bin in \
     super-stt-consent \
     super-stt-app \
     super-stt-cosmic-applet \
+    super-stt-applet-full \
+    super-stt-applet-left \
+    super-stt-applet-right \
     stt
 do
-    if [ -e "$INSTALL_PREFIX/bin/$bin" ]; then
-        rm -f "$INSTALL_PREFIX/bin/$bin"
-        print_info "  removed $INSTALL_PREFIX/bin/$bin"
-    fi
+    for dir in "$SYSTEM_BIN_DIR" "$LEGACY_BIN_DIR"; do
+        remove_path "$dir/$bin" && print_info "  removed $dir/$bin"
+    done
 done
 
-# 3. Desktop entries.
+# 3. Desktop entries (system + legacy per-user).
 print_info "Removing desktop entries..."
-for desktop in \
-    "$DESKTOP_DIR/super-stt-app.desktop" \
-    "$DESKTOP_DIR/super-stt-cosmic-applet-full.desktop" \
-    "$DESKTOP_DIR/super-stt-cosmic-applet-left.desktop" \
-    "$DESKTOP_DIR/super-stt-cosmic-applet-right.desktop"
+for name in \
+    super-stt-app.desktop \
+    super-stt-cosmic-applet-full.desktop \
+    super-stt-cosmic-applet-left.desktop \
+    super-stt-cosmic-applet-right.desktop
 do
-    [ -f "$desktop" ] && rm -f "$desktop" && print_info "  removed $desktop"
+    for dir in "$SYSTEM_DESKTOP_DIR" "$DESKTOP_DIR"; do
+        remove_path "$dir/$name" && print_info "  removed $dir/$name"
+    done
 done
 
-# 4. Icons (try both hicolor-scalable and the flat layout some old
-#    versions of the script used).
+# 4. Icons (system hicolor, legacy hicolor-scalable, and the flat
+#    layout some old versions of the script used).
 print_info "Removing icons..."
-for icon in \
-    "$ICON_DIR_HICOLOR/super-stt-app.svg" \
-    "$ICON_DIR_HICOLOR/super-stt-cosmic-applet.svg" \
-    "$ICON_DIR_FLAT/super-stt-app.svg" \
-    "$ICON_DIR_FLAT/super-stt-cosmic-applet.svg"
-do
-    [ -f "$icon" ] && rm -f "$icon" && print_info "  removed $icon"
+for name in super-stt-app.svg super-stt-cosmic-applet.svg; do
+    for dir in "$SYSTEM_ICON_DIR" "$ICON_DIR_HICOLOR" "$ICON_DIR_FLAT"; do
+        remove_path "$dir/$name" && print_info "  removed $dir/$name"
+    done
 done
 
-# 5. metainfo
-if [ -f "$METAINFO_DIR/super-stt-app.metainfo.xml" ]; then
-    rm -f "$METAINFO_DIR/super-stt-app.metainfo.xml"
-    print_info "Removed metainfo file"
-fi
+# 5. metainfo (system + legacy per-user)
+for dir in "$SYSTEM_METAINFO_DIR" "$METAINFO_DIR"; do
+    remove_path "$dir/super-stt-app.metainfo.xml" && print_info "Removed $dir/super-stt-app.metainfo.xml"
+done
 
 # 6. Refresh icon / desktop caches so the system reflects the removal.
 if command -v gtk-update-icon-cache &> /dev/null; then
     gtk-update-icon-cache -f "$ICON_DIR_FLAT/hicolor" 2>/dev/null || true
+    if [ "$SYSTEM_INSTALL_PRESENT" = true ]; then
+        $SUDO gtk-update-icon-cache -f "$SYSTEM_ICON_THEME_DIR" 2>/dev/null || true
+    fi
 fi
 if command -v update-desktop-database &> /dev/null; then
     update-desktop-database "$DESKTOP_DIR" 2>/dev/null || true
+    if [ "$SYSTEM_INSTALL_PRESENT" = true ]; then
+        $SUDO update-desktop-database "$SYSTEM_DESKTOP_DIR" 2>/dev/null || true
+    fi
 fi
 
 # 7. COSMIC custom keyboard shortcut. Remove only if Super STT is the
@@ -143,11 +193,14 @@ if [ -d "$RUN_DIR" ]; then
     print_info "Removed runtime dir $RUN_DIR"
 fi
 
-# 9. systemd unit file + reload so systemd forgets the unit.
-if [ -f "$USER_SYSTEMD_DIR/$SERVICE_NAME.service" ]; then
-    rm -f "$USER_SYSTEMD_DIR/$SERVICE_NAME.service"
-    print_info "Removed systemd unit file"
-fi
+# 9. systemd unit file (system + legacy per-user) + reload so systemd
+#    forgets the unit.
+for unit in \
+    "$SYSTEM_SYSTEMD_DIR/$SERVICE_NAME.service" \
+    "$USER_SYSTEMD_DIR/$SERVICE_NAME.service"
+do
+    remove_path "$unit" && print_info "Removed systemd unit $unit"
+done
 if command -v systemctl &> /dev/null; then
     systemctl --user daemon-reload 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary
- Everything installs root-owned under `/usr/local` — binaries, desktop files, icons, and the `stt` wrapper — in both release installers **and** the `just install*` dev recipes, escalating with sudo (one up-front password prompt, kept alive through long builds)
- The systemd **user** unit moves to `/usr/lib/systemd/user/` with a bare `ExecStart=super-stt-daemon`, so the same template serves `/usr/local/bin` (script install) and `/usr/bin` (future AUR package) without editing
- Legacy per-user installs are cleaned up on upgrade: `~/.local/bin` binaries (including the old `super-stt-applet-{full,left,right}` names), the user-local unit (which would shadow the packaged one), stale desktop entries/icons, and COSMIC shortcuts pointing at removed paths
- `uninstall.sh` removes both layouts and only invokes sudo when root-owned files actually exist
- **Daemon fix**: the consent-helper/official-client trust check required daemon-uid ownership, so root-owned installs failed every auth with `popup_failed`; it now also trusts root-owned siblings (root can already replace the daemon binary itself), still rejecting other users and world-writable files
- `just install-daemon` now `restart`s the service — `start` was a no-op on a running unit, leaving a freshly installed binary unused
- README/SECURITY.md document the model channel-agnostically (root-owned files, unprivileged user-session daemon)

## Release note
Current release tarballs still package the old `%h/.local/bin` unit and a daemon with the old ownership check — a release should be cut promptly after merging, or curl-installs of existing tarballs will fail with 203/EXEC and `popup_failed`.

## Test plan
- [x] `cargo test -p super-stt-daemon --lib consent` — 12 pass, incl. new root-owned trust tests
- [x] `cargo clippy --all-features --workspace` (pedantic) clean
- [x] `bash -n` on all four install scripts; `just --summary` parses
- [x] End-to-end on Manjaro/COSMIC: uninstall → `just install-all` → daemon runs from `/usr/local/bin`, consent popup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)