### PR TITLE
Notify on recording failures instead of typing them

### DIFF
--- a/docs/protocol/endpoints/v1/events.md
+++ b/docs/protocol/endpoints/v1/events.md
@@ -88,7 +88,9 @@ that follows.
 
 **Lifecycle terminal and optional events:**
 - `transcribing_started` is emitted only when model decode actually begins
-  (Phase 4). If the cycle fails during audio capture it is skipped entirely.
+  (Phase 4). It is skipped entirely when the cycle fails during audio capture,
+  and when the capture contained no speech — in the latter case the cycle still
+  completes successfully, with `final_stt` carrying empty text.
 - `final_stt` is emitted only on a successful transcription (including "no
   speech detected", where `text` is empty). A failed cycle reports its error
   via `transcribing_stopped.error`; no `final_stt` is emitted.

--- a/docs/protocol/endpoints/v1/notification_method.md
+++ b/docs/protocol/endpoints/v1/notification_method.md
@@ -1,0 +1,99 @@
+# `/notification_method`
+
+Read and set how the daemon surfaces a recording failure to the user.
+
+A failure — no model loaded, the recorder could not start, capture died
+partway, or the model could not transcribe the audio — is reported to the
+caller in the response and on the `error` event regardless of this setting.
+This setting controls the additional, human-facing notice.
+
+| Method  | Notes                                                                                          |
+|---------|------------------------------------------------------------------------------------------------|
+| `auto`  | Send a desktop notification; if it cannot be delivered, type the notice instead (the default). |
+| `dbus`  | Send a desktop notification only. If it cannot be delivered, the failure is logged and nothing is shown. |
+| `typed` | Type a fixed notice into the focused window.                                                   |
+| `off`   | Log the failure only; never surface it.                                                        |
+
+Desktop notifications use the freedesktop Desktop Notifications interface
+(`org.freedesktop.Notifications`) on the session bus, so they work on any
+desktop that provides a notification server.
+
+Typing requires a `POST /transcribe` with `write_mode: true`. For a recording
+that is not in write mode, `typed` — and `auto` once notification delivery has
+failed — logs the failure instead.
+
+The new method takes effect on the next recording.
+
+## Auth
+
+- **Required scope:** `settings`.
+- `Authorization: Bearer <session_token>` is required.
+- Tokens without the `settings` scope get `403 scope_denied`.
+
+## `POST /notification_method`
+
+**Request:**
+
+```http
+POST /notification_method HTTP/1.1
+Host: stt.local
+Authorization: Bearer stt_…64hex…
+Content-Type: application/json
+
+{
+  "method": "dbus"
+}
+```
+
+| Field    | Type   | Required | Notes                                          |
+|----------|--------|----------|--------------------------------------------------|
+| `method` | string | yes      | One of `auto`, `dbus`, `typed`, `off`          |
+
+**Response (200):**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status":              "success",
+  "notification_method": "dbus"
+}
+```
+
+**Errors:**
+
+| HTTP | `message`                     | Meaning                                        |
+|------|-------------------------------|--------------------------------------------------|
+| 400  | `invalid_notification_method` | `method` wasn't one of the four known values   |
+| 401  | `invalid_session`             | Token unknown / expired / `exe_changed`        |
+| 403  | `scope_denied`                | Token lacks the `settings` scope               |
+
+## `GET /notification_method`
+
+**Request:**
+
+```http
+GET /notification_method HTTP/1.1
+Host: stt.local
+Authorization: Bearer stt_…64hex…
+```
+
+**Response (200):**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status":              "success",
+  "notification_method": "auto"
+}
+```
+
+**Errors:**
+
+| HTTP | `message`         | Meaning                                        |
+|------|-------------------|--------------------------------------------------|
+| 401  | `invalid_session` | Token unknown / expired / `exe_changed`        |
+| 403  | `scope_denied`    | Token lacks the `settings` scope               |

--- a/docs/protocol/endpoints/v1/notification_method.md
+++ b/docs/protocol/endpoints/v1/notification_method.md
@@ -4,7 +4,8 @@ Read and set how the daemon surfaces a recording failure to the user.
 
 A failure — no model loaded, the recorder could not start, capture died
 partway, or the model could not transcribe the audio — is reported to the
-caller in the response and on the `error` event regardless of this setting.
+caller regardless of this setting: as the direct error response (e.g. `409
+model_not_loaded`) or, once an SSE stream has started, via the `error` event.
 This setting controls the additional, human-facing notice.
 
 | Method  | Notes                                                                                          |

--- a/docs/protocol/endpoints/v1/transcribe.md
+++ b/docs/protocol/endpoints/v1/transcribe.md
@@ -84,7 +84,7 @@ To stop an in-flight daemon-mic capture, see
 | `event:`   | `data:` payload                       | When                                                                  |
 |------------|---------------------------------------|-----------------------------------------------------------------------|
 | `preview`  | `{ "text": "hello wor…" }`            | Streaming preview while audio keeps arriving                          |
-| `done`     | `{ "transcription": "hello world" }`  | Final transcription; stream closes after this                         |
+| `done`     | `{ "transcription": "hello world" }`  | Final transcription; stream closes after this. Empty when the captured take had no speech — that capture still completes successfully. |
 | `error`    | `{ "message": "..." }`                | Fatal error before `done`; stream closes after this                   |
 
 The daemon also writes SSE comment frames (lines starting with `:`) —
@@ -125,14 +125,17 @@ when a capture is already in progress.
 | 429  | `rate_limited`                     | Per-client rate limit hit; back off and retry                           |
 | 503  | `connection_rejected`              | Server refused the connection                                           |
 
-When the request set `write_mode: true`, a failure also types a short fixed
-notice into the focused window — for example `[Super STT: no model loaded]` —
-because a write-mode client is looking at a text field rather than at this
-response. The notice is a fixed daemon-authored string; backend-supplied error
-detail is never typed. The failure is still reported normally — as the direct
-error response (e.g. `409 model_not_loaded`, checked and answered before the
-`202`/SSE envelope for a daemon-mic capture commits) or, once an SSE stream has
-started, via the `error` event — with an empty transcription.
+A failure is also surfaced to the user according to the
+[`/notification_method`](./notification_method.md) setting. With the default,
+`auto`, the daemon sends a desktop notification; typing a short fixed notice
+into the focused window — for example `[Super STT: no model loaded]` — happens
+only as a fallback when notification delivery fails, and only for a request
+that set `write_mode: true`. The notice is a fixed daemon-authored string;
+backend-supplied error detail is never typed. The failure is still reported
+normally — as the direct error response (e.g. `409 model_not_loaded`, checked
+and answered before the `202`/SSE envelope for a daemon-mic capture commits)
+or, once an SSE stream has started, via the `error` event — with an empty
+transcription.
 
 Once an SSE response has started (`200 text/event-stream`), late
 errors arrive as an in-stream `event: error` block followed by the

--- a/docs/protocol/scopes/settings.md
+++ b/docs/protocol/scopes/settings.md
@@ -31,7 +31,7 @@ scope and asked for `daemon_status_changed` or `download_progress`.
 | Mutation                                                                                                                          | Mirrored as an SSE event?                                                                            |
 |-----------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
 | `/active_model`, `/active_backend`, `/active_device`, `/allow_online_models` (when it triggers a fallback)                       | Yes — `daemon_status_changed` (and `download_progress` while files are being pulled)                 |
-| `/audio_theme`, `/volume`, `/write_method`, `/recording_stop_mode`, `/preview_typing`, `/allow_online_models` (no fallback), `/custom_models_dir` | No. Clients that want to see *another* app change one of these must re-`GET` the relevant endpoint.  |
+| `/audio_theme`, `/volume`, `/write_method`, `/notification_method`, `/recording_stop_mode`, `/preview_typing`, `/allow_online_models` (no fallback), `/custom_models_dir` | No. Clients that want to see *another* app change one of these must re-`GET` the relevant endpoint.  |
 
 ## Endpoint reference
 
@@ -50,6 +50,7 @@ scope and asked for `daemon_status_changed` or `download_progress`.
 | [`/recording_stop_mode`](../endpoints/v1/recording_stop_mode.md) | POST, GET | Default stop behavior for `/transcribe` (silence_only / silence_and_manual / manual_only)                  |
 | [`/preview_typing`](../endpoints/v1/preview_typing.md)      | POST, GET  | Toggle live typing of preview text while recording                                                    |
 | [`/write_method`](../endpoints/v1/write_method.md)          | POST, GET  | Keyboard simulation method (auto / xdg_desktop_portal / ydotool / wayland_protocol)                   |
