### PR TITLE
Add regression tests for startup active_backend adoption

### DIFF
--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -1,44 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use super::*;
-use crate::config::DaemonConfig;
-use crate::daemon::events::EventBus;
-use crate::download_progress::DownloadStateManager;
-use crate::input::audio::AudioProcessor;
-use crate::resource_management::ResourceManager;
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, RwLock};
+use crate::daemon::types::test_daemon;
 use super_stt_shared::models::protocol::ErrorCode;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
-use super_stt_shared::theme::AudioTheme;
-use tokio::sync::broadcast;
 use tokio::time::{Duration, timeout};
-
-async fn test_daemon() -> SuperSTTDaemon {
-    let model = Arc::new(tokio::sync::RwLock::new(None));
-    let audio_processor = Arc::new(AudioProcessor::new());
-    let (shutdown_tx, _) = broadcast::channel(1);
-    SuperSTTDaemon {
-        model,
-        audio_processor,
-        shutdown_tx,
-        dbus_manager: None,
-        events: Arc::new(EventBus::new()),
-        audio_theme: Arc::new(RwLock::new(AudioTheme::default())),
-        volume: Arc::new(RwLock::new(100)),
-        busy: Arc::new(tokio::sync::RwLock::new(false)),
-        download_manager: Arc::new(DownloadStateManager::new()),
-        preferred_device: Arc::new(tokio::sync::RwLock::new("cpu".to_string())),
-        actual_device: Arc::new(tokio::sync::RwLock::new("cpu".to_string())),
-        config: Arc::new(tokio::sync::RwLock::new(DaemonConfig::default())),
-        resource_manager: Arc::new(ResourceManager::development()),
-        preview_typing_enabled: Arc::new(AtomicBool::new(false)),
-        manual_stop_tx: Arc::new(tokio::sync::RwLock::new(None)),
-        simulator: Arc::new(tokio::sync::RwLock::new(None)),
-        preview_text: Arc::new(tokio::sync::RwLock::new(None)),
-        backends: Arc::new(tokio::sync::RwLock::new(Vec::new())),
-        active_backend: Arc::new(tokio::sync::RwLock::new(None)),
-    }
-}
 
 fn make_request(command: &str) -> DaemonRequest {
     DaemonRequest {

--- a/super-stt-daemon/src/daemon/startup.rs
+++ b/super-stt-daemon/src/daemon/startup.rs
@@ -246,6 +246,42 @@ impl SuperSTTDaemon {
         changed
     }
 
+    /// Record the backend serving `source` as the active one when nothing has
+    /// selected one yet, returning whether it changed anything.
+    ///
+    /// The startup path resolves its model from the legacy
+    /// `preferred_model`/`preferred_provider`/`preferred_source` config, which
+    /// carries no `active_backend` — a config written before that field
+    /// existed loads it as `None`. Without this the daemon transcribes
+    /// happily while `GET /active_backend` stays null, so the settings app
+    /// shows its "no backend loaded" empty state and `GET /models` (scoped to
+    /// the active backend) returns nothing.
+    ///
+    /// Guarded on `is_none()`, so it only ever fills a gap: an explicit
+    /// selection through `set_active_backend`/`set_model` always wins.
+    ///
+    /// Persisting is deliberately left to the caller. Keeping this free of
+    /// disk I/O is what lets it be unit-tested without writing over the user's
+    /// real config.
+    async fn adopt_active_backend_for(&self, source: &str) -> bool {
+        if self.active_backend.read().await.is_some() {
+            return false;
+        }
+        let dir_name = {
+            let backends = self.backends.read().await;
+            backends
+                .iter()
+                .find(|b| b.source == source)
+                .and_then(backends::dir_name)
+        };
+        let Some(dir) = dir_name else {
+            return false;
+        };
+        *self.active_backend.write().await = Some(dir.clone());
+        self.config.write().await.transcription.active_backend = Some(dir);
+        true
+    }
+
     async fn load_initial_model_and_broadcast(
         daemon: &SuperSTTDaemon,
         name: String,
@@ -261,24 +297,10 @@ impl SuperSTTDaemon {
 
         info!("model {name} via {provider} loaded successfully");
 
-        // Derive the active backend from the loaded model's source when the
-        // daemon started via the legacy `preferred_model`/`preferred_source`
-        // config (which don't set `active_backend`). Without this the app
-        // shows "no backend loaded" even though a model is actively running.
-        if daemon.active_backend.read().await.is_none() {
-            let backends = daemon.backends.read().await;
-            let dir_name = backends
-                .iter()
-                .find(|b| b.source == source)
-                .and_then(backends::dir_name);
-            drop(backends);
-            if let Some(ref dir) = dir_name {
-                *daemon.active_backend.write().await = Some(dir.clone());
-                daemon.config.write().await.transcription.active_backend = Some(dir.clone());
-                if let Err(e) = daemon.persist_config().await {
-                    warn!("Failed to persist active_backend after startup load: {e}");
-                }
-            }
+        if daemon.adopt_active_backend_for(&source).await
+            && let Err(e) = daemon.persist_config().await
+        {
+            warn!("Failed to persist active_backend after startup load: {e}");
         }
 
         // Capture the device label before moving `instance` into the shared
@@ -299,3 +321,7 @@ impl SuperSTTDaemon {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[path = "startup_tests.rs"]
+mod tests;

--- a/super-stt-daemon/src/daemon/startup_tests.rs
+++ b/super-stt-daemon/src/daemon/startup_tests.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Startup-path tests.
+//!
+//! These cover the seam between "a model is loaded" and "a backend is
+//! selected". The two are set by different code paths — `switch.rs` records
+//! the selection when a user picks a model, while the startup path resolves
+//! its model from the legacy `preferred_model`/`preferred_provider`/
+//! `preferred_source` config, which carries no `active_backend` at all. When
+//! the startup path forgets to record it the daemon still transcribes, so
+//! nothing fails and no log line complains; the only symptom is that the
+//! settings app renders its "no backend loaded" empty state and the model
+//! picker comes back empty.
+
+use crate::daemon::types::test_daemon;
+use crate::stt_models::backends::DiscoveredBackend;
+use std::path::PathBuf;
+
+const WHISPER_SOURCE: &str = "github.com/jorge-menjivar/super-stt-whisper";
+
+/// A discovered backend installed at `<backends_dir>/<dir>`, serving `source`.
+/// Only `dir` and `source` matter here: the adoption looks a backend up by
+/// `source` and stores its install-dir name.
+fn discovered(dir: &str, source: &str) -> DiscoveredBackend {
+    DiscoveredBackend {
+        dir: PathBuf::from("/var/lib/super-stt/backends").join(dir),
+        source: source.to_string(),
+        name: "Whisper (local)".to_string(),
+        kind: "subprocess".to_string(),
+        entrypoint: "whisper".to_string(),
+        allowed_hosts: Vec::new(),
+        secrets: Vec::new(),
+        options: Vec::new(),
+        models: Vec::new(),
+    }
+}
+
+/// The regression: a daemon that loads its model from a legacy config must end
+/// up with an active backend. A config written before `active_backend` existed
+/// deserializes it as `None` while still naming a model, so this is the state
+/// every upgrading user starts in.
+///
+/// Both the runtime lock and the config are asserted — setting only the lock
+/// would look correct until the next restart, when the selection would be gone
+/// again.
+#[tokio::test]
+async fn a_startup_load_adopts_the_backend_serving_the_model() {
+    let daemon = test_daemon().await;
+    *daemon.backends.write().await = vec![discovered("whisper", WHISPER_SOURCE)];
+
+    let adopted = daemon.adopt_active_backend_for(WHISPER_SOURCE).await;
+
+    assert!(adopted, "a startup load left no backend selected");
+    assert_eq!(
+        daemon.active_backend.read().await.as_deref(),
+        Some("whisper"),
+        "runtime active_backend was not set to the install dir"
+    );
+    assert_eq!(
+        daemon
+            .config
+            .read()
+            .await
+            .transcription
+            .active_backend
+            .as_deref(),
+        Some("whisper"),
+        "active_backend was not recorded in config, so it would not survive a restart"
+    );
+}
+
+/// The stored value is the backend's **install-dir name**, not its `source`.
+/// The daemon keys `active_backend` by directory everywhere (`handle_list_models`,
+/// `active_backend_payload`) and converts to a source only on the wire, so
+/// storing a source here would resolve to nothing and reproduce the same empty
+/// UI this fix exists to prevent.
+#[tokio::test]
+async fn the_adopted_value_is_the_install_dir_not_the_source() {
+    let daemon = test_daemon().await;
+    *daemon.backends.write().await = vec![discovered("whisper", WHISPER_SOURCE)];
+
+    daemon.adopt_active_backend_for(WHISPER_SOURCE).await;
+
+    let active = daemon.active_backend.read().await.clone();
+    assert_eq!(active.as_deref(), Some("whisper"));
+    assert_ne!(
+        active.as_deref(),
+        Some(WHISPER_SOURCE),
+        "stored the source where a directory name is expected"
+    );
+}
+
+/// Adoption fills a gap; it never overrides. A user who selected a backend
+/// explicitly has that recorded already, and a startup load of some other
+/// backend's model must not silently repoint the selection.
+#[tokio::test]
+async fn an_existing_selection_is_never_overridden() {
+    let daemon = test_daemon().await;
+    *daemon.backends.write().await = vec![discovered("whisper", WHISPER_SOURCE)];
+    *daemon.active_backend.write().await = Some("openai".to_string());
+
+    let adopted = daemon.adopt_active_backend_for(WHISPER_SOURCE).await;
+
+    assert!(!adopted, "reported a change it did not make");
+    assert_eq!(
+        daemon.active_backend.read().await.as_deref(),
+        Some("openai"),
+        "an explicit selection was overwritten by the startup load"
+    );
+}
+
+/// A model whose backend is no longer discovered leaves the daemon idle rather
+/// than inventing a selection that `handle_list_models` could not resolve.
+#[tokio::test]
+async fn an_undiscovered_source_adopts_nothing() {
+    let daemon = test_daemon().await;
+    *daemon.backends.write().await = vec![discovered("whisper", WHISPER_SOURCE)];
+
+    let adopted = daemon
+        .adopt_active_backend_for("github.com/someone/uninstalled")
+        .await;
+
+    assert!(!adopted);
+    assert!(
+        daemon.active_backend.read().await.is_none(),
+        "selected a backend that is not installed"
+    );
+}

--- a/super-stt-daemon/src/daemon/types.rs
+++ b/super-stt-daemon/src/daemon/types.rs
@@ -93,6 +93,38 @@ pub struct SuperSTTDaemon {
     pub active_backend: Arc<tokio::sync::RwLock<Option<String>>>,
 }
 
+/// A daemon wired up with inert defaults: no model, no backends, nothing
+/// selected, and a `DaemonConfig::default()` that is never written to disk.
+///
+/// Lives beside the struct so there is exactly one copy — a second would drift
+/// as fields are added (the compiler catches the drift, but only after someone
+/// has fixed the same literal twice).
+#[cfg(test)]
+pub(crate) async fn test_daemon() -> SuperSTTDaemon {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    SuperSTTDaemon {
+        model: Arc::new(tokio::sync::RwLock::new(None)),
+        audio_processor: Arc::new(AudioProcessor::new()),
+        shutdown_tx,
+        dbus_manager: None,
+        events: Arc::new(EventBus::new()),
+        audio_theme: Arc::new(RwLock::new(AudioTheme::default())),
+        volume: Arc::new(RwLock::new(100)),
+        busy: Arc::new(tokio::sync::RwLock::new(false)),
+        download_manager: Arc::new(DownloadStateManager::new()),
+        preferred_device: Arc::new(tokio::sync::RwLock::new("cpu".to_string())),
+        actual_device: Arc::new(tokio::sync::RwLock::new("cpu".to_string())),
+        config: Arc::new(tokio::sync::RwLock::new(DaemonConfig::default())),
+        resource_manager: Arc::new(ResourceManager::development()),
+        preview_typing_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        manual_stop_tx: Arc::new(tokio::sync::RwLock::new(None)),
+        simulator: Arc::new(tokio::sync::RwLock::new(None)),
+        preview_text: Arc::new(tokio::sync::RwLock::new(None)),
+        backends: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+        active_backend: Arc::new(tokio::sync::RwLock::new(None)),
+    }
+}
+
 impl SuperSTTDaemon {
     /// Resolve a wire-level `(name, provider, source)` triple into a
     /// [`ModelDefinition`] from the discovered backends. Returns `None` on miss.


### PR DESCRIPTION
Follow-up to #327, which fixed #326 but shipped without test coverage.

This regression is unusually easy to reintroduce because it fails silently. When a startup load leaves `active_backend` unset, the daemon loads the model, transcribes normally, and logs nothing unusual — the only symptoms are in the app: the Models page renders its "no backend loaded" empty state, and `GET /models` (scoped to the active backend in `handle_list_models`) returns nothing. Reproduced by hand before writing this: a config naming `whisper-tiny` with no `active_backend` loads and transcribes fine while the config never gains the field and the picker stays empty.

## The extraction

The fix landed inline in `load_initial_model_and_broadcast`, which instantiates a real backend — unreachable from a unit test. It moves to `SuperSTTDaemon::adopt_active_backend_for(&self, source) -> bool`, which mutates the runtime lock and the in-memory config and reports whether it changed anything.

**Persisting deliberately stays at the call site.** `persist_config` writes the user's real `~/.config/super-stt/daemon.toml`, so keeping it out of the tested path is what lets these tests run without clobbering it. Behaviour is unchanged:

```rust
if daemon.adopt_active_backend_for(&source).await
    && let Err(e) = daemon.persist_config().await
{
    warn!("Failed to persist active_backend after startup load: {e}");
}
```

## What the tests pin

- **`a_startup_load_adopts_the_backend_serving_the_model`** — the regression proper. Asserts both the runtime lock *and* the config: setting only the lock would look correct until the next restart, when the selection would be gone again.
- **`the_adopted_value_is_the_install_dir_not_the_source`** — pins the value *kind*. `active_backend` is keyed by install directory everywhere (`handle_list_models`, `active_backend_payload`) and converted to a source only on the wire, so storing a source would resolve to nothing and reproduce the same empty UI.
- **`an_existing_selection_is_never_overridden`** — the `is_none()` guard; a startup load must not repoint a selection the user made explicitly.
- **`an_undiscovered_source_adopts_nothing`** — no phantom selection when the backend is no longer installed.

## One refactor worth flagging

`test_daemon()` moves from `core_tests.rs` to `types.rs` as a `#[cfg(test)] pub(crate)` helper, and `core_tests.rs` imports it. There was exactly one copy and a second file needed it; duplicating a 25-field struct literal means fixing it twice every time the daemon gains a field. That accounts for most of the `-37` in `core_tests.rs`.

## Verification

- Daemon lib suite: **268 passed, 0 failed**
- **Negative control** — neutering `adopt_active_backend_for` to a no-op fails the two positive tests with *"a startup load left no backend selected"*. The two guard tests correctly keep passing, since they assert non-action. Restored and re-verified.
- `just check`-equivalent clippy clean; `cargo fmt --check` clean.
