### PR TITLE
Add mic volume and ydotool tips to README troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ This is a snapshot. The app always shows the current catalog, published live at 
 ## 🩺 Troubleshooting
 
 - **`stt: command not found`**: binaries are installed system-wide and are on `PATH` by default — restart your terminal so it rehashes, and check the installer finished without errors.
-- **Daemon won't start / misbehaves**: check `journalctl --user -u super-stt -n 49`.
-- **A stale legacy build is interfering** (auth popup shows `Path: <unknown>`, or errors mention an `stt` group): remove the old binaries and reinstall: `just uninstall` (or `rm -f ~/.local/bin/super-stt*`), then `just install`.
-
+- **Daemon won't start / misbehaves**: check `journalctl --user -u super-stt -n 50`.
+- **Transcriptions seem less accurate than they should be**: your microphone input volume may be set too high or too low. Adjust the mic volume in your system sound settings and try again.
+- **Typing doesn't work in some apps**: [`ydotool`](https://github.com/ReimuNotMoe/ydotool) types reliably across virtually all apps. Install it via your package manager, then try it out first by running `sudo ydotoold --socket-path="$HOME/.ydotool_socket" --socket-own="$(id -u):$(id -g)"` in a terminal and setting the write method to **ydotool** in Settings. If that fixes typing, make it permanent by enabling the service (e.g. `systemctl --user enable --now ydotool`).
 
 ## 🧑‍💻 Developers
 


### PR DESCRIPTION
## Summary
- **Accuracy tip**: transcriptions that seem less accurate than expected are often a mic input level problem (too hot clips, too quiet starves the model) — adjust it in system sound settings.
- **Typing tip**: for apps where text injection fails, point users at `ydotool`, with a try-before-you-commit flow: run `sudo ydotoold --socket-path="$HOME/.ydotool_socket" --socket-own="$(id -u):$(id -g)"` in a terminal (the socket lands at the ydotool client's default lookup path, owned by the user, so the daemon-spawned client finds it with no env config), switch the write method to **ydotool** in Settings, and only enable the distro's service once it's confirmed working. The explicit write-method switch matters because Auto prefers the XDG Portal whenever it's available.
- Also bumps the `journalctl` example to `-n 50` and drops the stale-legacy-build entry.

## Test plan
- [x] ydotool advice verified against the daemon code: `ydotool_backend.rs` availability check requires a reachable `ydotoold`, and `auto()` tries Portal → ydotool → Wayland, so the Settings switch is required when the portal is present
- [x] Unit name checked against the Arch/Manjaro package (`/usr/lib/systemd/user/ydotool.service` — user scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)