+| [`/notification_method`](../endpoints/v1/notification_method.md) | POST, GET  | How recording failures are surfaced (auto / dbus / typed / off)                                       |
 | [`/allow_online_models`](../endpoints/v1/allow_online_models.md) | POST, GET | Privacy gate for online providers (OpenAI / Mistral / Deepgram)                                       |
 | [`/custom_models_dir`](../endpoints/v1/custom_models_dir.md) | POST, GET | Where to scan for user-supplied models                                                                |
 | [`/backends`](../endpoints/v1/backends.md)                  | GET, DELETE | List installed backends; uninstall a backend                                                  |

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::AppModel;
-use crate::daemon::client::{set_preview_typing, set_recording_stop_mode, set_write_method};
+use crate::daemon::client::{
+    set_notification_method, set_preview_typing, set_recording_stop_mode, set_write_method,
+};
 use crate::ui::messages::{
-    Message, PreviewTypingMessage, RecordingStopModeMessage, WriteMethodMessage,
+    Message, NotificationMethodMessage, PreviewTypingMessage, RecordingStopModeMessage,
+    WriteMethodMessage,
 };
 use cosmic::prelude::*;
 
@@ -121,6 +124,46 @@ impl AppModel {
                 self.set_action_error(
                     crate::state::ErrorScope::InputSimulation,
                     format!("Couldn't save write method: {err}"),
+                );
+                Task::none()
+            }
+        }
+    }
+
+    /// Handle notification method messages
+    pub(in crate::core::app) fn handle_notification_method_messages(
+        &mut self,
+        message: NotificationMethodMessage,
+    ) -> Task<cosmic::Action<Message>> {
+        match message {
+            // Confirm-then-apply, as with the write method: apply only on the
+            // daemon ack so a failed save doesn't strand an optimistic value.
+            NotificationMethodMessage::Changed(method) => {
+                let method_str = method.to_string();
+                Task::perform(
+                    set_notification_method(method_str),
+                    move |result| match result {
+                        Ok(()) => cosmic::Action::App(Message::NotificationMethod(
+                            NotificationMethodMessage::Loaded(method),
+                        )),
+                        Err(e) => cosmic::Action::App(Message::NotificationMethod(
+                            NotificationMethodMessage::Error(e.to_string()),
+                        )),
+                    },
+                )
+            }
+
+            NotificationMethodMessage::Loaded(method) => {
+                self.notification_method = method;
+                self.clear_action_error(crate::state::ErrorScope::Recording);
+                Task::none()
+            }
+
+            NotificationMethodMessage::Error(err) => {
+                log::warn!("Notification method error: {err}");
+                self.set_action_error(
+                    crate::state::ErrorScope::Recording,
+                    format!("Couldn't save notification method: {err}"),
                 );
                 Task::none()
             }

--- a/super-stt-app/src/core/app/handlers/tasks.rs
+++ b/super-stt-app/src/core/app/handlers/tasks.rs
@@ -4,13 +4,13 @@
 //! result-to-`Message` mapping isn't re-rolled at each call site.
 
 use crate::daemon::client::{
-    get_current_audio_theme, get_custom_models_dir, get_preview_typing, get_recording_stop_mode,
-    get_volume, get_write_method, list_backends, ping_daemon,
+    get_current_audio_theme, get_custom_models_dir, get_notification_method, get_preview_typing,
+    get_recording_stop_mode, get_volume, get_write_method, list_backends, ping_daemon,
 };
 use crate::state::AudioTheme;
 use crate::ui::messages::{
-    BackendMessage, DaemonMessage, Message, ModelsPageMessage, PreviewTypingMessage,
-    RecordingStopModeMessage, WriteMethodMessage,
+    BackendMessage, DaemonMessage, Message, ModelsPageMessage, NotificationMethodMessage,
+    PreviewTypingMessage, RecordingStopModeMessage, WriteMethodMessage,
 };
 use cosmic::prelude::*;
 use log::warn;
@@ -133,6 +133,23 @@ pub(in crate::core::app) fn build_load_settings_tasks() -> Task<cosmic::Action<M
                     cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Loaded(
                         WriteMethod::default(),
                     )))
