### PR TITLE
Correct the docs about a declared base_url default

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -484,12 +484,13 @@ name        = "openai_api_key"
 label       = "OpenAI API key"
 description = "Used to authenticate requests to api.openai.com."
 
+# No `default`: it is forbidden on `base_url`. The component carries the
+# stock endpoint and treats this option as an override.
 [[options]]
 name        = "base_url"
 label       = "API base URL"
 description = "Override the API base URL, e.g. for a gateway."
 type        = "string"
-default     = "https://api.openai.com"
 
 [[models]]
 name                = "whisper-1"

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -276,8 +276,9 @@ impl SuperSTTDaemon {
     /// The value is read from the config override **only** — never from the
     /// manifest default, which the backend author writes and which therefore
     /// cannot be allowed to widen the sandbox. (A manifest declaring one is
-    /// refused at parse; this read stands on its own so the invariant does not
-    /// depend on that check.) Because the value is the user's, it may be
+    /// refused at publication and scrubbed at load; this read stands on its own
+    /// so the invariant does not depend on either check.) Because the value is
+    /// the user's, it may be
     /// loopback or private, e.g. a local gateway.
     ///
     /// The bare host carries no such relaxation; it keeps the gateway's other

--- a/super-stt-daemon/src/stt_models/backends/base_url.rs
+++ b/super-stt-daemon/src/stt_models/backends/base_url.rs
@@ -3,8 +3,9 @@
 //! endpoint, and the one option whose value widens the sandbox.
 //!
 //! A configured value authorizes egress the SSRF guard would otherwise refuse,
-//! so the daemon reads it from the user's config only; a `backend.toml`
-//! declaring a `default` for it is rejected at parse. Deriving the endpoint
+//! so the daemon reads it from the user's config only: a `default` a
+//! `backend.toml` declares for it is refused at publication, and dropped with a
+//! warning if the backend was installed some other way. Deriving the endpoint
 //! lives here rather than at either call site so the egress list the transport
 //! enforces and the host the catalog discloses can never disagree about what a
 //! given value means. See `docs/protocol/backend/config.md`.


### PR DESCRIPTION
Two places described a `base_url` default incorrectly.

`docs/protocol/backend/config.md` — the "Example: cloud backend (WASM)" manifest declared `default = "https://api.openai.com"`, contradicting the field table on the same page ("Forbidden on `base_url`") and the generated JSON Schema, which rejects it. This is the example a backend author copies. Dropped the line and left a comment saying why it is absent.

`super-stt-daemon/src/stt_models/backends/base_url.rs` — the module doc placed the rejection "at parse". Parse is lenient: the indexer refuses the release at publication, the manifest→index conversion drops the value, and `load_backend` scrubs it with a warning. Reworded to match.

No behavior change. `just fmt` clean; daemon clippy passes with `--all-features --all-targets`.

Swept for the same claim elsewhere — `wasm.md` and `endpoints/v1/backends.md` were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)