### PR TITLE
Hand backends a canonical base_url

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -184,12 +184,30 @@ of the box carries it in the component and treats the option as an override.
 That is what the missing `x-stt-option-base_url` header means when the user has
 set nothing.
 
+The value the backend receives is **canonical**, not the string the user typed.
+The daemon parses it once at model-load time and re-serializes it as
+`scheme://host[:port][/path]`: the scheme is lowercased, and supplied as `https`
+when absent; userinfo is stripped; a trailing slash is removed; any query or
+fragment is dropped. A port appears only when the user gave one — the daemon
+does not add the scheme's default, which would otherwise travel to the upstream
+in the `Host` header. The path is preserved exactly as written: it plays no part
+in egress, and only the backend knows which path its own API serves.
+
+Normalizing here rather than in each backend keeps every backend working from
+the same value the daemon authorized, and spares each one its own URL parser.
+Config storage is untouched — the settings UI still shows what the user typed.
+
+A value the daemon cannot read as a URL fails the model load, with a message
+naming the option. It is not quietly dropped: falling back to the backend's
+built-in endpoint would send the user's audio and credentials to the very vendor
+they had configured their way out of.
+
 The daemon derives exactly one `host:port` authority from the configured value.
 An explicit port is taken as written; otherwise the scheme's default applies —
 `http` and `ws` ⇒ 80, `https` and `wss` ⇒ 443 — and a value carrying no scheme
-is read as `https`. Any path, query, or userinfo is discarded, and a value that
-yields no host contributes nothing: the backend keeps whatever egress its
-manifest declares.
+is read as `https`. Any path, query, or userinfo in the value plays no part in
+this derivation, and a value that yields no host contributes nothing: the
+backend keeps whatever egress its manifest declares.
 
 The host is authorized on its own as well, so a gateway stays reachable on its
 other ports — but only the derived `host:port` carries the relaxation below.

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -93,6 +93,12 @@ headers — external clients cannot set them.
 - Secrets and options come from the backend's [configuration](./config.md),
   with values set by the user in the settings UI. The header for a secret or
   option the user has not set is omitted.
