### PR TITLE
Scope user-authorized base_url egress to the endpoint the user named

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -155,6 +155,25 @@ default     = 30
 | `default`     | matches `type` | no       | Value used when the user sets none.                    |
 | `required`    | bool           | no       | Whether a value must be set before the backend can load. Default `false`. |
 
+#### `base_url` and egress
+
+An option named `base_url` is the convention for a backend's configurable
+endpoint. When the user sets one, the daemon treats its host as
+**user-authorized egress** for the backend: it is added to the WASM transport's
+`allowed_hosts` at model-load time *and* exempt from the SSRF resolver guard
+(see [wasm.md — Network egress](./wasm.md#network-egress)). This lets a cloud
+backend be pointed at an arbitrary gateway — public, local, or on a private
+network — without re-installing the backend. The host is derived from the
+effective value (config override → manifest default) and must be in origin
+form (`host` or `host:port`, scheme optional); a value carrying a path is
+treated as its bare host.
+
+The exemption is safe because options are **user-writable only**: the daemon
+reads them from config set through the settings-scoped API, never from the
+(untrusted) backend, so a component cannot self-authorize a metadata endpoint
+or localhost target. Manifest-declared `[network].allowed_hosts` entries remain
+SSRF-guarded.
+
 Both secrets and options reach the backend the same way — injected request
 headers on every `/v1` request — and differ only in how the daemon stores
 them at rest. See [request headers](./contract.md#request-headers).

--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -88,7 +88,7 @@ allowed_hosts = ["api.openai.com"]
 
 | Field           | Type             | Required | Notes                                                              |
 |-----------------|------------------|----------|--------------------------------------------------------------------|
-| `allowed_hosts` | array of string  | no       | Host or `host:port` egress allowlist. Empty or absent ⇒ no network. |
+| `allowed_hosts` | array of string  | no       | Host or `host:port` egress allowlist. Empty or absent ⇒ no network beyond a user-set [`base_url`](#base_url-and-egress). |
 
 `allowed_hosts` is honored for `wasm` backends, where the daemon enforces it
 on every outbound request (see [wasm.md](./wasm.md#network-egress)).
@@ -136,7 +136,6 @@ name        = "base_url"
 label       = "API base URL"
 description = "Override the API base URL, e.g. for a gateway."
 type        = "string"
-default     = "https://api.openai.com"
 
 [[options]]
 name        = "request_timeout_seconds"
@@ -152,27 +151,55 @@ default     = 30
 | `label`       | string         | no       | Human-readable label shown in the settings UI. Falls back to `name` when absent. |
 | `description` | string         | yes      | Help text shown beside the input in the settings UI.   |
 | `type`        | string         | no       | `string`, `integer`, or `bool`. Drives the input the UI renders. Default `string`. |
-| `default`     | matches `type` | no       | Value used when the user sets none.                    |
+| `default`     | matches `type` | no       | Value used when the user sets none. Forbidden on `base_url` — see below. |
 | `required`    | bool           | no       | Whether a value must be set before the backend can load. Default `false`. |
 
 #### `base_url` and egress
 
 An option named `base_url` is the convention for a backend's configurable
-endpoint. When the user sets one, the daemon treats its host as
+endpoint. When the user sets one, the daemon treats its authority as
 **user-authorized egress** for the backend: it is added to the WASM transport's
-`allowed_hosts` at model-load time *and* exempt from the SSRF resolver guard
+egress set at model-load time, and the SSRF resolver guard is relaxed for it
 (see [wasm.md — Network egress](./wasm.md#network-egress)). This lets a cloud
 backend be pointed at an arbitrary gateway — public, local, or on a private
-network — without re-installing the backend. The host is derived from the
-effective value (config override → manifest default) and must be in origin
-form (`host` or `host:port`, scheme optional); a value carrying a path is
-treated as its bare host.
+network — without re-installing the backend.
 
-The exemption is safe because options are **user-writable only**: the daemon
-reads them from config set through the settings-scoped API, never from the
-(untrusted) backend, so a component cannot self-authorize a metadata endpoint
-or localhost target. Manifest-declared `[network].allowed_hosts` entries remain
-SSRF-guarded.
+`base_url` is the one option a manifest may declare but not supply a value for.
+The reason is the paragraph below — the value authorizes egress the sandbox
+would otherwise refuse, and a value the backend author wrote is not user intent.
+Every other option keeps its default.
+
+A manifest that declares one is refused **at publication**: the registry indexer
+rejects the release, so it never reaches a user. A backend installed some other
+way still loads, with the option intact and the declared value dropped and
+logged — an author's mistake costs the user a setting, not the backend. Either
+way the value never takes effect, so a backend that needs a working endpoint out
+of the box carries it in the component and treats the option as an override.
+That is what the missing `x-stt-option-base_url` header means when the user has
+set nothing.
+
+The daemon derives exactly one `host:port` authority from the configured value.
+An explicit port is taken as written; otherwise the scheme's default applies —
+`http` and `ws` ⇒ 80, `https` and `wss` ⇒ 443 — and a value carrying no scheme
+is read as `https`. Any path, query, or userinfo is discarded, and a value that
+yields no host contributes nothing: the backend keeps whatever egress its
+manifest declares.
+
+The host is authorized on its own as well, so a gateway stays reachable on its
+other ports — but only the derived `host:port` carries the relaxation below.
+Another port on the same host is therefore reachable while it is public, and
+refused once it is local or private.
+
+Relaxing the guard is safe because the value is **the user's only**: the daemon
+reads it from config set through the settings-scoped API, never from the
+component and never from the manifest, so a backend cannot self-authorize a
+metadata endpoint or localhost target. The relaxation lifts the loopback and
+private-range blocks — reaching a gateway on `127.0.0.1` or `10.0.0.0/8` is the
+point of the option — and nothing further. Link-local addresses
+(`169.254.0.0/16`, `fe80::/10`), including the cloud metadata endpoint
+`169.254.169.254`, along with the unspecified and broadcast addresses, stay
+refused for every backend however they were authorized. Manifest-declared
+`[network].allowed_hosts` entries remain fully SSRF-guarded.
 
 Both secrets and options reach the backend the same way — injected request
 headers on every `/v1` request — and differ only in how the daemon stores

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -407,7 +407,12 @@ reach:
   `wasi:http/outgoing-handler`, validated against the `allowed_hosts` in its
   configuration; raw sockets are not granted. A subprocess backend runs with no
   network at all. See [wasm.md](./wasm.md) and
-  [subprocess.md](./subprocess.md).
+  [subprocess.md](./subprocess.md). One deliberate exception: a host the *user*
+  sets in a backend's `base_url` option is added to that backend's egress and
+  exempted from the SSRF guard, so a user can point a cloud backend at a local
+  or private gateway. Options are user-writable only, so a backend cannot
+  self-authorize this; see
+  [config.md — `base_url` and egress](./config.md#base_url-and-egress).
 - **Filesystem.** A subprocess backend is confined to its own directory; a
   WASM backend has no ambient filesystem access.
 - **Secrets and options.** A backend declares the API keys (secrets) and

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -407,11 +407,13 @@ reach:
   `wasi:http/outgoing-handler`, validated against the `allowed_hosts` in its
   configuration; raw sockets are not granted. A subprocess backend runs with no
   network at all. See [wasm.md](./wasm.md) and
-  [subprocess.md](./subprocess.md). One deliberate exception: a host the *user*
-  sets in a backend's `base_url` option is added to that backend's egress and
-  exempted from the SSRF guard, so a user can point a cloud backend at a local
-  or private gateway. Options are user-writable only, so a backend cannot
-  self-authorize this; see
+  [subprocess.md](./subprocess.md). One deliberate exception: the `host:port`
+  the *user* sets in a backend's `base_url` option is added to that backend's
+  egress with the SSRF guard relaxed for it, so a user can point a cloud backend
+  at a local or private gateway. It covers that one authority, never the
+  link-local/metadata range, and the value must be the user's — a `default` a
+  manifest declares for `base_url` never takes effect — so a backend cannot
+  self-authorize it; see
   [config.md — `base_url` and egress](./config.md#base_url-and-egress).
 - **Filesystem.** A subprocess backend is confined to its own directory; a
   WASM backend has no ambient filesystem access.

--- a/docs/protocol/backend/wasm.md
+++ b/docs/protocol/backend/wasm.md
@@ -47,6 +47,16 @@ which the daemon implements. The daemon enforces the configuration's
 
 A backend with an empty `allowed_hosts` has no network at all.
 
+**User-authorized egress (`base_url`).** A backend that declares an option
+named `base_url` (see [config.md — `base_url` and egress](./config.md#base_url-and-egress))
+lets the user point it at an arbitrary gateway. At model-load time the daemon
+adds the effective `base_url`'s host to the backend's egress set **and** exempts
+that host from the SSRF guard — so a user-set gateway may be on localhost or a
+private network. Only hosts the *user* configured through the settings-scoped
+API get this exception: options are never writable by the component, so a
+malicious backend still cannot self-authorize the metadata endpoint or a
+localhost service. Manifest `allowed_hosts` entries remain SSRF-guarded.
+
 ## Secrets and options
 
 The active model (`x-stt-model`) and the secrets and options a backend

--- a/docs/protocol/backend/wasm.md
+++ b/docs/protocol/backend/wasm.md
@@ -45,17 +45,27 @@ which the daemon implements. The daemon enforces the configuration's
   to loopback, link-local, or private ranges — including the metadata
   address `169.254.169.254` — to prevent server-side request forgery.
 
-A backend with an empty `allowed_hosts` has no network at all.
+A backend with an empty `allowed_hosts` has no network at all, unless the user
+authorizes one endpoint through `base_url`.
 
 **User-authorized egress (`base_url`).** A backend that declares an option
 named `base_url` (see [config.md — `base_url` and egress](./config.md#base_url-and-egress))
 lets the user point it at an arbitrary gateway. At model-load time the daemon
-adds the effective `base_url`'s host to the backend's egress set **and** exempts
-that host from the SSRF guard — so a user-set gateway may be on localhost or a
-private network. Only hosts the *user* configured through the settings-scoped
-API get this exception: options are never writable by the component, so a
-malicious backend still cannot self-authorize the metadata endpoint or a
-localhost service. Manifest `allowed_hosts` entries remain SSRF-guarded.
+derives one `host:port` authority from the configured value, adds it to the
+backend's egress set, and relaxes the SSRF guard for it — so a user-set gateway
+may be on localhost or a private network. Only what the *user* configured
+through the settings-scoped API gets this treatment: the option is never
+writable by the component, and a `default` a manifest declares for `base_url` is
+dropped at discovery (and refused outright by the registry), so a malicious
+backend cannot self-authorize a localhost service.
+
+The relaxation is bounded in both directions. It covers the derived authority
+only — the host is authorized on its own too, so a public gateway keeps its
+other ports, but reaching a local or private address needs the endpoint the user
+actually named. And it lifts only the loopback and private-range blocks, so
+link-local addresses — the metadata endpoint `169.254.169.254` among them — and
+the unspecified and broadcast addresses stay refused no matter who named them.
+Manifest `allowed_hosts` entries remain fully SSRF-guarded.
 
 ## Secrets and options
 

--- a/docs/protocol/endpoints/v1/backends.md
+++ b/docs/protocol/endpoints/v1/backends.md
@@ -135,6 +135,12 @@ For both, `POST` sets a value and `DELETE` resets it to its default — the
 manifest default for an option, the unset state for a secret. `GET` on a secret
 reports only whether it is configured; `GET` on an option returns its value.
 
+Setting an option named `base_url` additionally authorizes that host for the
+backend's network egress (with an SSRF exception) on its next model load — see
+[config.md — `base_url` and egress](../../../backend/config.md#base_url-and-egress).
+This is how a cloud backend is pointed at an alternate endpoint (a gateway,
+proxy, or local OpenAI-compatible server) without re-installing it.
+
 ## DELETE /backends/{source}
 
 Uninstalls a backend. Works for any installed backend — registry-installed,

--- a/docs/protocol/endpoints/v1/backends.md
+++ b/docs/protocol/endpoints/v1/backends.md
@@ -61,7 +61,7 @@ Authorization: Bearer stt_…64hex…
       "source": "github.com/super-stt/openai",
       "name":   "OpenAI",
       "kind":   "wasm",                 // "wasm" | "subprocess"
-      "allowed_hosts": ["api.openai.com"],  // hosts the backend may reach; [] for subprocess/local
+      "allowed_hosts": ["api.openai.com"],  // hosts the manifest declares; [] for subprocess/local
       "models": [
         {
           "name":                 "whisper-1",
@@ -87,9 +87,9 @@ Authorization: Bearer stt_…64hex…
           "label":       "API base URL",
           "description": "Override the API base URL, e.g. for a gateway.",
           "type":        "string",
-          "default":     "https://api.openai.com",
+          "default":     null,                     // a `base_url` default never takes effect
           "required":    false,
-          "value":       "https://api.openai.com"  // effective value (override or default)
+          "value":       "https://gw.example.com"  // effective value (override or default)
         }
       ]
     }
@@ -103,7 +103,7 @@ Authorization: Bearer stt_…64hex…
 | `…[].source`      | string           | Backend repo id; the `source` of every model it serves.              |
 | `…[].name`        | string           | Human-readable backend name.                                         |
 | `…[].kind`        | string           | `wasm` or `subprocess`.                                              |
-| `…[].allowed_hosts` | array of strings | Hosts the backend is permitted to reach (`[network].allowed_hosts` from its `backend.toml`). Empty for `subprocess` backends (which run with no network) and for backends that declare none. Surfaced in the settings UI's "Online model" badge so the user sees where a cloud backend's audio would go. |
+| `…[].allowed_hosts` | array of strings | Hosts the backend **declared** in its `backend.toml` (`[network].allowed_hosts`). Empty for `subprocess` backends (which run with no network) and for backends that declare none. Surfaced in the settings UI's "Online model" badge so the user sees where a cloud backend's audio would go. It is the manifest's declaration alone: a user-set [`base_url`](../../backend/config.md#base_url-and-egress) authorizes a further endpoint, which clients read from that option's `value` rather than from this list. |
 | `…[].models`      | array            | Models served, as `{ name, multilingual, primary_language, supported_languages, supported_devices, estimated_vram_bytes }`. `multilingual` is `true` when the model accepts a language tag. `primary_language` is the model's default BCP-47 tag (the fallback when no override or global setting applies). `supported_languages` is the non-empty array of BCP-47 tags the model accepts; these feed the per-model language picker and the [`/backends/{source}/models/{model}/language`](./backends/model-language.md) resolution. `supported_devices` is a non-empty array drawn from `["cpu", "cuda", "metal", "none"]`; `"none"` marks a remote/online model with no local compute. `estimated_vram_bytes` is a conservative GPU memory estimate (weights + KV cache + overhead); `0` when unknown or not GPU-resident. See [`GET /gpu_info`](./gpu_info.md) for the detected GPU memory it's weighed against. |
 | `…[].secrets`     | array            | Declared secrets: `{ name, label, description, required }`. `label` falls back to `name` when absent. Secret **values** are never returned. |
 | `…[].options`     | array            | Declared options: `{ name, label, description, type, default, required, value }`. `label` falls back to `name` when absent; `value` is the effective value (config override if set, else `default`). |
@@ -135,9 +135,11 @@ For both, `POST` sets a value and `DELETE` resets it to its default — the
 manifest default for an option, the unset state for a secret. `GET` on a secret
 reports only whether it is configured; `GET` on an option returns its value.
 
-Setting an option named `base_url` additionally authorizes that host for the
-backend's network egress (with an SSRF exception) on its next model load — see
-[config.md — `base_url` and egress](../../../backend/config.md#base_url-and-egress).
+Setting an option named `base_url` additionally authorizes that `host:port` for
+the backend's network egress (with the SSRF guard relaxed for it) on its next
+model load. Only a value set here does so: a `default` a `backend.toml`
+declares for that option never takes effect — see
+[config.md — `base_url` and egress](../../backend/config.md#base_url-and-egress).
 This is how a cloud backend is pointed at an alternate endpoint (a gateway,
 proxy, or local OpenAI-compatible server) without re-installing it.
 

--- a/super-stt-app/src/ui/views/models/active.rs
+++ b/super-stt-app/src/ui/views/models/active.rs
@@ -14,8 +14,8 @@ use crate::ui::messages::{
 };
 
 use super::chips::{
-    backend_is_online, backend_supports_cpu, backend_supports_gpu, capability_chips, count_chip,
-    requirement_warning,
+    CloudEgress, backend_has_user_url, backend_is_online, backend_supports_cpu,
+    backend_supports_gpu, capability_chips, count_chip, requirement_warning,
 };
 use super::fmt::vram_warning;
 use super::status::unmet_requirements;
@@ -191,12 +191,15 @@ pub(super) fn active_backend_card<'a>(
     // Capability chips advertise the backend's compute: GPU / CPU for local
     // models, Cloud for online ones (with the hosts it reaches on hover); a
     // trailing "N models" count chip rounds out the row.
-    let hosts = online.then_some(backend.allowed_hosts.as_slice());
+    let egress = online.then(|| CloudEgress {
+        hosts: backend.allowed_hosts.as_slice(),
+        user_url: backend_has_user_url(backend),
+    });
     let mut chip_row = row![].spacing(spacing.space_xxs).align_y(Alignment::Center);
     if let Some(chips) = capability_chips(
         backend_supports_gpu(backend),
         backend_supports_cpu(backend),
-        hosts,
+        egress,
         true,
     ) {
         chip_row = chip_row.push(chips);

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -37,6 +37,23 @@ pub(super) fn backend_supports_cpu(backend: &crate::daemon::backends::BackendInf
         .any(|m| m.supported_devices.iter().any(|d| d == "cpu"))
 }
 
+/// Whether the user pointed this backend at an endpoint of their own — a
+/// `base_url` option carrying a value. That value is egress the backend's
+/// `allowed_hosts` does not describe, so the Cloud chip has to account for it;
+/// the address itself stays out of the card (see [`cloud_chip`]).
+///
+/// Keyed on the value being present, which is the daemon's own rule: it
+/// authorizes whatever the override holds, whether or not that happens to equal
+/// a `default` some older daemon still reports. Testing against `default` would
+/// hide the line for a user who set the endpoint to the same string, on a card
+/// whose whole job is disclosing where audio goes.
+pub(super) fn backend_has_user_url(backend: &crate::daemon::backends::BackendInfo) -> bool {
+    backend.options.iter().any(|o| {
+        o.name == super_stt_registry_types::manifest::BASE_URL_OPTION
+            && o.value.as_ref().is_some_and(|v| !v.trim().is_empty())
+    })
+}
+
 /// A small rounded "pill" advertising one backend capability — a tinted icon
 /// and a short label over a soft, same-hue fill. `fg` is the full-strength
 /// tone (icon, text, and border); the fill and border are derived from it at a
@@ -169,27 +186,48 @@ pub(super) fn models_inventory(names: &[String]) -> Option<Element<'static, Mess
     Some(inventory.into())
 }
 
+/// Where an online backend sends audio, as a card can describe it: the hosts
+/// its `backend.toml` declares, plus whether the user pointed it at an endpoint
+/// of their own.
+#[derive(Clone, Copy)]
+pub(super) struct CloudEgress<'a> {
+    /// The backend's declared `[network].allowed_hosts`.
+    pub hosts: &'a [String],
+    /// Whether a `base_url` the user set adds an endpoint beyond `hosts`.
+    pub user_url: bool,
+}
+
 /// The Cloud capability chip: a [`capability_chip`] with a hover tooltip
 /// listing the hosts the backend transmits audio to. Shares the GPU/CPU
 /// chips' neutral tone so "runs in the cloud" reads as a plain capability,
 /// not a golden/premium value judgment.
-pub(super) fn cloud_chip(fg: cosmic::iced::Color, hosts: &[String]) -> Element<'static, Message> {
+///
+/// A user-set `base_url` is named as a line, never as the address: it is the
+/// user's own value, and printing it would put a configured endpoint on a card
+/// they may be showing someone.
+pub(super) fn cloud_chip(
+    fg: cosmic::iced::Color,
+    egress: CloudEgress<'_>,
+) -> Element<'static, Message> {
     use super::surface::rounded_tooltip;
     let chip = capability_chip(icons::CLOUD, "Cloud", fg);
-    if hosts.is_empty() {
+    if egress.hosts.is_empty() && !egress.user_url {
         return chip;
     }
-    let mut popup = widget::column::with_capacity(hosts.len() + 1)
+    let mut popup = widget::column::with_capacity(egress.hosts.len() + 2)
         .push(text::body("Transmits audio to:"))
         .spacing(cosmic::theme::spacing().space_xxxs);
-    for host in hosts {
+    for host in egress.hosts {
         popup = popup.push(text::body(format!("• {host}")));
+    }
+    if egress.user_url {
+        popup = popup.push(text::body("• another URL you set"));
     }
     rounded_tooltip(chip, popup, widget::tooltip::Position::Top)
 }
 
 /// The capability-chip row for a backend: GPU / CPU advertise local compute,
-/// Cloud (when `online_hosts` is `Some`) flags an online backend. Returns
+/// Cloud (when `online` is `Some`) flags an online backend. Returns
 /// `None` when there's nothing to advertise, so callers skip the row rather
 /// than render an empty band.
 ///
@@ -205,7 +243,7 @@ pub(super) fn cloud_chip(fg: cosmic::iced::Color, hosts: &[String]) -> Element<'
 pub(super) fn capability_chips(
     supports_gpu: bool,
     supports_cpu: bool,
-    online_hosts: Option<&[String]>,
+    online: Option<CloudEgress<'_>>,
     tooltips: bool,
 ) -> Option<Element<'static, Message>> {
     use super::surface::rounded_tooltip;
@@ -237,9 +275,9 @@ pub(super) fn capability_chips(
             chip
         });
     }
-    if let Some(hosts) = online_hosts {
+    if let Some(egress) = online {
         chips.push(if tooltips {
-            cloud_chip(neutral, hosts)
+            cloud_chip(neutral, egress)
         } else {
             capability_chip(icons::CLOUD, "Cloud", neutral)
         });
@@ -404,5 +442,47 @@ mod capability_tests {
         let b = backend_with_devices(&[&["cpu"], &["cuda"]]);
         assert!(backend_supports_gpu(&b));
         assert!(backend_supports_cpu(&b));
+    }
+
+    /// Build a backend declaring a `base_url` option with the given effective
+    /// value — what `GET /backends` reports once the user has (or hasn't) set
+    /// one.
+    fn backend_with_base_url(value: Option<&str>) -> BackendInfo {
+        use crate::daemon::backends::BackendOption;
+        let mut b = backend_with_devices(&[&["none"]]);
+        b.options = vec![BackendOption {
+            name: "base_url".to_string(),
+            label: None,
+            description: String::new(),
+            r#type: Some("string".to_string()),
+            default: None,
+            required: false,
+            value: value.map(ToString::to_string),
+        }];
+        b
+    }
+
+    /// The Cloud chip has to account for egress the manifest does not describe.
+    /// A `base_url` the user set is exactly that; an unset or blank one is not,
+    /// and must not put a phantom line on the card.
+    #[test]
+    fn user_url_is_flagged_only_once_a_value_is_set() {
+        assert!(backend_has_user_url(&backend_with_base_url(Some(
+            "https://gw.example.com"
+        ))));
+        assert!(!backend_has_user_url(&backend_with_base_url(None)));
+        assert!(!backend_has_user_url(&backend_with_base_url(Some("  "))));
+        // A backend that declares no such option never flags one.
+        assert!(!backend_has_user_url(&backend_with_devices(&[&["none"]])));
+    }
+
+    /// The daemon authorizes whatever the override holds, so a value equal to a
+    /// `default` an older daemon still reports is still egress the manifest did
+    /// not declare. The card must say so rather than compare the two.
+    #[test]
+    fn user_url_is_flagged_even_when_it_equals_a_reported_default() {
+        let mut b = backend_with_base_url(Some("https://api.example.com"));
+        b.options[0].default = Some("https://api.example.com".to_string());
+        assert!(backend_has_user_url(&b));
     }
 }

--- a/super-stt-app/src/ui/views/models/download.rs
+++ b/super-stt-app/src/ui/views/models/download.rs
@@ -10,7 +10,7 @@ use crate::ui::icons;
 use crate::ui::messages::{Message, ModelsPageMessage, ShellMessage};
 
 use super::active::backend_header;
-use super::chips::{capability_chips, result_count};
+use super::chips::{CloudEgress, capability_chips, result_count};
 use super::surface::{card_divider, card_surface, models_line, muted_text_color};
 
 /// Browse tab split into its two regions: the fixed search + filter toolbar
@@ -247,10 +247,13 @@ pub(super) fn download_card<'a>(
             vec![],
         ));
 
-    let online_hosts = entry.online.then_some(entry.allowed_hosts.as_slice());
-    if let Some(chips) =
-        capability_chips(entry.supports_gpu, entry.supports_cpu, online_hosts, true)
-    {
+    // Browse describes a backend that is not installed, so nothing of the
+    // user's is configured for it yet.
+    let egress = entry.online.then_some(CloudEgress {
+        hosts: entry.allowed_hosts.as_slice(),
+        user_url: false,
+    });
+    if let Some(chips) = capability_chips(entry.supports_gpu, entry.supports_cpu, egress, true) {
         card = card.push(chips);
     }
 

--- a/super-stt-app/src/ui/views/models/installed.rs
+++ b/super-stt-app/src/ui/views/models/installed.rs
@@ -11,8 +11,8 @@ use crate::ui::messages::{Message, ModelsPageMessage};
 
 use super::active::backend_glyph_tile;
 use super::chips::{
-    backend_is_online, backend_supports_cpu, backend_supports_gpu, capability_chips,
-    models_inventory,
+    CloudEgress, backend_has_user_url, backend_is_online, backend_supports_cpu,
+    backend_supports_gpu, capability_chips, models_inventory,
 };
 use super::surface::{card_divider, card_surface, card_title_block, repo_button};
 
@@ -95,12 +95,15 @@ pub(super) fn installed_card<'a>(
     // Facts row: the served-models inventory takes the width; the GPU / CPU /
     // Cloud capability chips sit opposite it.
     let model_names: Vec<String> = backend.models.iter().map(|m| m.name.clone()).collect();
-    let hosts = online.then_some(backend.allowed_hosts.as_slice());
+    let egress = online.then(|| CloudEgress {
+        hosts: backend.allowed_hosts.as_slice(),
+        user_url: backend_has_user_url(backend),
+    });
     let inventory = models_inventory(&model_names);
     let caps = capability_chips(
         backend_supports_gpu(backend),
         backend_supports_cpu(backend),
-        hosts,
+        egress,
         // Suppress chip tooltips while this card's overflow menu is open, so the
         // menu paints cleanly on top instead of a tooltip showing half-behind it.
         !menu_open,

--- a/super-stt-app/src/ui/views/models/load_sheet.rs
+++ b/super-stt-app/src/ui/views/models/load_sheet.rs
@@ -12,7 +12,8 @@ use crate::ui::messages::{Message, ModelsPageMessage, ShellMessage};
 
 use super::active::backend_glyph_tile;
 use super::chips::{
-    backend_is_online, backend_supports_cpu, backend_supports_gpu, capability_chips,
+    CloudEgress, backend_has_user_url, backend_is_online, backend_supports_cpu,
+    backend_supports_gpu, capability_chips,
 };
 use super::surface::muted_text_color;
 
@@ -88,7 +89,10 @@ pub fn load_backend_sheet(app: &AppModel) -> Element<'_, Message> {
 fn load_backend_row(backend: &BackendInfo, is_active: bool) -> Element<'static, Message> {
     let spacing = cosmic::theme::spacing();
     let online = backend_is_online(backend);
-    let hosts = online.then_some(backend.allowed_hosts.as_slice());
+    let egress = online.then(|| CloudEgress {
+        hosts: backend.allowed_hosts.as_slice(),
+        user_url: backend_has_user_url(backend),
+    });
 
     let mut meta = widget::column::with_capacity(2)
         .spacing(spacing.space_xxxs)
@@ -97,7 +101,7 @@ fn load_backend_row(backend: &BackendInfo, is_active: bool) -> Element<'static, 
     if let Some(chips) = capability_chips(
         backend_supports_gpu(backend),
         backend_supports_cpu(backend),
-        hosts,
+        egress,
         true,
     ) {
         meta = meta.push(chips);

--- a/super-stt-daemon/src/daemon/backend_config_handlers.rs
+++ b/super-stt-daemon/src/daemon/backend_config_handlers.rs
@@ -78,6 +78,11 @@ impl SuperSTTDaemon {
                     source: b.source.clone(),
                     name: b.name.clone(),
                     kind: b.kind.clone(),
+                    // The manifest's declared egress, and only that. A user-set
+                    // `base_url` authorizes an endpoint beyond it, but it is the
+                    // user's own value and does not belong in a field clients
+                    // read as "what this backend declared": the settings UI
+                    // reports it from the `base_url` option instead.
                     allowed_hosts: b.allowed_hosts.clone(),
                     models,
                     secrets,

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -600,35 +600,15 @@ async fn set_model_local_works_without_online_toggle() {
 /// override is reflected in an option's effective `value`. Keyring-free.
 #[tokio::test]
 async fn list_backends_catalog_and_option_override() {
+    use crate::daemon::test_fixtures::openai_backend;
     use crate::stt_models::ModelDefinition;
-    use crate::stt_models::backends::DiscoveredBackend;
-    use crate::stt_models::backends::manifest::{Opt, OptionDefault, OptionType, Secret};
     use std::time::Duration;
 
     let daemon = test_daemon().await;
     let source = "github.com/super-stt/openai";
-    let backend = DiscoveredBackend {
-        dir: std::path::PathBuf::from("/tmp/openai"),
-        source: source.to_string(),
-        name: "OpenAI".to_string(),
-        kind: "wasm".to_string(),
-        entrypoint: "openai.wasm".to_string(),
-        allowed_hosts: vec!["api.openai.com".to_string()],
-        secrets: vec![Secret {
-            name: "openai_api_key".to_string(),
-            label: Some("OpenAI API key".to_string()),
-            description: "key".to_string(),
-            required: true,
-        }],
-        options: vec![Opt {
-            name: "base_url".to_string(),
-            label: Some("API base URL".to_string()),
-            description: "Base URL".to_string(),
-            r#type: Some(OptionType::String),
-            default: Some(OptionDefault::String("https://api.openai.com".to_string())),
-            required: false,
-        }],
-        models: vec![ModelDefinition {
+    let backend = openai_backend(
+        source,
+        vec![ModelDefinition {
             name: "whisper-1".to_string(),
             source: source.to_string(),
             is_multilingual: true,
@@ -640,7 +620,10 @@ async fn list_backends_catalog_and_option_override() {
             realtime: false,
             provider: None,
         }],
-    };
+        // A manifest may not declare a default for `base_url`, so the catalog's
+        // effective value starts unset and only the override fills it in.
+        None,
+    );
     *daemon.backends.write().await = vec![backend];
 
     let resp = daemon.handle_list_backends().await;
@@ -653,8 +636,8 @@ async fn list_backends_catalog_and_option_override() {
     assert_eq!(cat[0]["models"][0]["name"], "whisper-1");
     assert_eq!(cat[0]["secrets"][0]["name"], "openai_api_key");
     assert_eq!(cat[0]["secrets"][0]["label"], "OpenAI API key");
-    // No override yet → option value is the manifest default.
-    assert_eq!(cat[0]["options"][0]["value"], "https://api.openai.com");
+    // No override yet, and `base_url` may carry no manifest default → no value.
+    assert!(cat[0]["options"][0]["value"].is_null());
 
     // In-memory override (avoids a config disk write in tests).
     daemon
@@ -673,6 +656,15 @@ async fn list_backends_catalog_and_option_override() {
         .backends
         .expect("backends catalog");
     assert_eq!(cat[0]["options"][0]["value"], "https://gw.example");
+    // `allowed_hosts` stays the manifest's own declaration; the user's gateway
+    // is reported through the option's value, which is what the settings UI
+    // reads to say a user-set URL exists.
+    assert_eq!(
+        cat[0]["allowed_hosts"][0], "api.openai.com",
+        "a user-set base_url must not be folded into the manifest's list: {:?}",
+        cat[0]["allowed_hosts"]
+    );
+    assert!(cat[0]["allowed_hosts"][1].is_null());
 }
 
 /// Build a `DiscoveredBackend` whose `dir` ends in `dir_name` and that

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -93,7 +93,20 @@ async fn set(
     axum::Json(body): axum::Json<OptionBody>,
 ) -> Response {
     let source = decode_source(&source);
-    if body.value.is_empty() {
+    // `base_url` is normalized at the boundary. The daemon acts on this value
+    // rather than only passing it through — it is injected as a header *and*
+    // parsed into the egress the backend is granted — so storing it padded
+    // would leave `GET`, the component, and the authorized endpoint holding
+    // three different strings, and a whitespace-only value would show in the UI
+    // as an active override that authorizes nothing. Other options keep the
+    // value verbatim: whitespace may carry meaning in one the daemon does not
+    // interpret.
+    let value = if name == crate::stt_models::backends::base_url::OPTION_NAME {
+        body.value.trim()
+    } else {
+        body.value.as_str()
+    };
+    if value.is_empty() {
         return json_error(StatusCode::BAD_REQUEST, "invalid_request");
     }
     if let Some(r) = guard_missing(&s, &source, &name).await {
@@ -102,7 +115,7 @@ async fn set(
     let (code, _hdrs, body_str) = dispatch_command(
         &s.daemon,
         "set_backend_option",
-        Some(serde_json::json!({ "source": source, "name": name, "value": body.value })),
+        Some(serde_json::json!({ "source": source, "name": name, "value": value })),
     )
     .await;
     if code != StatusCode::OK {

--- a/super-stt-daemon/src/daemon/mod.rs
+++ b/super-stt-daemon/src/daemon/mod.rs
@@ -13,6 +13,8 @@ pub mod recording;
 pub mod settings_handlers;
 pub mod startup;
 pub mod status_handlers;
+#[cfg(test)]
+pub(crate) mod test_fixtures;
 pub mod theme_handlers;
 pub mod transcription;
 pub mod types;

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -59,9 +59,13 @@ impl SuperSTTDaemon {
             crate::stt_models::backends::manifest::Manifest::load(&backend.dir)?
                 .capabilities
                 .websocket;
+        // Egress = the manifest-pinned `allowed_hosts` (SSRF-guarded) plus any
+        // host the user authorized via the `base_url` option (SSRF exception).
+        let user_allowed_hosts = self.base_url_egress_hosts(backend).await;
         let inst = crate::stt_models::wasm::WasmBackend::with_info(
             &component,
             backend.allowed_hosts.clone(),
+            user_allowed_hosts,
             info,
             headers,
             websocket_capability,
@@ -199,16 +203,168 @@ impl SuperSTTDaemon {
                 None => {}
             }
         }
-        let config = self.config.read().await;
         for opt in &backend.options {
-            let value = config
-                .backend_option(&backend.source, &opt.name)
-                .map(str::to_string)
-                .or_else(|| opt.default.as_ref().map(ToString::to_string));
-            if let Some(v) = value {
+            if let Some(v) = self.resolved_backend_option(backend, opt).await {
                 headers.push((format!("x-stt-option-{}", opt.name), v));
             }
         }
         Ok(headers)
+    }
+
+    /// The effective value of a backend option: the user's config override if
+    /// set, else the manifest default. The single source of truth for option
+    /// resolution — shared by header injection ([`Self::backend_headers`]) and
+    /// egress allowlist derivation ([`Self::base_url_egress_hosts`]).
+    #[cfg(feature = "wasm-backends")]
+    async fn resolved_backend_option(
+        &self,
+        backend: &DiscoveredBackend,
+        opt: &backends::manifest::Opt,
+    ) -> Option<String> {
+        self.config
+            .read()
+            .await
+            .backend_option(&backend.source, &opt.name)
+            .map(str::to_string)
+            .or_else(|| opt.default.as_ref().map(ToString::to_string))
+    }
+
+    /// Hosts the *user* authorized via a `base_url` option, derived from its
+    /// effective value (config override → manifest default).
+    ///
+    /// `base_url` is the documented convention for a backend's configurable
+    /// endpoint (`docs/protocol/backend/config.md`); any backend declaring an
+    /// option with that name gets the SSRF exception for its host. A backend
+    /// cannot self-authorize these — options are set by the user only — so the
+    /// host is exempt from the egress SSRF guard (it may be loopback/private,
+    /// e.g. a local gateway). Unparseable or unset values contribute nothing.
+    #[cfg(feature = "wasm-backends")]
+    async fn base_url_egress_hosts(&self, backend: &DiscoveredBackend) -> Vec<String> {
+        let Some(opt) = backend.options.iter().find(|o| o.name == "base_url") else {
+            return Vec::new();
+        };
+        let Some(value) = self.resolved_backend_option(backend, opt).await else {
+            return Vec::new();
+        };
+        base_url_host(&value).into_iter().collect()
+    }
+}
+
+/// Extract the bare host (or `host[:port]`) from a base URL, mirroring the
+/// origin-form assumption the OpenAI-style WASM backends make: `base_url` is a
+/// scheme + authority, not a full-path URL. A bare host (no scheme) is treated
+/// as a host. Returns `None` when nothing parseable remains.
+#[cfg(feature = "wasm-backends")]
+fn base_url_host(base_url: &str) -> Option<String> {
+    let rest = base_url
+        .strip_prefix("https://")
+        .or_else(|| base_url.strip_prefix("http://"))
+        .unwrap_or(base_url);
+    let rest = rest.trim_end_matches('/');
+    let host = match rest.find('/') {
+        Some(i) => &rest[..i],
+        None => rest,
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.to_string())
+}
+
+#[cfg(all(test, feature = "wasm-backends"))]
+mod tests {
+    use super::base_url_host;
+
+    #[test]
+    fn base_url_host_extracts_authority() {
+        assert_eq!(
+            base_url_host("https://api.openai.com"),
+            Some("api.openai.com".to_string())
+        );
+        assert_eq!(
+            base_url_host("https://api.openai.com/"),
+            Some("api.openai.com".to_string())
+        );
+        assert_eq!(
+            base_url_host("http://gw.example.com:8080"),
+            Some("gw.example.com:8080".to_string())
+        );
+        // A bare host (no scheme) is treated as a host.
+        assert_eq!(
+            base_url_host("gw.example.com"),
+            Some("gw.example.com".to_string())
+        );
+        // Any path after the authority is dropped — the backends assume origin form.
+        assert_eq!(
+            base_url_host("https://gw.example.com/v1/audio"),
+            Some("gw.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn base_url_host_rejects_unparseable() {
+        assert_eq!(base_url_host(""), None);
+        assert_eq!(base_url_host("https://"), None);
+        assert_eq!(base_url_host("/"), None);
+        assert_eq!(base_url_host("https:///path"), None);
+    }
+
+    /// The user-set `base_url` option's host feeds the egress allowlist:
+    /// manifest default when unset, the override (port included) when set, and
+    /// nothing for a backend that declares no such option.
+    #[tokio::test]
+    async fn base_url_egress_hosts_resolves_override_or_default() {
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+        use crate::stt_models::backends::manifest::{Opt, OptionDefault, OptionType};
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        let backend = DiscoveredBackend {
+            dir: std::path::PathBuf::from("/tmp/openai"),
+            source: source.to_string(),
+            name: "OpenAI".to_string(),
+            kind: "wasm".to_string(),
+            entrypoint: "openai.wasm".to_string(),
+            allowed_hosts: vec!["api.openai.com".to_string()],
+            secrets: vec![],
+            options: vec![Opt {
+                name: "base_url".to_string(),
+                label: Some("API base URL".to_string()),
+                description: "Base URL".to_string(),
+                r#type: Some(OptionType::String),
+                default: Some(OptionDefault::String("https://api.openai.com".to_string())),
+                required: false,
+            }],
+            models: vec![],
+        };
+
+        // No override → the manifest default's host.
+        assert_eq!(
+            daemon.base_url_egress_hosts(&backend).await,
+            vec!["api.openai.com"]
+        );
+
+        // Config override pointing at a local gateway → that host, port kept.
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert("base_url".to_string(), "http://localhost:8080".to_string());
+        assert_eq!(
+            daemon.base_url_egress_hosts(&backend).await,
+            vec!["localhost:8080"]
+        );
+
+        // A backend declaring no `base_url` option contributes nothing.
+        let no_base = DiscoveredBackend {
+            options: vec![],
+            ..backend
+        };
+        assert!(daemon.base_url_egress_hosts(&no_base).await.is_empty());
     }
 }

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -43,7 +43,12 @@ impl SuperSTTDaemon {
         def: &ModelDefinition,
     ) -> Result<Box<dyn Transcribe>> {
         use crate::stt_models::transcribe::ModelInfoData;
-        let headers = self.backend_headers(backend).await?;
+        // One snapshot of the user's options for both the headers the component
+        // is handed and the egress it is granted: read separately, a config
+        // write landing between them would authorize a different endpoint than
+        // the one the component is told to use.
+        let overrides = self.backend_option_overrides(&backend.source).await;
+        let headers = self.backend_headers(backend, &overrides).await?;
         let component = backend.dir.join(&backend.entrypoint);
         let info = ModelInfoData::new(
             def.name.clone(),
@@ -59,9 +64,10 @@ impl SuperSTTDaemon {
             crate::stt_models::backends::manifest::Manifest::load(&backend.dir)?
                 .capabilities
                 .websocket;
-        // Egress = the manifest-pinned `allowed_hosts` (SSRF-guarded) plus any
-        // host the user authorized via the `base_url` option (SSRF exception).
-        let user_allowed_hosts = self.base_url_egress_hosts(backend).await;
+        // Egress = the manifest-pinned `allowed_hosts` (fully SSRF-guarded) plus
+        // what the user authorized via the `base_url` option, whose `host:port`
+        // may be local or private.
+        let user_allowed_hosts = Self::base_url_egress_hosts(backend, &overrides);
         let inst = crate::stt_models::wasm::WasmBackend::with_info(
             &component,
             backend.allowed_hosts.clone(),
@@ -177,7 +183,11 @@ impl SuperSTTDaemon {
     /// specific backend. Options use the config override if set, else the
     /// manifest default. A required secret that resolves to nothing is an error.
     #[cfg(feature = "wasm-backends")]
-    async fn backend_headers(&self, backend: &DiscoveredBackend) -> Result<Vec<(String, String)>> {
+    async fn backend_headers(
+        &self,
+        backend: &DiscoveredBackend,
+        overrides: &std::collections::HashMap<String, String>,
+    ) -> Result<Vec<(String, String)>> {
         let mut headers = Vec::new();
         for secret in &backend.secrets {
             let value = crate::keyring::get_backend_secret_async(
@@ -204,148 +214,162 @@ impl SuperSTTDaemon {
             }
         }
         for opt in &backend.options {
-            if let Some(v) = self.resolved_backend_option(backend, opt).await {
+            if let Some(v) = resolved_backend_option(overrides, opt) {
                 headers.push((format!("x-stt-option-{}", opt.name), v));
             }
         }
         Ok(headers)
     }
 
-    /// The effective value of a backend option: the user's config override if
-    /// set, else the manifest default. The single source of truth for option
-    /// resolution — shared by header injection ([`Self::backend_headers`]) and
-    /// egress allowlist derivation ([`Self::base_url_egress_hosts`]).
+    /// Snapshot of the user's option overrides for one backend.
+    ///
+    /// Taken once per load and shared by header injection and egress
+    /// derivation. Resolving them separately let a config write land in
+    /// between, so the component could be handed one gateway while a different
+    /// one was authorized, and every request would then be refused until the
+    /// model was reloaded. Cloned rather than held as a guard: the header path
+    /// awaits a keyring round-trip, and a read guard spanning that would block
+    /// config writers for its duration.
+    ///
+    /// `base_url` is normalized on the way out. It is the one value the two
+    /// paths must read *identically* — one dials it, the other authorizes what
+    /// it names — so surrounding whitespace, from a paste into the settings
+    /// field or from a hand-edited config that never passed through the API,
+    /// would otherwise leave them working from different strings. A value that
+    /// is only whitespace is no value at all and is dropped, so it neither
+    /// reaches the component nor authorizes anything. Every other option is
+    /// passed through exactly as the user set it: whitespace may carry meaning
+    /// in a value the daemon does not interpret.
     #[cfg(feature = "wasm-backends")]
-    async fn resolved_backend_option(
+    async fn backend_option_overrides(
         &self,
-        backend: &DiscoveredBackend,
-        opt: &backends::manifest::Opt,
-    ) -> Option<String> {
-        self.config
+        source: &str,
+    ) -> std::collections::HashMap<String, String> {
+        let mut overrides: std::collections::HashMap<String, String> = self
+            .config
             .read()
             .await
-            .backend_option(&backend.source, &opt.name)
-            .map(str::to_string)
-            .or_else(|| opt.default.as_ref().map(ToString::to_string))
+            .backends
+            .options
+            .get(source)
+            .cloned()
+            .unwrap_or_default();
+        let name = backends::base_url::OPTION_NAME;
+        match overrides.get(name).map(|v| v.trim().to_string()) {
+            Some(trimmed) if trimmed.is_empty() => {
+                overrides.remove(name);
+            }
+            Some(trimmed) => {
+                overrides.insert(name.to_string(), trimmed);
+            }
+            None => {}
+        }
+        overrides
     }
 
-    /// Hosts the *user* authorized via a `base_url` option, derived from its
-    /// effective value (config override → manifest default).
+    /// What the *user* authorized via a `base_url` option: the `host:port` the
+    /// value points at, followed by the bare host.
     ///
     /// `base_url` is the documented convention for a backend's configurable
     /// endpoint (`docs/protocol/backend/config.md`); any backend declaring an
-    /// option with that name gets the SSRF exception for its host. A backend
-    /// cannot self-authorize these — options are set by the user only — so the
-    /// host is exempt from the egress SSRF guard (it may be loopback/private,
-    /// e.g. a local gateway). Unparseable or unset values contribute nothing.
+    /// option with that name has the SSRF guard relaxed for that one authority.
+    /// The value is read from the config override **only** — never from the
+    /// manifest default, which the backend author writes and which therefore
+    /// cannot be allowed to widen the sandbox. (A manifest declaring one is
+    /// refused at parse; this read stands on its own so the invariant does not
+    /// depend on that check.) Because the value is the user's, it may be
+    /// loopback or private, e.g. a local gateway.
+    ///
+    /// The bare host carries no such relaxation; it keeps the gateway's other
+    /// ports reachable while they stay public, so no extra port on a local or
+    /// private gateway opens up (see
+    /// [`check_host_allowed`](crate::stt_models::wasm::host::check_host_allowed)).
+    /// Unparseable or unset values contribute nothing.
+    ///
+    /// Both outcomes are logged. This is the one path that relaxes the sandbox,
+    /// so an operator asking later why a backend reached a private address needs
+    /// a record of which endpoint was authorized for which backend, and when.
     #[cfg(feature = "wasm-backends")]
-    async fn base_url_egress_hosts(&self, backend: &DiscoveredBackend) -> Vec<String> {
-        let Some(opt) = backend.options.iter().find(|o| o.name == "base_url") else {
+    fn base_url_egress_hosts(
+        backend: &DiscoveredBackend,
+        overrides: &std::collections::HashMap<String, String>,
+    ) -> Vec<String> {
+        if !backend
+            .options
+            .iter()
+            .any(|o| o.name == backends::base_url::OPTION_NAME)
+        {
+            return Vec::new();
+        }
+        let Some(value) = overrides.get(backends::base_url::OPTION_NAME) else {
             return Vec::new();
         };
-        let Some(value) = self.resolved_backend_option(backend, opt).await else {
-            return Vec::new();
-        };
-        base_url_host(&value).into_iter().collect()
+        let entries = backends::base_url::egress_entries(value);
+        // Log the derived authority, never the configured value: the parser
+        // discards userinfo, so a URL pasted with credentials in it cannot reach
+        // the journal through here.
+        match entries.first() {
+            Some(endpoint) => log::info!(
+                "Backend {}: user-set base_url authorizes egress to {endpoint}, with the SSRF guard relaxed for it",
+                backend.source
+            ),
+            None => log::warn!(
+                "Backend {}: base_url is set but names no host the daemon can read; it authorizes nothing and the backend keeps only its manifest egress",
+                backend.source
+            ),
+        }
+        entries
     }
 }
 
-/// Extract the bare host (or `host[:port]`) from a base URL, mirroring the
-/// origin-form assumption the OpenAI-style WASM backends make: `base_url` is a
-/// scheme + authority, not a full-path URL. A bare host (no scheme) is treated
-/// as a host. Returns `None` when nothing parseable remains.
+/// The effective value of a backend option — the user's override if set, else
+/// the manifest default — as injected into the backend's headers by
+/// [`SuperSTTDaemon::backend_headers`].
+///
+/// Not what authorizes egress: `base_url_egress_hosts` deliberately reads the
+/// override alone, because a manifest default is the backend author's value and
+/// must not widen the sandbox. The settings-facing read path
+/// (`http/v1/backends/options.rs::effective`) resolves the same two sources
+/// separately, for display.
 #[cfg(feature = "wasm-backends")]
-fn base_url_host(base_url: &str) -> Option<String> {
-    let rest = base_url
-        .strip_prefix("https://")
-        .or_else(|| base_url.strip_prefix("http://"))
-        .unwrap_or(base_url);
-    let rest = rest.trim_end_matches('/');
-    let host = match rest.find('/') {
-        Some(i) => &rest[..i],
-        None => rest,
-    };
-    if host.is_empty() {
-        return None;
-    }
-    Some(host.to_string())
+fn resolved_backend_option(
+    overrides: &std::collections::HashMap<String, String>,
+    opt: &backends::manifest::Opt,
+) -> Option<String> {
+    overrides
+        .get(&opt.name)
+        .cloned()
+        .or_else(|| opt.default.as_ref().map(ToString::to_string))
 }
 
 #[cfg(all(test, feature = "wasm-backends"))]
 mod tests {
-    use super::base_url_host;
+    use super::SuperSTTDaemon;
 
-    #[test]
-    fn base_url_host_extracts_authority() {
-        assert_eq!(
-            base_url_host("https://api.openai.com"),
-            Some("api.openai.com".to_string())
-        );
-        assert_eq!(
-            base_url_host("https://api.openai.com/"),
-            Some("api.openai.com".to_string())
-        );
-        assert_eq!(
-            base_url_host("http://gw.example.com:8080"),
-            Some("gw.example.com:8080".to_string())
-        );
-        // A bare host (no scheme) is treated as a host.
-        assert_eq!(
-            base_url_host("gw.example.com"),
-            Some("gw.example.com".to_string())
-        );
-        // Any path after the authority is dropped — the backends assume origin form.
-        assert_eq!(
-            base_url_host("https://gw.example.com/v1/audio"),
-            Some("gw.example.com".to_string())
-        );
-    }
-
-    #[test]
-    fn base_url_host_rejects_unparseable() {
-        assert_eq!(base_url_host(""), None);
-        assert_eq!(base_url_host("https://"), None);
-        assert_eq!(base_url_host("/"), None);
-        assert_eq!(base_url_host("https:///path"), None);
-    }
-
-    /// The user-set `base_url` option's host feeds the egress allowlist:
-    /// manifest default when unset, the override (port included) when set, and
-    /// nothing for a backend that declares no such option.
+    /// Only a user-set `base_url` feeds the egress allowlist, as the endpoint it
+    /// names followed by its bare host. A backend declaring no such option, and
+    /// one the user has not configured, both contribute nothing — a manifest
+    /// value must never widen the sandbox.
     #[tokio::test]
     async fn base_url_egress_hosts_resolves_override_or_default() {
+        use crate::daemon::test_fixtures::openai_backend;
         use crate::daemon::types::test_daemon;
         use crate::stt_models::backends::DiscoveredBackend;
-        use crate::stt_models::backends::manifest::{Opt, OptionDefault, OptionType};
 
         let daemon = test_daemon().await;
         let source = "github.com/super-stt/openai";
-        let backend = DiscoveredBackend {
-            dir: std::path::PathBuf::from("/tmp/openai"),
-            source: source.to_string(),
-            name: "OpenAI".to_string(),
-            kind: "wasm".to_string(),
-            entrypoint: "openai.wasm".to_string(),
-            allowed_hosts: vec!["api.openai.com".to_string()],
-            secrets: vec![],
-            options: vec![Opt {
-                name: "base_url".to_string(),
-                label: Some("API base URL".to_string()),
-                description: "Base URL".to_string(),
-                r#type: Some(OptionType::String),
-                default: Some(OptionDefault::String("https://api.openai.com".to_string())),
-                required: false,
-            }],
-            models: vec![],
-        };
+        // The manifest default is one `Manifest::parse` would reject; it is here
+        // to prove this read does not depend on that rejection.
+        let backend = openai_backend(source, Vec::new(), Some("https://api.openai.com"));
 
-        // No override → the manifest default's host.
-        assert_eq!(
-            daemon.base_url_egress_hosts(&backend).await,
-            vec!["api.openai.com"]
-        );
+        // No override → nothing, even though the option carries a default: a
+        // value the backend author wrote must not authorize egress.
+        let overrides = daemon.backend_option_overrides(source).await;
+        assert!(SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides).is_empty());
 
-        // Config override pointing at a local gateway → that host, port kept.
+        // Config override pointing at a local gateway → that endpoint, port kept.
+        // Only the `host:port` entry carries the relaxation, so the bare host
+        // opens no other local port.
         daemon
             .config
             .write()
@@ -355,16 +379,126 @@ mod tests {
             .entry(source.to_string())
             .or_default()
             .insert("base_url".to_string(), "http://localhost:8080".to_string());
+        let overrides = daemon.backend_option_overrides(source).await;
         assert_eq!(
-            daemon.base_url_egress_hosts(&backend).await,
-            vec!["localhost:8080"]
+            SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides),
+            vec!["localhost:8080", "localhost"]
         );
 
-        // A backend declaring no `base_url` option contributes nothing.
+        // A backend declaring no `base_url` option contributes nothing, even
+        // with the override still in config.
         let no_base = DiscoveredBackend {
             options: vec![],
             ..backend
         };
-        assert!(daemon.base_url_egress_hosts(&no_base).await.is_empty());
+        assert!(SuperSTTDaemon::base_url_egress_hosts(&no_base, &overrides).is_empty());
+    }
+
+    /// A `base_url` pasted with surrounding whitespace must reach both paths as
+    /// the same string: the component dials the header it is given, and the
+    /// daemon authorizes what the value names. A value that is only whitespace
+    /// is no value — it must not be injected or authorize anything.
+    #[tokio::test]
+    async fn whitespace_in_base_url_cannot_split_the_two_paths() {
+        use crate::daemon::test_fixtures::openai_backend;
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        // No secrets: the assertions run through the real header path, which
+        // would otherwise reach the keyring for the fixture's required key.
+        let backend = DiscoveredBackend {
+            secrets: Vec::new(),
+            ..openai_backend(source, Vec::new(), None)
+        };
+
+        for (stored, expected_header) in [
+            ("  http://10.0.0.5:8080  ", Some("http://10.0.0.5:8080")),
+            ("\thttp://10.0.0.5:8080\n", Some("http://10.0.0.5:8080")),
+            ("   ", None),
+        ] {
+            daemon
+                .config
+                .write()
+                .await
+                .backends
+                .options
+                .entry(source.to_string())
+                .or_default()
+                .insert("base_url".to_string(), stored.to_string());
+
+            let overrides = daemon.backend_option_overrides(source).await;
+            let headers = daemon
+                .backend_headers(&backend, &overrides)
+                .await
+                .expect("headers for a secret-free backend");
+            let injected = headers
+                .iter()
+                .find(|(k, _)| k == "x-stt-option-base_url")
+                .map(|(_, v)| v.as_str());
+            let egress = SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides);
+            assert_eq!(injected, expected_header, "header for {stored:?}");
+            match expected_header {
+                Some(_) => assert_eq!(egress, vec!["10.0.0.5:8080", "10.0.0.5"]),
+                None => assert!(egress.is_empty(), "egress for {stored:?}"),
+            }
+        }
+    }
+
+    /// Headers and egress must describe one config state. Resolving them
+    /// separately let a write land in between, handing the component one
+    /// endpoint while a different one was authorized; both now read the same
+    /// snapshot, so the pair either sees the write or does not.
+    #[tokio::test]
+    async fn headers_and_egress_read_the_same_snapshot() {
+        use crate::daemon::test_fixtures::openai_backend;
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        // No secrets: this drives the real `backend_headers`, which would
+        // otherwise reach the keyring for the fixture's required key.
+        let backend = DiscoveredBackend {
+            secrets: Vec::new(),
+            ..openai_backend(source, Vec::new(), None)
+        };
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert("base_url".to_string(), "http://10.0.0.5:8080".to_string());
+
+        let overrides = daemon.backend_option_overrides(source).await;
+        // A write landing here reaches neither side, which is the point.
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert("base_url".to_string(), "http://10.0.0.9:8080".to_string());
+
+        // Drive the real header path, not the resolver it happens to call: the
+        // regression this pins is `backend_headers` reading config for itself.
+        let headers = daemon
+            .backend_headers(&backend, &overrides)
+            .await
+            .expect("headers for a secret-free backend");
+        let injected = headers
+            .iter()
+            .find(|(k, _)| k == "x-stt-option-base_url")
+            .map(|(_, v)| v.as_str())
+            .expect("base_url is injected from the snapshot");
+        let egress = SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides);
+        assert_eq!(injected, "http://10.0.0.5:8080");
+        assert_eq!(egress, vec!["10.0.0.5:8080", "10.0.0.5"]);
     }
 }

--- a/super-stt-daemon/src/daemon/test_fixtures.rs
+++ b/super-stt-daemon/src/daemon/test_fixtures.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Backend fixtures shared across the daemon's test modules.
+//!
+//! One builder per shape, so a field added to `DiscoveredBackend` or `Opt`
+//! breaks a single definition instead of a hand-written literal in every module
+//! that happens to need a backend.
+
+use crate::stt_models::ModelDefinition;
+use crate::stt_models::backends::DiscoveredBackend;
+use crate::stt_models::backends::manifest::{Opt, OptionDefault, OptionType, Secret};
+
+/// The cloud-backend shape the option, egress, and catalog tests all need: one
+/// required secret, `api.openai.com` as declared egress, and a `base_url`
+/// option.
+///
+/// `base_url_default` is normally `None` — a manifest may not declare a default
+/// for that option, and [`Manifest::parse`] rejects one. Pass `Some` only to
+/// build the state the parser forbids, where the point of the test is that the
+/// daemon does not rely on that rejection.
+///
+/// [`Manifest::parse`]: super_stt_registry_types::manifest::Manifest::parse
+pub(crate) fn openai_backend(
+    source: &str,
+    models: Vec<ModelDefinition>,
+    base_url_default: Option<&str>,
+) -> DiscoveredBackend {
+    DiscoveredBackend {
+        dir: std::path::PathBuf::from("/tmp/openai"),
+        source: source.to_string(),
+        name: "OpenAI".to_string(),
+        kind: "wasm".to_string(),
+        entrypoint: "openai.wasm".to_string(),
+        allowed_hosts: vec!["api.openai.com".to_string()],
+        secrets: vec![Secret {
+            name: "openai_api_key".to_string(),
+            label: Some("OpenAI API key".to_string()),
+            description: "key".to_string(),
+            required: true,
+        }],
+        options: vec![Opt {
+            name: "base_url".to_string(),
+            label: Some("API base URL".to_string()),
+            description: "Base URL".to_string(),
+            r#type: Some(OptionType::String),
+            default: base_url_default.map(|d| OptionDefault::String(d.to_string())),
+            required: false,
+        }],
+        models,
+    }
+}

--- a/super-stt-daemon/src/stt_models/backends/base_url.rs
+++ b/super-stt-daemon/src/stt_models/backends/base_url.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! The `base_url` option — the convention for a backend's configurable
+//! endpoint, and the one option whose value widens the sandbox.
+//!
+//! A configured value authorizes egress the SSRF guard would otherwise refuse,
+//! so the daemon reads it from the user's config only; a `backend.toml`
+//! declaring a `default` for it is rejected at parse. Deriving the endpoint
+//! lives here rather than at either call site so the egress list the transport
+//! enforces and the host the catalog discloses can never disagree about what a
+//! given value means. See `docs/protocol/backend/config.md`.
+
+/// Name of the option that carries a backend's configurable endpoint, from the
+/// crate the daemon, the indexer, and the catalog synthesis all share.
+pub(crate) const OPTION_NAME: &str = super_stt_registry_types::manifest::BASE_URL_OPTION;
+
+/// Extract the host and port a base URL points at. Parsed with the same [`Uri`]
+/// the transports match against, so what this produces and the authority
+/// [`check_host_allowed`](crate::stt_models::wasm::host::check_host_allowed)
+/// sees agree on userinfo, case, and the bracketed IPv6 form.
+///
+/// The port is explicit or the scheme's default, never absent: it is what
+/// distinguishes the endpoint the user chose — the one that may be local — from
+/// the rest of the host. A value with no scheme is an authority, read as
+/// `https`. Returns `None` when no host can be read, which authorizes nothing.
+///
+/// The port a scheme implies when a URI carries none.
+///
+/// Both transports and this module's derivation must answer that question the
+/// same way: the entry the daemon authorizes is compared byte-for-byte against
+/// the authority the transport builds, so a scheme the two rank differently
+/// would make them disagree about the very endpoint the user named.
+#[cfg(feature = "wasm-backends")]
+pub(crate) fn default_port(scheme: Option<&str>) -> u16 {
+    match scheme {
+        Some("http" | "ws") => 80,
+        _ => 443,
+    }
+}
+
+/// Egress derivation is meaningful only for the wasm transport, which is the
+/// one that grants a component network at all; discovery uses [`OPTION_NAME`]
+/// regardless of build.
+///
+/// [`Uri`]: hyper::Uri
+#[cfg(feature = "wasm-backends")]
+pub(crate) fn authority(value: &str) -> Option<(String, u16)> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Give a scheme-less value one, so `Uri` reads it as an authority rather
+    // than as `scheme:path`.
+    let uri: hyper::Uri = if trimmed.contains("://") {
+        trimmed.parse().ok()?
+    } else {
+        format!("https://{trimmed}").parse().ok()?
+    };
+    let host = uri.host()?;
+    if host.is_empty() {
+        return None;
+    }
+    let port = uri
+        .port_u16()
+        .unwrap_or_else(|| default_port(uri.scheme_str()));
+    Some((host.to_string(), port))
+}
+
+/// The egress entries a configured value contributes: the endpoint the user
+/// named, which has the SSRF guard relaxed, followed by its bare host, which
+/// does not — that entry keeps a public gateway reachable on its other ports
+/// without opening any further local one.
+#[cfg(feature = "wasm-backends")]
+pub(crate) fn egress_entries(value: &str) -> Vec<String> {
+    authority(value).map_or_else(Vec::new, |(host, port)| {
+        vec![format!("{host}:{port}"), host]
+    })
+}
+
+#[cfg(all(test, feature = "wasm-backends"))]
+mod tests {
+    use super::{authority, default_port, egress_entries};
+
+    #[test]
+    fn derives_the_authority_port() {
+        // The relaxation covers one endpoint, so a value with no explicit port
+        // is pinned to its scheme's default rather than to every port on the
+        // host.
+        assert_eq!(
+            authority("https://api.openai.com"),
+            Some(("api.openai.com".to_string(), 443))
+        );
+        assert_eq!(
+            authority("https://api.openai.com/"),
+            Some(("api.openai.com".to_string(), 443))
+        );
+        assert_eq!(
+            authority("http://gw.example.com"),
+            Some(("gw.example.com".to_string(), 80))
+        );
+        assert_eq!(
+            authority("http://gw.example.com:8080"),
+            Some(("gw.example.com".to_string(), 8080))
+        );
+        // A realtime endpoint carries the ws schemes.
+        assert_eq!(
+            authority("wss://gw.example.com"),
+            Some(("gw.example.com".to_string(), 443))
+        );
+        assert_eq!(
+            authority("ws://gw.example.com"),
+            Some(("gw.example.com".to_string(), 80))
+        );
+        // A value with no scheme is an authority, read as https.
+        assert_eq!(
+            authority("gw.example.com"),
+            Some(("gw.example.com".to_string(), 443))
+        );
+        assert_eq!(
+            authority("gw.example.com:8080"),
+            Some(("gw.example.com".to_string(), 8080))
+        );
+        // Any path after the authority is dropped — the backends assume origin
+        // form.
+        assert_eq!(
+            authority("https://gw.example.com/v1/audio"),
+            Some(("gw.example.com".to_string(), 443))
+        );
+    }
+
+    /// The first egress entry is the endpoint the user named; it is compared
+    /// against the authority the request URI carries, so both sides must agree
+    /// on the forms a user can paste.
+    fn endpoint(value: &str) -> Option<String> {
+        egress_entries(value).first().cloned()
+    }
+
+    #[test]
+    fn matches_what_the_transport_sees() {
+        // The entry is compared against the authority the request URI carries,
+        // so both sides must agree on the forms a user can paste: an uppercase
+        // scheme, userinfo, surrounding whitespace, a query, and the bracketed
+        // IPv6 literal form.
+        assert_eq!(
+            endpoint("HTTP://gw.example.com:8080"),
+            Some("gw.example.com:8080".to_string())
+        );
+        assert_eq!(
+            endpoint("https://user:pass@gw.example.com"),
+            Some("gw.example.com:443".to_string())
+        );
+        assert_eq!(
+            endpoint("  https://gw.example.com:8443  "),
+            Some("gw.example.com:8443".to_string())
+        );
+        assert_eq!(
+            endpoint("https://gw.example.com/v1?key=value"),
+            Some("gw.example.com:443".to_string())
+        );
+        assert_eq!(
+            endpoint("http://[::1]:8080"),
+            Some("[::1]:8080".to_string())
+        );
+        assert_eq!(endpoint("http://[::1]"), Some("[::1]:80".to_string()));
+    }
+
+    /// The transports derive the enforced authority's port with this same
+    /// function; a scheme ranked differently there would make the authorized
+    /// entry and the enforced one disagree.
+    #[test]
+    fn default_port_follows_the_scheme() {
+        assert_eq!(default_port(Some("http")), 80);
+        assert_eq!(default_port(Some("ws")), 80);
+        assert_eq!(default_port(Some("https")), 443);
+        assert_eq!(default_port(Some("wss")), 443);
+        assert_eq!(default_port(None), 443);
+    }
+
+    #[test]
+    fn rejects_unparseable() {
+        for value in ["", "   ", "https://", "/", "https:///path", "http://:8080"] {
+            assert_eq!(authority(value), None, "{value:?}");
+            assert!(egress_entries(value).is_empty(), "{value:?}");
+        }
+    }
+
+    #[test]
+    fn egress_entries_are_the_endpoint_then_the_bare_host() {
+        assert_eq!(
+            egress_entries("http://192.168.1.50"),
+            vec!["192.168.1.50:80".to_string(), "192.168.1.50".to_string()]
+        );
+    }
+}

--- a/super-stt-daemon/src/stt_models/backends/manifest.rs
+++ b/super-stt-daemon/src/stt_models/backends/manifest.rs
@@ -371,11 +371,11 @@ contract = "v1"
 description = "Test backend."
 
 [[options]]
-name = "base_url"
-label = "API base URL"
-description = "Override the base URL."
+name = "region"
+label = "Upstream region"
+description = "Override the upstream region."
 type = "string"
-default = "https://api.openai.com"
+default = "us-east-1"
 
 [[options]]
 name = "request_timeout_seconds"
@@ -386,13 +386,13 @@ default = 30
         let manifest = Manifest::parse(toml_src).expect("parse");
         assert_eq!(manifest.options.len(), 2);
 
-        let base = &manifest.options[0];
-        assert_eq!(base.name, "base_url");
-        assert_eq!(base.label.as_deref(), Some("API base URL"));
-        assert_eq!(base.r#type, Some(OptionType::String));
+        let region = &manifest.options[0];
+        assert_eq!(region.name, "region");
+        assert_eq!(region.label.as_deref(), Some("Upstream region"));
+        assert_eq!(region.r#type, Some(OptionType::String));
         assert_eq!(
-            base.default,
-            Some(OptionDefault::String("https://api.openai.com".into()))
+            region.default,
+            Some(OptionDefault::String("us-east-1".into()))
         );
 
         let timeout = &manifest.options[1];

--- a/super-stt-daemon/src/stt_models/backends/mod.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod.rs
@@ -7,6 +7,7 @@
 //! native binary). This module scans that directory and turns each manifest
 //! into a [`DiscoveredBackend`] carrying fully-resolved [`ModelDefinition`]s.
 
+pub(crate) mod base_url;
 pub mod manifest;
 
 use std::collections::HashSet;
@@ -115,8 +116,24 @@ fn dedup_sources(backends: Vec<DiscoveredBackend>) -> Vec<DiscoveredBackend> {
 /// manifest; this function enforces the cross-field device rules via
 /// [`validate_supported_devices`].
 fn load_backend(dir: &Path) -> anyhow::Result<DiscoveredBackend> {
-    let m = Manifest::load(dir)?;
+    let mut m = Manifest::load(dir)?;
     manifest::validate_runtime(&m)?;
+    // A `base_url` value authorizes egress the sandbox would otherwise refuse,
+    // so only the user may supply one. A manifest that declares a default is
+    // wrong, but refusing to load the whole backend would punish the user for
+    // the author's mistake — and leave them with a backend that silently
+    // vanished. Drop the value, keep the option, say so. The registry indexer
+    // refuses such a release outright, so this is the sideloaded/local case.
+    for opt in &mut m.options {
+        if opt.name == base_url::OPTION_NAME && opt.default.take().is_some() {
+            warn!(
+                "Backend {}: ignoring the `base_url` default declared in {}; \
+                 only a value the user sets authorizes egress",
+                m.backend.source,
+                dir.display()
+            );
+        }
+    }
     let source = m.backend.source.clone();
 
     let mut models = Vec::new();

--- a/super-stt-daemon/src/stt_models/backends/mod_tests.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod_tests.rs
@@ -43,7 +43,6 @@ required = true
 name = "base_url"
 description = "Base URL."
 type = "string"
-default = "https://api.openai.com"
 
 [[models]]
 name = "whisper-1"
@@ -581,4 +580,65 @@ fn an_empty_source_resolves_nothing() {
 
     // A source that serves a different name is still a miss.
     assert!(find_model(&backends, "whisper-large", "github.com/other/zeta").is_none());
+}
+
+/// A manifest that declares a `default` for `base_url` is wrong — that value
+/// authorizes egress the sandbox would otherwise refuse, and only the user may
+/// ask for it. The backend still loads, with the option intact and the value
+/// dropped, so an author's mistake costs the user a setting rather than the
+/// whole backend. (The registry indexer refuses to publish such a release, so
+/// this is the sideloaded/local case.)
+#[test]
+fn discovery_drops_a_base_url_default_and_keeps_the_backend() {
+    let root = scratch("base-url-default");
+    let backend_dir = root.join("openai");
+    fs::create_dir_all(&backend_dir).unwrap();
+    fs::write(
+        backend_dir.join("backend.toml"),
+        r#"
+[backend]
+source = "github.com/super-stt/openai"
+name = "OpenAI"
+version = "0.1.0"
+kind = "wasm"
+entrypoint = "openai.wasm"
+contract = "v1"
+description = "Test backend."
+
+[[options]]
+name = "base_url"
+description = "Base URL."
+type = "string"
+default = "http://127.0.0.1:11434"
+
+[[options]]
+name = "region"
+description = "Region."
+type = "string"
+default = "us-east-1"
+
+[[models]]
+name = "whisper-1"
+primary_language = "en"
+supported_languages = ["en"]
+supported_devices = ["none"]
+"#,
+    )
+    .unwrap();
+
+    let backends = discover(&root);
+    assert_eq!(
+        backends.len(),
+        1,
+        "the backend must still load: {backends:?}"
+    );
+    let opts = &backends[0].options;
+    assert_eq!(opts[0].name, "base_url");
+    assert!(
+        opts[0].default.is_none(),
+        "the manifest's base_url value must not survive discovery"
+    );
+    // Only that option is touched; every other default is the author's to set.
+    assert_eq!(opts[1].name, "region");
+    assert!(opts[1].default.is_some());
 }

--- a/super-stt-daemon/src/stt_models/wasm/host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/host.rs
@@ -46,7 +46,17 @@ impl WasiHttpView for Host {
 /// implements here — so a request to a host outside the allowlist never
 /// leaves the machine.
 pub struct AllowlistHooks {
+    /// Hosts pinned by the backend's own (unreviewed) `[network].allowed_hosts`
+    /// manifest. These are SSRF-guarded: a manifest entry does **not** authorize
+    /// loopback/private/link-local/metadata destinations, because the backend
+    /// author is not a trusted operator.
     pub allowed_hosts: Vec<String>,
+    /// Hosts the *user* authorized through backend options (e.g. a `base_url`
+    /// set in the settings UI). These are exempt from the SSRF guard — the
+    /// component cannot self-authorize them (options are user-writable only), so
+    /// user intent to reach a local/private gateway is honored. Anything not in
+    /// this set keeps the full allowlist + SSRF enforcement.
+    pub user_allowed_hosts: Vec<String>,
     /// Permit egress to loopback addresses (`127.0.0.0/8`, `::1`). Off in
     /// production — the SSRF guard blocks loopback so an untrusted backend
     /// can't reach a service bound to localhost. Tests and local development
@@ -87,8 +97,13 @@ impl WasiHttpHooks for AllowlistHooks {
                 } else {
                     443
                 });
-        if let Err(msg) = check_host_allowed(&self.allowed_hosts, &host, port, self.allow_loopback)
-        {
+        if let Err(msg) = check_host_allowed(
+            &self.allowed_hosts,
+            &self.user_allowed_hosts,
+            &host,
+            port,
+            self.allow_loopback,
+        ) {
             return Err(ErrorCode::InternalError(Some(msg)).into());
         }
 
@@ -96,31 +111,45 @@ impl WasiHttpHooks for AllowlistHooks {
     }
 }
 
-/// Confines an outbound connection to the backend's `allowed_hosts` and runs
-/// the SSRF resolver guard. Shared by the HTTP hook and the `ws` host so both
-/// transports enforce identical egress rules.
+/// Confines an outbound connection to the backend's `allowed_hosts` — plus any
+/// `user_allowed` hosts — and runs the SSRF resolver guard. Shared by the HTTP
+/// hook and the `ws` host so both transports enforce identical egress rules.
 ///
 /// `host` is the bare hostname or IP literal; `port` is the resolved port.
 /// `allowed` entries may be either a bare host or a `host:port` authority.
+/// Entries in `user_allowed` may too, but a match there skips the SSRF guard
+/// (see [`AllowlistHooks::user_allowed_hosts`]).
 ///
 /// # Errors
-/// Returns a human-readable reason when the host is not on the allowlist or a
-/// hostname resolves to a loopback/private/link-local/unspecified address.
+/// Returns a human-readable reason when the host is on neither list, or when a
+/// manifest-allowlisted hostname resolves to a
+/// loopback/private/link-local/unspecified address.
 pub(crate) fn check_host_allowed(
     allowed: &[String],
+    user_allowed: &[String],
     host: &str,
     port: u16,
     allow_loopback: bool,
 ) -> Result<(), String> {
     let authority = format!("{host}:{port}");
-    let on_allowlist = allowed
+    let on_manifest = allowed
         .iter()
         .any(|a| a.as_str() == host || a.as_str() == authority);
-    if !on_allowlist {
-        return Err(format!("outbound host not allowed: {host}"));
+    if on_manifest {
+        return guard_egress_host(host, port, allow_loopback);
     }
-
-    guard_egress_host(host, port, allow_loopback)
+    // A host the *user* authorized via a backend option is exempt from the SSRF
+    // guard. Unlike manifest `allowed_hosts` — written by the untrusted backend
+    // author, who therefore cannot self-authorize a metadata/localhost target —
+    // this list is user intent: the daemon reads these from options set through
+    // the settings-scoped API, never from the component.
+    let on_user = user_allowed
+        .iter()
+        .any(|a| a.as_str() == host || a.as_str() == authority);
+    if on_user {
+        return Ok(());
+    }
+    Err(format!("outbound host not allowed: {host}"))
 }
 
 /// Reject an outbound target that points at an address a sandboxed backend must
@@ -222,19 +251,19 @@ mod tests {
     fn ip_literal_metadata_on_allowlist_is_still_rejected() {
         // A backend cannot self-authorize the metadata endpoint by listing it.
         let allow = vec!["169.254.169.254".to_string()];
-        assert!(check_host_allowed(&allow, "169.254.169.254", 80, false).is_err());
+        assert!(check_host_allowed(&allow, &[], "169.254.169.254", 80, false).is_err());
     }
 
     #[test]
     fn public_ip_literal_on_allowlist_is_permitted() {
         let allow = vec!["93.184.216.34".to_string()];
-        assert!(check_host_allowed(&allow, "93.184.216.34", 443, false).is_ok());
+        assert!(check_host_allowed(&allow, &[], "93.184.216.34", 443, false).is_ok());
     }
 
     #[test]
     fn host_not_on_allowlist_is_rejected() {
         let allow = vec!["api.example.com".to_string()];
-        assert!(check_host_allowed(&allow, "169.254.169.254", 80, false).is_err());
+        assert!(check_host_allowed(&allow, &[], "169.254.169.254", 80, false).is_err());
     }
 
     #[test]
@@ -245,18 +274,72 @@ mod tests {
         // `ws` host now route through `check_host_allowed`, so `["h:443"]` behaves
         // identically for `https://h/` and `wss://h/`. Loopback avoids real DNS.
         let allow = vec!["127.0.0.1:443".to_string()];
-        assert!(check_host_allowed(&allow, "127.0.0.1", 443, true).is_ok());
+        assert!(check_host_allowed(&allow, &[], "127.0.0.1", 443, true).is_ok());
     }
 
     #[test]
     fn loopback_blocked_by_default_opt_in_permits_only_loopback() {
         let allow = vec!["127.0.0.1:8088".to_string()];
         // Default: loopback egress is refused even when allowlisted (SSRF).
-        assert!(check_host_allowed(&allow, "127.0.0.1", 8088, false).is_err());
+        assert!(check_host_allowed(&allow, &[], "127.0.0.1", 8088, false).is_err());
         // Opt-in (tests / local mock upstream): loopback is permitted.
-        assert!(check_host_allowed(&allow, "127.0.0.1", 8088, true).is_ok());
+        assert!(check_host_allowed(&allow, &[], "127.0.0.1", 8088, true).is_ok());
         // The opt-in relaxes loopback ONLY — metadata stays blocked.
         let meta = vec!["169.254.169.254".to_string()];
-        assert!(check_host_allowed(&meta, "169.254.169.254", 80, true).is_err());
+        assert!(check_host_allowed(&meta, &[], "169.254.169.254", 80, true).is_err());
+    }
+
+    #[test]
+    fn user_allowed_loopback_passes_without_loopback_opt_in() {
+        // A host the user authorized via a backend option (e.g. a base_url set in
+        // the settings UI) is exempt from the SSRF guard — no loopback opt-in.
+        let user = vec!["127.0.0.1".to_string()];
+        assert!(check_host_allowed(&[], &user, "127.0.0.1", 8088, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_metadata_is_permitted_by_user_intent() {
+        // The SSRF exception is user intent: the component cannot self-authorize
+        // this (options are user-writable only), so a user-chosen destination is
+        // honored even for the metadata address.
+        let user = vec!["169.254.169.254".to_string()];
+        assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_private_host_is_permitted() {
+        let user = vec!["10.0.0.5".to_string()];
+        assert!(check_host_allowed(&[], &user, "10.0.0.5", 8443, false).is_ok());
+        let user6 = vec!["fd12:3456::1".to_string()];
+        assert!(check_host_allowed(&[], &user6, "fd12:3456::1", 8443, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_matches_bare_host_across_ports() {
+        // A user-authorized bare host authorizes any port (same authority
+        // matching rules as the manifest allowlist).
+        let user = vec!["gw.example.com".to_string()];
+        assert!(check_host_allowed(&[], &user, "gw.example.com", 443, false).is_ok());
+        assert!(check_host_allowed(&[], &user, "gw.example.com", 8443, false).is_ok());
+    }
+
+    #[test]
+    fn user_allowed_does_not_loosen_other_hosts() {
+        // Only hosts in `user_allowed` are exempt; a different disallowed target
+        // is still refused even while a user host is present.
+        let user = vec!["gw.example.com".to_string()];
+        assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_err());
+        assert!(check_host_allowed(&[], &user, "api.openai.com", 443, false).is_err());
+    }
+
+    #[test]
+    fn manifest_host_still_ssrf_guarded_alongside_user_host() {
+        // The manifest allowlist stays SSRF-guarded even when a user host is
+        // present: loopback/private via the manifest is refused, while the user
+        // host passes.
+        let allow = vec!["10.0.0.9".to_string()];
+        let user = vec!["gw.example.com".to_string()];
+        assert!(check_host_allowed(&allow, &user, "10.0.0.9", 443, false).is_err());
+        assert!(check_host_allowed(&allow, &user, "gw.example.com", 443, false).is_ok());
     }
 }

--- a/super-stt-daemon/src/stt_models/wasm/host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/host.rs
@@ -41,21 +41,25 @@ impl WasiHttpView for Host {
     }
 }
 
-/// Enforces the backend's `allowed_hosts` on every outbound request. A
-/// component's only egress is `wasi:http/outgoing-handler`, which the daemon
-/// implements here — so a request to a host outside the allowlist never
-/// leaves the machine.
+/// Enforces the backend's egress rules on every outbound request. A component's
+/// only egress is `wasi:http/outgoing-handler`, which the daemon implements
+/// here — so a request to a destination neither list below permits never leaves
+/// the machine.
 pub struct AllowlistHooks {
     /// Hosts pinned by the backend's own (unreviewed) `[network].allowed_hosts`
     /// manifest. These are SSRF-guarded: a manifest entry does **not** authorize
     /// loopback/private/link-local/metadata destinations, because the backend
     /// author is not a trusted operator.
     pub allowed_hosts: Vec<String>,
-    /// Hosts the *user* authorized through backend options (e.g. a `base_url`
-    /// set in the settings UI). These are exempt from the SSRF guard — the
-    /// component cannot self-authorize them (options are user-writable only), so
-    /// user intent to reach a local/private gateway is honored. Anything not in
-    /// this set keeps the full allowlist + SSRF enforcement.
+    /// What the *user* authorized through backend options (e.g. a `base_url` set
+    /// in the settings UI): the `host:port` the value names, plus its bare host.
+    /// The SSRF guard is relaxed for the authority alone — loopback and private
+    /// addresses are reachable there, because pointing a backend at a local
+    /// gateway is the point of the option, and the component cannot
+    /// self-authorize one (options are user-writable only). The relaxation stops
+    /// there: link-local (metadata), unspecified, and broadcast addresses stay
+    /// refused, and the bare host is judged like a manifest entry, so a gateway's
+    /// other ports stay reachable only while they are public.
     pub user_allowed_hosts: Vec<String>,
     /// Permit egress to loopback addresses (`127.0.0.0/8`, `::1`). Off in
     /// production — the SSRF guard blocks loopback so an untrusted backend
@@ -88,15 +92,9 @@ impl WasiHttpHooks for AllowlistHooks {
                 ErrorCode::InternalError(Some("outbound request has no host".to_string())).into(),
             );
         };
-        let port =
-            request
-                .uri()
-                .port_u16()
-                .unwrap_or(if request.uri().scheme_str() == Some("http") {
-                    80
-                } else {
-                    443
-                });
+        let port = request.uri().port_u16().unwrap_or_else(|| {
+            crate::stt_models::backends::base_url::default_port(request.uri().scheme_str())
+        });
         if let Err(msg) = check_host_allowed(
             &self.allowed_hosts,
             &self.user_allowed_hosts,
@@ -111,19 +109,33 @@ impl WasiHttpHooks for AllowlistHooks {
     }
 }
 
+/// How far an outbound destination may reach once a list permits it.
+#[derive(Clone, Copy)]
+enum EgressScope {
+    /// Public addresses only — the SSRF guard in full. Applies to every manifest
+    /// entry, and to a `user_allowed` entry that names no port and so authorizes
+    /// no particular endpoint.
+    PublicOnly,
+    /// The user named this exact `host:port`: loopback and private addresses are
+    /// reachable, the never-routable ones still are not.
+    UserAuthorized,
+}
+
 /// Confines an outbound connection to the backend's `allowed_hosts` — plus any
-/// `user_allowed` hosts — and runs the SSRF resolver guard. Shared by the HTTP
-/// hook and the `ws` host so both transports enforce identical egress rules.
+/// `user_allowed` endpoints — and runs the SSRF resolver guard. Shared by the
+/// HTTP hook and the `ws` host so both transports enforce identical egress
+/// rules.
 ///
-/// `host` is the bare hostname or IP literal; `port` is the resolved port.
-/// `allowed` entries may be either a bare host or a `host:port` authority.
-/// Entries in `user_allowed` may too, but a match there skips the SSRF guard
-/// (see [`AllowlistHooks::user_allowed_hosts`]).
+/// `host` is the hostname or IP literal as a URI authority carries it (IPv6
+/// bracketed); `port` is the resolved port. Entries in either list may be a bare
+/// host or a `host:port` authority, matched case-insensitively. A
+/// `user_allowed` entry matching the full authority relaxes the guard for that
+/// endpoint alone (see [`AllowlistHooks::user_allowed_hosts`]); every other
+/// match is guarded in full.
 ///
 /// # Errors
-/// Returns a human-readable reason when the host is on neither list, or when a
-/// manifest-allowlisted hostname resolves to a
-/// loopback/private/link-local/unspecified address.
+/// Returns a human-readable reason when the host is on neither list, or when the
+/// destination resolves to an address its scope does not permit.
 pub(crate) fn check_host_allowed(
     allowed: &[String],
     user_allowed: &[String],
@@ -132,57 +144,78 @@ pub(crate) fn check_host_allowed(
     allow_loopback: bool,
 ) -> Result<(), String> {
     let authority = format!("{host}:{port}");
+    // The endpoint the *user* named, and the only case that may reach a local or
+    // private address. Unlike manifest `allowed_hosts` — written by the untrusted
+    // backend author, who therefore cannot self-authorize a localhost target —
+    // this list is user intent: the daemon reads it from options set through the
+    // settings-scoped API, never from the component. Checked before the manifest
+    // so a backend that also lists the host cannot cost the user the endpoint
+    // they authorized.
+    if user_allowed
+        .iter()
+        .any(|a| a.eq_ignore_ascii_case(&authority))
+    {
+        return guard_egress_host(host, port, allow_loopback, EgressScope::UserAuthorized);
+    }
+    // Everything else is guarded in full. A manifest entry may name a bare host
+    // or an authority; a `user_allowed` entry is only reached here in its bare
+    // form, since its authority form returned above — so the two lists are
+    // matched by the rules they actually have, not by one predicate that would
+    // read as if a user authority could land in this scope too.
     let on_manifest = allowed
         .iter()
-        .any(|a| a.as_str() == host || a.as_str() == authority);
-    if on_manifest {
-        return guard_egress_host(host, port, allow_loopback);
-    }
-    // A host the *user* authorized via a backend option is exempt from the SSRF
-    // guard. Unlike manifest `allowed_hosts` — written by the untrusted backend
-    // author, who therefore cannot self-authorize a metadata/localhost target —
-    // this list is user intent: the daemon reads these from options set through
-    // the settings-scoped API, never from the component.
-    let on_user = user_allowed
-        .iter()
-        .any(|a| a.as_str() == host || a.as_str() == authority);
-    if on_user {
-        return Ok(());
+        .any(|a| a.eq_ignore_ascii_case(host) || a.eq_ignore_ascii_case(&authority));
+    let on_user_bare = user_allowed.iter().any(|a| a.eq_ignore_ascii_case(host));
+    if on_manifest || on_user_bare {
+        return guard_egress_host(host, port, allow_loopback, EgressScope::PublicOnly);
     }
     Err(format!("outbound host not allowed: {host}"))
 }
 
-/// Reject an outbound target that points at an address a sandboxed backend must
-/// never reach. An IP literal is checked directly against the disallow-list —
-/// the `allowed_hosts` list comes from the backend's own (unreviewed) manifest,
-/// so a backend author is not a trusted operator and cannot self-authorize the
+/// Reject an outbound target that points at an address the destination's
+/// [`EgressScope`] does not permit. An IP literal is checked directly — the
+/// `allowed_hosts` list comes from the backend's own (unreviewed) manifest, so a
+/// backend author is not a trusted operator and cannot self-authorize the
 /// metadata endpoint via `allowed_hosts = ["169.254.169.254"]`. A hostname is
 /// resolved and every resulting address checked.
-fn guard_egress_host(host: &str, port: u16, allow_loopback: bool) -> Result<(), String> {
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        // Loopback is opt-in (tests / local mock upstream); everything else on
-        // the disallow-list — including the metadata endpoint — stays blocked.
-        if allow_loopback && ip.is_loopback() {
+fn guard_egress_host(
+    host: &str,
+    port: u16,
+    allow_loopback: bool,
+    scope: EgressScope,
+) -> Result<(), String> {
+    if let Some(ip) = ip_literal(host) {
+        if is_egress_permitted(&ip, allow_loopback, scope) {
             return Ok(());
         }
-        if is_disallowed_ip(&ip) {
-            return Err(format!("host {host} is a disallowed address {ip}"));
-        }
-        return Ok(());
+        return Err(format!("host {host} is a disallowed address {ip}"));
     }
-    check_resolved_addrs(host, port, allow_loopback)
+    check_resolved_addrs(host, port, allow_loopback, scope)
 }
 
-/// Resolves `host:port` and rejects if any address is disallowed.
-fn check_resolved_addrs(host: &str, port: u16, allow_loopback: bool) -> Result<(), String> {
+/// Parse a host that is an IP literal, accepting the bracketed IPv6 form
+/// (`[::1]`) a URI authority carries. `None` for a hostname, which is resolved
+/// instead.
+fn ip_literal(host: &str) -> Option<IpAddr> {
+    host.strip_prefix('[')
+        .and_then(|inner| inner.strip_suffix(']'))
+        .unwrap_or(host)
+        .parse()
+        .ok()
+}
+
+/// Resolves `host:port` and rejects if any address is out of scope.
+fn check_resolved_addrs(
+    host: &str,
+    port: u16,
+    allow_loopback: bool,
+    scope: EgressScope,
+) -> Result<(), String> {
     match (host, port).to_socket_addrs() {
         Ok(addrs) => {
             for addr in addrs {
                 let ip = addr.ip();
-                if allow_loopback && ip.is_loopback() {
-                    continue;
-                }
-                if is_disallowed_ip(&ip) {
+                if !is_egress_permitted(&ip, allow_loopback, scope) {
                     return Err(format!("host {host} resolves to a disallowed address {ip}"));
                 }
             }
@@ -192,36 +225,66 @@ fn check_resolved_addrs(host: &str, port: u16, allow_loopback: bool) -> Result<(
     }
 }
 
-/// Addresses a sandboxed backend must never reach.
-pub(crate) fn is_disallowed_ip(ip: &IpAddr) -> bool {
+/// Whether a resolved address may be reached under `scope`.
+fn is_egress_permitted(ip: &IpAddr, allow_loopback: bool, scope: EgressScope) -> bool {
+    // Nothing authorizes these — a gateway a user means to reach never lives on
+    // the link-local range, and the metadata endpoint is the address an escaped
+    // backend wants most.
+    if is_never_routable_ip(ip) {
+        return false;
+    }
+    match scope {
+        // Loopback and private are exactly what a local gateway needs.
+        EgressScope::UserAuthorized => true,
+        // Loopback stays opt-in (tests / local mock upstream); private ranges
+        // stay blocked outright.
+        EgressScope::PublicOnly => (allow_loopback && ip.is_loopback()) || !is_local_ip(ip),
+    }
+}
+
+/// Addresses no allowlist authorizes, whoever wrote it: the link-local range
+/// (the cloud metadata endpoint `169.254.169.254` among it), the unspecified
+/// address, and broadcast.
+fn is_never_routable_ip(ip: &IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => is_disallowed_v4(*v4),
+        IpAddr::V4(v4) => is_never_routable_v4(*v4),
         IpAddr::V6(v6) => {
             // An IPv4-mapped address (`::ffff:a.b.c.d`) reaches the same host
             // as the bare v4 — e.g. `::ffff:169.254.169.254` is the metadata
             // endpoint — so re-check it through the v4 rules.
             if let Some(mapped) = v6.to_ipv4_mapped() {
-                return is_disallowed_v4(mapped);
+                return is_never_routable_v4(mapped);
             }
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || v6.is_unique_local()
-                || v6.is_unicast_link_local()
+            v6.is_unspecified() || v6.is_unicast_link_local()
         }
     }
 }
 
-fn is_disallowed_v4(v4: Ipv4Addr) -> bool {
-    v4.is_loopback()
-        || v4.is_private()
-        || v4.is_link_local()
-        || v4.is_unspecified()
-        || v4.is_broadcast()
+fn is_never_routable_v4(v4: Ipv4Addr) -> bool {
+    v4.is_link_local() || v4.is_unspecified() || v4.is_broadcast()
+}
+
+/// Loopback and private addresses: off-limits to a manifest-declared
+/// destination, reachable for the endpoint the user named.
+fn is_local_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_local_v4(*v4),
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_local_v4(mapped);
+            }
+            v6.is_loopback() || v6.is_unique_local()
+        }
+    }
+}
+
+fn is_local_v4(v4: Ipv4Addr) -> bool {
+    v4.is_loopback() || v4.is_private()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{check_host_allowed, is_disallowed_ip};
+    use super::{check_host_allowed, is_local_ip, is_never_routable_ip};
     use std::net::IpAddr;
 
     fn ip(s: &str) -> IpAddr {
@@ -229,22 +292,28 @@ mod tests {
     }
 
     #[test]
-    fn rejects_v6_internal_ranges_and_mapped_metadata() {
-        assert!(is_disallowed_ip(&ip("fc00::1")), "unique-local");
-        assert!(is_disallowed_ip(&ip("fd12:3456::1")), "unique-local");
-        assert!(is_disallowed_ip(&ip("fe80::1")), "link-local");
-        assert!(is_disallowed_ip(&ip("::1")), "loopback");
+    fn classifies_v6_internal_ranges_and_mapped_metadata() {
+        // Never routable: refused under either scope.
+        assert!(is_never_routable_ip(&ip("fe80::1")), "link-local");
+        assert!(is_never_routable_ip(&ip("::")), "unspecified");
         assert!(
-            is_disallowed_ip(&ip("::ffff:169.254.169.254")),
+            is_never_routable_ip(&ip("::ffff:169.254.169.254")),
             "mapped metadata"
         );
-        assert!(is_disallowed_ip(&ip("::ffff:127.0.0.1")), "mapped loopback");
+        // Local: refused for a manifest destination, reached only by the endpoint
+        // the user named.
+        assert!(is_local_ip(&ip("fc00::1")), "unique-local");
+        assert!(is_local_ip(&ip("fd12:3456::1")), "unique-local");
+        assert!(is_local_ip(&ip("::1")), "loopback");
+        assert!(is_local_ip(&ip("::ffff:127.0.0.1")), "mapped loopback");
     }
 
     #[test]
     fn allows_public_addresses() {
-        assert!(!is_disallowed_ip(&ip("93.184.216.34")));
-        assert!(!is_disallowed_ip(&ip("2606:2800:220:1:248:1893:25c8:1946")));
+        for addr in ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"] {
+            assert!(!is_never_routable_ip(&ip(addr)), "{addr}");
+            assert!(!is_local_ip(&ip(addr)), "{addr}");
+        }
     }
 
     #[test]
@@ -290,56 +359,104 @@ mod tests {
     }
 
     #[test]
-    fn user_allowed_loopback_passes_without_loopback_opt_in() {
-        // A host the user authorized via a backend option (e.g. a base_url set in
-        // the settings UI) is exempt from the SSRF guard — no loopback opt-in.
-        let user = vec!["127.0.0.1".to_string()];
+    fn user_allowed_authority_reaches_loopback_without_the_opt_in() {
+        // The endpoint the user named in a backend option (e.g. a base_url set in
+        // the settings UI) reaches a local gateway with no loopback opt-in.
+        let user = vec!["127.0.0.1:8088".to_string()];
         assert!(check_host_allowed(&[], &user, "127.0.0.1", 8088, false).is_ok());
     }
 
     #[test]
-    fn user_allowed_metadata_is_permitted_by_user_intent() {
-        // The SSRF exception is user intent: the component cannot self-authorize
-        // this (options are user-writable only), so a user-chosen destination is
-        // honored even for the metadata address.
-        let user = vec!["169.254.169.254".to_string()];
-        assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_ok());
+    fn user_allowed_authority_does_not_widen_to_other_ports() {
+        // The authorization covers one `host:port`. Every other port on that host
+        // is only as reachable as the manifest allowlist makes it — here, not at
+        // all, and local addresses stay refused even when it does list them.
+        let user = vec!["127.0.0.1:8088".to_string()];
+        assert!(check_host_allowed(&[], &user, "127.0.0.1", 22, false).is_err());
+        let allow = vec!["127.0.0.1".to_string()];
+        assert!(check_host_allowed(&allow, &user, "127.0.0.1", 22, false).is_err());
     }
 
     #[test]
-    fn user_allowed_private_host_is_permitted() {
-        let user = vec!["10.0.0.5".to_string()];
+    fn user_allowed_bare_host_keeps_public_ports_not_local_ones() {
+        // Both entries a `base_url` produces: the endpoint, then its bare host.
+        // The bare host names no particular endpoint, so it buys no local reach —
+        // a gateway keeps its other ports only while they are public.
+        let public = vec!["93.184.216.34:443".to_string(), "93.184.216.34".to_string()];
+        assert!(check_host_allowed(&[], &public, "93.184.216.34", 8443, false).is_ok());
+        let local = vec!["127.0.0.1:8088".to_string(), "127.0.0.1".to_string()];
+        assert!(check_host_allowed(&[], &local, "127.0.0.1", 8088, false).is_ok());
+        assert!(check_host_allowed(&[], &local, "127.0.0.1", 22, false).is_err());
+    }
+
+    #[test]
+    fn user_allowed_metadata_is_refused_even_when_user_set() {
+        // The relaxation lifts the loopback and private blocks only. No gateway a
+        // user means to reach lives on the link-local range, so a value pointing
+        // at the metadata endpoint is refused however it got there.
+        let user = vec!["169.254.169.254:80".to_string()];
+        assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_err());
+        let mapped = vec!["[::ffff:169.254.169.254]:80".to_string()];
+        assert!(check_host_allowed(&[], &mapped, "[::ffff:169.254.169.254]", 80, false).is_err());
+    }
+
+    #[test]
+    fn user_allowed_unspecified_and_broadcast_are_refused() {
+        let unspecified = vec!["0.0.0.0:8080".to_string()];
+        assert!(check_host_allowed(&[], &unspecified, "0.0.0.0", 8080, false).is_err());
+        let broadcast = vec!["255.255.255.255:8080".to_string()];
+        assert!(check_host_allowed(&[], &broadcast, "255.255.255.255", 8080, false).is_err());
+    }
+
+    #[test]
+    fn user_allowed_private_authority_is_permitted() {
+        let user = vec!["10.0.0.5:8443".to_string()];
         assert!(check_host_allowed(&[], &user, "10.0.0.5", 8443, false).is_ok());
-        let user6 = vec!["fd12:3456::1".to_string()];
-        assert!(check_host_allowed(&[], &user6, "fd12:3456::1", 8443, false).is_ok());
+        // IPv6 arrives bracketed from a URI authority, on both sides of the match.
+        let user6 = vec!["[fd12:3456::1]:8443".to_string()];
+        assert!(check_host_allowed(&[], &user6, "[fd12:3456::1]", 8443, false).is_ok());
     }
 
     #[test]
-    fn user_allowed_matches_bare_host_across_ports() {
-        // A user-authorized bare host authorizes any port (same authority
-        // matching rules as the manifest allowlist).
-        let user = vec!["gw.example.com".to_string()];
-        assert!(check_host_allowed(&[], &user, "gw.example.com", 443, false).is_ok());
-        assert!(check_host_allowed(&[], &user, "gw.example.com", 8443, false).is_ok());
+    fn user_allowed_authority_matches_case_insensitively() {
+        // Hostnames are case-insensitive; exact-authority matching must not turn
+        // a difference in case into a refusal. A hostname entry reaches the
+        // resolver, so what shows the match is that the destination is judged on
+        // the addresses it resolves to rather than refused as unlisted.
+        let user = vec!["GW.Example.com:443".to_string()];
+        let res = check_host_allowed(&[], &user, "gw.example.com", 443, false);
+        assert!(
+            !matches!(&res, Err(msg) if msg.contains("not allowed")),
+            "case-mismatched entry was treated as unlisted: {res:?}"
+        );
+    }
+
+    #[test]
+    fn user_authority_survives_the_same_host_on_the_manifest_list() {
+        // A backend that lists `localhost` must not cost the user the endpoint
+        // they authorized: the user's exact authority is honored first.
+        let allow = vec!["127.0.0.1".to_string()];
+        let user = vec!["127.0.0.1:8080".to_string()];
+        assert!(check_host_allowed(&allow, &user, "127.0.0.1", 8080, false).is_ok());
     }
 
     #[test]
     fn user_allowed_does_not_loosen_other_hosts() {
-        // Only hosts in `user_allowed` are exempt; a different disallowed target
-        // is still refused even while a user host is present.
-        let user = vec!["gw.example.com".to_string()];
+        // Only what the user named is relaxed; a different disallowed target is
+        // still refused even while a user endpoint is present.
+        let user = vec!["10.0.0.5:8443".to_string()];
         assert!(check_host_allowed(&[], &user, "169.254.169.254", 80, false).is_err());
-        assert!(check_host_allowed(&[], &user, "api.openai.com", 443, false).is_err());
+        assert!(check_host_allowed(&[], &user, "10.0.0.6", 8443, false).is_err());
     }
 
     #[test]
     fn manifest_host_still_ssrf_guarded_alongside_user_host() {
-        // The manifest allowlist stays SSRF-guarded even when a user host is
-        // present: loopback/private via the manifest is refused, while the user
-        // host passes.
+        // The manifest allowlist stays fully SSRF-guarded even when a user
+        // endpoint is present: loopback/private via the manifest is refused,
+        // while the user's own endpoint passes.
         let allow = vec!["10.0.0.9".to_string()];
-        let user = vec!["gw.example.com".to_string()];
+        let user = vec!["10.0.0.5:8443".to_string()];
         assert!(check_host_allowed(&allow, &user, "10.0.0.9", 443, false).is_err());
-        assert!(check_host_allowed(&allow, &user, "gw.example.com", 443, false).is_ok());
+        assert!(check_host_allowed(&allow, &user, "10.0.0.5", 8443, false).is_ok());
     }
 }

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -44,6 +44,9 @@ pub struct WasmBackend {
     engine: Engine,
     pre: BackendPre,
     allowed_hosts: Vec<String>,
+    /// Hosts the *user* authorized via backend options (e.g. a `base_url` set in
+    /// the settings UI). Exempt from the SSRF guard — see [`AllowlistHooks`].
+    user_allowed_hosts: Vec<String>,
     allow_loopback: bool,
     transcribe_headers: Vec<(String, String)>,
     model_id: String,
@@ -58,11 +61,16 @@ impl WasmBackend {
     /// Load a component for a discovered model. The transcribe headers are the
     /// already-formed `x-stt-secret-*` / `x-stt-option-*` pairs to inject.
     ///
+    /// `allowed_hosts` are the backend's manifest-pinned `[network].allowed_hosts`
+    /// (SSRF-guarded); `user_allowed_hosts` are hosts the user authorized via
+    /// backend options (e.g. a `base_url`) and are exempt from the SSRF guard.
+    ///
     /// # Errors
     /// Returns an error if the component cannot be loaded or linked.
     pub fn with_info(
         component_path: &Path,
         allowed_hosts: Vec<String>,
+        user_allowed_hosts: Vec<String>,
         info: ModelInfoData,
         transcribe_headers: Vec<(String, String)>,
         websocket_capability: bool,
@@ -100,6 +108,7 @@ impl WasmBackend {
             engine,
             pre,
             allowed_hosts,
+            user_allowed_hosts,
             allow_loopback: false,
             transcribe_headers,
             model_id,
@@ -151,6 +160,7 @@ impl WasmBackend {
         Self::with_info(
             component_path,
             allowed_hosts,
+            Vec::new(),
             info,
             transcribe_headers,
             false,
@@ -180,6 +190,7 @@ impl WasmBackend {
         Self::with_info(
             component_path,
             allowed_hosts,
+            Vec::new(),
             info,
             transcribe_headers,
             true,
@@ -231,6 +242,7 @@ impl WasmBackend {
             http: WasiHttpCtx::new(),
             hooks: AllowlistHooks {
                 allowed_hosts: self.allowed_hosts.clone(),
+                user_allowed_hosts: self.user_allowed_hosts.clone(),
                 allow_loopback: self.allow_loopback,
             },
         };
@@ -447,6 +459,7 @@ impl Transcribe for WasmBackend {
             http: WasiHttpCtx::new(),
             hooks: AllowlistHooks {
                 allowed_hosts: self.allowed_hosts.clone(),
+                user_allowed_hosts: self.user_allowed_hosts.clone(),
                 allow_loopback: self.allow_loopback,
             },
         };

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -6,7 +6,8 @@
 //! over wasmtime's `wasi:http` host, and presents the result through the
 //! daemon's [`Transcribe`] trait. Secrets and options are injected as
 //! `x-stt-secret-*` / `x-stt-option-*` request headers; outbound egress is
-//! confined to the backend's `allowed_hosts` (see [`host::AllowlistHooks`]).
+//! confined to the backend's `allowed_hosts` plus the endpoint the user
+//! authorized through its `base_url` option (see [`host::AllowlistHooks`]).
 
 pub mod host;
 pub mod ws_host;
@@ -62,8 +63,9 @@ impl WasmBackend {
     /// already-formed `x-stt-secret-*` / `x-stt-option-*` pairs to inject.
     ///
     /// `allowed_hosts` are the backend's manifest-pinned `[network].allowed_hosts`
-    /// (SSRF-guarded); `user_allowed_hosts` are hosts the user authorized via
-    /// backend options (e.g. a `base_url`) and are exempt from the SSRF guard.
+    /// (SSRF-guarded); `user_allowed_hosts` is what the user authorized via a
+    /// `base_url` option, whose `host:port` has the guard relaxed (see
+    /// [`host::AllowlistHooks::user_allowed_hosts`]).
     ///
     /// # Errors
     /// Returns an error if the component cannot be loaded or linked.
@@ -115,6 +117,24 @@ impl WasmBackend {
             realtime,
             info,
         })
+    }
+
+    /// The egress policy every invocation of this backend enforces — the one
+    /// place the two lists are wired into the hooks, so the batch and realtime
+    /// paths cannot drift into disagreeing about which list is which.
+    ///
+    /// The distinction is load-bearing: `allowed_hosts` is the backend's own
+    /// manifest and stays fully SSRF-guarded, while `user_allowed_hosts` is what
+    /// the user authorized and has the guard relaxed for its `host:port`. Wiring
+    /// them the other way round would hand a backend the relaxation for hosts it
+    /// declared itself.
+    #[must_use]
+    pub fn allowlist_hooks(&self) -> AllowlistHooks {
+        AllowlistHooks {
+            allowed_hosts: self.allowed_hosts.clone(),
+            user_allowed_hosts: self.user_allowed_hosts.clone(),
+            allow_loopback: self.allow_loopback,
+        }
     }
 
     /// Permit this backend's egress to loopback addresses (`127.0.0.1`, `::1`).
@@ -240,11 +260,7 @@ impl WasmBackend {
             table: ResourceTable::new(),
             wasi: WasiCtx::builder().build(),
             http: WasiHttpCtx::new(),
-            hooks: AllowlistHooks {
-                allowed_hosts: self.allowed_hosts.clone(),
-                user_allowed_hosts: self.user_allowed_hosts.clone(),
-                allow_loopback: self.allow_loopback,
-            },
+            hooks: self.allowlist_hooks(),
         };
         let mut store = Store::new(&self.engine, host);
 
@@ -457,11 +473,7 @@ impl Transcribe for WasmBackend {
             table: ResourceTable::new(),
             wasi: WasiCtx::builder().build(),
             http: WasiHttpCtx::new(),
-            hooks: AllowlistHooks {
-                allowed_hosts: self.allowed_hosts.clone(),
-                user_allowed_hosts: self.user_allowed_hosts.clone(),
-                allow_loopback: self.allow_loopback,
-            },
+            hooks: self.allowlist_hooks(),
         };
         let mut store = Store::new(&self.engine, host);
         // Inject the same x-stt-* headers a batch call gets, plus the model id.

--- a/super-stt-daemon/src/stt_models/wasm/ws_host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/ws_host.rs
@@ -140,9 +140,11 @@ impl self::super_stt::realtime::ws::Host for Host {
             _ => 443,
         });
 
-        // Same egress allowlist + SSRF guard the HTTP host enforces.
+        // Same egress allowlist + SSRF guard the HTTP host enforces, including
+        // the user-authorized `base_url` exception.
         if let Err(msg) = check_host_allowed(
             &self.hooks.allowed_hosts,
+            &self.hooks.user_allowed_hosts,
             host,
             port,
             self.hooks.allow_loopback,

--- a/super-stt-daemon/src/stt_models/wasm/ws_host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/ws_host.rs
@@ -4,8 +4,9 @@
 //! A realtime backend imports `super-stt:realtime/ws` to open a WebSocket to
 //! its upstream cloud API. The daemon implements that import here, against the
 //! same egress allowlist + SSRF guard the HTTP host uses (see
-//! [`host::check_host_allowed`]) so a realtime backend's only network reach is
-//! its declared `allowed_hosts`.
+//! [`check_host_allowed`]) so a realtime backend's only network reach is
+//! its declared `allowed_hosts` plus the endpoint the user authorized through
+//! its `base_url` option.
 //!
 //! Only the *outgoing* `ws` interface lives here. The *incoming* `ws-server`
 //! interface (which the backend exports and the daemon invokes per consumer
@@ -135,13 +136,12 @@ impl self::super_stt::realtime::ws::Host for Host {
         let Some(host) = uri.host() else {
             return Ok(Err(WsError::InvalidUrl("url has no host".to_string())));
         };
-        let port = uri.port_u16().unwrap_or(match uri.scheme_str() {
-            Some("ws") => 80,
-            _ => 443,
+        let port = uri.port_u16().unwrap_or_else(|| {
+            crate::stt_models::backends::base_url::default_port(uri.scheme_str())
         });
 
         // Same egress allowlist + SSRF guard the HTTP host enforces, including
-        // the user-authorized `base_url` exception.
+        // the relaxation for the user-authorized `base_url` endpoint.
         if let Err(msg) = check_host_allowed(
             &self.hooks.allowed_hosts,
             &self.hooks.user_allowed_hosts,

--- a/super-stt-daemon/tests/http_smoke_backend_options.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_options.rs
@@ -86,7 +86,13 @@ name = "base_url"
 label = "Base URL"
 description = "Override the OpenAI API base URL."
 type = "string"
-default = "https://api.openai.com"
+
+[[options]]
+name = "region"
+label = "Region"
+description = "Upstream region."
+type = "string"
+default = "us-east-1"
 
 [[models]]
 name = "whisper-1"
@@ -215,13 +221,13 @@ async fn delete_req(p: &PathBuf, path: &str, token: &str) -> (StatusCode, serde_
 #[tokio::test]
 async fn option_set_get_and_reset_to_default() {
     let (_guard, sock, token) = start_daemon(&["settings"]).await;
-    let opt_path = format!("/backends/{FIXTURE_SOURCE_ENC}/options/base_url");
+    let opt_path = format!("/backends/{FIXTURE_SOURCE_ENC}/options/region");
 
     // Default before any override.
     let (s, body) = get(&sock, &opt_path, &token).await;
     assert_eq!(s, StatusCode::OK, "GET option before set: {body}");
     assert_eq!(
-        body["value"], "https://api.openai.com",
+        body["value"], "us-east-1",
         "should start at manifest default: {body}"
     );
 
@@ -230,12 +236,12 @@ async fn option_set_get_and_reset_to_default() {
         &sock,
         &opt_path,
         &token,
-        serde_json::json!({ "value": "https://gw.example.com" }),
+        serde_json::json!({ "value": "eu-west-1" }),
     )
     .await;
     assert_eq!(s, StatusCode::OK, "POST option: {body}");
     assert_eq!(
-        body["value"], "https://gw.example.com",
+        body["value"], "eu-west-1",
         "value should reflect override: {body}"
     );
 
@@ -243,8 +249,44 @@ async fn option_set_get_and_reset_to_default() {
     let (s, body) = delete_req(&sock, &opt_path, &token).await;
     assert_eq!(s, StatusCode::OK, "DELETE option: {body}");
     assert_eq!(
-        body["value"], "https://api.openai.com",
+        body["value"], "us-east-1",
         "value should revert to manifest default after DELETE: {body}"
+    );
+}
+
+/// `base_url` is the one option a manifest may not supply a value for — its
+/// host is authorized for egress, so only the user may name it. It therefore
+/// round-trips through the unset state rather than through a default.
+#[tokio::test]
+async fn base_url_round_trips_through_unset() {
+    let (_guard, sock, token) = start_daemon(&["settings"]).await;
+    let opt_path = format!("/backends/{FIXTURE_SOURCE_ENC}/options/base_url");
+
+    let (s, body) = get(&sock, &opt_path, &token).await;
+    assert_eq!(s, StatusCode::OK, "GET base_url before set: {body}");
+    assert!(
+        body["value"].is_null() && body["default"].is_null(),
+        "base_url starts unset, with no manifest default: {body}"
+    );
+
+    let (s, body) = post_req(
+        &sock,
+        &opt_path,
+        &token,
+        serde_json::json!({ "value": "https://gw.example.com" }),
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "POST base_url: {body}");
+    assert_eq!(
+        body["value"], "https://gw.example.com",
+        "value should reflect override: {body}"
+    );
+
+    let (s, body) = delete_req(&sock, &opt_path, &token).await;
+    assert_eq!(s, StatusCode::OK, "DELETE base_url: {body}");
+    assert!(
+        body["value"].is_null(),
+        "clearing the override leaves base_url unset, not defaulted: {body}"
     );
 }
 
@@ -258,13 +300,16 @@ async fn option_list_returns_declared_options() {
     assert_eq!(s, StatusCode::OK, "GET options/list: {body}");
     assert_eq!(body["status"], "success", "list status: {body}");
     let options = body["options"].as_array().expect("options array");
-    assert_eq!(options.len(), 1, "one declared option: {body}");
+    assert_eq!(options.len(), 2, "two declared options: {body}");
     let o0 = &options[0];
     assert_eq!(o0["name"], "base_url", "option name: {body}");
-    assert_eq!(
-        o0["value"], "https://api.openai.com",
-        "default value in list: {body}"
+    assert!(
+        o0["value"].is_null(),
+        "base_url carries no default, so no value until the user sets one: {body}"
     );
+    let o1 = &options[1];
+    assert_eq!(o1["name"], "region", "option name: {body}");
+    assert_eq!(o1["value"], "us-east-1", "default value in list: {body}");
 }
 
 /// GET on an undeclared option name returns 404 `unknown_option`.

--- a/super-stt-daemon/tests/wasm_mock.rs
+++ b/super-stt-daemon/tests/wasm_mock.rs
@@ -9,8 +9,9 @@
 #![cfg(feature = "wasm-backends")]
 
 use std::path::PathBuf;
+use std::time::Duration;
 
-use super_stt_daemon::stt_models::transcribe::Transcribe;
+use super_stt_daemon::stt_models::transcribe::{ModelInfoData, Transcribe};
 use super_stt_daemon::stt_models::wasm::WasmBackend;
 
 /// Path to the prebuilt mock component (`just build-mock-wasm-backend`).
@@ -47,4 +48,52 @@ async fn wasm_orchestration_against_mock() {
         .await
         .expect("transcription should succeed");
     assert_eq!(text, "mock transcription");
+}
+
+/// The two egress lists must reach the hooks in the right slots. Nothing else
+/// covers this: the guard's own tests build argument lists directly, and every
+/// other harness here passes an empty user list, so swapping the two adjacent
+/// `Vec<String>` parameters of `with_info` — which would hand a backend the SSRF
+/// relaxation for hosts it declared in its own manifest — would leave the suite
+/// green. Both invocation paths (batch and realtime) build their hooks through
+/// `allowlist_hooks`, so asserting on it covers both.
+#[tokio::test]
+async fn egress_lists_reach_the_hooks_in_their_own_slots() {
+    let Some(path) = mock_component() else {
+        eprintln!("skipping: mock component not built (run `just build-mock-wasm-backend`)");
+        return;
+    };
+
+    let backend = WasmBackend::with_info(
+        &path,
+        vec!["manifest.example".to_string()],
+        vec!["gw.example:8443".to_string(), "gw.example".to_string()],
+        ModelInfoData::new(
+            "mock",
+            "github.com/super-stt/mock",
+            false,
+            true,
+            Duration::from_secs(0),
+        ),
+        Vec::new(),
+        false,
+        false,
+    )
+    .expect("load mock backend");
+
+    let hooks = backend.allowlist_hooks();
+    assert_eq!(
+        hooks.allowed_hosts,
+        vec!["manifest.example".to_string()],
+        "the manifest list must stay in the SSRF-guarded slot"
+    );
+    assert_eq!(
+        hooks.user_allowed_hosts,
+        vec!["gw.example:8443".to_string(), "gw.example".to_string()],
+        "the user's endpoint must stay in the relaxed slot"
+    );
+    assert!(
+        !hooks.allow_loopback,
+        "loopback egress stays off unless explicitly opted into"
+    );
 }

--- a/super-stt-indexer/src/manifest.rs
+++ b/super-stt-indexer/src/manifest.rs
@@ -35,6 +35,13 @@ pub enum ManifestError {
          GPL-3.0-only) or \"other\""
     )]
     LicenseNotAllowed(String),
+    #[error(
+        "option `base_url` must not declare a `default`: its value authorizes \
+         egress the sandbox would otherwise refuse, so it has to come from the \
+         user. Carry the endpoint in the component and leave the option as an \
+         override."
+    )]
+    BaseUrlDefault,
 }
 
 pub fn validate(
@@ -93,6 +100,17 @@ pub fn validate(
                 return Err(ManifestError::CudnnRequiresCuda { file: a.label() });
             }
         }
+    }
+    // A `base_url` value is user intent: the daemon authorizes the host it names
+    // for egress with the SSRF guard relaxed. A manifest-supplied one is the
+    // backend author's, so a release carrying it does not go in the registry.
+    // The daemon is laxer on purpose — it drops the value and loads the backend
+    // — because refusing to load punishes the user for the author's mistake;
+    // refusing to publish stops it reaching users at all.
+    if m.options.iter().any(|o| {
+        o.name == super_stt_registry_types::manifest::BASE_URL_OPTION && o.default.is_some()
+    }) {
+        return Err(ManifestError::BaseUrlDefault);
     }
     crate::license::check(m.backend.license.as_deref())?;
     Ok(())
@@ -220,6 +238,47 @@ mod tests {
         let m = Manifest::parse(t).unwrap();
         let err = validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap_err();
         assert!(matches!(err, ManifestError::CudaMissingMajor { .. }));
+    }
+
+    /// A release may declare the `base_url` option, but not a value for it: the
+    /// host it names is authorized for egress with the SSRF guard relaxed, which
+    /// only the user may ask for. The registry is where that is refused — the
+    /// daemon loads such a backend with the value dropped.
+    #[test]
+    fn rejects_a_base_url_default_but_accepts_the_option() {
+        const BASE: &str = r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
+            description = "Test backend."
+            license = "Apache-2.0"
+
+            [assets]
+            wasm = "y.wasm"
+
+            [[options]]
+            name = "base_url"
+            description = "Endpoint."
+            type = "string"
+        "#;
+        let m = Manifest::parse(BASE).unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
+
+        let m = Manifest::parse(&format!("{BASE}\ndefault = \"https://api.y.com\"\n")).unwrap();
+        let err = validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap_err();
+        assert!(
+            matches!(err, ManifestError::BaseUrlDefault),
+            "expected BaseUrlDefault, got {err:?}"
+        );
+
+        // Every other option keeps its default.
+        let m =
+            Manifest::parse(&BASE.replace(r#"name = "base_url""#, r#"name = "region""#)).unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
     }
 
     #[test]

--- a/super-stt-indexer/tests/integration.rs
+++ b/super-stt-indexer/tests/integration.rs
@@ -27,9 +27,9 @@ name = "y_api_key"
 description = "Key."
 
 [[options]]
-name = "base_url"
+name = "region"
 description = "Override."
-default = "https://api.y.example"
+default = "us-east-1"
 
 [[models]]
 name = "y-1"
@@ -108,12 +108,9 @@ async fn end_to_end_indexes_a_single_wasm_backend() {
     // Relaxation fallbacks: a secret without `label` falls back to `name`;
     // an option without `label`/`type` falls back to `name`/"string".
     assert_eq!(v["backends"][0]["secrets"][0]["label"], "y_api_key");
-    assert_eq!(v["backends"][0]["options"][0]["label"], "base_url");
+    assert_eq!(v["backends"][0]["options"][0]["label"], "region");
     assert_eq!(v["backends"][0]["options"][0]["type"], "string");
-    assert_eq!(
-        v["backends"][0]["options"][0]["default"],
-        "https://api.y.example"
-    );
+    assert_eq!(v["backends"][0]["options"][0]["default"], "us-east-1");
     // The fixture's only model declares the `none` device sentinel — pins the
     // `supported_devices = ["none"]` → `online: true` mapping.
     assert_eq!(v["backends"][0]["online"], true);

--- a/super-stt-registry-types/src/index.rs
+++ b/super-stt-registry-types/src/index.rs
@@ -163,16 +163,29 @@ impl IndexBackend {
             options: m
                 .options
                 .into_iter()
-                .map(|o| IndexOption {
-                    label: o.label.unwrap_or_else(|| o.name.clone()),
-                    name: o.name,
-                    r#type: o
-                        .r#type
-                        .map_or_else(|| "string".to_string(), |t| t.to_string()),
-                    // Untagged serialize yields the plain JSON value
-                    // (string/number/bool). `.ok()` drops the theoretically
-                    // impossible failure rather than panicking in a library.
-                    default: o.default.and_then(|d| serde_json::to_value(d).ok()),
+                .map(|o| {
+                    // A `base_url` value authorizes egress, so only the user may
+                    // supply one (see [`BASE_URL_OPTION`]). Dropping it here is
+                    // what keeps every install path agreeing with the daemon:
+                    // this synthesis is shared by the registry indexer, the
+                    // custom-repo resolver, and the local-dir import, and the
+                    // daemon drops the same value at discovery. Advertising it
+                    // would show the user a default their install then loses.
+                    let default = (o.name != crate::manifest::BASE_URL_OPTION)
+                        .then_some(o.default)
+                        .flatten()
+                        // Untagged serialize yields the plain JSON value
+                        // (string/number/bool). `.ok()` drops the theoretically
+                        // impossible failure rather than panicking in a library.
+                        .and_then(|d| serde_json::to_value(d).ok());
+                    IndexOption {
+                        label: o.label.unwrap_or_else(|| o.name.clone()),
+                        name: o.name,
+                        r#type: o
+                            .r#type
+                            .map_or_else(|| "string".to_string(), |t| t.to_string()),
+                        default,
+                    }
                 })
                 .collect(),
             assets,
@@ -455,6 +468,62 @@ mod tests {
         assert_eq!(b.options.len(), 1, "option must not be dropped");
         assert_eq!(b.options[0].label, "base_url", "label falls back to name");
         assert_eq!(b.options[0].r#type, "string", "type defaults to string");
+    }
+
+    /// Every install path — registry, custom repo, local dir — synthesizes its
+    /// catalog entry here, and the daemon drops a manifest-declared `base_url`
+    /// value at discovery. Carrying one into the catalog would advertise a
+    /// default that disappears the moment the backend is installed, and would
+    /// leave the Configure sheet offering to "reset" to a value nothing holds.
+    /// Every other option keeps its default.
+    #[test]
+    fn from_manifest_drops_a_base_url_default_and_keeps_the_others() {
+        let m = crate::manifest::Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
+            description = "Test backend."
+
+            [assets]
+            wasm = "y.wasm"
+
+            [[options]]
+            name = "base_url"
+            description = "Override."
+            default = "https://api.y.example"
+
+            [[options]]
+            name = "region"
+            description = "Region."
+            default = "us-east-1"
+            "#,
+        )
+        .unwrap();
+
+        let b = IndexBackend::from_manifest(
+            id_from_source("github.com/x/y"),
+            m,
+            "1.0.0".into(),
+            "v1.0.0".into(),
+            IndexAssets::default(),
+            None,
+        );
+
+        assert_eq!(b.options[0].name, "base_url");
+        assert!(
+            b.options[0].default.is_none(),
+            "a manifest-declared base_url value must not reach the catalog"
+        );
+        assert_eq!(b.options[1].name, "region");
+        assert_eq!(
+            b.options[1].default,
+            Some(serde_json::Value::String("us-east-1".into()))
+        );
     }
 
     /// A backend with no `license` field still deserializes (lenient read),

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -13,6 +13,17 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+/// The option name that carries a backend's configurable endpoint.
+///
+/// It is the one option whose *value* changes what the daemon permits: the host
+/// it names is authorized for egress with the SSRF guard relaxed. That is sound
+/// only while the value is the user's, so consumers treat a manifest-supplied
+/// one as no value — the indexer refuses such a release, the catalog synthesis
+/// in [`IndexBackend::from_manifest`](crate::index::IndexBackend::from_manifest)
+/// drops it, and the daemon drops it at discovery. Named here so those checks
+/// cannot drift apart over a string literal.
+pub const BASE_URL_OPTION: &str = "base_url";
+
 /// A backend's `backend.toml`: identity, packaging, network policy,
 /// secrets/options, and the models it provides.
 #[derive(Debug, Clone, Deserialize)]
@@ -598,7 +609,7 @@ mod tests {
             description = "Key."
 
             [[options]]
-            name = "base_url"
+            name = "region"
             description = "Override."
             type = "string"
             default = "https://api.y.com"
@@ -622,6 +633,41 @@ mod tests {
         );
         assert_eq!(m.options[1].default, Some(OptionDefault::Integer(30)));
         assert_eq!(m.options[1].default.as_ref().unwrap().to_string(), "30");
+    }
+
+    /// `base_url` names the endpoint whose host is authorized for egress with
+    /// the SSRF guard relaxed, so a value for it must come from the user. The
+    /// format stays lenient about that — the parser keeps whatever the manifest
+    /// wrote, and the consumers enforce the rule: the indexer refuses to publish
+    /// such a release, and the daemon drops the value and loads the backend
+    /// anyway (`super-stt-indexer::manifest::validate`,
+    /// `super_stt_daemon::stt_models::backends`).
+    #[test]
+    fn parse_keeps_a_base_url_default_for_consumers_to_judge() {
+        let m = Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
+            description = "Test backend."
+
+            [[options]]
+            name = "base_url"
+            description = "Endpoint."
+            type = "string"
+            default = "https://api.y.com"
+            "#,
+        )
+        .expect("parse stays lenient; policy lives in each consumer");
+        assert_eq!(m.options[0].name, "base_url");
+        assert_eq!(
+            m.options[0].default,
+            Some(OptionDefault::String("https://api.y.com".into()))
+        );
     }
 
     #[test]

--- a/super-stt-registry-types/src/schema.rs
+++ b/super-stt-registry-types/src/schema.rs
@@ -51,6 +51,91 @@ fn push_all_of(schema_obj: &mut Value, cond: Value) {
         .push(cond);
 }
 
+/// The conditionals and constraints that live on individual definitions
+/// rather than the root: asset shape, the `base_url` value ban, non-empty
+/// lists, and the license enum.
+///
+/// # Panics
+/// Panics if a definition the builder targets is missing — see
+/// [`backend_schema`].
+fn inject_definition_rules(defs: &mut serde_json::Map<String, Value>) {
+    let asset = defs
+        .get_mut("SubprocessAsset")
+        .expect("SubprocessAsset def");
+    push_all_of(
+        asset,
+        json!({
+            "if": {
+                "required": ["accel"],
+                "properties": { "accel": { "const": "cuda" } }
+            },
+            "then": { "required": ["cuda_major"] },
+            "else": { "properties": {
+                "cuda_major": false,
+                "cuda_sm": false,
+                "cudnn": { "const": false }
+            } }
+        }),
+    );
+    // Exactly one of `file` (single archive) or `parts` (multi-part). `oneOf`
+    // passes only when one branch matches: file-only or parts-only is valid;
+    // both or neither fails — the schema mirror of the parser's xor guard.
+    push_all_of(
+        asset,
+        json!({
+            "oneOf": [
+                { "required": ["file"] },
+                { "required": ["parts"] }
+            ]
+        }),
+    );
+    // A multi-part `parts` list must be non-empty (serde can't express minItems).
+    asset["properties"]["parts"]
+        .as_object_mut()
+        .expect("parts property")
+        .insert("minItems".into(), json!(1));
+    // `FileSpec` is flat — `url` and `destination` are required by serde and
+    // `sha256` is optional, so no cross-field conditional is needed here.
+
+    // `base_url` is the option whose value relaxes the egress guard, so it must
+    // be the user's — the manifest may declare the option but never a value for
+    // it. Mirrors the parser's `BaseUrlDefault` guard.
+    let opt = defs.get_mut("Opt").expect("Opt def");
+    push_all_of(
+        opt,
+        json!({
+            "if": {
+                "required": ["name"],
+                "properties": { "name": { "const": crate::manifest::BASE_URL_OPTION } }
+            },
+            "then": { "properties": { "default": false } }
+        }),
+    );
+
+    // `supported_devices` must be non-empty (discovery rejects an empty
+    // list); serde can't express minItems, so inject it here.
+    let model = defs.get_mut("ModelEntry").expect("ModelEntry def");
+    model["properties"]["supported_devices"]
+        .as_object_mut()
+        .expect("supported_devices property")
+        .insert("minItems".into(), serde_json::json!(1));
+
+    // Embed the accepted license values (recognized FOSS SPDX ids + `other`) as
+    // an enum so editors offer them and reject anything else — a self-contained
+    // snapshot of the FOSS subset of the SPDX list, requiring no external fetch
+    // by the editor. Built from the same predicate the indexer validates with
+    // (`crate::license`), so the schema and the indexer never disagree.
+    let licenses: Vec<Value> = crate::license::accepted_schema_values()
+        .into_iter()
+        .map(|s| json!(s))
+        .collect();
+    let backend = defs.get_mut("BackendMeta").expect("BackendMeta def");
+    backend["properties"]["license"]
+        .as_object_mut()
+        .expect("license property")
+        .insert("enum".into(), json!(licenses));
+}
+
 /// The full `backend.toml` schema.
 ///
 /// # Panics
@@ -116,70 +201,11 @@ pub fn backend_schema() -> Value {
     );
 
     // Per-definition conditionals.
-    let defs = root
-        .get_mut("definitions")
-        .and_then(Value::as_object_mut)
-        .expect("definitions");
-    let asset = defs
-        .get_mut("SubprocessAsset")
-        .expect("SubprocessAsset def");
-    push_all_of(
-        asset,
-        json!({
-            "if": {
-                "required": ["accel"],
-                "properties": { "accel": { "const": "cuda" } }
-            },
-            "then": { "required": ["cuda_major"] },
-            "else": { "properties": {
-                "cuda_major": false,
-                "cuda_sm": false,
-                "cudnn": { "const": false }
-            } }
-        }),
+    inject_definition_rules(
+        root.get_mut("definitions")
+            .and_then(Value::as_object_mut)
+            .expect("definitions"),
     );
-    // Exactly one of `file` (single archive) or `parts` (multi-part). `oneOf`
-    // passes only when one branch matches: file-only or parts-only is valid;
-    // both or neither fails — the schema mirror of the parser's xor guard.
-    push_all_of(
-        asset,
-        json!({
-            "oneOf": [
-                { "required": ["file"] },
-                { "required": ["parts"] }
-            ]
-        }),
-    );
-    // A multi-part `parts` list must be non-empty (serde can't express minItems).
-    asset["properties"]["parts"]
-        .as_object_mut()
-        .expect("parts property")
-        .insert("minItems".into(), json!(1));
-    // `FileSpec` is flat — `url` and `destination` are required by serde and
-    // `sha256` is optional, so no cross-field conditional is needed here.
-
-    // `supported_devices` must be non-empty (discovery rejects an empty
-    // list); serde can't express minItems, so inject it here.
-    let model = defs.get_mut("ModelEntry").expect("ModelEntry def");
-    model["properties"]["supported_devices"]
-        .as_object_mut()
-        .expect("supported_devices property")
-        .insert("minItems".into(), serde_json::json!(1));
-
-    // Embed the accepted license values (recognized FOSS SPDX ids + `other`) as
-    // an enum so editors offer them and reject anything else — a self-contained
-    // snapshot of the FOSS subset of the SPDX list, requiring no external fetch
-    // by the editor. Built from the same predicate the indexer validates with
-    // (`crate::license`), so the schema and the indexer never disagree.
-    let licenses: Vec<Value> = crate::license::accepted_schema_values()
-        .into_iter()
-        .map(|s| json!(s))
-        .collect();
-    let backend = defs.get_mut("BackendMeta").expect("BackendMeta def");
-    backend["properties"]["license"]
-        .as_object_mut()
-        .expect("license property")
-        .insert("enum".into(), json!(licenses));
 
     close_objects(&mut root);
     root

--- a/super-stt-registry-types/tests/schema_validation.rs
+++ b/super-stt-registry-types/tests/schema_validation.rs
@@ -225,10 +225,31 @@ fn rejects_contract_violations() {
             d["backend"]["license"] = json!("Definitely-Not-A-License");
             d
         }),
+        ("base_url option declaring a default", {
+            let mut d = wasm_base();
+            d["options"] = json!([{ "name": "base_url", "description": "Endpoint.",
+                "type": "string", "default": "https://api.y.example" }]);
+            d
+        }),
     ];
     for (label, doc) in cases {
         assert!(!v.is_valid(&doc), "{label}: should have failed validation");
     }
+}
+
+/// The `base_url` rule is narrow: the option may be declared, and every other
+/// option keeps its `default`. Without this the conditional could be widened to
+/// ban defaults outright and the rejection case above would still pass.
+#[test]
+fn base_url_may_be_declared_without_a_default() {
+    let v = backend_validator();
+    let mut d = wasm_base();
+    d["options"] = json!([
+        { "name": "base_url", "description": "Endpoint." },
+        { "name": "region", "description": "Region.", "default": "us" }
+    ]);
+    let errors: Vec<String> = v.iter_errors(&d).map(|e| format!("{e}")).collect();
+    assert!(errors.is_empty(), "schema errors: {errors:#?}");
 }
 
 /// `close_objects` only walks root + definitions; if a future type change
@@ -333,6 +354,12 @@ fn conditional_property_names_exist() {
         model_entry_props.contains_key("supported_devices"),
         "ModelEntry missing `supported_devices`"
     );
+    let opt_props = defs["Opt"]["properties"]
+        .as_object()
+        .expect("Opt properties");
+    for key in ["name", "default"] {
+        assert!(opt_props.contains_key(key), "Opt missing `{key}`");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Supersedes #343, which this branch builds directly on — @haydonryan's commit is the
first here, so the idea and its authorship stay intact. The rework was substantial
enough that it seemed wrong to push it onto a contributor's fork and call it theirs.

## What the feature is

A backend's outbound reach is its manifest's `[network].allowed_hosts`, fully
SSRF-guarded. #343 adds a second source: the `host:port` a user names in the backend's
`base_url` option, so a cloud backend can be pointed at a local or private gateway
without re-installing it.

## What changed from #343

**The relaxation is scoped to the endpoint the user named.** It covers that one
authority and lifts only the loopback and private blocks. Link-local — the cloud
metadata endpoint among it — plus unspecified and broadcast are refused under every
scope, whoever named them. A portless value no longer authorizes every port on the host;
the bare host is authorized separately and stays public-only, so a public gateway keeps
its other ports while a local one does not.

**The value is the user's alone.** Egress reads the config override, never the manifest
default. A `backend.toml` declaring a default is refused by the registry indexer, dropped
by the catalog synthesis every install path shares, and dropped again at discovery with a
warning — so an author's mistake costs a setting, not the whole backend.

**The endpoint is parsed with the same `Uri` the transports match against**, so uppercase
schemes, userinfo, query strings, whitespace, and bracketed IPv6 can't produce an entry
that never matches. A backend listing the same host in its manifest no longer costs the
user their gateway.

**Options resolve once per model load**, so the injected header and the authorized egress
can't come from different config states.

**The Cloud chip says a user endpoint exists** without printing the address, and the
authorization is logged at load.

## Verification

`clippy --all-features --workspace --all-targets -W pedantic -D warnings`, `just fmt`,
`just check-features`, `just doctest`, and the full workspace suite (41 binaries, 659
tests) all pass. Two review passes ran against the branch; every finding is fixed or
recorded in #348 as its own follow-up.

## Deferred

Three items are deliberately out of scope and documented in #348: an IPv6
classification gap in the egress guard that predates this work, per-invocation cloning of
the allowlists, and the untyped `base_url` naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
