### PR TITLE
Reject a local install missing its entrypoint

### DIFF
--- a/docs/protocol/endpoints/v1/registry/install.md
+++ b/docs/protocol/endpoints/v1/registry/install.md
@@ -59,6 +59,14 @@ cannot copy a link target's bytes into the install dir). The synchronous
 response carries `warning: "unverified_source"`; the `selected_asset` reflects
 the local copy with `accel = "local"` and an empty `target`.
 
+The directory must already contain the file `[backend].entrypoint` names — the
+`.wasm` component or the executable. A registry release ships it built and
+named; an import is staged by the operator, so nothing else establishes that it
+is there. Without this check the install would succeed and the backend would
+fail at model load with a read error naming a path, long after the operator
+could connect it to what they staged. A source checkout is the usual cause: a
+build tree names its artifact after the crate, not after the entrypoint.
+
 **Integrity & limits.** Operator base-URL overrides (`GITHUB_API_BASE`,
 `SUPER_STT_REGISTRY_URL`) must be `https://` (loopback `http://` is allowed for
 testing); insecure values are ignored and the secure default is used. Downloads
@@ -136,7 +144,7 @@ Typed `error` values:
 | Status | Cause |
 |---|---|
 | `400` | Body has zero or more than one of `source` / `repo_url` / `local_path`. Body: `{"error":"bad_request"}`. For Custom-repo, `repo_url` not a `<host>/<owner>/<repo>` reference: `{"error":"bad_repo_url"}`. Custom-repo `forge` missing: `{"error":"bad_request"}` (an unrecognized `forge` value is rejected earlier as a malformed body). For Import-from-dir, `local_path` not an absolute path: `{"error":"bad_local_path"}`. |