+                }
+            }
+        }),
+        Task::perform(get_notification_method(), |result| {
+            use super_stt_shared::models::notification_method::NotificationMethod;
+            match result {
+                Ok(method_str) => {
+                    let method = method_str.parse::<NotificationMethod>().unwrap_or_default();
+                    cosmic::Action::App(Message::NotificationMethod(
+                        NotificationMethodMessage::Loaded(method),
+                    ))
+                }
+                Err(e) => {
+                    warn!("Failed to load notification method: {e}");
+                    cosmic::Action::App(Message::NotificationMethod(
+                        NotificationMethodMessage::Loaded(NotificationMethod::default()),
+                    ))
                 }
             }
         }),

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -127,6 +127,8 @@ impl AppModel {
             recording_stop_mode:
                 super_stt_shared::models::recording_stop_mode::RecordingStopMode::default(),
             write_method: super_stt_shared::models::write_method::WriteMethod::default(),
+            notification_method:
+                super_stt_shared::models::notification_method::NotificationMethod::default(),
             volume: 100,
             last_committed_volume: 100,
 

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -131,6 +131,9 @@ pub struct AppModel {
     // Write method
     pub write_method: super_stt_shared::models::write_method::WriteMethod,
 
+    // Notification method
+    pub notification_method: super_stt_shared::models::notification_method::NotificationMethod,
+
     // Master volume (0-100)
     pub volume: u8,
     /// Last value successfully committed to (or loaded from) the daemon. The

--- a/super-stt-app/src/core/app/update.rs
+++ b/super-stt-app/src/core/app/update.rs
@@ -24,6 +24,7 @@ impl AppModel {
             Message::PreviewTyping(m) => self.handle_preview_typing_messages(m),
             Message::RecordingStopMode(m) => self.handle_recording_stop_mode_messages(m),
             Message::WriteMethod(m) => self.handle_write_method_messages(m),
+            Message::NotificationMethod(m) => self.handle_notification_method_messages(m),
             Message::Backend(m) => self.handle_backend_messages(m),
             Message::Language(m) => self.handle_language_messages(m),
             Message::Recording(m) => self.handle_recording_messages(m),

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -162,6 +162,7 @@ impl AppModel {
             Page::Recording => views::recording::page(
                 self.recording_stop_mode,
                 self.preview_typing_enabled,
+                self.notification_method,
                 &self.recording_status,
                 &self.transcription_text,
                 self.audio_level,

--- a/super-stt-app/src/daemon/client/mod.rs
+++ b/super-stt-app/src/daemon/client/mod.rs
@@ -29,6 +29,7 @@ pub use v1::settings::backends::{
     set_active_backend, set_backend_option,
 };
 pub use v1::settings::custom_models_dir::get_custom_models_dir;
+pub use v1::settings::notification_method::{get_notification_method, set_notification_method};
 pub use v1::settings::preview_typing::{get_preview_typing, set_preview_typing};
 pub use v1::settings::recording_stop_mode::{get_recording_stop_mode, set_recording_stop_mode};
 pub use v1::settings::volume::{get_volume, set_volume};

--- a/super-stt-app/src/daemon/client/v1/settings/mod.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/mod.rs
@@ -65,6 +65,7 @@ pub(crate) mod backend_secrets;
 pub(crate) mod backends;
 pub(crate) mod custom_models_dir;
 pub(crate) mod language;
+pub(crate) mod notification_method;
 pub(crate) mod preview_typing;
 pub(crate) mod recording_stop_mode;
 pub(crate) mod volume;

--- a/super-stt-app/src/daemon/client/v1/settings/notification_method.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/notification_method.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! `/notification_method` — how recording failures are surfaced (auto, dbus,
+//! typed, off).
+settings_getter!(
+    get_notification_method -> String, "/notification_method", "get_notification_method",
+    |resp| resp.notification_method.unwrap_or_else(|| "auto".to_string())
+);
+settings_setter!(
+    set_notification_method,
+    method: String,
+    "/notification_method",
+    "method",
+    "set_notification_method"
+);

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -8,6 +8,7 @@
 //! `match`es its sub-enum exhaustively — so a newly added variant is a compile
 //! error at both ends instead of silently falling through to `Task::none()`.
 
+use super_stt_shared::models::notification_method::NotificationMethod;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::models::write_method::WriteMethod;
 
@@ -28,6 +29,7 @@ pub enum Message {
     PreviewTyping(PreviewTypingMessage),
     RecordingStopMode(RecordingStopModeMessage),
     WriteMethod(WriteMethodMessage),
+    NotificationMethod(NotificationMethodMessage),
     Backend(BackendMessage),
     Language(LanguageMessage),
     Recording(RecordingMessage),
@@ -267,6 +269,14 @@ pub enum WriteMethodMessage {
     Error(String),
 }
 
+/// Notification-method setting.
+#[derive(Debug, Clone)]
+pub enum NotificationMethodMessage {
+    Changed(NotificationMethod),
+    Loaded(NotificationMethod),
+    Error(String),
+}
+
 /// Backend catalog + per-backend secret/option configuration.
 /// Secrets are managed via the daemon's secrets endpoints; options go to the
 /// daemon config via the client.
@@ -414,6 +424,7 @@ message_from! {
     PreviewTyping => PreviewTypingMessage,
     RecordingStopMode => RecordingStopModeMessage,
     WriteMethod => WriteMethodMessage,
+    NotificationMethod => NotificationMethodMessage,
     Backend => BackendMessage,
     Language => LanguageMessage,
     Recording => RecordingMessage,

--- a/super-stt-app/src/ui/views/recording.rs
+++ b/super-stt-app/src/ui/views/recording.rs
@@ -141,6 +141,7 @@ fn test_section<'a>(
 }
 
 /// Recording page: settings + test recording
+// reason: one parameter per piece of view state the page renders; grouping them would only add indirection.
 #[allow(clippy::too_many_arguments)]
 pub fn page<'a>(
     recording_stop_mode: RecordingStopMode,

--- a/super-stt-app/src/ui/views/recording.rs
+++ b/super-stt-app/src/ui/views/recording.rs
@@ -3,12 +3,14 @@ use cosmic::Element;
 use cosmic::iced::widget::row;
 use cosmic::iced::{Alignment, Length};
 use cosmic::widget::{self, button, settings, text};
+use super_stt_shared::models::notification_method::NotificationMethod;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 
 use super::common::{error_banner, page_layout};
 use crate::state::RecordingStatus;
 use crate::ui::messages::{
-    Message, PreviewTypingMessage, RecordingMessage, RecordingStopModeMessage,
+    Message, NotificationMethodMessage, PreviewTypingMessage, RecordingMessage,
+    RecordingStopModeMessage,
 };
 
 /// Recording settings section: stop mode + preview typing
@@ -42,6 +44,41 @@ fn settings_section(
                     cosmic::widget::toggler(preview_typing_enabled)
                         .on_toggle(|b| Message::PreviewTyping(PreviewTypingMessage::Toggled(b))),
                 ),
+        )
+        .into()
+}
+
+/// Notifications section: how recording failures reach the user
+fn notifications_section(notification_method: NotificationMethod) -> Element<'static, Message> {
+    let methods = [
+        NotificationMethod::Auto,
+        NotificationMethod::Dbus,
+        NotificationMethod::Typed,
+        NotificationMethod::Off,
+    ];
+    let method_names: Vec<String> = methods
+        .iter()
+        .map(|m| m.pretty_name().to_string())
+        .collect();
+    let selected_index = methods.iter().position(|m| *m == notification_method);
+
+    settings::section()
+        .title("Notifications")
+        .add(
+            settings::item::builder("Failure Notices")
+                .description(
+                    "How recording failures are reported. Desktop notifications \
+                     work on any desktop with a notification server.",
+                )
+                .control(widget::dropdown(
+                    method_names,
+                    selected_index,
+                    move |index| {
+                        Message::NotificationMethod(NotificationMethodMessage::Changed(
+                            methods[index],
+                        ))
+                    },
+                )),
         )
         .into()
 }
@@ -104,9 +141,11 @@ fn test_section<'a>(
 }
 
 /// Recording page: settings + test recording
+#[allow(clippy::too_many_arguments)]
 pub fn page<'a>(
     recording_stop_mode: RecordingStopMode,
     preview_typing_enabled: bool,
+    notification_method: NotificationMethod,
     recording_status: &'a RecordingStatus,
     transcription_text: &'a str,
     audio_level: f32,
@@ -121,6 +160,7 @@ pub fn page<'a>(
         recording_stop_mode,
         preview_typing_enabled,
     ));
+    blocks.push(notifications_section(notification_method));
     blocks.push(test_section(
         recording_status,
         transcription_text,

--- a/super-stt-daemon/src/audio/recorder.rs
+++ b/super-stt-daemon/src/audio/recorder.rs
@@ -517,4 +517,16 @@ impl DaemonAudioRecorder {
     pub fn get_audio_buffer_ref(&self) -> Arc<Mutex<VecDeque<f32>>> {
         Arc::clone(&self.audio_buffer)
     }
+
+    /// Share the recorder's speech-detection state with the recording flow.
+    ///
+    /// The recorder is moved into its own task, so callers must clone this
+    /// handle out *before* the move (the same way `get_audio_buffer_ref` is
+    /// used) and read it after the task joins. `RecordingState::recording` is a
+    /// one-way per-take latch — false at the end means the take contained no
+    /// speech.
+    #[must_use]
+    pub fn recording_state_ref(&self) -> Arc<Mutex<RecordingState>> {
+        Arc::clone(&self.recording_state)
+    }
 }

--- a/super-stt-daemon/src/audio/state.rs
+++ b/super-stt-daemon/src/audio/state.rs
@@ -161,7 +161,12 @@ impl RecordingState {
 
 #[cfg(test)]
 mod tests {
-    use super::RecordingState;
+    use super::*;
+    use crate::audio::processing::process_audio_samples;
+    use parking_lot::Mutex;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
 
     /// A non-finite RMS (an empty capture buffer computes `0.0/0.0 = NaN`, and a
     /// misbehaving device can deliver NaN samples) must not reach the percentile
@@ -182,6 +187,65 @@ mod tests {
         assert!(
             state.active_level.is_finite(),
             "active level poisoned by NaN"
+        );
+    }
+
+    /// Drive `process_audio_samples` over `chunks` chunks of constant
+    /// amplitude and report whether the speech latch ever flipped.
+    fn latch_after_chunks(amplitude: f32, chunks: usize) -> bool {
+        let buffer = Arc::new(Mutex::new(VecDeque::new()));
+        let state = Arc::new(Mutex::new(RecordingState::new()));
+        let (level_tx, _rx) = broadcast::channel(64);
+
+        let samples = vec![amplitude; 480];
+        for _ in 0..chunks {
+            process_audio_samples(&samples, &buffer, &state, &level_tx);
+        }
+
+        let flipped = state.lock().recording;
+        flipped
+    }
+
+    /// The whole silence gate rests on this: a take with no speech must leave
+    /// `recording` false, so the daemon can skip transcription.
+    #[test]
+    fn latch_stays_false_through_pure_silence() {
+        assert!(
+            !latch_after_chunks(0.0, 20),
+            "silence must never flip the speech latch"
+        );
+    }
+
+    /// And the converse — real audio must flip it, or the gate would swallow
+    /// genuine speech.
+    #[test]
+    fn latch_flips_on_speech_level_audio() {
+        assert!(
+            latch_after_chunks(0.5, 20),
+            "speech-level audio must flip the speech latch"
+        );
+    }
+
+    /// The latch is one-way within a take: speech followed by trailing silence
+    /// still reports that speech happened.
+    #[test]
+    fn latch_stays_true_after_speech_then_silence() {
+        let buffer = Arc::new(Mutex::new(VecDeque::new()));
+        let state = Arc::new(Mutex::new(RecordingState::new()));
+        let (level_tx, _rx) = broadcast::channel(64);
+
+        let loud = vec![0.5f32; 480];
+        for _ in 0..5 {
+            process_audio_samples(&loud, &buffer, &state, &level_tx);
+        }
+        let quiet = vec![0.0f32; 480];
+        for _ in 0..20 {
+            process_audio_samples(&quiet, &buffer, &state, &level_tx);
+        }
+
+        assert!(
+            state.lock().recording,
+            "trailing silence must not clear the latch"
         );
     }
 }

--- a/super-stt-daemon/src/audio/state.rs
+++ b/super-stt-daemon/src/audio/state.rs
@@ -202,8 +202,7 @@ mod tests {
             process_audio_samples(&samples, &buffer, &state, &level_tx);
         }
 
-        let flipped = state.lock().recording;
-        flipped
+        state.lock().recording
     }
 
     /// The whole silence gate rests on this: a take with no speech must leave

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use super_stt_shared::models::notification_method::NotificationMethod;
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::models::write_method::WriteMethod;
 use super_stt_shared::theme::AudioTheme;
@@ -103,6 +104,13 @@ pub struct TranscriptionConfig {
         deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
     )]
     pub write_method: WriteMethod,
+    /// How a recording failure is surfaced to the user. An unparseable stored
+    /// value degrades to the default rather than failing the whole config load.
+    #[serde(
+        default,
+        deserialize_with = "super_stt_shared::utils::serde_helpers::deserialize_or_default"
+    )]
+    pub notification_method: NotificationMethod,
     /// Vestigial: retained for config compatibility. Custom models are now
     /// provided as backends discovered under [`backends_dir`].
     #[serde(default)]
@@ -144,6 +152,7 @@ impl Default for DaemonConfig {
                 preview_typing_enabled: false, // Default to disabled (beta feature)
                 recording_stop_mode: RecordingStopMode::default(),
                 write_method: WriteMethod::default(),
+                notification_method: NotificationMethod::default(),
                 custom_models_dir: None,
                 backends_dir: None,
                 active_backend: None,

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -164,10 +164,43 @@ impl Default for DaemonConfig {
     }
 }
 
