### PR TITLE
Fix useless_vec in the indexer unpack-budget test

### DIFF
--- a/super-stt-indexer/src/assets.rs
+++ b/super-stt-indexer/src/assets.rs
@@ -295,7 +295,7 @@ mod tests {
         // with a deliberately tiny `total_cap` so the check trips on a small
         // archive — no need to materialize gigabytes.
         let bytes = make_tarball(|tb| {
-            let body = vec![0u8; 200];
+            let body = [0u8; 200];
             let mut h = tar::Header::new_gnu();
             h.set_size(body.len() as u64);
             h.set_mode(0o755);


### PR DESCRIPTION
`super-stt-indexer/src/assets.rs:298` builds a fixed-size fixture buffer with `vec![0u8; 200]`. Clippy 1.95 flags that as `useless_vec`; an array works identically here since the buffer is only read via `body.len()` and `&body[..]`.

Doesn't fire on CI's currently-pinned toolchain, so this is pre-emptive — it would have broken the `Clippy` job at the next toolchain bump.

## Verification

- `cargo clippy --all-features -p super-stt-indexer --all-targets -- -W clippy::pedantic -D warnings -D unused_must_use` → clean (was 1 error)
- `cargo test -p super-stt-indexer --all-features` → 47 passed, 0 failed, including `rejects_output_over_the_unpack_budget_at_publish` which owns this fixture
- `cargo fmt --all -- --check` → clean

## Scope note

This clears `super-stt-indexer` but not the workspace. A full scan on clippy 1.95 (`--workspace --all-targets`, warnings not denied so nothing aborts early) reports **~110 lints across ~30 files**. Rough shape:

| Area | Notable |
|---|---|
| `super-stt-daemon/tests/http_smoke_*.rs` | `zombie_processes` (~12 files), `unreadable_literal` on `Duration` |
| `super-stt-daemon/src/audio/beeper.rs` | 4× `assertions_on_constants`, 5× `float_cmp` |
| `super-stt-shared/src/audio/analysis.rs` | 5× `float_cmp`, 2× `cast_precision_loss` |
| `super-stt-shared/src/models/theme.rs` | 2× `manual_range_contains`, `uninlined_format_args` |
| various | `doc_markdown` (~15), `items_after_test_module`, `too_many_lines` |

Most are mechanical, but a few want a judgment call rather than a rewrite — the `float_cmp` hits in the audio tests are comparing known-exact values on purpose and probably want a scoped `#[allow]` with a reason, not restructuring. Worth doing as its own pass before the toolchain moves, rather than folding into this one.
