### PR TITLE
refactor(forge): replace Release bools with ReleaseKind enum

### DIFF
--- a/super-stt-forge/src/github.rs
+++ b/super-stt-forge/src/github.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use crate::{ForgeClient, ForgeError, Release, ReleaseAsset, RepoRef};
+use crate::{ForgeClient, ForgeError, Release, ReleaseAsset, ReleaseKind, RepoRef};
 
 const DEFAULT_BASE: &str = "https://api.github.com";
 
@@ -39,10 +39,16 @@ struct GhAsset {
 
 impl From<GhRelease> for Release {
     fn from(r: GhRelease) -> Self {
+        let kind = if r.draft {
+            ReleaseKind::Draft
+        } else if r.prerelease {
+            ReleaseKind::Prerelease
+        } else {
+            ReleaseKind::Published
+        };
         Release {
             tag: r.tag_name,
-            draft: r.draft,
-            prerelease: r.prerelease,
+            kind,
             assets: r.assets.into_iter().map(Into::into).collect(),
         }
     }
@@ -154,7 +160,7 @@ impl ForgeClient for Github {
 #[cfg(test)]
 mod tests {
     use super::Github;
-    use crate::{ForgeClient, RepoRef};
+    use crate::{ForgeClient, ReleaseKind, RepoRef};
 
     #[tokio::test]
     async fn latest_release_maps_github_json_to_neutral_release() {
@@ -171,8 +177,11 @@ mod tests {
         let repo = RepoRef::parse("github.com/x/y").unwrap();
         let r = gh.latest_release(&repo).await.unwrap();
         assert_eq!(r.tag, "v1.2.3");
-        assert!(!r.draft, "draft defaults to false when omitted");
-        assert!(!r.prerelease, "prerelease defaults to false when omitted");
+        assert_eq!(
+            r.kind,
+            ReleaseKind::Published,
+            "default release is published"
+        );
         assert_eq!(r.assets.len(), 1);
         assert_eq!(r.assets[0].name, "a.tar.gz");
         assert_eq!(r.assets[0].download_url, "https://dl/a");

--- a/super-stt-forge/src/lib.rs
+++ b/super-stt-forge/src/lib.rs
@@ -61,12 +61,23 @@ impl RepoRef {
     }
 }
 
+/// Whether a forge release is a published release, an unpublished draft, or a
+/// pre-release. These three states are mutually exclusive on every forge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseKind {
+    /// A stable, published release.
+    Published,
+    /// An unpublished draft.
+    Draft,
+    /// A pre-release (e.g. GitHub's `prerelease` flag).
+    Prerelease,
+}
+
 /// A forge-neutral release. Adapters map their host's JSON onto this.
 #[derive(Debug, Clone)]
 pub struct Release {
     pub tag: String,
-    pub draft: bool,
-    pub prerelease: bool,
+    pub kind: ReleaseKind,
     pub assets: Vec<ReleaseAsset>,
 }
 

--- a/super-stt-indexer/src/resolve.rs
+++ b/super-stt-indexer/src/resolve.rs
@@ -4,7 +4,7 @@
 use semver::Version;
 use thiserror::Error;
 
-use super_stt_forge::{ForgeClient, Release, RepoRef};
+use super_stt_forge::{ForgeClient, Release, ReleaseKind, RepoRef};
 
 use crate::registry_toml::Entry;
 
@@ -50,7 +50,7 @@ fn select_release(releases: Vec<Release>, entry: &Entry) -> Result<Resolved, Rel
 
     let mut best: Option<(Version, Release)> = None;
     for r in releases {
-        if r.draft || r.prerelease {
+        if r.kind != ReleaseKind::Published {
             continue;
         }
         let stripped = match &entry.tag_prefix {
@@ -104,13 +104,12 @@ fn parse_semver(s: &str) -> Result<Version, String> {
 mod tests {
     use super::*;
     use crate::registry_toml::Entry;
-    use super_stt_forge::Release;
+    use super_stt_forge::{Release, ReleaseKind};
 
     fn rel(tag: &str) -> Release {
         Release {
             tag: tag.into(),
-            draft: false,
-            prerelease: false,
+            kind: ReleaseKind::Published,
             assets: vec![],
         }
     }
@@ -165,7 +164,7 @@ mod tests {
     #[test]
     fn skips_prerelease() {
         let mut releases = vec![rel("v1.0.0"), rel("v2.0.0")];
-        releases[1].prerelease = true;
+        releases[1].kind = ReleaseKind::Prerelease;
         let r = select_release(releases, &entry(None, None)).unwrap();
         assert_eq!(r.version, Version::new(1, 0, 0));
     }


### PR DESCRIPTION
The Release struct previously used two booleans (draft, prerelease) to represent three mutually exclusive release states. A release cannot be both draft and prerelease, but the type permitted that impossible combination.

Replace with a ReleaseKind enum (Published, Draft, Prerelease) so the invalid state is unrepresentable at the type level.