### PR TITLE
Refresh COSMIC launcher caches after desktop entry changes

### DIFF
--- a/justfile
+++ b/justfile
@@ -430,6 +430,12 @@ install-app:
         sudo gtk-update-icon-cache -f -t {{ icon_theme_dir }} 2>/dev/null || true
     fi
 
+    # Nudge COSMIC's launcher caches (app grid + search backend) so the
+    # entry appears without a relogin; both respawn on demand and rescan.
+    pkill -f '^cosmic-app-library$' 2>/dev/null || true
+    pkill -f '^cosmic-launcher$' 2>/dev/null || true
+    pkill -f '^pop-launcher( |$)' 2>/dev/null || true
+
     echo "✓ Super STT app installed: {{ app_dst }}"
     echo "✓ Desktop entry installed: {{ app_desktop_file_dst }}"
     echo "✓ App icon installed: {{ app_icon_dst }}"
@@ -481,6 +487,12 @@ install-applet:
     if command -v gtk-update-icon-cache &> /dev/null; then
         sudo gtk-update-icon-cache -f -t {{ icon_theme_dir }} 2>/dev/null || true
     fi
+
+    # Nudge COSMIC's launcher caches (app grid + search backend) so the
+    # entries appear without a relogin; both respawn on demand and rescan.
+    pkill -f '^cosmic-app-library$' 2>/dev/null || true
+    pkill -f '^cosmic-launcher$' 2>/dev/null || true
+    pkill -f '^pop-launcher( |$)' 2>/dev/null || true
 
     echo "✓ COSMIC applet installed: {{ applet_dst }}"
     echo "✓ Desktop entries installed for panel integration:"
@@ -823,6 +835,11 @@ uninstall-app:
         sudo gtk-update-icon-cache -f -t {{ icon_theme_dir }} 2>/dev/null || true
     fi
 
+    # Drop the entry from COSMIC's launcher caches without a relogin.
+    pkill -f '^cosmic-app-library$' 2>/dev/null || true
+    pkill -f '^cosmic-launcher$' 2>/dev/null || true
+    pkill -f '^pop-launcher( |$)' 2>/dev/null || true
+
     echo "✓ Super STT App uninstalled"
     echo "✓ Desktop entry removed"
     echo "✓ App icon removed"
@@ -837,6 +854,12 @@ uninstall-applet:
     sudo rm -f {{ applet_right_desktop_file_dst }}
     # Remove the applet icon
     sudo rm -f {{ applet_icon_dst }}
+
+    # Drop the entries from COSMIC's launcher caches without a relogin.
+    pkill -f '^cosmic-app-library$' 2>/dev/null || true
+    pkill -f '^cosmic-launcher$' 2>/dev/null || true
+    pkill -f '^pop-launcher( |$)' 2>/dev/null || true
+
     echo "✓ COSMIC applet uninstalled"
     echo "✓ Desktop entries removed"
     echo "✓ Applet icon removed"

--- a/scripts/install-beta.sh
+++ b/scripts/install-beta.sh
@@ -598,6 +598,16 @@ case $INSTALL_OPTION in
         ;;
 esac
 
+# Nudge COSMIC's launcher caches (app grid + search backend): both scan
+# desktop entries at session start and miss entries added to a directory
+# they weren't watching. They respawn on demand and rescan. (-f because
+# cosmic-app-library exceeds pkill's 15-char comm-name limit.)
+if [ "$INSTALL_OPTION" != "daemon" ]; then
+    pkill -f '^cosmic-app-library$' 2>/dev/null || true
+    pkill -f '^cosmic-launcher$' 2>/dev/null || true
+    pkill -f '^pop-launcher( |$)' 2>/dev/null || true
+fi
+
 # Configure COSMIC shortcut if daemon was installed and in interactive mode
 if [ "$INTERACTIVE" = true ] && ([ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]); then
     configure_cosmic_shortcut "$INSTALL_PREFIX"

--- a/scripts/install-stable.sh
+++ b/scripts/install-stable.sh
@@ -547,6 +547,16 @@ case $INSTALL_OPTION in
         ;;
 esac
 
+# Nudge COSMIC's launcher caches (app grid + search backend): both scan
+# desktop entries at session start and miss entries added to a directory
+# they weren't watching. They respawn on demand and rescan. (-f because
+# cosmic-app-library exceeds pkill's 15-char comm-name limit.)
+if [ "$INSTALL_OPTION" != "daemon" ]; then
+    pkill -f '^cosmic-app-library$' 2>/dev/null || true
+    pkill -f '^cosmic-launcher$' 2>/dev/null || true
+    pkill -f '^pop-launcher( |$)' 2>/dev/null || true
+fi
+
 # Configure COSMIC shortcut if daemon was installed and in interactive mode
 if [ "$INTERACTIVE" = true ] && ([ "$INSTALL_OPTION" = "all" ] || [ "$INSTALL_OPTION" = "daemon" ]); then
     configure_cosmic_shortcut "$INSTALL_PREFIX"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -168,6 +168,11 @@ if command -v update-desktop-database &> /dev/null; then
         $SUDO update-desktop-database "$SYSTEM_DESKTOP_DIR" 2>/dev/null || true
     fi
 fi
+# Nudge COSMIC's launcher caches so the removed entries disappear without
+# a relogin; both processes respawn on demand and rescan.
+pkill -f '^cosmic-app-library$' 2>/dev/null || true
+pkill -f '^cosmic-launcher$' 2>/dev/null || true
+pkill -f '^pop-launcher( |$)' 2>/dev/null || true
 
 # 7. COSMIC custom keyboard shortcut. Remove only if Super STT is the
 #    only entry; otherwise the user has other custom bindings we


### PR DESCRIPTION
## Summary
- COSMIC keeps three session-lifetime processes that cache app data independently: `pop-launcher` (desktop entries for search), `cosmic-app-library` (the app grid), and `cosmic-launcher` (search UI, which caches **resolved icon paths**). None of them notice entries added to a directory after session start — and after #316 moved installs to `/usr/local`, `cosmic-launcher` could also hold a cached icon path pointing at the deleted legacy `~/.local` location. Result: freshly installed apps were missing from the launcher (or showed without an icon) until relogin.
- Both release installers, `uninstall.sh`, and the justfile app/applet recipes now `pkill` all three after changing desktop entries. They respawn on demand within a second or two and rescan. (`-f` matching because `cosmic-app-library` exceeds the 15-char comm-name limit; skipped for daemon-only installs.)

## Test plan
- [x] Verified root cause on a live COSMIC session: fresh `pop-launcher` finds the entry; a probe against `cosmic-freedesktop-icons` resolves the icon from `/usr/local`; stale processes from the prior login did neither
- [x] After nudging all three processes, entry + icon appear in search and grid without relogin
- [x] `bash -n` on all scripts; `just --summary` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)