### PR TITLE
Withhold GPU device nodes from models that declare no GPU

### DIFF
--- a/docs/protocol/backend/subprocess.md
+++ b/docs/protocol/backend/subprocess.md
@@ -67,7 +67,7 @@ unit. The backend cannot relax these restrictions; design against them:
 | `ProtectHome=yes`, `PrivateTmp=yes` | `$HOME` is inaccessible; `/tmp` is private.                  |
 | `NoNewPrivileges=yes`             | The process cannot acquire new privileges.                     |
 | `SystemCallFilter=@system-service` | A seccomp allowlist; privileged syscall groups are denied.    |
-| `DeviceAllow=<gpu nodes>`         | The GPU device nodes, granted only when a GPU device is requested. |
+| `PrivateDevices=yes`              | A private `/dev` with no GPU nodes, unless the model declares a GPU. |
 
 Two consequences worth stating plainly:
 
@@ -79,7 +79,14 @@ Two consequences worth stating plainly:
   the GPU device nodes, and the GPU driver is privileged kernel attack
   surface. This is inherent to GPU compute and is not closed by the sandbox;
   it is the reason untrusted, network-facing backends belong on the WASM
-  transport instead.
+  transport instead. The hole is opened only where it is needed, and the
+  manifest decides: a model whose `supported_devices` names `cuda` or `metal`
+  is spawned with the host `/dev`. A model that names neither — CPU-only, or
+  the `none` sentinel of a remote model — runs with a private `/dev` holding
+  only the pseudo-devices, so the GPU nodes are not there to open. The
+  sandbox is fixed when the unit spawns, which is before `load`, so the
+  `device` a load request asks for cannot widen it; declare every device the
+  model can use.
 
 A subprocess backend whose CUDA kernels are multi-architecture (for example a
 bundled PyTorch wheel) may publish a single CUDA asset that omits `cuda_sm`;

--- a/super-stt-daemon/src/stt_models/subprocess/mod.rs
+++ b/super-stt-daemon/src/stt_models/subprocess/mod.rs
@@ -127,7 +127,15 @@ impl SubprocessBackend {
             std::process::id()
         );
 
-        systemd::spawn_systemd_unit(&unit, &binary, backend_dir, &socket_dir, &socket).await?;
+        systemd::spawn_systemd_unit(
+            &unit,
+            &binary,
+            backend_dir,
+            &socket_dir,
+            &socket,
+            &model.supported_devices,
+        )
+        .await?;
 
         let interval = model
             .processing_interval_ms

--- a/super-stt-daemon/src/stt_models/subprocess/systemd.rs
+++ b/super-stt-daemon/src/stt_models/subprocess/systemd.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use log::{info, warn};
 
+use crate::stt_models::backends::manifest::Device;
+
 /// Stop any leftover `super-stt-backend-*` `--user` transient units. Called
 /// at daemon startup as defense against a previous daemon run that exited
 /// without running `Transcribe::shutdown()` (SIGKILL / panic /
@@ -74,12 +76,16 @@ pub async fn cleanup_orphan_units() {
 }
 
 /// Spawn the backend binary in a hardened `systemd-run --user` transient unit.
