### PR TITLE
feat(daemon): authorize user-set base_url host for wasm backend egress

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -155,6 +155,25 @@ default     = 30
 | `default`     | matches `type` | no       | Value used when the user sets none.                    |
 | `required`    | bool           | no       | Whether a value must be set before the backend can load. Default `false`. |
 
+#### `base_url` and egress
+
+An option named `base_url` is the convention for a backend's configurable
+endpoint. When the user sets one, the daemon treats its host as
+**user-authorized egress** for the backend: it is added to the WASM transport's
+`allowed_hosts` at model-load time *and* exempt from the SSRF resolver guard
+(see [wasm.md — Network egress](./wasm.md#network-egress)). This lets a cloud
+backend be pointed at an arbitrary gateway — public, local, or on a private
+network — without re-installing the backend. The host is derived from the
+effective value (config override → manifest default) and must be in origin
+form (`host` or `host:port`, scheme optional); a value carrying a path is
+treated as its bare host.
+
+The exemption is safe because options are **user-writable only**: the daemon
+reads them from config set through the settings-scoped API, never from the
+(untrusted) backend, so a component cannot self-authorize a metadata endpoint
+or localhost target. Manifest-declared `[network].allowed_hosts` entries remain
+SSRF-guarded.
+
 Both secrets and options reach the backend the same way — injected request
 headers on every `/v1` request — and differ only in how the daemon stores
 them at rest. See [request headers](./contract.md#request-headers).

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -407,7 +407,12 @@ reach:
   `wasi:http/outgoing-handler`, validated against the `allowed_hosts` in its
   configuration; raw sockets are not granted. A subprocess backend runs with no
   network at all. See [wasm.md](./wasm.md) and
-  [subprocess.md](./subprocess.md).
+  [subprocess.md](./subprocess.md). One deliberate exception: a host the *user*
+  sets in a backend's `base_url` option is added to that backend's egress and
+  exempted from the SSRF guard, so a user can point a cloud backend at a local
+  or private gateway. Options are user-writable only, so a backend cannot
+  self-authorize this; see
+  [config.md — `base_url` and egress](./config.md#base_url-and-egress).
 - **Filesystem.** A subprocess backend is confined to its own directory; a
   WASM backend has no ambient filesystem access.
 - **Secrets and options.** A backend declares the API keys (secrets) and

--- a/docs/protocol/backend/wasm.md
+++ b/docs/protocol/backend/wasm.md
@@ -47,6 +47,16 @@ which the daemon implements. The daemon enforces the configuration's
 
 A backend with an empty `allowed_hosts` has no network at all.
 
+**User-authorized egress (`base_url`).** A backend that declares an option
+named `base_url` (see [config.md — `base_url` and egress](./config.md#base_url-and-egress))
+lets the user point it at an arbitrary gateway. At model-load time the daemon
+adds the effective `base_url`'s host to the backend's egress set **and** exempts
+that host from the SSRF guard — so a user-set gateway may be on localhost or a
+private network. Only hosts the *user* configured through the settings-scoped
+API get this exception: options are never writable by the component, so a
+malicious backend still cannot self-authorize the metadata endpoint or a
+localhost service. Manifest `allowed_hosts` entries remain SSRF-guarded.
+
 ## Secrets and options
 
 The active model (`x-stt-model`) and the secrets and options a backend

--- a/docs/protocol/endpoints/v1/backends.md
+++ b/docs/protocol/endpoints/v1/backends.md
@@ -135,6 +135,12 @@ For both, `POST` sets a value and `DELETE` resets it to its default — the
 manifest default for an option, the unset state for a secret. `GET` on a secret
 reports only whether it is configured; `GET` on an option returns its value.
 
+Setting an option named `base_url` additionally authorizes that host for the
+backend's network egress (with an SSRF exception) on its next model load — see
+[config.md — `base_url` and egress](../../../backend/config.md#base_url-and-egress).
+This is how a cloud backend is pointed at an alternate endpoint (a gateway,
+proxy, or local OpenAI-compatible server) without re-installing it.
+
 ## DELETE /backends/{source}
 
 Uninstalls a backend. Works for any installed backend — registry-installed,

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -59,9 +59,13 @@ impl SuperSTTDaemon {
             crate::stt_models::backends::manifest::Manifest::load(&backend.dir)?
                 .capabilities
                 .websocket;
+        // Egress = the manifest-pinned `allowed_hosts` (SSRF-guarded) plus any
+        // host the user authorized via the `base_url` option (SSRF exception).
+        let user_allowed_hosts = self.base_url_egress_hosts(backend).await;
         let inst = crate::stt_models::wasm::WasmBackend::with_info(
             &component,
             backend.allowed_hosts.clone(),
+            user_allowed_hosts,
             info,
             headers,
             websocket_capability,
@@ -199,16 +203,168 @@ impl SuperSTTDaemon {
                 None => {}
             }
         }
-        let config = self.config.read().await;
         for opt in &backend.options {
-            let value = config
-                .backend_option(&backend.source, &opt.name)
-                .map(str::to_string)
-                .or_else(|| opt.default.as_ref().map(ToString::to_string));
-            if let Some(v) = value {
+            if let Some(v) = self.resolved_backend_option(backend, opt).await {
                 headers.push((format!("x-stt-option-{}", opt.name), v));
             }
         }
         Ok(headers)
+    }
+
+    /// The effective value of a backend option: the user's config override if
+    /// set, else the manifest default. The single source of truth for option
+    /// resolution — shared by header injection ([`Self::backend_headers`]) and
+    /// egress allowlist derivation ([`Self::base_url_egress_hosts`]).
+    #[cfg(feature = "wasm-backends")]
+    async fn resolved_backend_option(
+        &self,
+        backend: &DiscoveredBackend,
+        opt: &backends::manifest::Opt,
+    ) -> Option<String> {
+        self.config
+            .read()
+            .await
+            .backend_option(&backend.source, &opt.name)
+            .map(str::to_string)
+            .or_else(|| opt.default.as_ref().map(ToString::to_string))
+    }
+
+    /// Hosts the *user* authorized via a `base_url` option, derived from its
+    /// effective value (config override → manifest default).
+    ///
+    /// `base_url` is the documented convention for a backend's configurable
+    /// endpoint (`docs/protocol/backend/config.md`); any backend declaring an
+    /// option with that name gets the SSRF exception for its host. A backend
+    /// cannot self-authorize these — options are set by the user only — so the
+    /// host is exempt from the egress SSRF guard (it may be loopback/private,
+    /// e.g. a local gateway). Unparseable or unset values contribute nothing.
+    #[cfg(feature = "wasm-backends")]
+    async fn base_url_egress_hosts(&self, backend: &DiscoveredBackend) -> Vec<String> {
+        let Some(opt) = backend.options.iter().find(|o| o.name == "base_url") else {
+            return Vec::new();
+        };
+        let Some(value) = self.resolved_backend_option(backend, opt).await else {
+            return Vec::new();
+        };
+        base_url_host(&value).into_iter().collect()
+    }
+}
+
+/// Extract the bare host (or `host[:port]`) from a base URL, mirroring the
+/// origin-form assumption the OpenAI-style WASM backends make: `base_url` is a
+/// scheme + authority, not a full-path URL. A bare host (no scheme) is treated
+/// as a host. Returns `None` when nothing parseable remains.
+#[cfg(feature = "wasm-backends")]
+fn base_url_host(base_url: &str) -> Option<String> {
+    let rest = base_url
+        .strip_prefix("https://")
+        .or_else(|| base_url.strip_prefix("http://"))
+        .unwrap_or(base_url);
+    let rest = rest.trim_end_matches('/');
+    let host = match rest.find('/') {
+        Some(i) => &rest[..i],
+        None => rest,
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.to_string())
+}
+
+#[cfg(all(test, feature = "wasm-backends"))]
+mod tests {
+    use super::base_url_host;
+
+    #[test]
+    fn base_url_host_extracts_authority() {
+        assert_eq!(
+            base_url_host("https://api.openai.com"),
+            Some("api.openai.com".to_string())
+        );
+        assert_eq!(
+            base_url_host("https://api.openai.com/"),
+            Some("api.openai.com".to_string())
+        );
+        assert_eq!(
+            base_url_host("http://gw.example.com:8080"),
+            Some("gw.example.com:8080".to_string())
+        );
+        // A bare host (no scheme) is treated as a host.
+        assert_eq!(
+            base_url_host("gw.example.com"),
+            Some("gw.example.com".to_string())
+        );
+        // Any path after the authority is dropped — the backends assume origin form.
+        assert_eq!(
+            base_url_host("https://gw.example.com/v1/audio"),
+            Some("gw.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn base_url_host_rejects_unparseable() {
+        assert_eq!(base_url_host(""), None);
+        assert_eq!(base_url_host("https://"), None);
+        assert_eq!(base_url_host("/"), None);
+        assert_eq!(base_url_host("https:///path"), None);
+    }
+
+    /// The user-set `base_url` option's host feeds the egress allowlist:
+    /// manifest default when unset, the override (port included) when set, and
+    /// nothing for a backend that declares no such option.
+    #[tokio::test]
+    async fn base_url_egress_hosts_resolves_override_or_default() {
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+        use crate::stt_models::backends::manifest::{Opt, OptionDefault, OptionType};
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        let backend = DiscoveredBackend {
+            dir: std::path::PathBuf::from("/tmp/openai"),
+            source: source.to_string(),
+            name: "OpenAI".to_string(),
+            kind: "wasm".to_string(),
+            entrypoint: "openai.wasm".to_string(),
+            allowed_hosts: vec!["api.openai.com".to_string()],
+            secrets: vec![],
+            options: vec![Opt {
+                name: "base_url".to_string(),
+                label: Some("API base URL".to_string()),
+                description: "Base URL".to_string(),
+                r#type: Some(OptionType::String),
+                default: Some(OptionDefault::String("https://api.openai.com".to_string())),
+                required: false,
+            }],
+            models: vec![],
+        };
+
+        // No override → the manifest default's host.
+        assert_eq!(
+            daemon.base_url_egress_hosts(&backend).await,
+            vec!["api.openai.com"]
+        );
+
+        // Config override pointing at a local gateway → that host, port kept.
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert("base_url".to_string(), "http://localhost:8080".to_string());
+        assert_eq!(
+            daemon.base_url_egress_hosts(&backend).await,
+            vec!["localhost:8080"]
+        );
+
+        // A backend declaring no `base_url` option contributes nothing.
+        let no_base = DiscoveredBackend {
+            options: vec![],
+            ..backend
+        };
+        assert!(daemon.base_url_egress_hosts(&no_base).await.is_empty());
     }
 }

--- a/super-stt-daemon/src/stt_models/wasm/host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/host.rs
@@ -46,7 +46,17 @@ impl WasiHttpView for Host {
 /// implements here — so a request to a host outside the allowlist never
 /// leaves the machine.
 pub struct AllowlistHooks {
+    /// Hosts pinned by the backend's own (unreviewed) `[network].allowed_hosts`
+    /// manifest. These are SSRF-guarded: a manifest entry does **not** authorize
+    /// loopback/private/link-local/metadata destinations, because the backend
+    /// author is not a trusted operator.
     pub allowed_hosts: Vec<String>,
+    /// Hosts the *user* authorized through backend options (e.g. a `base_url`
+    /// set in the settings UI). These are exempt from the SSRF guard — the
+    /// component cannot self-authorize them (options are user-writable only), so
+    /// user intent to reach a local/private gateway is honored. Anything not in
+    /// this set keeps the full allowlist + SSRF enforcement.
+    pub user_allowed_hosts: Vec<String>,
     /// Permit egress to loopback addresses (`127.0.0.0/8`, `::1`). Off in
     /// production — the SSRF guard blocks loopback so an untrusted backend
     /// can't reach a service bound to localhost. Tests and local development
@@ -87,8 +97,13 @@ impl WasiHttpHooks for AllowlistHooks {
                 } else {
                     443
                 });
-        if let Err(msg) = check_host_allowed(&self.allowed_hosts, &host, port, self.allow_loopback)
-        {
+        if let Err(msg) = check_host_allowed(
+            &self.allowed_hosts,
+            &self.user_allowed_hosts,
+            &host,
+            port,
+            self.allow_loopback,
+        ) {
             return Err(ErrorCode::InternalError(Some(msg)).into());
         }
 
@@ -96,31 +111,45 @@ impl WasiHttpHooks for AllowlistHooks {
     }
 }
 
-/// Confines an outbound connection to the backend's `allowed_hosts` and runs
-/// the SSRF resolver guard. Shared by the HTTP hook and the `ws` host so both
-/// transports enforce identical egress rules.
+/// Confines an outbound connection to the backend's `allowed_hosts` — plus any
+/// `user_allowed` hosts — and runs the SSRF resolver guard. Shared by the HTTP
+/// hook and the `ws` host so both transports enforce identical egress rules.
 ///
 /// `host` is the bare hostname or IP literal; `port` is the resolved port.
 /// `allowed` entries may be either a bare host or a `host:port` authority.
+/// Entries in `user_allowed` may too, but a match there skips the SSRF guard
+/// (see [`AllowlistHooks::user_allowed_hosts`]).
 ///
 /// # Errors
-/// Returns a human-readable reason when the host is not on the allowlist or a
-/// hostname resolves to a loopback/private/link-local/unspecified address.
+/// Returns a human-readable reason when the host is on neither list, or when a
+/// manifest-allowlisted hostname resolves to a
+/// loopback/private/link-local/unspecified address.
 pub(crate) fn check_host_allowed(
     allowed: &[String],
+    user_allowed: &[String],
     host: &str,
     port: u16,
     allow_loopback: bool,
 ) -> Result<(), String> {
     let authority = format!("{host}:{port}");
-    let on_allowlist = allowed
+    let on_manifest = allowed
         .iter()
         .any(|a| a.as_str() == host || a.as_str() == authority);
-    if !on_allowlist {
-        return Err(format!("outbound host not allowed: {host}"));
+    if on_manifest {
+        return guard_egress_host(host, port, allow_loopback);
     }
-
-    guard_egress_host(host, port, allow_loopback)
+    // A host the *user* authorized via a backend option is exempt from the SSRF
+    // guard. Unlike manifest `allowed_hosts` — written by the untrusted backend
+    // author, who therefore cannot self-authorize a metadata/localhost target —
+    // this list is user intent: the daemon reads these from options set through
+    // the settings-scoped API, never from the component.
+    let on_user = user_allowed
+        .iter()
+        .any(|a| a.as_str() == host || a.as_str() == authority);
+    if on_user {
+        return Ok(());
+    }
+    Err(format!("outbound host not allowed: {host}"))
 }
 
 /// Reject an outbound target that points at an address a sandboxed backend must
@@ -222,19 +251,19 @@ mod tests {
     fn ip_literal_metadata_on_allowlist_is_still_rejected() {
         // A backend cannot self-authorize the metadata endpoint by listing it.
         let allow = vec!["169.254.169.254".to_string()];
-        assert!(check_host_allowed(&allow, "169.254.169.254", 80, false).is_err());
+        assert!(check_host_allowed(&allow, &[], "169.254.169.254", 80, false).is_err());
     }
 
     #[test]
     fn public_ip_literal_on_allowlist_is_permitted() {
         let allow = vec!["93.184.216.34".to_string()];
-        assert!(check_host_allowed(&allow, "93.184.216.34", 443, false).is_ok());
+        assert!(check_host_allowed(&allow, &[], "93.184.216.34", 443, false).is_ok());
     }
 
     #[test]
     fn host_not_on_allowlist_is_rejected() {
         let allow = vec!["api.example.com".to_string()];
-        assert!(check_host_allowed(&allow, "169.254.169.254", 80, false).is_err());
+        assert!(check_host_allowed(&allow, &[], "169.254.169.254", 80, false).is_err());
     }
 
     #[test]
@@ -245,18 +274,72 @@ mod tests {
         // `ws` host now route through `check_host_allowed`, so `["h:443"]` behaves
         // identically for `https://h/` and `wss://h/`. Loopback avoids real DNS.
         let allow = vec!["127.0.0.1:443".to_string()];
-        assert!(check_host_allowed(&allow, "127.0.0.1", 443, true).is_ok());
+        assert!(check_host_allowed(&allow, &[], "127.0.0.1", 443, true).is_ok());
     }
 
     #[test]
     fn loopback_blocked_by_default_opt_in_permits_only_loopback() {
         let allow = vec!["127.0.0.1:8088".to_string()];
         // Default: loopback egress is refused even when allowlisted (SSRF).
-        assert!(check_host_allowed(&allow, "127.0.0.1", 8088, false).is_err());
+        assert!(check_host_allowed(&allow, &[], "127.0.0.1", 8088, false).is_err());
         // Opt-in (tests / local mock upstream): loopback is permitted.
-        assert!(check_host_allowed(&allow, "127.0.0.1", 8088, true).is_ok());
+        assert!(check_host_allowed(&allow, &[], "127.0.0.1", 8088, true).is_ok());
         // The opt-in relaxes loopback ONLY — metadata stays blocked.
         let meta = vec!["169.254.169.254".to_string()];
-        assert!(check_host_allowed(&meta, "169.254.169.254", 80, true).is_err());
+        assert!(check_host_allowed(&meta, &[], "169.254.169.254", 80, true).is_err());
+    }
+
+    #[test]
+    fn user_allowed_loopback_passes_without_loopback_opt_in() {
+        // A host the user authorized via a backend option (e.g. a base_url set in
+        // the settings UI) is exempt from the SSRF guard — no loopback opt-in.
+        let user = vec!["127.0.0.1".to_string()];
+        assert!(check_host_allowed(&[], &user, "127.0.0.1", 8088, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_metadata_is_permitted_by_user_intent() {
+        // The SSRF exception is user intent: the component cannot self-authorize
+        // this (options are user-writable only), so a user-chosen destination is
+        // honored even for the metadata address.
+        let user = vec!["169.254.169.254".to_string()];
+        assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_private_host_is_permitted() {
+        let user = vec!["10.0.0.5".to_string()];
+        assert!(check_host_allowed(&[], &user, "10.0.0.5", 8443, false).is_ok());
+        let user6 = vec!["fd12:3456::1".to_string()];
+        assert!(check_host_allowed(&[], &user6, "fd12:3456::1", 8443, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_matches_bare_host_across_ports() {
+        // A user-authorized bare host authorizes any port (same authority
+        // matching rules as the manifest allowlist).
+        let user = vec!["gw.example.com".to_string()];
+        assert!(check_host_allowed(&[], &user, "gw.example.com", 443, false).is_ok());
+        assert!(check_host_allowed(&[], &user, "gw.example.com", 8443, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_does_not_loosen_other_hosts() {
+        // Only hosts in `user_allowed` are exempt; a different disallowed target
+        // is still refused even while a user host is present.
+        let user = vec!["gw.example.com".to_string()];
+        assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_err());
+        assert!(check_host_allowed(&[], &user, "api.openai.com", 443, false).is_err());
+    }
+
+    #[test]
+    fn manifest_host_still_ssrf_guarded_alongside_user_host() {
+        // The manifest allowlist stays SSRF-guarded even when a user host is
+        // present: loopback/private via the manifest is refused, while the user
+        // host passes.
+        let allow = vec!["10.0.0.9".to_string()];
+        let user = vec!["gw.example.com".to_string()];
+        assert!(check_host_allowed(&allow, &user, "10.0.0.9", 443, false).is_err());
+        assert!(check_host_allowed(&allow, &user, "gw.example.com", 443, false).is_ok());
     }
 }

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -44,6 +44,9 @@ pub struct WasmBackend {
     engine: Engine,
     pre: BackendPre,
     allowed_hosts: Vec<String>,
+    /// Hosts the *user* authorized via backend options (e.g. a `base_url` set in
+    /// the settings UI). Exempt from the SSRF guard — see [`AllowlistHooks`].
+    user_allowed_hosts: Vec<String>,
     allow_loopback: bool,
     transcribe_headers: Vec<(String, String)>,
     model_id: String,
@@ -58,11 +61,16 @@ impl WasmBackend {
     /// Load a component for a discovered model. The transcribe headers are the
     /// already-formed `x-stt-secret-*` / `x-stt-option-*` pairs to inject.
     ///
+    /// `allowed_hosts` are the backend's manifest-pinned `[network].allowed_hosts`
+    /// (SSRF-guarded); `user_allowed_hosts` are hosts the user authorized via
+    /// backend options (e.g. a `base_url`) and are exempt from the SSRF guard.
+    ///
     /// # Errors
     /// Returns an error if the component cannot be loaded or linked.
     pub fn with_info(
         component_path: &Path,
         allowed_hosts: Vec<String>,
+        user_allowed_hosts: Vec<String>,
         info: ModelInfoData,
         transcribe_headers: Vec<(String, String)>,
         websocket_capability: bool,
@@ -100,6 +108,7 @@ impl WasmBackend {
             engine,
             pre,
             allowed_hosts,
+            user_allowed_hosts,
             allow_loopback: false,
             transcribe_headers,
             model_id,
@@ -151,6 +160,7 @@ impl WasmBackend {
         Self::with_info(
             component_path,
             allowed_hosts,
+            Vec::new(),
             info,
             transcribe_headers,
             false,
@@ -180,6 +190,7 @@ impl WasmBackend {
         Self::with_info(
             component_path,
             allowed_hosts,
+            Vec::new(),
             info,
             transcribe_headers,
             true,
@@ -231,6 +242,7 @@ impl WasmBackend {
             http: WasiHttpCtx::new(),
             hooks: AllowlistHooks {
                 allowed_hosts: self.allowed_hosts.clone(),
+                user_allowed_hosts: self.user_allowed_hosts.clone(),
                 allow_loopback: self.allow_loopback,
             },
         };
@@ -447,6 +459,7 @@ impl Transcribe for WasmBackend {
             http: WasiHttpCtx::new(),
             hooks: AllowlistHooks {
                 allowed_hosts: self.allowed_hosts.clone(),
+                user_allowed_hosts: self.user_allowed_hosts.clone(),
                 allow_loopback: self.allow_loopback,
             },
         };

--- a/super-stt-daemon/src/stt_models/wasm/ws_host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/ws_host.rs
@@ -140,9 +140,11 @@ impl self::super_stt::realtime::ws::Host for Host {
             _ => 443,
         });
 
-        // Same egress allowlist + SSRF guard the HTTP host enforces.
+        // Same egress allowlist + SSRF guard the HTTP host enforces, including
+        // the user-authorized `base_url` exception.
         if let Err(msg) = check_host_allowed(
             &self.hooks.allowed_hosts,
+            &self.hooks.user_allowed_hosts,
             host,
             port,
             self.hooks.allow_loopback,


### PR DESCRIPTION
As we were discussing in the other PR or issue. Was able to build out the feature to allow configurable endpoints. I tested this against parakeet on localhost and whisper on a remove computer with FQDN and CPU. Both worked as expected.

We did have to mess a bit with the allowed addresses for wasm, deepseek did flag that if we add localhost then that does open up the sandbox to be able to access anything on local host.

Let me know if you think we should redesign the feature or make any changes.

This depends on: https://github.com/jorge-menjivar/super-stt-openai/pull/2