+- `x-stt-option-base_url` is the one option header the daemon normalizes. It
+  carries a canonical `scheme://host[:port][/path]`: lowercase scheme, no
+  userinfo, no trailing slash, no query or fragment, and a port only when the
+  user set one. A backend can split it at the first `/` after the scheme and
+  needs no further parsing. Every other option is passed through exactly as the
+  user set it. See [config.md — `base_url` and egress](./config.md#base_url-and-egress).
 - **Secret values are sensitive.** The daemon stores them encrypted and
   redacts the `x-stt-secret-*` headers from logs. A backend uses a secret only
   to authenticate its own outbound calls — it must never echo one in a

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -93,14 +93,15 @@ async fn set(
     axum::Json(body): axum::Json<OptionBody>,
 ) -> Response {
     let source = decode_source(&source);
-    // `base_url` is normalized at the boundary. The daemon acts on this value
-    // rather than only passing it through — it is injected as a header *and*
-    // parsed into the egress the backend is granted — so storing it padded
-    // would leave `GET`, the component, and the authorized endpoint holding
-    // three different strings, and a whitespace-only value would show in the UI
-    // as an active override that authorizes nothing. Other options keep the
-    // value verbatim: whitespace may carry meaning in one the daemon does not
-    // interpret.
+    // `base_url` is trimmed at the boundary. Model load canonicalizes it again
+    // — the component and the authorized endpoint are derived there, from one
+    // value, so they agree however this was stored — but that rewrite never
+    // reaches config, which deliberately keeps what the user typed so the
+    // settings field reads back as they wrote it. Trimming here is what keeps
+    // that stored value honest: a padded one would read back padded, and a
+    // whitespace-only one would show as an active override that authorizes
+    // nothing. Other options keep the value verbatim: whitespace may carry
+    // meaning in one the daemon does not interpret.
     //
     // Normalized, not validated: this deliberately does not check that the value
     // parses into a host. Doing so would reject garbage but not the mistake that

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -47,7 +47,7 @@ impl SuperSTTDaemon {
         // is handed and the egress it is granted: read separately, a config
         // write landing between them would authorize a different endpoint than
         // the one the component is told to use.
-        let overrides = self.backend_option_overrides(&backend.source).await;
+        let overrides = self.backend_option_overrides(backend).await?;
         let headers = self.backend_headers(backend, &overrides).await?;
         let component = backend.dir.join(&backend.entrypoint);
         let info = ModelInfoData::new(
@@ -231,40 +231,64 @@ impl SuperSTTDaemon {
     /// awaits a keyring round-trip, and a read guard spanning that would block
     /// config writers for its duration.
     ///
-    /// `base_url` is normalized on the way out. It is the one value the two
-    /// paths must read *identically* — one dials it, the other authorizes what
-    /// it names — so surrounding whitespace, from a paste into the settings
-    /// field or from a hand-edited config that never passed through the API,
-    /// would otherwise leave them working from different strings. A value that
-    /// is only whitespace is no value at all and is dropped, so it neither
-    /// reaches the component nor authorizes anything. Every other option is
-    /// passed through exactly as the user set it: whitespace may carry meaning
-    /// in a value the daemon does not interpret.
+    /// `base_url` is canonicalized on the way out (see
+    /// [`normalize`](backends::base_url::normalize)). It is the one value the
+    /// two paths must read *identically* — one dials it, the other authorizes
+    /// what it names — and the component is handed it verbatim, so the rewrite
+    /// that keeps the pair consistent is also what spares every backend its own
+    /// URL parser. Every other option is passed through exactly as the user set
+    /// it: whitespace may carry meaning in a value the daemon does not
+    /// interpret.
+    ///
+    /// The two ways a value can fail are not the same failure. One that is only
+    /// whitespace is no value at all: it is dropped, so it neither reaches the
+    /// component nor authorizes anything, and the backend falls back to its
+    /// built-in endpoint exactly as if nothing were set. One the daemon cannot
+    /// read as a URL is a setting the user meant, so it fails the load instead —
+    /// dropping it would fall back to that same built-in endpoint and send the
+    /// user's audio and credentials to the vendor they had configured their way
+    /// out of.
+    ///
+    /// A value stored for an option this backend does not declare is inert —
+    /// nothing injects or authorizes it — so it is left alone rather than
+    /// validated.
+    ///
+    /// # Errors
+    /// Returns an error when a declared, non-empty `base_url` yields no host.
     #[cfg(feature = "wasm-backends")]
     async fn backend_option_overrides(
         &self,
-        source: &str,
-    ) -> std::collections::HashMap<String, String> {
+        backend: &DiscoveredBackend,
+    ) -> Result<std::collections::HashMap<String, String>> {
         let mut overrides: std::collections::HashMap<String, String> = self
             .config
             .read()
             .await
             .backends
             .options
-            .get(source)
+            .get(&backend.source)
             .cloned()
             .unwrap_or_default();
         let name = backends::base_url::OPTION_NAME;
-        match overrides.get(name).map(|v| v.trim().to_string()) {
-            Some(trimmed) if trimmed.is_empty() => {
-                overrides.remove(name);
-            }
-            Some(trimmed) => {
-                overrides.insert(name.to_string(), trimmed);
-            }
-            None => {}
+        let Some(opt) = backend.options.iter().find(|o| o.name == name) else {
+            return Ok(overrides);
+        };
+        let Some(raw) = overrides.get(name).cloned() else {
+            return Ok(overrides);
+        };
+        if raw.trim().is_empty() {
+            overrides.remove(name);
+        } else if let Some(canonical) = backends::base_url::normalize(&raw) {
+            overrides.insert(name.to_string(), canonical);
+        } else {
+            // Shaped like the missing-secret error above: name the setting the
+            // user can act on, never the internals.
+            bail!(
+                "{} is not a valid URL.",
+                opt.label.as_deref().unwrap_or(&opt.name)
+            );
         }
-        overrides
+        Ok(overrides)
     }
 
     /// What the *user* authorized via a `base_url` option: the `host:port` the
@@ -365,7 +389,10 @@ mod tests {
 
         // No override → nothing, even though the option carries a default: a
         // value the backend author wrote must not authorize egress.
-        let overrides = daemon.backend_option_overrides(source).await;
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
         assert!(SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides).is_empty());
 
         // Config override pointing at a local gateway → that endpoint, port kept.
@@ -380,7 +407,10 @@ mod tests {
             .entry(source.to_string())
             .or_default()
             .insert("base_url".to_string(), "http://localhost:8080".to_string());
-        let overrides = daemon.backend_option_overrides(source).await;
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
         assert_eq!(
             SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides),
             vec!["localhost:8080", "localhost"]
@@ -429,7 +459,10 @@ mod tests {
                 .or_default()
                 .insert("base_url".to_string(), stored.to_string());
 
-            let overrides = daemon.backend_option_overrides(source).await;
+            let overrides = daemon
+                .backend_option_overrides(&backend)
+                .await
+                .expect("a valid base_url");
             let headers = daemon
                 .backend_headers(&backend, &overrides)
                 .await
@@ -445,6 +478,98 @@ mod tests {
                 None => assert!(egress.is_empty(), "egress for {stored:?}"),
             }
         }
+    }
+
+    /// The component is handed the canonical form, not the string the user
+    /// typed. A backend dials this value directly, so the rewrite and the
+    /// authorization have to describe one endpoint — and a backend reading it
+    /// can split at the first `/` rather than carry a URL parser of its own.
+    #[tokio::test]
+    async fn the_injected_base_url_is_canonical() {
+        use crate::daemon::test_fixtures::openai_backend;
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        // No secrets: this drives the real header path, which would otherwise
+        // reach the keyring for the fixture's required key.
+        let backend = DiscoveredBackend {
+            secrets: Vec::new(),
+            ..openai_backend(source, Vec::new(), None)
+        };
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert(
+                "base_url".to_string(),
+                "  HTTPS://user:pass@gw.example.com:8443/v1/?k=v  ".to_string(),
+            );
+
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
+        let headers = daemon
+            .backend_headers(&backend, &overrides)
+            .await
+            .expect("headers for a secret-free backend");
+        let injected = headers
+            .iter()
+            .find(|(k, _)| k == "x-stt-option-base_url")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(injected, Some("https://gw.example.com:8443/v1"));
+        assert_eq!(
+            SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides),
+            vec!["gw.example.com:8443", "gw.example.com"]
+        );
+    }
+
+    /// A value the daemon cannot read fails the load rather than being dropped:
+    /// dropping it would fall back to the backend's built-in endpoint and send
+    /// the user's audio and credentials to the vendor they had configured their
+    /// way out of. The error names the setting, not the internals.
+    ///
+    /// The same stored value is inert for a backend declaring no such option —
+    /// nothing injects or authorizes it — so it must not block that load.
+    #[tokio::test]
+    async fn an_unreadable_base_url_fails_the_load() {
+        use crate::daemon::test_fixtures::openai_backend;
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        let backend = openai_backend(source, Vec::new(), None);
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert("base_url".to_string(), "http://".to_string());
+
+        let err = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect_err("an unreadable base_url fails the load");
+        assert!(err.to_string().contains("API base URL"), "{err}");
+
+        let undeclared = DiscoveredBackend {
+            options: Vec::new(),
+            ..backend
+        };
+        assert!(
+            daemon.backend_option_overrides(&undeclared).await.is_ok(),
+            "a value for an undeclared option must not block a load"
+        );
     }
 
     /// Headers and egress must describe one config state. Resolving them
@@ -475,7 +600,10 @@ mod tests {
             .or_default()
             .insert("base_url".to_string(), "http://10.0.0.5:8080".to_string());
 
-        let overrides = daemon.backend_option_overrides(source).await;
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
         // A write landing here reaches neither side, which is the point.
         daemon
             .config

--- a/super-stt-daemon/src/stt_models/backends/base_url.rs
+++ b/super-stt-daemon/src/stt_models/backends/base_url.rs
@@ -32,9 +32,60 @@ pub(crate) const OPTION_NAME: &str = super_stt_registry_types::manifest::BASE_UR
 /// would make them disagree about the very endpoint the user named.
 #[cfg(feature = "wasm-backends")]
 pub(crate) fn default_port(scheme: Option<&str>) -> u16 {
+    // Matched case-insensitively: `Uri` canonicalizes `http` and `https` but
+    // leaves any other scheme's case as written, so `WS://` would otherwise be
+    // ranked with the 443 schemes.
     match scheme {
-        Some("http" | "ws") => 80,
+        Some(s) if s.eq_ignore_ascii_case("http") || s.eq_ignore_ascii_case("ws") => 80,
         _ => 443,
+    }
+}
+
+/// Rewrite a configured value into the canonical form the backend is handed:
+/// `scheme://host[:port][/path]`.
+///
+/// The daemon acts on this value twice — it authorizes an endpoint and it tells
+/// the component which one to dial — and a backend that re-derived the endpoint
+/// from raw text would be writing a second URL parser whose disagreements with
+/// this one surface as a refused request. Normalizing once, here, is what lets
+/// a backend split the value at the first `/` and stop.
+///
+/// The scheme is lowercased and supplied when absent, userinfo is stripped, a
+/// trailing slash is removed, and any query or fragment is dropped. Two things
+/// are deliberately left alone: the port is emitted only when the value carried
+/// one, since a synthesized `:443` would travel to the upstream in the `Host`
+/// header for no gain — [`authority`] already pins the port the egress entry
+/// names — and the path is preserved verbatim, because it does not affect
+/// egress and only the backend knows which path its API serves.
+///
+/// Returns `None` for a value no host can be read from, which is a
+/// misconfiguration the caller reports rather than silently discards.
+#[cfg(feature = "wasm-backends")]
+pub(crate) fn normalize(value: &str) -> Option<String> {
+    let uri = parse(value)?;
+    let host = uri.host().filter(|h| !h.is_empty())?;
+    let scheme = uri.scheme_str().unwrap_or("https").to_ascii_lowercase();
+    let port = uri.port_u16().map(|p| format!(":{p}")).unwrap_or_default();
+    // `path()` is `/` when the value carried none, and already excludes the
+    // query and fragment.
+    let path = uri.path().trim_end_matches('/');
+    Some(format!("{scheme}://{host}{port}{path}"))
+}
+
+/// Read a configured value as a [`Uri`], giving a scheme-less one a scheme so
+/// it parses as an authority rather than as `scheme:path`.
+///
+/// [`Uri`]: hyper::Uri
+#[cfg(feature = "wasm-backends")]
+fn parse(value: &str) -> Option<hyper::Uri> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.contains("://") {
+        trimmed.parse().ok()
+    } else {
+        format!("https://{trimmed}").parse().ok()
     }
 }
 
@@ -45,21 +96,8 @@ pub(crate) fn default_port(scheme: Option<&str>) -> u16 {
 /// [`Uri`]: hyper::Uri
 #[cfg(feature = "wasm-backends")]
 pub(crate) fn authority(value: &str) -> Option<(String, u16)> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    // Give a scheme-less value one, so `Uri` reads it as an authority rather
-    // than as `scheme:path`.
-    let uri: hyper::Uri = if trimmed.contains("://") {
-        trimmed.parse().ok()?
-    } else {
-        format!("https://{trimmed}").parse().ok()?
-    };
-    let host = uri.host()?;
-    if host.is_empty() {
-        return None;
-    }
+    let uri = parse(value)?;
+    let host = uri.host().filter(|h| !h.is_empty())?;
     let port = uri
         .port_u16()
         .unwrap_or_else(|| default_port(uri.scheme_str()));
@@ -79,7 +117,120 @@ pub(crate) fn egress_entries(value: &str) -> Vec<String> {
 
 #[cfg(all(test, feature = "wasm-backends"))]
 mod tests {
-    use super::{authority, default_port, egress_entries};
+    use super::{authority, default_port, egress_entries, normalize};
+
+    /// The form a backend is handed. Everything it may stop parsing for is
+    /// asserted here, since a backend reading the value has only this
+    /// guarantee to lean on.
+    #[test]
+    fn canonicalizes_what_the_backend_is_handed() {
+        let cases = [
+            // Already canonical — unchanged.
+            ("https://api.openai.com", "https://api.openai.com"),
+            ("https://api.openai.com/v1", "https://api.openai.com/v1"),
+            ("http://localhost:11434/v1", "http://localhost:11434/v1"),
+            // Scheme lowercased, and supplied when absent.
+            ("HTTPS://api.openai.com", "https://api.openai.com"),
+            ("WSS://gw.example.com/rt", "wss://gw.example.com/rt"),
+            ("gw.example.com:8080", "https://gw.example.com:8080"),
+            // Userinfo never reaches the component.
+            (
+                "https://user:pass@gw.example.com/v1",
+                "https://gw.example.com/v1",
+            ),
+            // One trailing slash, so a backend can append a suffix blindly.
+            ("https://api.openai.com/", "https://api.openai.com"),
+            ("https://gw.example.com/v1/", "https://gw.example.com/v1"),
+            // A query or fragment cannot compose with a path suffix.
+            (
+                "https://gw.example.com/v1?key=v#frag",
+                "https://gw.example.com/v1",
+            ),
+            // Surrounding whitespace from a paste.
+            ("  https://gw.example.com/v1  ", "https://gw.example.com/v1"),
+            // The bracketed IPv6 form survives as the component must send it.
+            ("http://[::1]:8080/v1", "http://[::1]:8080/v1"),
+            // A path is preserved verbatim: only the backend knows its API's shape.
+            (
+                "https://api.groq.com/openai/v1",
+                "https://api.groq.com/openai/v1",
+            ),
+        ];
+        for (input, want) in cases {
+            assert_eq!(normalize(input).as_deref(), Some(want), "{input:?}");
+        }
+    }
+
+    /// A port the user did not write is not invented. `authority` pins the
+    /// egress entry's port regardless, and a synthesized one would reach the
+    /// upstream in the `Host` header.
+    #[test]
+    fn keeps_the_port_the_user_wrote_and_no_other() {
+        assert_eq!(
+            normalize("https://gw.example.com").as_deref(),
+            Some("https://gw.example.com")
+        );
+        assert_eq!(
+            normalize("https://gw.example.com:443").as_deref(),
+            Some("https://gw.example.com:443")
+        );
+        assert_eq!(
+            authority("https://gw.example.com"),
+            authority("https://gw.example.com:443")
+        );
+    }
+
+    /// Re-normalizing is a no-op. The value is stored raw and canonicalized on
+    /// every load, so a value that changed on each pass would make the entry
+    /// authorized and the endpoint dialed drift apart across reloads.
+    #[test]
+    fn normalizing_is_idempotent() {
+        for value in [
+            "HTTPS://user:pass@gw.example.com:8443/v1/?k=v",
+            "gw.example.com",
+            "http://[::1]:8080/",
+            "https://api.groq.com/openai/v1",
+        ] {
+            let once = normalize(value).expect("parses");
+            assert_eq!(
+                normalize(&once).as_deref(),
+                Some(once.as_str()),
+                "{value:?}"
+            );
+        }
+    }
+
+    /// Normalization must not move the endpoint: the entry the guard enforces
+    /// is derived from the same value the component is told to dial, so the two
+    /// have to agree before and after.
+    #[test]
+    fn normalizing_preserves_the_authorized_endpoint() {
+        for value in [
+            "HTTPS://user:pass@gw.example.com:8443/v1?k=v",
+            "gw.example.com",
+            "WS://gw.example.com/rt",
+            "http://[::1]:8080/",
+            "http://192.168.1.50/v1",
+        ] {
+            let canonical = normalize(value).expect("parses");
+            assert_eq!(authority(value), authority(&canonical), "{value:?}");
+            assert_eq!(
+                egress_entries(value),
+                egress_entries(&canonical),
+                "{value:?}"
+            );
+        }
+    }
+
+    /// The caller reports these rather than dropping them: falling back to the
+    /// backend's built-in endpoint would send the user's audio and credentials
+    /// to the vendor they configured their way out of.
+    #[test]
+    fn normalize_rejects_what_yields_no_host() {
+        for value in ["", "   ", "https://", "/", "https:///path", "http://:8080"] {
+            assert_eq!(normalize(value), None, "{value:?}");
+        }
+    }
 
     #[test]
     fn derives_the_authority_port() {


### PR DESCRIPTION
Stacked on #352 — review that one first; the base here retargets to `main` once it merges.

## The problem

The daemon parses `base_url` to derive the `host:port` it authorizes for egress, then injects the user's **raw string** into the component. So it knows exactly which endpoint it permitted and doesn't tell the backend, leaving every backend to re-derive it from unparsed text — and any disagreement between the two parses means the daemon's own guard refuses the request the component makes.

The openai backend shows the cost. Its `parse_base` is 8 lines of string-slicing that mishandles `HTTPS://` and folds an inner path into the authority, which `wasmtime-wasi-http` then rejects. Measured against the real component:

```
     http://AUTH => Ok(ok)
  http://AUTH/v1 => Err(set_authority)     # every OpenAI-compatible URL looks like this
     HTTP://AUTH => Err(set_authority)     # the daemon handles this form; the component can't
```

## The change

`base_url::normalize()` rewrites a configured value to `scheme://host[:port][/path]` — lowercase scheme, supplied when absent; userinfo stripped; trailing slash removed; query and fragment dropped. It runs in `backend_option_overrides()`, already the single snapshot feeding both header injection and egress derivation, so the two stay consistent by construction rather than by both sides agreeing.

Two things are deliberately preserved:

- **The port, only if the user wrote one.** A synthesized `:443` would travel to the upstream in the `Host` header for no gain — the egress entry's port is pinned by `authority()` either way.
- **The path, verbatim.** It plays no part in egress, and only the backend knows which path its own API serves. Normalizing it away would foreclose SDK-compatible base URLs.

Config storage is untouched — the settings field still reads back what the user typed.

## Unreadable values fail the load

Previously an unreadable value was injected and failed inside the component. Dropping it instead would be worse than either: the user pointed the backend at a private gateway, and falling back to the built-in endpoint would ship their audio and API key to the vendor they were configuring their way out of. It now fails the load with a message naming the option, the same shape as the existing missing-secret error. A value stored for an option the backend does not declare stays inert.

This does not conflict with the decision not to validate at the settings write boundary (`options.rs`) — that reasoning is about rejecting garbage while a well-formed URL with the wrong port sails through, and it still holds. I updated that comment, which claimed the stored trim was what kept the component and the authorized endpoint in agreement; the load-time rewrite is what does that now.

## Also

`default_port` now matches the scheme case-insensitively. `Uri` canonicalizes `http`/`https` but leaves other schemes as written, so `WS://` was being ranked with the 443 schemes — latent today, and normalization would have hidden it rather than fixed it.

Contract written into `docs/protocol/backend/contract.md` and `config.md` before the code, per the house rule.

## Verification

`just fmt`, workspace clippy `--all-features --all-targets` pedantic, `just check-features`, `just doctest`, and `SUPER_STT_AUTO_APPROVE=1 cargo test --workspace --all-features` — all clean. New tests cover the canonical form a backend may rely on, idempotence, that normalization does not move the authorized endpoint, the injected header, and both failure paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)