-| `404` | `source` not in the cached or refreshed index, or Custom-repo repo/release/`backend.toml` not found at the forge: `{"error":"not_found"}`. For Import-from-dir, `<local_path>` or its `backend.toml` does not exist: `{"error":"not_found"}`. |
+| `404` | `source` not in the cached or refreshed index, or Custom-repo repo/release/`backend.toml` not found at the forge: `{"error":"not_found"}`. For Import-from-dir, `<local_path>`, its `backend.toml`, or the file `[backend].entrypoint` names does not exist: `{"error":"not_found"}`. |
 | `409` | An install for this `source` is already in flight. Body: `{"error":"install_in_progress"}`. |
 | `422` | No compatible asset on this host: `{"error":"incompatible"}`. For Custom-repo, `backend.toml` invalid: `{"error":"manifest_invalid"}` or `{"error":"manifest_too_large"}`; a declared asset is missing from the release: `{"error":"asset_missing"}`; the manifest's `source` is not the repo it was fetched from or namespaced under it (identity spoofing): `{"error":"source_mismatch"}`. For Import-from-dir, `<local_path>/backend.toml` failed to parse or yields an unsafe install id: `{"error":"manifest_invalid"}`. |
 | `502` | Custom-repo: forge API unreachable. Body: `{"error":"forge_unavailable"}`. |

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -58,9 +58,9 @@ fn local_dir_error_response(
     use crate::registry::local_dir::ResolveError;
     match e {
         ResolveError::NotAbsolute(_) => (StatusCode::BAD_REQUEST, "bad_local_path"),
-        ResolveError::NotFound(_) | ResolveError::NoManifest(_) => {
-            (StatusCode::NOT_FOUND, "not_found")
-        }
+        ResolveError::NotFound(_)
+        | ResolveError::NoManifest(_)
+        | ResolveError::NoEntrypoint(..) => (StatusCode::NOT_FOUND, "not_found"),
         ResolveError::NotADirectory(_) => (StatusCode::UNPROCESSABLE_ENTITY, "bad_local_path"),
         ResolveError::Manifest(_) | ResolveError::UnsafeId(_) => {
             (StatusCode::UNPROCESSABLE_ENTITY, "manifest_invalid")

--- a/super-stt-daemon/src/registry/local_dir.rs
+++ b/super-stt-daemon/src/registry/local_dir.rs
@@ -26,6 +26,10 @@ pub enum ResolveError {
     NotADirectory(String),
     #[error("local_path `{0}` has no backend.toml")]
     NoManifest(String),
+    #[error(
+        "local_path `{0}` has no `{1}`, the entrypoint backend.toml declares (a build tree names the artifact after the crate — stage it under the entrypoint name)"
+    )]
+    NoEntrypoint(String, String),
     #[error("backend.toml: {0:#}")]
     Manifest(#[from] anyhow::Error),
     #[error("backend.toml `source = {0:?}` yields an unsafe install id")]
@@ -38,7 +42,8 @@ pub enum ResolveError {
 ///
 /// # Errors
 /// Returns a [`ResolveError`] when the path is missing, not a directory,
-/// has no `backend.toml`, or the manifest fails to parse or validate.
+/// has no `backend.toml`, does not contain the file `[backend].entrypoint`
+/// names, or the manifest fails to parse or validate.
 pub fn resolve(local_path: &Path) -> Result<IndexBackend, ResolveError> {
     if !local_path.is_absolute() {
         return Err(ResolveError::NotAbsolute(local_path.display().to_string()));
@@ -56,6 +61,18 @@ pub fn resolve(local_path: &Path) -> Result<IndexBackend, ResolveError> {
     }
     let m = Manifest::load(local_path).map_err(anyhow::Error::from)?;
     crate::stt_models::backends::manifest::validate_runtime(&m)?;
+
+    // A registry release ships the entrypoint built and named; an import is
+    // staged by hand, so nothing else establishes that it is there. Checked
+    // here rather than left to the loader: the install would otherwise succeed
+    // and the backend fail at model load with a read error naming a path,
+    // long after the operator could connect it to what they staged.
+    if !local_path.join(&m.backend.entrypoint).is_file() {
+        return Err(ResolveError::NoEntrypoint(
+            local_path.display().to_string(),
+            m.backend.entrypoint.clone(),
+        ));
+    }
 
     let id = id_from_source(&m.backend.source);
     if !super_stt_shared::registry::is_safe_component(&id) {
@@ -154,6 +171,38 @@ description = "Test backend."
         let dir = tempdir().unwrap();
         let err = resolve(dir.path()).unwrap_err();
         assert!(matches!(err, ResolveError::NoManifest(_)));
+    }
+
+    /// The shape that sent an operator here: a source checkout, where the build
+    /// tree holds the component under the crate's name rather than the
+    /// entrypoint's. Caught at install, while the operator still knows what they
+    /// staged, instead of at model load as a read error naming a path.
+    #[test]
+    fn rejects_dir_without_its_entrypoint() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("backend.toml"), MIN_MANIFEST).unwrap();
+        fs::create_dir_all(dir.path().join("target/wasm32-wasip2/release")).unwrap();
+        fs::write(
+            dir.path()
+                .join("target/wasm32-wasip2/release/crate_name.wasm"),
+            [0u8; 4],
+        )
+        .unwrap();
+        let err = resolve(dir.path()).unwrap_err();
+        assert!(matches!(err, ResolveError::NoEntrypoint(_, ref e) if e == "y.wasm"));
+        // The message names the file to stage, since that is the operator's fix.
+        assert!(err.to_string().contains("y.wasm"), "{err}");
+    }
+
+    /// A directory sharing the entrypoint's name is not an entrypoint. The
+    /// loader would fail to read it exactly as if nothing were staged.
+    #[test]
+    fn rejects_an_entrypoint_that_is_not_a_file() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("backend.toml"), MIN_MANIFEST).unwrap();
+        fs::create_dir(dir.path().join("y.wasm")).unwrap();
+        let err = resolve(dir.path()).unwrap_err();
+        assert!(matches!(err, ResolveError::NoEntrypoint(..)));
     }
 
     #[test]


### PR DESCRIPTION
Found while installing a WASM backend from a local directory. The install succeeded, then the model load failed with:

```
loading component …/super-stt-openai/openai.wasm: failed to read from `…/super-stt-openai/openai.wasm`
```

which reads like a corrupt or unreadable component. The file simply was not there.

## Cause

`local_dir::resolve()` checks the path, the directory, `backend.toml`, the parsed manifest, and the install id — but never that the directory contains the file `[backend].entrypoint` names. Import-from-dir is the one install path where nothing else establishes that: a registry release ships the entrypoint built and named by CI, while an import is staged by hand.

The specific trap is importing a source checkout. A build tree holds the artifact under the crate's name (`target/wasm32-wasip2/release/super_stt_backend_openai.wasm`), never under the entrypoint name the manifest declares (`openai.wasm`) — that rename happens only when the release workflow attaches the asset. So the directory looks complete and installs cleanly.

## Change

`resolve()` now fails with `NoEntrypoint` when the declared entrypoint is not a file in the staged directory, and the message names the file to stage plus why a build tree lacks it. Mapped to `404 not_found`, alongside the existing missing-path and missing-manifest cases.

`is_file()` rather than `exists()`: a directory sharing the entrypoint's name would fail at load exactly as if nothing were staged.

The existing tests already wrote a `y.wasm` beside the manifest, so the contract was implied — just unenforced. Two new tests cover the source-checkout shape and the not-a-file case.

Docs updated first, per the house rule: `docs/protocol/endpoints/v1/registry/install.md` gains the requirement in the Import-from-dir section and the `404` row of the failure table.

## Verification

`just fmt`, workspace clippy `--all-features --all-targets` pedantic, `just check-features`, and `SUPER_STT_AUTO_APPROVE=1 cargo test --workspace --all-features` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)