### PR TITLE
Say that the base_url option name is load-bearing

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -164,6 +164,12 @@ egress set at model-load time, and the SSRF resolver guard is relaxed for it
 backend be pointed at an arbitrary gateway — public, local, or on a private
 network — without re-installing the backend.
 
+The name is load-bearing: the daemon recognizes `base_url` and nothing else. An
+option called `endpoint`, `api_base`, or `server_url` is a perfectly valid
+option, but its value authorizes no egress, so a backend that reads one instead
+will have every request refused with `outbound host not allowed` once the user
+points it somewhere the manifest's `allowed_hosts` does not cover.
+
 `base_url` is the one option a manifest may declare but not supply a value for.
 The reason is the paragraph below — the value authorizes egress the sandbox
 would otherwise refuse, and a value the backend author wrote is not user intent.


### PR DESCRIPTION
Item 3 from #348, resolved as a documentation change rather than a contract change: the `base_url` convention stays as-is.

The failure it addresses is an author naming their endpoint option `endpoint` or `api_base` — valid in every other respect, silently granting no egress, and surfacing only as `outbound host not allowed` at transcription time. The spec described the convention but never said that no other name works.

Deliberately not a heuristic warning at discovery: matching names that look like an endpoint guesses at intent and would fire on a legitimate `webhook_url` that was never meant to authorize anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)