### PR TITLE
Scope the simulator cache bypass to the enigo backend

### DIFF
--- a/super-stt-daemon/src/daemon/core.rs
+++ b/super-stt-daemon/src/daemon/core.rs
@@ -164,12 +164,13 @@ impl SuperSTTDaemon {
             self.preview_typing_enabled
                 .store(original_preview, std::sync::atomic::Ordering::Relaxed);
         }
-        // Don't cache the simulator — Wayland compositors recycle idle
-        // connections, leaving a stale enego `Con` that silently fails on
-        // the next recording. Creating a fresh connection per-recording is
-        // cheap and avoids stale-pipe issues.
-        drop(typer.take_simulator());
-        *self.simulator.write().await = None;
+        // Return the simulator to the cache for reuse, unless this backend
+        // goes stale while idle (see `Simulator::is_cacheable`) — in which
+        // case it is dropped here and the next recording builds a fresh one.
+        let simulator = typer.take_simulator();
+        if simulator.is_cacheable() {
+            *self.simulator.write().await = Some(simulator);
+        }
         response
     }
 }

--- a/super-stt-daemon/src/daemon/types.rs
+++ b/super-stt-daemon/src/daemon/types.rs
@@ -79,7 +79,8 @@ pub struct SuperSTTDaemon {
     pub preview_typing_enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
     // Sender used to signal a running recording to stop early (shortcut or external stop)
     pub manual_stop_tx: Arc<tokio::sync::RwLock<Option<tokio::sync::broadcast::Sender<()>>>>,
-    // Cached keyboard simulator (session persists across recordings)
+    // Cached keyboard simulator (session persists across recordings, except
+    // for backends that go stale while idle — see `Simulator::is_cacheable`)
     pub simulator: Arc<tokio::sync::RwLock<Option<crate::output::keyboard::Simulator>>>,
     // Streams preview text to the one waiting `/transcribe` client. See
     // [`PreviewSlot`]: the id closes the busy-check TOCTOU that let a losing

--- a/super-stt-daemon/src/output/keyboard/mod.rs
+++ b/super-stt-daemon/src/output/keyboard/mod.rs
@@ -80,6 +80,19 @@ impl Simulator {
         Ok(Self::WaylandProtocol(Box::new(EnigoBackend::new()?)))
     }
 
+    /// Whether this backend may be held across recordings.
+    ///
+    /// Everything except enigo is cached. Rebuilding the portal session costs
+    /// three D-Bus round-trips before capture can start and may prompt the
+    /// user for authorization each time, so paying it per recording is not an
+    /// option. enigo is the exception: Wayland compositors recycle idle
+    /// connections, leaving a stale `Con` that fails silently on the next
+    /// recording, and recreating it is cheap.
+    #[must_use]
+    pub fn is_cacheable(&self) -> bool {
+        !matches!(self, Self::WaylandProtocol(_))
+    }
+
     /// Human-readable name for logging.
     #[must_use]
     pub fn name(&self) -> &'static str {
@@ -170,5 +183,16 @@ mod tests {
         assert_eq!(*buf.lock().unwrap(), "hello w");
 
         assert_eq!(sim.name(), "capture (test)");
+    }
+
+    /// Caching is the default; only enigo opts out. A regression that inverts
+    /// this rebuilds the portal session before every recording, costing three
+    /// D-Bus round-trips and possibly an authorization prompt. enigo itself
+    /// needs a live compositor to construct, so this pins the side of the rule
+    /// that is reachable in a test.
+    #[test]
+    fn backends_are_cached_by_default() {
+        let (sim, _buf) = Simulator::capture();
+        assert!(sim.is_cacheable());
     }
 }


### PR DESCRIPTION
Follow-up to #332. Keeps that fix for #328 but scopes it to the backend that actually goes stale.

## The problem

#332 stopped returning the `Simulator` to `self.simulator` after every recording. The stale-`Con` problem it targets is enigo/Wayland-specific, but the change applied to all three backends — and under the default write method, enigo is not the one being used.

`WriteMethod::default()` is `Auto`, and `Simulator::auto()` tries the portal first (`keyboard/mod.rs:64-71`). So on a default install every recording now runs `XdgPortalBackend::new()` → `CreateSession` → `SelectDevices` → `Start`. Three D-Bus round-trips, each awaiting a `Response` signal, all of it before `handle_record_internal` opens the mic (`core.rs:140` runs before `core.rs:158`). For a push-to-talk tool that's clipped first words.

Worse, `Start` carries this comment in-tree:

```rust
// Step 3: Start (may show authorization dialog)
```

with a 30s timeout and an empty options map — no `persist_mode` or `restore_token` is requested. On portal implementations that prompt for RemoteDesktop, that's an authorization dialog per recording.

It's also paid when `write_mode` is false, where the simulator is never used. That's pre-existing, but caching used to hide it and #332 started billing it every time.

## The change

Cache everything except enigo, behind a named predicate so the rule is greppable rather than an inline `matches!`:

```rust
let simulator = typer.take_simulator();
if simulator.is_cacheable() {
    *self.simulator.write().await = Some(simulator);
}
```

This also un-breaks some state that #332 left dead. With nothing ever writing `Some` back, `guard.take()` always yielded `None`, so the `Some(s)` branch at `core.rs:133` was unreachable, the "invalidate the cached simulator" handler at `settings_handlers.rs:102` was a no-op, and the comments at `types.rs:82` and `typer.rs:196` were false. Restoring caching makes all of them live again. `types.rs:82` is updated to note the exception.

Also fixes the `enego` → `enigo` typo, by way of rewriting that comment.

## What this does not address

The root cause is still unconfirmed. #328's analysis is attributed to an LLM, and the report is of *silent* failure — but `type_text` errors are logged at error level in most paths. Note `typer.rs:247` swallows a `type_text` error in the preview-diff path (`let _ = ...`), alongside the `backspace_n` at `:244`. So the symptom is also consistent with a preview-path fault rather than a stale connection.

If that turns out to be the real cause, the better shape is failure-driven invalidation — drop and rebuild once on `Err` from `type_text` — which fixes it regardless of cause and also covers a dead portal session. That's a larger change and worth doing on a confirmed diagnosis rather than a guess. This PR restores the fast path in the meantime without giving up the #328 fix.

## Verification

- `cargo test -p super-stt-daemon --lib --all-features` → 269 passed, 0 failed, 1 ignored
- `cargo fmt --all -- --check` → clean
- Clippy: no new lints in the touched files. `keyboard/mod.rs` reports two pre-existing `missing_panics_doc` hits on `type_text`/`backspace_n` that are identical on `main` (newer local clippy 1.95 than CI's toolchain), untouched here.

The new test only pins the default-cache side of the rule — enigo needs a live compositor to construct, so the exclusion itself isn't reachable from a test. It does catch an inversion of the predicate, which is the regression that would hurt.
