### PR TITLE
Document ReleaseKind's flag collapse and cover the GitHub mapping

### DIFF
--- a/super-stt-forge/src/github.rs
+++ b/super-stt-forge/src/github.rs
@@ -39,6 +39,9 @@ struct GhAsset {
 
 impl From<GhRelease> for Release {
     fn from(r: GhRelease) -> Self {
+        // GitHub's two flags are independent and a release may set both, so
+        // `draft` is checked first: an unpublished release is unusable no
+        // matter how it would be labelled once published.
         let kind = if r.draft {
             ReleaseKind::Draft
         } else if r.prerelease {
@@ -180,12 +183,46 @@ mod tests {
         assert_eq!(
             r.kind,
             ReleaseKind::Published,
-            "default release is published"
+            "draft/prerelease default to false when omitted, so the release is published"
         );
         assert_eq!(r.assets.len(), 1);
         assert_eq!(r.assets[0].name, "a.tar.gz");
         assert_eq!(r.assets[0].download_url, "https://dl/a");
         assert_eq!(r.assets[0].size, 7);
+    }
+
+    /// Fetch `/releases/latest` from a stubbed body and return the mapped kind.
+    async fn kind_of(body: &str) -> ReleaseKind {
+        crate::install_crypto_provider();
+        let mut s = mockito::Server::new_async().await;
+        s.mock("GET", "/repos/x/y/releases/latest")
+            .with_status(200)
+            .with_body(body)
+            .create_async()
+            .await;
+        let gh = Github::new(s.url(), None);
+        let repo = RepoRef::parse("github.com/x/y").unwrap();
+        gh.latest_release(&repo).await.unwrap().kind
+    }
+
+    #[tokio::test]
+    async fn draft_flag_maps_to_draft() {
+        let kind = kind_of(r#"{"tag_name":"v1.0.0","draft":true}"#).await;
+        assert_eq!(kind, ReleaseKind::Draft);
+    }
+
+    #[tokio::test]
+    async fn prerelease_flag_maps_to_prerelease() {
+        let kind = kind_of(r#"{"tag_name":"v1.0.0","prerelease":true}"#).await;
+        assert_eq!(kind, ReleaseKind::Prerelease);
+    }
+
+    #[tokio::test]
+    async fn draft_wins_over_prerelease() {
+        // GitHub's two flags are independent, so a draft pre-release is a real
+        // state. Pin the precedence rather than leaving it to chance.
+        let kind = kind_of(r#"{"tag_name":"v1.0.0","draft":true,"prerelease":true}"#).await;
+        assert_eq!(kind, ReleaseKind::Draft);
     }
 
     #[tokio::test]

--- a/super-stt-forge/src/lib.rs
+++ b/super-stt-forge/src/lib.rs
@@ -61,15 +61,24 @@ impl RepoRef {
     }
 }
 
-/// Whether a forge release is a published release, an unpublished draft, or a
-/// pre-release. These three states are mutually exclusive on every forge.
+/// How a release should be treated when selecting an installable version.
+///
+/// A forge does not necessarily model this as a single field. GitHub exposes
+/// two independent booleans — `draft` (unpublished) and `prerelease` (not a
+/// full release) — and a release may set both. Adapters collapse whatever
+/// their host reports onto this enum, with `Draft` taking precedence, so a
+/// draft pre-release maps to [`ReleaseKind::Draft`].
+///
+/// Only [`ReleaseKind::Published`] is installable, so that collapse loses
+/// nothing that release selection depends on. A caller needing a host's exact
+/// flags must read them from that adapter's own response type instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReleaseKind {
-    /// A stable, published release.
+    /// A full, published release — the only kind eligible for selection.
     Published,
-    /// An unpublished draft.
+    /// An unpublished draft, whether or not it is also flagged a pre-release.
     Draft,
-    /// A pre-release (e.g. GitHub's `prerelease` flag).
+    /// A published pre-release.
     Prerelease,
 }
 
@@ -79,6 +88,14 @@ pub struct Release {
     pub tag: String,
     pub kind: ReleaseKind,
     pub assets: Vec<ReleaseAsset>,
+}
+
+impl Release {
+    /// Whether this release is eligible for selection and install.
+    #[must_use]
+    pub fn is_published(&self) -> bool {
+        matches!(self.kind, ReleaseKind::Published)
+    }
 }
 
 /// A forge-neutral release asset. `download_url` is a plain HTTPS URL.

--- a/super-stt-indexer/src/resolve.rs
+++ b/super-stt-indexer/src/resolve.rs
@@ -4,7 +4,7 @@
 use semver::Version;
 use thiserror::Error;
 
-use super_stt_forge::{ForgeClient, Release, ReleaseKind, RepoRef};
+use super_stt_forge::{ForgeClient, Release, RepoRef};
 
 use crate::registry_toml::Entry;
 
@@ -50,7 +50,7 @@ fn select_release(releases: Vec<Release>, entry: &Entry) -> Result<Resolved, Rel
 
     let mut best: Option<(Version, Release)> = None;
     for r in releases {
-        if r.kind != ReleaseKind::Published {
+        if !r.is_published() {
             continue;
         }
         let stripped = match &entry.tag_prefix {
@@ -165,6 +165,14 @@ mod tests {
     fn skips_prerelease() {
         let mut releases = vec![rel("v1.0.0"), rel("v2.0.0")];
         releases[1].kind = ReleaseKind::Prerelease;
+        let r = select_release(releases, &entry(None, None)).unwrap();
+        assert_eq!(r.version, Version::new(1, 0, 0));
+    }
+
+    #[test]
+    fn skips_draft() {
+        let mut releases = vec![rel("v1.0.0"), rel("v2.0.0")];
+        releases[1].kind = ReleaseKind::Draft;
         let r = select_release(releases, &entry(None, None)).unwrap();
         assert_eq!(r.version, Version::new(1, 0, 0));
     }


### PR DESCRIPTION
Follow-up to #331, addressing the review feedback there. No behavior change — docs, tests, and one helper.

## The doc was wrong

`ReleaseKind`'s doc comment claimed:

> These three states are mutually exclusive on every forge.

They aren't. GitHub's `draft` and `prerelease` are independent booleans on orthogonal axes — publication status vs. release maturity — and a release may set both:

> `draft`: true to create a draft (unpublished) release, false to create a published one.
> `prerelease`: true to identify the release as a prerelease, false to identify the release as a full release.

The adapter collapses them with `draft` winning, which is the right call, but that was an undocumented accident rather than a stated rule. This documents the collapse, why `draft` takes precedence, and that the loss is confined to information release selection doesn't use — so a future caller that needs GitHub's exact flags knows to go to the adapter's own response type rather than assuming `ReleaseKind` is lossless.

## Tests

The mapping had three branches and only `Published` was covered. Adds adapter tests for each combination, including `draft:true, prerelease:true` → `Draft`, which pins the precedence so it can't silently flip. Also adds the `skips_draft` case in `resolve.rs`, which only had `skips_prerelease`.

These are characterization tests — they pass against the current code. The point is that the precedence is now pinned rather than incidental.

## Helper

`select_release`'s filter moves behind `Release::is_published()`, so the definition of "installable" lives in one place instead of as an inline `!=` at the call site.

## Verification

- `cargo test -p super-stt-forge -p super-stt-indexer --all-features` → 60 passed, 0 failed (was 56; the 4 new tests)
- `cargo fmt --all -- --check` → clean
- Clippy is clean for these crates apart from a pre-existing `useless_vec` at `super-stt-indexer/src/assets.rs:298` that also fires on `main` — newer local clippy (1.95) than CI's toolchain, untouched by this PR. Worth a separate cleanup before the next toolchain bump.
