### PR TITLE
Share the egress lists instead of copying them per call

### DIFF
--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -101,6 +101,13 @@ async fn set(
     // as an active override that authorizes nothing. Other options keep the
     // value verbatim: whitespace may carry meaning in one the daemon does not
     // interpret.
+    //
+    // Normalized, not validated: this deliberately does not check that the value
+    // parses into a host. Doing so would reject garbage but not the mistake that
+    // actually misleads people — a well-formed URL naming the wrong port — while
+    // a value the daemon cannot read is already logged at model load and shows
+    // up as a failed transcription. Revisit alongside a settings UI that can
+    // surface the error where the user is looking.
     let value = if name == crate::stt_models::backends::base_url::OPTION_NAME {
         body.value.trim()
     } else {

--- a/super-stt-daemon/src/stt_models/wasm/host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/host.rs
@@ -3,6 +3,7 @@
 //! outbound-host allowlist that confines a component's network egress.
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
+use std::sync::Arc;
 
 use wasmtime::component::ResourceTable;
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
@@ -50,7 +51,7 @@ pub struct AllowlistHooks {
     /// manifest. These are SSRF-guarded: a manifest entry does **not** authorize
     /// loopback/private/link-local/metadata destinations, because the backend
     /// author is not a trusted operator.
-    pub allowed_hosts: Vec<String>,
+    pub allowed_hosts: Arc<[String]>,
     /// What the *user* authorized through backend options (e.g. a `base_url` set
     /// in the settings UI): the `host:port` the value names, plus its bare host.
     /// The SSRF guard is relaxed for the authority alone — loopback and private
@@ -60,7 +61,7 @@ pub struct AllowlistHooks {
     /// there: link-local (metadata), unspecified, and broadcast addresses stay
     /// refused, and the bare host is judged like a manifest entry, so a gateway's
     /// other ports stay reachable only while they are public.
-    pub user_allowed_hosts: Vec<String>,
+    pub user_allowed_hosts: Arc<[String]>,
     /// Permit egress to loopback addresses (`127.0.0.0/8`, `::1`). Off in
     /// production — the SSRF guard blocks loopback so an untrusted backend
     /// can't reach a service bound to localhost. Tests and local development

--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -13,6 +13,7 @@ pub mod host;
 pub mod ws_host;
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -44,10 +45,10 @@ enum BackendPre {
 pub struct WasmBackend {
     engine: Engine,
     pre: BackendPre,
-    allowed_hosts: Vec<String>,
+    allowed_hosts: Arc<[String]>,
     /// Hosts the *user* authorized via backend options (e.g. a `base_url` set in
     /// the settings UI). Exempt from the SSRF guard — see [`AllowlistHooks`].
-    user_allowed_hosts: Vec<String>,
+    user_allowed_hosts: Arc<[String]>,
     allow_loopback: bool,
     transcribe_headers: Vec<(String, String)>,
     model_id: String,
@@ -109,8 +110,8 @@ impl WasmBackend {
         Ok(Self {
             engine,
             pre,
-            allowed_hosts,
-            user_allowed_hosts,
+            allowed_hosts: allowed_hosts.into(),
+            user_allowed_hosts: user_allowed_hosts.into(),
             allow_loopback: false,
             transcribe_headers,
             model_id,
@@ -128,6 +129,10 @@ impl WasmBackend {
     /// the user authorized and has the guard relaxed for its `host:port`. Wiring
     /// them the other way round would hand a backend the relaxation for hosts it
     /// declared itself.
+    ///
+    /// Both lists are immutable for the backend's lifetime and the hooks only
+    /// read them, so they are shared rather than copied: this runs once per
+    /// transcription and once per realtime session.
     #[must_use]
     pub fn allowlist_hooks(&self) -> AllowlistHooks {
         AllowlistHooks {

--- a/super-stt-daemon/tests/wasm_mock.rs
+++ b/super-stt-daemon/tests/wasm_mock.rs
@@ -83,13 +83,13 @@ async fn egress_lists_reach_the_hooks_in_their_own_slots() {
 
     let hooks = backend.allowlist_hooks();
     assert_eq!(
-        hooks.allowed_hosts,
-        vec!["manifest.example".to_string()],
+        &*hooks.allowed_hosts,
+        ["manifest.example".to_string()],
         "the manifest list must stay in the SSRF-guarded slot"
     );
     assert_eq!(
-        hooks.user_allowed_hosts,
-        vec!["gw.example:8443".to_string(), "gw.example".to_string()],
+        &*hooks.user_allowed_hosts,
+        ["gw.example:8443".to_string(), "gw.example".to_string()],
         "the user's endpoint must stay in the relaxed slot"
     );
     assert!(


### PR DESCRIPTION
Item 2 from #348 (which is being retired in favour of doing the work).

`AllowlistHooks` is constructed once per batch transcription and once per realtime
session, and each construction deep-copied both egress lists — two `Vec<String>` plus a
`String` per entry — to hand the guard data it only ever reads. The lists are immutable
for the backend's lifetime, so they are now `Arc<[String]>` and construction is a
refcount bump.

`Arc<[String]>` derefs to `&[String]`, so `check_host_allowed` and both transports are
unchanged. The single construction point stays, and the property that the two lists land
in their own slots is still pinned by `egress_lists_reach_the_hooks_in_their_own_slots`.

Also folds in the reasoning for a decision that lived only in #348's prose: the
`base_url` write path normalizes but deliberately does not validate. That note now sits
in `options.rs`, next to the code it constrains, so it survives the doc going away.

Full workspace suite (687 tests), clippy pedantic, `just fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