+/// The `daemon.toml` path used by `DaemonConfig::get_config_path()` under
+/// `#[cfg(test)]`: a directory under the OS temp dir, unique per test
+/// *process* (keyed by pid) and cached for the life of that process so every
+/// test in the binary agrees on the same path. This is what keeps unit tests
+/// that call `load()`/`save()` off the developer's real config file.
+#[cfg(test)]
+fn test_config_path() -> PathBuf {
+    use std::sync::OnceLock;
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let dir =
+            std::env::temp_dir().join(format!("super-stt-test-config-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        dir.join("daemon.toml")
+    })
+    .clone()
+}
+
 impl DaemonConfig {
-    /// Get the config file path
+    /// Get the config file path.
+    ///
+    /// Under `#[cfg(test)]` this resolves to a process-local temp file instead
+    /// of the real XDG config path, so `load()`/`save()` in this crate's unit
+    /// tests can never read or clobber the developer's real
+    /// `~/.config/super-stt/daemon.toml`. Known limitation: this only covers
+    /// unit tests compiled *into* this crate (`cfg(test)`). Integration tests
+    /// under `tests/` link against the crate without `cfg(test)`, so they
+    /// still resolve the real path — not addressed here.
     fn get_config_path() -> PathBuf {
-        super_stt_shared::paths::config_dir().join("daemon.toml")
+        #[cfg(test)]
+        {
+            test_config_path()
+        }
+        #[cfg(not(test))]
+        {
+            super_stt_shared::paths::config_dir().join("daemon.toml")
+        }
     }
 
     /// Parse config file `content` into a [`DaemonConfig`], falling back to

--- a/super-stt-daemon/src/config_tests.rs
+++ b/super-stt-daemon/src/config_tests.rs
@@ -590,6 +590,75 @@ fn a_model_switch_updates_preferred_provider() {
     assert_eq!(config.transcription.preferred_provider, "");
 }
 
+/// A stored method round-trips.
+#[test]
+fn daemon_config_reads_notification_method() {
+    let toml = r#"
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "classic"
+volume = 100
+
+[transcription]
+preferred_model = "whisper"
+notification_method = "dbus"
+"#;
+    let cfg: DaemonConfig = toml::from_str(toml).unwrap();
+    assert_eq!(
+        cfg.transcription.notification_method,
+        NotificationMethod::Dbus
+    );
+}
+
+/// Config-load resilience: an unknown stored value degrades to the default
+/// instead of failing the whole parse. (The wire setter, by contrast, rejects
+/// it — see the endpoint doc.)
+#[test]
+fn daemon_bad_notification_method_falls_back_preserving_rest() {
+    let toml = r#"
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "classic"
+volume = 100
+
+[transcription]
+preferred_model = "whisper"
+notification_method = "BogusMethod"
+write_method = "ydotool"
+"#;
+    let cfg: DaemonConfig = toml::from_str(toml).unwrap();
+    assert_eq!(
+        cfg.transcription.notification_method,
+        NotificationMethod::default()
+    );
+    assert_eq!(cfg.transcription.write_method, WriteMethod::Ydotool);
+}
+
+/// An absent field is the default.
+#[test]
+fn daemon_missing_notification_method_is_auto() {
+    let toml = r#"
+[device]
+preferred_device = "cpu"
+
+[audio]
+theme = "classic"
+volume = 100
+
+[transcription]
+preferred_model = "whisper"
+"#;
+    let cfg: DaemonConfig = toml::from_str(toml).unwrap();
+    assert_eq!(
+        cfg.transcription.notification_method,
+        NotificationMethod::Auto
+    );
+}
+
 /// Every path that drops the model preference drops the provider with it —
 /// otherwise the persisted triple names a model that is no longer selected.
 #[test]

--- a/super-stt-daemon/src/daemon/core.rs
+++ b/super-stt-daemon/src/daemon/core.rs
@@ -53,6 +53,10 @@ impl SuperSTTDaemon {
             Command::GetRecordingStopMode => self.handle_get_recording_stop_mode().await,
             Command::SetWriteMethod { method } => self.handle_set_write_method(method).await,
             Command::GetWriteMethod => self.handle_get_write_method().await,
+            Command::SetNotificationMethod { method } => {
+                self.handle_set_notification_method(method).await
+            }
+            Command::GetNotificationMethod => self.handle_get_notification_method().await,
             Command::SetVolume { volume } => self.handle_set_volume(volume),
             Command::GetVolume => self.handle_get_volume(),
             Command::SetPrimaryLanguage { language } => {

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -1438,6 +1438,10 @@ async fn handle_transcribe_errors_when_no_model_loaded() {
 // what the preflight does, not how long the notice waits.
 #[tokio::test(start_paused = true)]
 async fn record_with_no_model_types_a_notice_in_write_mode() {
+    // `test_daemon()` carries a notifier that always fails delivery (never
+    // the real session bus — see its doc comment), so the config-default
+    // `Auto` method falls through to typing here; that fallback is what this
+    // test checks.
     let daemon = test_daemon().await;
     let (sim, buf) = crate::output::keyboard::Simulator::capture();
     let mut typer = crate::output::typer::Typer::new(sim);
@@ -1460,6 +1464,8 @@ async fn record_with_no_model_types_a_notice_in_write_mode() {
 /// the error response and nothing is typed.
 #[tokio::test]
 async fn record_with_no_model_types_nothing_without_write_mode() {
+    // See the write-mode test above: `test_daemon()`'s notifier never reaches
+    // the real session bus.
     let daemon = test_daemon().await;
     let (sim, buf) = crate::output::keyboard::Simulator::capture();
     let mut typer = crate::output::typer::Typer::new(sim);

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -329,6 +329,49 @@ async fn set_audio_theme_rejects_unknown_theme() {
     assert_eq!(daemon.get_audio_theme(), before);
 }
 
+/// An unknown notification method is a client error:
+/// `docs/protocol/endpoints/v1/notification_method.md` documents `400
+/// invalid_notification_method`. The daemon must reject it (not silently
+/// apply the default and report success), and the config must not be
+/// mutated by a rejected wire set.
+#[tokio::test]
+async fn set_notification_method_rejects_unknown_method() {
+    let daemon = test_daemon().await;
+    let before = daemon.config.read().await.transcription.notification_method;
+
+    let resp = daemon
+        .handle_set_notification_method("definitely-not-a-method".to_string())
+        .await;
+
+    assert_eq!(resp.status, "error");
+    assert_eq!(resp.message.as_deref(), Some("invalid_notification_method"));
+    assert_eq!(resp.error_code, Some(ErrorCode::InvalidValue));
+    assert_eq!(resp.error_code.map(ErrorCode::http_status), Some(400));
+    // The rejected value must not have changed the persisted setting.
+    assert_eq!(
+        daemon.config.read().await.transcription.notification_method,
+        before
+    );
+}
+
+/// A valid value round-trips through `set_notification_method` and
+/// `get_notification_method` end to end (dispatch parse -> handler -> config).
+#[tokio::test]
+async fn set_notification_method_round_trips_through_set_and_get() {
+    let daemon = test_daemon().await;
+
+    let mut set_request = make_request("set_notification_method");
+    set_request.data = Some(serde_json::json!({ "method": "dbus" }));
+    let set_response = daemon.handle_command(set_request).await;
+    assert_eq!(set_response.status, "success");
+    assert_eq!(set_response.notification_method.as_deref(), Some("dbus"));
+
+    let get_response = daemon
+        .handle_command(make_request("get_notification_method"))
+        .await;
+    assert_eq!(get_response.notification_method.as_deref(), Some("dbus"));
+}
+
 #[tokio::test]
 async fn get_allow_online_models_returns_config_value() {
     let daemon = test_daemon().await;

--- a/super-stt-daemon/src/daemon/http/v1/settings/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/mod.rs
@@ -76,6 +76,7 @@ pub(crate) mod audio_theme;
 pub(crate) mod backends;
 pub(crate) mod custom_models_dir;
 pub(crate) mod language;
+pub(crate) mod notification_method;
 pub(crate) mod preview_typing;
 pub(crate) mod recording_stop_mode;
 pub(crate) mod volume;
@@ -123,6 +124,11 @@ pub(crate) fn routes() -> Router<AppState> {
         .route(
             "/write_method",
             get(write_method::get_write_method).post(write_method::set_write_method),
+        )
+        .route(
+            "/notification_method",
+            get(notification_method::get_notification_method)
+                .post(notification_method::set_notification_method),
         )
         .route(
             "/preview_typing",

--- a/super-stt-daemon/src/daemon/http/v1/settings/notification_method.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/notification_method.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
+settings_setter!(
+    set_notification_method,
+    SetNotificationMethodBody { method: String },
+    "set_notification_method",
+    "method"
+);
+settings_dispatch!(get_notification_method, "get_notification_method");

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -27,6 +27,10 @@ struct RecordingSession {
     // Shared with the recorder's ring buffer (`get_audio_buffer_ref`), which is
     // a `parking_lot::Mutex` (Tier 3 #5).
     pub(super) preview_buffer: Arc<parking_lot::Mutex<VecDeque<f32>>>,
+    // Shared with the recorder's speech-detection state. `recording` is a
+    // one-way per-take latch: false after the take means no speech was ever
+    // detected, so there is nothing to transcribe.
+    pub(super) speech_state: Arc<parking_lot::Mutex<crate::audio::state::RecordingState>>,
     pub(super) device_sample_rate: u32,
     pub(super) start_time: Instant,
 }
@@ -144,6 +148,9 @@ impl SuperSTTDaemon {
         self.run_preview_loop(&session, typer, write_mode, request_language)
             .await;
 
+        // Cloned out before `collect_and_clear_preview` consumes the session.
+        let speech_state = Arc::clone(&session.speech_state);
+
         // Phase 3: await the recorder; the mic releases here.
         let full_audio_data = match self
             .collect_and_clear_preview(session, typer, write_mode)
@@ -167,6 +174,25 @@ impl SuperSTTDaemon {
                 return Ok(Err(format!("recording error: {e}")));
             }
         };
+
+        // Nothing was spoken. Stopping a recording without speaking is not a
+        // failure, so the backend is never asked to transcribe silence and
+        // nothing is typed — the cycle simply completes with no text.
+        if !speech_state.lock().recording {
+            info!("🎤 No speech detected during the take; skipping transcription");
+            if write_mode {
+                // Typed nothing, but the per-recording transcript state still
+                // has to be cleared or it feeds the next recording's preview
+                // tail-matching.
+                typer.reset_after_recording(String::new());
+            }
+            // `transcribing_started` is deliberately NOT emitted: decode never
+            // begins. `finalize_recording_session` still emits `final_stt` with
+            // empty text plus the closing `transcribing_stopped`, which is what
+            // the events contract requires (docs/protocol/endpoints/v1/events.md).
+            self.finalize_recording_session("", true, None).await;
+            return Ok(Ok(String::new()));
+        }
 
         // Phase 4: final transcription.
         self.emit_transcribing_started();

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -36,6 +36,19 @@ struct RecordingSession {
 }
 
 impl SuperSTTDaemon {
+    /// Surface a recording failure through the user's configured channel.
+    ///
+    /// The failure is always reported to the caller through the response and
+    /// the `error` event; this is the additional human-facing notice. It fires
+    /// for every recording, write mode or not — the trigger is the failure, not
+    /// the output mode.
+    async fn surface_failure(&self, typer: &mut Typer, notice: &'static str, write_mode: bool) {
+        let method = self.config.read().await.transcription.notification_method;
+        let mut notifier = self.notifier.lock().await;
+        crate::output::notification::deliver(method, &mut notifier, typer, notice, write_mode)
+            .await;
+    }
+
     /// Internal record handling implementation
     pub async fn handle_record_internal(
         &self,
@@ -62,9 +75,8 @@ impl SuperSTTDaemon {
         // reason lands in the field they are actually looking at.
         if self.model.read().await.is_none() {
             warn!("Recording request rejected - no model loaded");
-            if write_mode {
-                typer.type_notice(notice::NO_MODEL_LOADED).await;
-            }
+            self.surface_failure(typer, notice::NO_MODEL_LOADED, write_mode)
+                .await;
             return DaemonResponse::error_with_code(
                 ErrorCode::ModelNotLoaded,
                 "No model is loaded. Load a model and try again.",
@@ -106,9 +118,8 @@ impl SuperSTTDaemon {
                     let mut guard = self.busy.write().await;
                     *guard = false;
                 }
-                if write_mode {
-                    typer.type_notice(notice::COULD_NOT_START_RECORDING).await;
-                }
+                self.surface_failure(typer, notice::COULD_NOT_START_RECORDING, write_mode)
+                    .await;
                 DaemonResponse::error(&format!("Recording failed: {e}"))
             }
         }
@@ -168,9 +179,8 @@ impl SuperSTTDaemon {
                 warn!("Recording capture failed: {e}");
                 self.finalize_recording_session("", false, Some(e.to_string()))
                     .await;
-                if write_mode {
-                    typer.type_notice(notice::RECORDING_FAILED).await;
-                }
+                self.surface_failure(typer, notice::RECORDING_FAILED, write_mode)
+                    .await;
                 return Ok(Err(format!("recording error: {e}")));
             }
         };
@@ -209,9 +219,8 @@ impl SuperSTTDaemon {
                 warn!("Final transcription failed: {e}");
                 self.finalize_recording_session("", false, Some(e.to_string()))
                     .await;
-                if write_mode {
-                    typer.type_notice(notice::TRANSCRIPTION_FAILED).await;
-                }
+                self.surface_failure(typer, notice::TRANSCRIPTION_FAILED, write_mode)
+                    .await;
                 return Ok(Err(format!("STT error: {e}")));
             }
         };

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -47,6 +47,9 @@ impl SuperSTTDaemon {
 
         // Get a reference to the recorder's internal audio buffer for direct preview access
         let preview_buffer = recorder.get_audio_buffer_ref();
+        // Same deal for the speech latch — must be cloned out before the
+        // recorder moves into its task below.
+        let speech_state = recorder.recording_state_ref();
 
         // Detect the actual device sample rate for correct buffer calculations.
         // This opens the cpal default input device, so run it on a blocking
@@ -82,6 +85,7 @@ impl SuperSTTDaemon {
             model_processing_interval,
             actually_typed,
             preview_buffer,
+            speech_state,
             device_sample_rate,
             start_time,
         })

--- a/super-stt-daemon/src/daemon/settings_handlers.rs
+++ b/super-stt-daemon/src/daemon/settings_handlers.rs
@@ -3,7 +3,8 @@
 use crate::config::DaemonConfig;
 use crate::daemon::types::SuperSTTDaemon;
 use log::{info, warn};
-use super_stt_shared::models::protocol::DaemonResponse;
+use super_stt_shared::models::notification_method::NotificationMethod;
+use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
 use super_stt_shared::models::recording_stop_mode::RecordingStopMode;
 use super_stt_shared::models::write_method::WriteMethod;
 
@@ -115,6 +116,37 @@ impl SuperSTTDaemon {
         let config = self.config.read().await;
         let method = config.transcription.write_method;
         DaemonResponse::success().with_write_method(method.to_string())
+    }
+
+    /// Handle set notification method command. An unknown method name is
+    /// rejected with `invalid_notification_method` (HTTP 400) per
+    /// `docs/protocol/endpoints/v1/notification_method.md`, rather than
+    /// silently applying the default and reporting success.
+    pub async fn handle_set_notification_method(&self, method_str: String) -> DaemonResponse {
+        let Ok(method) = method_str.parse::<NotificationMethod>() else {
+            return DaemonResponse::error_with_code(
+                ErrorCode::InvalidValue,
+                "invalid_notification_method",
+            );
+        };
+
+        let persist = self
+            .set_config_field(|c| c.transcription.notification_method = method)
+            .await;
+
+        info!("Notification method set to {method}");
+        Self::settings_saved(
+            DaemonResponse::success().with_notification_method(method.to_string()),
+            format!("Notification method set to {method}"),
+            persist,
+        )
+    }
+
+    /// Handle get notification method command
+    pub async fn handle_get_notification_method(&self) -> DaemonResponse {
+        let config = self.config.read().await;
+        let method = config.transcription.notification_method;
+        DaemonResponse::success().with_notification_method(method.to_string())
     }
 
     /// Handle set allow online models command

--- a/super-stt-daemon/src/daemon/startup.rs
+++ b/super-stt-daemon/src/daemon/startup.rs
@@ -108,6 +108,9 @@ impl SuperSTTDaemon {
             preview_text: Arc::new(tokio::sync::RwLock::new(None)),
             backends: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             active_backend: Arc::new(tokio::sync::RwLock::new(active_backend)),
+            notifier: Arc::new(tokio::sync::Mutex::new(
+                crate::output::notification::Notifier::dbus(),
+            )),
         };
 
         daemon.post_init().await;

--- a/super-stt-daemon/src/daemon/types.rs
+++ b/super-stt-daemon/src/daemon/types.rs
@@ -85,6 +85,9 @@ pub struct SuperSTTDaemon {
     // of the selected backend, or None when idle. Runtime mirror of
     // `config.transcription.active_backend`.
     pub active_backend: Arc<tokio::sync::RwLock<Option<String>>>,
+    // Desktop-notification channel for recording failures. Behind a mutex
+    // because sending mutates the cached connection and the replaces-id.
+    pub notifier: Arc<tokio::sync::Mutex<crate::output::notification::Notifier>>,
 }
 
 /// A daemon wired up with inert defaults: no model, no backends, nothing
@@ -116,6 +119,17 @@ pub(crate) async fn test_daemon() -> SuperSTTDaemon {
         preview_text: Arc::new(tokio::sync::RwLock::new(None)),
         backends: Arc::new(tokio::sync::RwLock::new(Vec::new())),
         active_backend: Arc::new(tokio::sync::RwLock::new(None)),
+        // A fake notifier, not `Notifier::dbus()`: no daemon test may reach
+        // the real session bus, or it can pop a genuine desktop notification
+        // on whoever's machine runs the suite. `fail = true` mirrors a
+        // headless/no-notification-server environment, which is also what
+        // makes `NotificationMethod::Auto` (the config default) degrade to
+        // typing — the behavior the write-mode failure-notice tests assert.
+        // A test that genuinely needs delivery to succeed can override
+        // `daemon.notifier` after construction.
+        notifier: Arc::new(tokio::sync::Mutex::new(
+            crate::output::notification::Notifier::fake(true).0,
+        )),
     }
 }
 

--- a/super-stt-daemon/src/output/mod.rs
+++ b/super-stt-daemon/src/output/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod keyboard;
 pub(crate) mod notice;
+pub mod notification;
 pub mod preview;
 pub mod typer;

--- a/super-stt-daemon/src/output/notice.rs
+++ b/super-stt-daemon/src/output/notice.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! Fixed notices typed into the focused window when a write-mode recording
-//! fails.
+//! Fixed notices typed into the focused window or placed in a desktop
+//! notification body when a recording fails, regardless of `write_mode`.
 //!
 //! These are compile-time constants rather than formatted error text on
 //! purpose. Backends are explicitly untrusted (audit 2 Tier 3 #8) and most
-//! failure detail originates in one, so typing it would put
-//! attacker-influencable text into whatever the user has focused. The detail
-//! goes to the log and the error response; only these fixed strings are typed.
+//! failure detail originates in one, so surfacing it verbatim would put
+//! attacker-influencable text into whatever the user has focused or into a
+//! notification body. The detail goes to the log and the error response;
+//! only these fixed strings ever reach the user.
 
 /// No model is loaded, so the cycle cannot produce text. Caught before capture.
 pub(crate) const NO_MODEL_LOADED: &str = "[Super STT: no model loaded]";

--- a/super-stt-daemon/src/output/notification.rs
+++ b/super-stt-daemon/src/output/notification.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Desktop notification delivery for recording failures.
+//!
+//! Uses the freedesktop Desktop Notifications interface
+//! (`org.freedesktop.Notifications`), which every mainstream desktop provides —
+//! GNOME, KDE Plasma, COSMIC, XFCE, MATE, Cinnamon, `LXQt` — as do the
+//! standalone servers used on bare compositors (mako, dunst, swaync). One code
+//! path covers all of them; nothing here is desktop-specific.
+//!
+//! Notification bodies carry only the fixed constants from [`crate::output::notice`],
+//! never backend error text. Backends are explicitly untrusted (audit 2 Tier 3
+//! #8) and notification servers may render limited markup in the body, so the
+//! same rule that governs typing governs this channel.
+
+use crate::output::typer::Typer;
+use anyhow::{Context, Result};
+use log::{debug, info, warn};
+use std::collections::HashMap;
+use super_stt_shared::models::notification_method::NotificationMethod;
+use zbus::Connection;
+use zbus::zvariant::Value;
+
+const NOTIFY_BUS: &str = "org.freedesktop.Notifications";
+const NOTIFY_PATH: &str = "/org/freedesktop/Notifications";
+const NOTIFY_IFACE: &str = "org.freedesktop.Notifications";
+
+const APP_NAME: &str = "Super STT";
+/// Installed into `share/icons/hicolor/scalable/apps` by the justfile.
+const APP_ICON: &str = "super-stt-app";
+const SUMMARY: &str = "Super STT";
+/// 0 = low, 1 = normal, 2 = critical.
+const URGENCY_NORMAL: u8 = 1;
+/// Let the notification server pick the timeout.
+const EXPIRE_DEFAULT: i32 = -1;
+
+/// Sends failure notices to the session's notification server.
+///
+/// `pub` (not `pub(crate)`) because it is held in a `pub` field on the `pub`
+/// `SuperSTTDaemon` — the same reason `keyboard::Simulator` is public.
+pub struct Notifier {
+    inner: Inner,
+    /// Id of the last notification sent, passed as `replaces_id` so repeated
+    /// failures replace the previous bubble instead of stacking. The spec
+    /// treats 0 as "do not replace".
+    last_id: u32,
+}
+
+enum Inner {
+    /// Session-bus connection, established on first send and cached.
+    Dbus(Option<Connection>),
+    #[cfg(test)]
+    Fake {
+        fail: bool,
+        sent: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    },
+}
+
+impl Notifier {
+    #[must_use]
+    pub fn dbus() -> Self {
+        Self {
+            inner: Inner::Dbus(None),
+            last_id: 0,
+        }
+    }
+
+    /// Deliver `body` as a desktop notification.
+    ///
+    /// # Errors
+    /// Returns an error when no session bus is reachable, or when no
+    /// notification server owns `org.freedesktop.Notifications`. Callers treat
+    /// both the same way: there is nowhere to show a notification.
+    ///
+    /// # Panics
+    /// Never in practice: the `expect` below only unwraps the connection slot
+    /// this same call just populated a few lines above.
+    pub async fn send(&mut self, body: &str) -> Result<()> {
+        match &mut self.inner {
+            Inner::Dbus(slot) => {
+                if slot.is_none() {
+                    *slot = Some(
+                        Connection::session()
+                            .await
+                            .context("no session bus available for notifications")?,
+                    );
+                }
+                let conn = slot.as_ref().expect("connection established above");
+                let proxy = zbus::Proxy::new(conn, NOTIFY_BUS, NOTIFY_PATH, NOTIFY_IFACE)
+                    .await
+                    .context("could not build the notifications proxy")?;
+
+                let mut hints: HashMap<&str, Value<'_>> = HashMap::new();
+                hints.insert("urgency", Value::U8(URGENCY_NORMAL));
+                let actions: Vec<&str> = Vec::new();
+
+                // Notify(app_name, replaces_id, app_icon, summary, body,
+                //        actions, hints, expire_timeout) -> id
+                let id: u32 = proxy
+                    .call(
+                        "Notify",
+                        &(
+                            APP_NAME,
+                            self.last_id,
+                            APP_ICON,
+                            SUMMARY,
+                            body,
+                            actions,
+                            hints,
+                            EXPIRE_DEFAULT,
+                        ),
+                    )
+                    .await
+                    .context("no notification server answered on the session bus")?;
+
+                self.last_id = id;
+                debug!("Delivered failure notification (id {id})");
+                Ok(())
+            }
+            #[cfg(test)]
+            Inner::Fake { fail, sent } => {
+                if *fail {
+                    anyhow::bail!("fake notifier: delivery failed");
+                }
+                sent.lock().unwrap().push(body.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// A notifier that records what it was asked to send, or fails every send
+    /// when `fail` is true.
+    #[cfg(test)]
+    pub(crate) fn fake(fail: bool) -> (Self, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+        let sent = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        (
+            Self {
+                inner: Inner::Fake {
+                    fail,
+                    sent: std::sync::Arc::clone(&sent),
+                },
+                last_id: 0,
+            },
+            sent,
+        )
+    }
+}
+
+/// Route a failure notice to the user through the configured channel.
+///
+/// Typing needs a keyboard channel, so `typed` is attempted only for write-mode
+/// recordings and otherwise degrades to a log line. `auto` degrades the same way
+/// once notification delivery has failed.
+pub(crate) async fn deliver(
+    method: NotificationMethod,
+    notifier: &mut Notifier,
+    typer: &mut Typer,
+    notice: &'static str,
+    write_mode: bool,
+) {
+    match method {
+        NotificationMethod::Off => {
+            info!("Recording failure: {notice} (surfacing disabled)");
+        }
+        NotificationMethod::Typed => type_or_log(typer, notice, write_mode).await,
+        NotificationMethod::Dbus => {
+            if let Err(e) = notifier.send(notice).await {
+                warn!("Could not deliver failure notification ({notice}): {e}");
+            }
+        }
+        NotificationMethod::Auto => {
+            if let Err(e) = notifier.send(notice).await {
+                warn!("Notification delivery failed ({e}); falling back to typing");
+                type_or_log(typer, notice, write_mode).await;
+            }
+        }
+    }
+}
+
+async fn type_or_log(typer: &mut Typer, notice: &'static str, write_mode: bool) {
+    if write_mode {
+        typer.type_notice(notice).await;
+    } else {
+        info!("Recording failure: {notice} (not in write mode, nothing typed)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::keyboard::Simulator;
+    use crate::output::notice;
+
+    /// Build a typer whose keystrokes land in a buffer we can assert on.
+    fn typer() -> (Typer, std::sync::Arc<std::sync::Mutex<String>>) {
+        let (sim, buf) = Simulator::capture();
+        (Typer::new(sim), buf)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn off_types_nothing_and_sends_nothing() {
+        let (mut n, sent) = Notifier::fake(false);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Off,
+            &mut n,
+            &mut t,
+            notice::TRANSCRIPTION_FAILED,
+            true,
+        )
+        .await;
+
+        assert!(sent.lock().unwrap().is_empty());
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn typed_types_the_notice_and_sends_nothing() {
+        let (mut n, sent) = Notifier::fake(false);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Typed,
+            &mut n,
+            &mut t,
+            notice::TRANSCRIPTION_FAILED,
+            true,
+        )
+        .await;
+
+        assert!(sent.lock().unwrap().is_empty());
+        assert_eq!(*typed.lock().unwrap(), notice::TRANSCRIPTION_FAILED);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dbus_sends_the_notice_and_types_nothing() {
+        let (mut n, sent) = Notifier::fake(false);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Dbus,
+            &mut n,
+            &mut t,
+            notice::RECORDING_FAILED,
+            true,
+        )
+        .await;
+
+        assert_eq!(*sent.lock().unwrap(), vec![notice::RECORDING_FAILED]);
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    /// `dbus` is the deliberate "notification or nothing" choice — a failed
+    /// delivery must NOT fall back to typing.
+    #[tokio::test(start_paused = true)]
+    async fn dbus_does_not_type_when_delivery_fails() {
+        let (mut n, _sent) = Notifier::fake(true);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Dbus,
+            &mut n,
+            &mut t,
+            notice::RECORDING_FAILED,
+            true,
+        )
+        .await;
+
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_sends_and_does_not_type_when_delivery_succeeds() {
+        let (mut n, sent) = Notifier::fake(false);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Auto,
+            &mut n,
+            &mut t,
+            notice::NO_MODEL_LOADED,
+            true,
+        )
+        .await;
+
+        assert_eq!(*sent.lock().unwrap(), vec![notice::NO_MODEL_LOADED]);
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    /// The fallback that keeps a bare compositor with no notification server
+    /// from silently swallowing failures.
+    #[tokio::test(start_paused = true)]
+    async fn auto_falls_back_to_typing_when_delivery_fails() {
+        let (mut n, _sent) = Notifier::fake(true);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Auto,
+            &mut n,
+            &mut t,
+            notice::NO_MODEL_LOADED,
+            true,
+        )
+        .await;
+
+        assert_eq!(*typed.lock().unwrap(), notice::NO_MODEL_LOADED);
+    }
+
+    /// Without write mode there is no keyboard channel, so `typed` logs.
+    #[tokio::test(start_paused = true)]
+    async fn typed_without_write_mode_types_nothing() {
+        let (mut n, _sent) = Notifier::fake(false);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Typed,
+            &mut n,
+            &mut t,
+            notice::TRANSCRIPTION_FAILED,
+            false,
+        )
+        .await;
+
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    /// Notifications are mode-independent: a non-write recording still notifies.
+    #[tokio::test(start_paused = true)]
+    async fn auto_still_notifies_without_write_mode() {
+        let (mut n, sent) = Notifier::fake(false);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Auto,
+            &mut n,
+            &mut t,
+            notice::TRANSCRIPTION_FAILED,
+            false,
+        )
+        .await;
+
+        assert_eq!(*sent.lock().unwrap(), vec![notice::TRANSCRIPTION_FAILED]);
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    /// And falls through to nothing when it cannot notify and cannot type.
+    #[tokio::test(start_paused = true)]
+    async fn auto_without_write_mode_and_failed_delivery_types_nothing() {
+        let (mut n, _sent) = Notifier::fake(true);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Auto,
+            &mut n,
+            &mut t,
+            notice::TRANSCRIPTION_FAILED,
+            false,
+        )
+        .await;
+
+        assert_eq!(*typed.lock().unwrap(), "");
+    }
+}

--- a/super-stt-daemon/src/output/typer.rs
+++ b/super-stt-daemon/src/output/typer.rs
@@ -304,6 +304,16 @@ impl Typer {
     pub async fn process_final_text(&mut self, transcription_result: &str) {
         // No preview typing, type directly
         let processed_text = preprocess_text(transcription_result, false);
+
+        // An empty transcript has nothing to type. Without this guard the
+        // `format!("{processed_text} ")` below deposits a bare space into the
+        // user's focused window every time a recording produces no text.
+        if processed_text.trim().is_empty() {
+            info!("Final transcription is empty; typing nothing");
+            self.reset_after_recording(processed_text);
+            return;
+        }
+
         let final_text = format!("{processed_text} ");
         if let Err(e) = self.keyboard_simulator.type_text(&final_text).await {
             warn!("Failed to type final transcription: {e}");
@@ -311,9 +321,18 @@ impl Typer {
             info!("Step 6 complete: Final transcription typed directly");
         }
 
-        // Reset state for next sentence - but keep the full session text for user reference
+        self.reset_after_recording(processed_text);
+    }
+
+    /// Clear the per-recording transcript state so the next recording starts
+    /// clean. Preview tail-matching reads `full_session_text` and `prev_text`,
+    /// so anything left here would be treated as a prefix to extend.
+    ///
+    /// Split out of [`Self::process_final_text`] because the no-speech path
+    /// finishes a recording without typing anything and still has to reset.
+    pub fn reset_after_recording(&mut self, last_transcription: String) {
         self.state.prev_text.clear();
-        self.state.last_transcription = processed_text;
+        self.state.last_transcription = last_transcription;
         self.state.last_growth_time = std::time::Instant::now();
 
         info!(

--- a/super-stt-daemon/src/output/typer_tests.rs
+++ b/super-stt-daemon/src/output/typer_tests.rs
@@ -160,3 +160,78 @@ async fn type_notice_waits_for_shortcut_keys_to_be_released_before_typing() {
     );
     assert_eq!(*buf.lock().unwrap(), "[Super STT: no model loaded]");
 }
+
+// ---------------------------------------------------------------------------
+// Empty-transcript handling
+// ---------------------------------------------------------------------------
+
+/// An empty transcript must type nothing at all. The final text is built as
+/// `format!("{processed} ")`, so without a guard a silent recording deposits a
+/// bare space into whatever the user has focused.
+#[tokio::test]
+async fn process_final_text_types_nothing_for_an_empty_transcript() {
+    let (sim, buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+
+    typer.process_final_text("").await;
+
+    assert_eq!(*buf.lock().unwrap(), "");
+}
+
+/// Whitespace-only is empty for this purpose — the backend returning " " must
+/// not type a space either.
+#[tokio::test]
+async fn process_final_text_types_nothing_for_a_whitespace_transcript() {
+    let (sim, buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+
+    typer.process_final_text("   ").await;
+
+    assert_eq!(*buf.lock().unwrap(), "");
+}
+
+/// The guard must not change the normal path.
+#[tokio::test]
+async fn process_final_text_still_types_a_non_empty_transcript() {
+    let (sim, buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+
+    typer.process_final_text("hello world").await;
+
+    assert!(
+        buf.lock().unwrap().contains("Hello world"),
+        "expected the transcript to be typed, got {:?}",
+        buf.lock().unwrap()
+    );
+}
+
+/// Skipping the typing must NOT skip the state reset: leftover session text
+/// would feed preview tail-matching on the next recording.
+#[tokio::test]
+async fn process_final_text_resets_state_even_when_it_types_nothing() {
+    let (sim, _buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+    typer.state.prev_text = "stale".to_string();
+    typer.state.full_session_text = "stale session".to_string();
+
+    typer.process_final_text("").await;
+
+    assert_eq!(typer.state.prev_text, "");
+    assert_eq!(typer.state.full_session_text, "");
+}
+
+/// The extracted reset is callable on its own — Task 2 uses it on the
+/// no-speech path, which does no typing at all.
+#[test]
+fn reset_after_recording_clears_transcript_state() {
+    let (sim, _buf) = Simulator::capture();
+    let mut typer = Typer::new(sim);
+    typer.state.prev_text = "stale".to_string();
+    typer.state.full_session_text = "stale session".to_string();
+
+    typer.reset_after_recording(String::new());
+
+    assert_eq!(typer.state.prev_text, "");
+    assert_eq!(typer.state.full_session_text, "");
+    assert_eq!(typer.state.last_transcription, "");
+}

--- a/super-stt-shared/src/models/mod.rs
+++ b/super-stt-shared/src/models/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pub mod audio_level;
 pub mod backends;
+pub mod notification_method;
 pub mod protocol;
 pub mod recording_stop_mode;
 pub mod theme;

--- a/super-stt-shared/src/models/notification_method.rs
+++ b/super-stt-shared/src/models/notification_method.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use super::wire_enum::wire_enum_strings;
+
+/// How the daemon surfaces a recording failure to the user.
+///
+/// The caller always learns about a failure through the response and the
+/// `error` event; this controls the additional human-facing notice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NotificationMethod {
+    /// Desktop notification, falling back to typing the notice if it cannot
+    /// be delivered.
+    #[default]
+    Auto,
+    /// Desktop notification only; log if it cannot be delivered.
+    Dbus,
+    /// Type a fixed notice into the focused window.
+    Typed,
+    /// Log only; never surface.
+    Off,
+}
+
+wire_enum_strings!(NotificationMethod {
+    Auto => "auto",
+    Dbus => "dbus",
+    Typed => "typed",
+    Off => "off",
+});
+
+impl NotificationMethod {
+    #[must_use]
+    pub fn pretty_name(self) -> &'static str {
+        match self {
+            Self::Auto => "Auto (recommended)",
+            Self::Dbus => "Desktop notification",
+            Self::Typed => "Type into window",
+            Self::Off => "Off",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_auto() {
+        assert_eq!(NotificationMethod::default(), NotificationMethod::Auto);
+    }
+
+    #[test]
+    fn display_roundtrip() {
+        for method in [
+            NotificationMethod::Auto,
+            NotificationMethod::Dbus,
+            NotificationMethod::Typed,
+            NotificationMethod::Off,
+        ] {
+            let s = method.to_string();
+            let parsed: NotificationMethod = s.parse().unwrap();
+            assert_eq!(parsed, method);
+        }
+    }
+
+    #[test]
+    fn wire_tokens_are_snake_case() {
+        assert_eq!(NotificationMethod::Auto.to_string(), "auto");
+        assert_eq!(NotificationMethod::Dbus.to_string(), "dbus");
+        assert_eq!(NotificationMethod::Typed.to_string(), "typed");
+        assert_eq!(NotificationMethod::Off.to_string(), "off");
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_and_plausible_aliases() {
+        assert!("nonsense".parse::<NotificationMethod>().is_err());
+        // No aliases: exactly one token maps to each variant.
+        for dropped in [
+            "notification",
+            "notify",
+            "d-bus",
+            "freedesktop",
+            "none",
+            "disabled",
+            "Auto",
+        ] {
+            assert!(
+                dropped.parse::<NotificationMethod>().is_err(),
+                "`{dropped}` must not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let method = NotificationMethod::Dbus;
+        let json = serde_json::to_string(&method).unwrap();
+        assert_eq!(json, "\"dbus\"");
+        let parsed: NotificationMethod = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, method);
+    }
+
+    #[test]
+    fn wire_variants_lists_every_token() {
+        assert_eq!(
+            NotificationMethod::WIRE_VARIANTS,
+            &["auto", "dbus", "typed", "off"]
+        );
+    }
+}

--- a/super-stt-shared/src/models/protocol/command.rs
+++ b/super-stt-shared/src/models/protocol/command.rs
@@ -59,6 +59,13 @@ pub enum Command {
         method: WriteMethod,
     },
     GetWriteMethod,
+    /// The raw wire string, unparsed. `handle_set_notification_method` parses
+    /// it (mirrors `SetAudioTheme`) so an unrecognized value can be rejected
+    /// with a classified `error_code` (400), not just a bare error string.
+    SetNotificationMethod {
+        method: String,
+    },
+    GetNotificationMethod,
     SetVolume {
         volume: u8,
     },

--- a/super-stt-shared/src/models/protocol/dispatch.rs
+++ b/super-stt-shared/src/models/protocol/dispatch.rs
@@ -38,6 +38,8 @@ impl TryFrom<DaemonRequest> for Command {
             "get_recording_stop_mode" => Ok(Command::GetRecordingStopMode),
             "set_write_method" => cmd_set_write_method(&request),
             "get_write_method" => Ok(Command::GetWriteMethod),
+            "set_notification_method" => cmd_set_notification_method(&request),
+            "get_notification_method" => Ok(Command::GetNotificationMethod),
             "set_volume" => cmd_set_volume(&request),
             "get_volume" => Ok(Command::GetVolume),
             "set_primary_language" => cmd_set_primary_language(&request),
@@ -218,6 +220,18 @@ fn cmd_set_write_method(request: &DaemonRequest) -> Result<Command, String> {
         .parse::<WriteMethod>()
         .map_err(|e| format!("Invalid input method: {e}"))?;
     Ok(Command::SetWriteMethod { method })
+}
+
+fn cmd_set_notification_method(request: &DaemonRequest) -> Result<Command, String> {
+    let method = request
+        .data
+        .as_ref()
+        .and_then(|data| data.get("method"))
+        .and_then(|v| v.as_str())
+        .ok_or("Missing method for set_notification_method command")?
+        .to_string();
+
+    Ok(Command::SetNotificationMethod { method })
 }
 
 fn cmd_set_allow_online_models(request: &DaemonRequest) -> Result<Command, String> {

--- a/super-stt-shared/src/models/protocol/response.rs
+++ b/super-stt-shared/src/models/protocol/response.rs
@@ -102,6 +102,10 @@ pub struct DaemonResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_method: Option<String>,
 
+    // Notification method
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notification_method: Option<String>,
+
     // Streaming preview text (intermediate transcription during recording)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preview_text: Option<String>,
@@ -362,6 +366,12 @@ impl DaemonResponse {
     #[must_use]
     pub fn with_write_method(mut self, method: String) -> Self {
         self.write_method = Some(method);
+        self
+    }
+
+    #[must_use]
+    pub fn with_notification_method(mut self, method: String) -> Self {
+        self.notification_method = Some(method);
         self
     }
 


### PR DESCRIPTION
Closes #338.

Stopping a recording without speaking used to dispatch near-silent audio to the
transcription backend, which errored — and the daemon then typed
`[Super STT: transcription failed]` into whatever window the user had focused.
Nothing was spoken, so nothing failed.

This branch fixes that, and changes how genuine failures reach the user.

## Silence is not a failure

The recorder already maintains a one-way per-take speech latch (it drives
auto-stop, and the 60-second no-speech timeout). The final transcription is now
gated on it: a take that never crossed the speech threshold skips the backend
entirely and completes as an ordinary empty transcription. Whatever a backend
does with an empty buffer stops mattering, and `[Super STT: transcription failed]`
comes to mean only a real backend failure.

The latch is maintained regardless of `silence_detection_disabled`, so this works
for manually-stopped recordings — the case in the issue.

Adjacent fix found along the way: `process_final_text` built its output as
`format!("{processed_text} ")`, so an empty transcript typed a bare space into the
focused window. It now types nothing.

## Failures notify instead of typing

New `notification_method` setting — `auto` (default), `dbus`, `typed`, `off` —
controlling how a recording failure is surfaced:

| Method  | Behavior                                                          |
|---------|-------------------------------------------------------------------|
| `auto`  | Desktop notification; types the notice only if delivery fails      |
| `dbus`  | Notification only; logs if undeliverable                           |
| `typed` | Types the notice into the focused window (the previous behavior)   |
| `off`   | Logs only                                                          |

Delivery goes over `org.freedesktop.Notifications`, the freedesktop Desktop
Notifications interface — so this works on GNOME, KDE Plasma, COSMIC, XFCE, MATE,
Cinnamon and LXQt, and with the standalone servers used on bare compositors (mako,
dunst, swaync). One code path, nothing desktop-specific.

Notifications fire for every failure regardless of write mode; typing is what
requires `write_mode: true`, so `typed` — and `auto` after a failed delivery —
degrades to a log line when there is no write mode. The notifier holds its own
lazily-established session connection rather than the daemon's `DBusManager` one,
so serving our own bus name and sending notifications fail independently.

Notification bodies carry only the fixed constants from `output/notice.rs`, never
backend error text. Backends are untrusted and notification servers may render
limited markup in the body, so the rule that governs typing governs this channel
too. Failure detail continues to go to the log and the error response.

## Protocol and UI

`POST`/`GET /v1/notification_method`, scope `settings`, specified in
`docs/protocol/endpoints/v1/notification_method.md` (written before the
implementation). The value travels in the existing generic `data` field on the
request; no new `DaemonRequest` field. An unknown value is rejected with
`400 invalid_notification_method`, while an unparseable value already stored in
the config file degrades to the default at load — deliberately different behaviors.

In the app, the setting appears as "Failure Notices" in a new Notifications
section on the Recording page.

`docs/protocol/endpoints/v1/transcribe.md` and `events.md` are updated to match:
the failure notice is described as routed by the new setting rather than
unconditionally typed, and a no-speech capture is documented as completing
successfully with an empty transcription.

## Test isolation fix

Not part of the feature, but this work surfaced it: the daemon lib test suite
persisted through to the developer's real `~/.config/super-stt/daemon.toml` with
no test-time override, and — once the notifier existed — could fire real desktop
notifications during a test run. Both happened. `get_config_path()` now redirects
to a process-local temp file under `#[cfg(test)]`, and `test_daemon()` constructs
a fake notifier, so neither can recur. Production behavior is unchanged.

Known limitation, documented in the code: `#[cfg(test)]` covers this crate's unit
tests only — integration targets under `tests/` still resolve the real path.

## Verification

- `cargo test -p super-stt-shared --lib` — 112 passed
- `cargo test -p super-stt-daemon --lib` — 304 passed, 1 ignored
- `cargo clippy --all-features --workspace -- -W clippy::pedantic -D warnings -D unused_must_use` — clean
- `cargo fmt --all -- --check` — clean
- Confirmed a full daemon suite run leaves `~/.config/super-stt/daemon.toml` byte-identical

Not yet verified manually: the app dropdown persisting across a restart.