+///
+/// `devices` is the model's declared `supported_devices`; it decides whether
+/// this unit is granted the GPU device nodes. See [`needs_gpu_access`].
 pub(super) async fn spawn_systemd_unit(
     unit: &str,
     binary: &Path,
     backend_dir: &Path,
     socket_dir: &Path,
     socket: &Path,
+    devices: &[Device],
 ) -> Result<()> {
     let mut cmd = tokio::process::Command::new("systemd-run");
     cmd.arg("--user")
@@ -87,7 +93,7 @@ pub(super) async fn spawn_systemd_unit(
         .arg("--quiet")
         // Garbage-collect the transient unit when it exits/fails.
         .arg("--collect");
-    for param in hardening_params(backend_dir, socket_dir) {
+    for param in hardening_params(backend_dir, socket_dir, needs_gpu_access(devices)) {
         cmd.arg("-p").arg(param);
     }
     cmd.arg(format!(
@@ -112,6 +118,26 @@ pub(super) async fn spawn_systemd_unit(
     Ok(())
 }
 
+/// Whether a model that declares `devices` is granted the GPU device nodes.
+///
+/// Exposing `/dev/nvidia*` hands the backend privileged kernel attack surface,
+/// so it is withheld from the models that provably cannot use it: those whose
+/// `supported_devices` name no GPU.
+///
+/// The *runtime* device preference deliberately does not decide this. The
+/// sandbox is fixed when the unit spawns, which happens before `load` — at
+/// that point no preference for this model exists yet (the settings UI offers
+/// the device picker only once a model is loaded), and the persisted default
+/// would hide the GPU from a CUDA-only model. A model's declared capability is
+/// known from `backend.toml` at spawn time and does not move afterwards, so a
+/// GPU-capable model keeps the nodes whether or not the user currently prefers
+/// the CPU — switching device must not depend on how the unit was spawned.
+fn needs_gpu_access(devices: &[Device]) -> bool {
+    devices
+        .iter()
+        .any(|d| matches!(d, Device::Cuda | Device::Metal))
+}
+
 /// The systemd sandbox directives applied to every spawned backend. Shared by
 /// the spawner and the sandbox-enforcement tests so they stay in lock-step.
 ///
@@ -120,9 +146,19 @@ pub(super) async fn spawn_systemd_unit(
 ///   read-only (the binary + model under `$HOME` stay visible read-only); only
 ///   the socket dir is writable.
 /// - `PrivateTmp`, `NoNewPrivileges`, `SystemCallFilter=@system-service`.
-/// - `DevicePolicy=closed` + `DeviceAllow`: only the GPU device nodes.
-fn hardening_params(backend_dir: &Path, socket_dir: &Path) -> Vec<String> {
-    vec![
+/// - `PrivateDevices` (models declaring no GPU): a private `/dev` holding just
+///   the pseudo-devices, so the GPU nodes are not there to open.
+/// - `DevicePolicy=closed` + `DeviceAllow`: the intended device allowlist.
+///
+/// The device *cgroup* controller (`DevicePolicy`/`DeviceAllow`) is only
+/// enforced for system units — a per-user manager records the properties and
+/// runs the unit without them, because installing the BPF device program is
+/// privileged. They are declared anyway so the policy is right if these units
+/// ever move to the system manager, but the CPU-only restriction cannot lean
+/// on them. `PrivateDevices` carries it instead: it is a mount namespace, so
+/// it applies to user units exactly as `PrivateTmp` does.
+fn hardening_params(backend_dir: &Path, socket_dir: &Path, gpu_access: bool) -> Vec<String> {
+    let mut params = vec![
         "PrivateNetwork=yes".to_string(),
         "ProtectSystem=strict".to_string(),
         "ProtectHome=read-only".to_string(),
@@ -131,19 +167,86 @@ fn hardening_params(backend_dir: &Path, socket_dir: &Path) -> Vec<String> {
         "PrivateTmp=yes".to_string(),
         "NoNewPrivileges=yes".to_string(),
         "DevicePolicy=closed".to_string(),
-        "DeviceAllow=/dev/nvidia0 rw".to_string(),
-        "DeviceAllow=/dev/nvidiactl rw".to_string(),
-        "DeviceAllow=/dev/nvidia-uvm rw".to_string(),
-        "DeviceAllow=/dev/nvidia-uvm-tools rw".to_string(),
-        "DeviceAllow=/dev/dri/renderD128 rw".to_string(),
-        "SystemCallFilter=@system-service".to_string(),
-    ]
+    ];
+    if gpu_access {
+        params.extend(
+            [
+                "DeviceAllow=/dev/nvidia0 rw",
+                "DeviceAllow=/dev/nvidiactl rw",
+                "DeviceAllow=/dev/nvidia-uvm rw",
+                "DeviceAllow=/dev/nvidia-uvm-tools rw",
+                "DeviceAllow=/dev/dri/renderD128 rw",
+            ]
+            .map(String::from),
+        );
+    } else {
+        params.push("PrivateDevices=yes".to_string());
+    }
+    params.push("SystemCallFilter=@system-service".to_string());
+    params
 }
 
 #[cfg(test)]
 mod tests {
-    use super::hardening_params;
-    use std::path::PathBuf;
+    use super::{Device, hardening_params, needs_gpu_access};
+    use std::path::{Path, PathBuf};
+
+    /// A model that declares no GPU device must not be handed the GPU nodes.
+    /// The GPU driver is privileged kernel attack surface, so the sandbox
+    /// opens it only for the backends that can actually compute on it.
+    ///
+    /// `PrivateDevices` is what makes this real: the daemon spawns `--user`
+    /// units, and a per-user manager does not enforce the device cgroup
+    /// controller, so dropping the `DeviceAllow` lines alone would restrict
+    /// nothing. `sandbox_is_enforced` proves the denial end-to-end.
+    #[test]
+    fn a_cpu_only_model_gets_no_gpu_device_nodes() {
+        let params = hardening_params(Path::new("/backend"), Path::new("/sock"), false);
+        assert!(
+            params.iter().any(|p| p == "PrivateDevices=yes"),
+            "cpu-only unit has no enforceable device restriction: {params:?}"
+        );
+        assert!(
+            !params.iter().any(|p| p.starts_with("DeviceAllow=")),
+            "cpu-only unit was granted device nodes: {params:?}"
+        );
+    }
+
+    /// The GPU path still gets every node CUDA needs, and must NOT get the
+    /// private `/dev` — that would hide the GPU from the one backend that
+    /// needs it, failing at model-load time as an opaque driver error rather
+    /// than as a permission problem.
+    #[test]
+    fn a_gpu_backend_gets_the_cuda_device_nodes() {
+        let params = hardening_params(Path::new("/backend"), Path::new("/sock"), true);
+        for node in [
+            "DeviceAllow=/dev/nvidia0 rw",
+            "DeviceAllow=/dev/nvidiactl rw",
+            "DeviceAllow=/dev/nvidia-uvm rw",
+            "DeviceAllow=/dev/nvidia-uvm-tools rw",
+            "DeviceAllow=/dev/dri/renderD128 rw",
+        ] {
+            assert!(params.iter().any(|p| p == node), "missing {node}");
+        }
+        assert!(
+            !params.iter().any(|p| p == "PrivateDevices=yes"),
+            "gpu backend was given a private /dev, hiding the GPU: {params:?}"
+        );
+    }
+
+    /// Pin the `supported_devices` → GPU-access mapping. A model keeps the
+    /// nodes if *any* declared device is a GPU, because the user may switch to
+    /// it after load; only a model that names no GPU at all — CPU-only, or the
+    /// `none` sentinel of a remote model — is spawned without them.
+    #[test]
+    fn only_a_model_declaring_a_gpu_gets_gpu_access() {
+        assert!(!needs_gpu_access(&[Device::Cpu]));
+        assert!(!needs_gpu_access(&[Device::None]));
+        assert!(!needs_gpu_access(&[]));
+        assert!(needs_gpu_access(&[Device::Cuda]));
+        assert!(needs_gpu_access(&[Device::Metal]));
+        assert!(needs_gpu_access(&[Device::Cpu, Device::Cuda]));
+    }
 
     /// Verify the systemd sandbox actually *enforces* its restrictions: a probe
     /// run under the same hardening as a real backend must be denied network,
@@ -179,7 +282,7 @@ grep -q "NoNewPrivs:[[:space:]]*1" /proc/self/status && echo NNP_SET || echo NNP
 [ -e "{marker}" ] && echo TMP_LEAK || echo TMP_PRIVATE
 touch "{sock}/.sbx_$$" 2>/dev/null && {{ echo SOCK_RW; rm -f "{sock}/.sbx_$$"; }} || echo SOCK_RO
 [ -r "{backend}/backend.toml" ] && echo BACKEND_READABLE || echo BACKEND_HIDDEN
-if [ -e /dev/nvidia-modeset ]; then head -c1 /dev/nvidia-modeset >/dev/null 2>&1 && echo MODESET_OPEN || echo MODESET_BLOCKED; fi
+[ -e /dev/nvidia0 ] && echo GPU_NODE_PRESENT || echo GPU_NODE_ABSENT
 "#,
             marker = marker,
             sock = socket_dir.display(),
@@ -191,7 +294,7 @@ if [ -e /dev/nvidia-modeset ]; then head -c1 /dev/nvidia-modeset >/dev/null 2>&1
             .arg("--pipe")
             .arg("--quiet")
             .arg("--collect");
-        for p in hardening_params(&backend_dir, &socket_dir) {
+        for p in hardening_params(&backend_dir, &socket_dir, true) {
             cmd.arg("-p").arg(p);
         }
         cmd.arg("--").arg("sh").arg("-c").arg(&probe);
@@ -216,17 +319,45 @@ if [ -e /dev/nvidia-modeset ]; then head -c1 /dev/nvidia-modeset >/dev/null 2>&1
                 "sandbox property not enforced: {expected}\n{stdout}\n{stderr}"
             );
         }
-        for violation in [
-            "HOME_WRITABLE",
-            "ETC_WRITABLE",
-            "TMP_LEAK",
-            "NET_LEAK",
-            "MODESET_OPEN",
-        ] {
+        for violation in ["HOME_WRITABLE", "ETC_WRITABLE", "TMP_LEAK", "NET_LEAK"] {
             assert!(
                 !stdout.contains(violation),
                 "sandbox violation detected: {violation}\n{stdout}"
             );
         }
+
+        // The GPU half of the check needs a host that actually has the node —
+        // otherwise "absent under the CPU params" is true for the wrong reason
+        // and proves nothing.
+        if !Path::new("/dev/nvidia0").exists() {
+            return;
+        }
+        assert!(
+            stdout.contains("GPU_NODE_PRESENT"),
+            "a GPU backend cannot see the GPU it was granted\n{stdout}\n{stderr}"
+        );
+
+        // Same probe under the params a model declaring no GPU would get.
+        // Asserting on the parameter list alone would only prove we omit a
+        // string; this proves systemd enforces the omission — and it is the
+        // reason that case carries `PrivateDevices` rather than just dropping
+        // the `DeviceAllow` lines, which a per-user manager ignores.
+        let mut cmd = tokio::process::Command::new("systemd-run");
+        cmd.arg("--user")
+            .arg("--pipe")
+            .arg("--quiet")
+            .arg("--collect");
+        for p in hardening_params(&backend_dir, &socket_dir, false) {
+            cmd.arg("-p").arg(p);
+        }
+        cmd.arg("--").arg("sh").arg("-c").arg(&probe);
+
+        let out = cmd.output().await.expect("run systemd-run");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("GPU_NODE_ABSENT"),
+            "a model declaring no GPU was left the GPU node\n{stdout}\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 }


### PR DESCRIPTION
Every subprocess backend was spawned with the host `/dev` and the full NVIDIA node set, whether or not it could use a GPU. A CPU-only Whisper build carried access to privileged GPU driver surface for no reason. This makes the sandbox grant it only to models that can actually compute on it.

## Two things had to change

**The `DeviceAllow` allowlist was never enforcing anything.** The daemon spawns backends with `systemd-run --user`, and the device cgroup controller isn't applied to per-user managers — installing the BPF device program is privileged. Verified on a live host: `DevicePolicy=strict` with an empty allowlist still lets `/dev/null` open, while `systemctl --user show` happily reports `DevicePolicy=closed` and every `DeviceAllow=` line. So gating that list would have been a no-op. `PrivateDevices=yes` carries the restriction instead — it's a mount namespace, so it applies to user units exactly as `PrivateTmp` already does. The `DeviceAllow` lines stay for the GPU path: still declarative, still correct if these units ever move to the system manager.

**The gate keys on the manifest, not the device preference.** The sandbox is fixed when the unit spawns, which is *before* `load`. At first spawn no device preference for that model exists yet — the settings UI only offers the picker once a model is loaded — and `preferred_device` defaults to `"cpu"`, so a preference-keyed gate would have hidden the GPU from a CUDA-only model on its very first load. `spawn()` already resolves the `ModelEntry` from `backend.toml`, so the model's declared `supported_devices` is known at the right moment and doesn't move afterwards. A GPU-capable model keeps the nodes whether or not the user currently prefers CPU, so switching device later can't depend on how the unit happened to be spawned.

Scope: this is a least-privilege default keyed on a self-declaration, not a containment boundary. A backend that wants the nodes declares `supported_devices = ["cuda"]`. Untrusted code still belongs on the WASM transport, which has no device access at all.

## Changes

- `subprocess/systemd.rs` — `needs_gpu_access(&[Device])`; `hardening_params` takes `gpu_access` and adds `PrivateDevices=yes` when it's false.
- `subprocess/mod.rs` — passes `&model.supported_devices` into `spawn_systemd_unit`. `device_pref` still goes to `load`, where it belongs.
- `docs/protocol/backend/subprocess.md` — the sandbox table and the "GPU access is a deliberate hole" note now describe what actually runs, plus the consequence for backend authors: a model that omits `cuda` can't obtain the GPU later by asking for `device: "cuda"`, because the private `/dev` is already in place.

## Verification

Run in a scratch worktree off `main`.

- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` — clean; `rustfmt --check` clean
- 4 tests pass, including `sandbox_is_enforced` against real systemd with `SUPER_STT_TEST_SANDBOX=1`: `GPU_NODE_PRESENT` under GPU params, `GPU_NODE_ABSENT` under the no-GPU params
- **Negative control** — deleting the `PrivateDevices=yes` line fails both the unit test and the end-to-end test with *"a model declaring no GPU was left the GPU node"*

The end-to-end probe was also fixed while here: it used `head -c1` on an nvidia node, which fails whether or not the device is allowed, so the old `MODESET_BLOCKED` assertion passed for the wrong reason and proved nothing. It now checks for the node's presence, which discriminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
