### PR TITLE
Copy only what an imported backend needs

### DIFF
--- a/docs/protocol/endpoints/v1/registry/install.md
+++ b/docs/protocol/endpoints/v1/registry/install.md
@@ -52,12 +52,34 @@ identity-checks the manifest). The synchronous response carries
 ```
 
 The daemon reads `<local_path>/backend.toml`, validates the manifest, and
-copies the directory contents into the backends directory as if a registry
-install had completed. No network access. No checksum verification — the
-operator chose the bytes. Symlinks in the directory are rejected (so an import
-cannot copy a link target's bytes into the install dir). The synchronous
-response carries `warning: "unverified_source"`; the `selected_asset` reflects
-the local copy with `accel = "local"` and an empty `target`.
+copies the backend into the backends directory as if a registry install had
+completed. No network access. No checksum verification — the operator chose the
+bytes. Symlinks are rejected (so an import cannot copy a link target's bytes
+into the install dir). The synchronous response carries
+`warning: "unverified_source"`; the `selected_asset` reflects the local copy
+with `accel = "local"` and an empty `target`.
+
+What gets copied depends on `[backend].kind`, and mirrors what a registry
+install of that kind produces:
+
+| Kind         | Copied                                                                 |
+|--------------|------------------------------------------------------------------------|
+| `wasm`       | `backend.toml` and the file `[backend].entrypoint` names — nothing else. |
+| `subprocess` | The directory tree, minus VCS metadata (`.git`).                        |
+
+A `wasm` install is exactly those two files, so the import takes them and
+ignores everything beside them: pointing `local_path` at a source checkout
+copies neither the build tree nor the repository history.
+
+A `subprocess` executable may need siblings no manifest field declares — a
+bundled interpreter, shared libraries, resource files — and the registry
+equivalent is an opaque tarball, so the whole tree is taken. Stage a
+subprocess backend as the directory you would have tarred, not as a source
+checkout: everything beside the executable is copied verbatim.
+
+Model files are not part of either copy. The daemon downloads each
+[`[[models.files]]`](../../../backend/config.md#modelsfiles) entry into its
+`destination` at load time.
 
 The directory must already contain the file `[backend].entrypoint` names — the
 `.wasm` component or the executable. A registry release ships it built and

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -266,7 +266,9 @@ where
 
     let src = src_dir.to_path_buf();
     let dst = staging.clone();
-    tokio::task::spawn_blocking(move || copy_dir_recursive(&src, &dst))
+    let kind = entry.kind.clone();
+    let entrypoint = entry.entrypoint.clone();
+    tokio::task::spawn_blocking(move || copy_staged_backend(&src, &dst, &kind, &entrypoint))
         .await
         .map_err(|e| {
             PipelineError::Io(std::io::Error::other(format!("copy join: {e}")))
@@ -284,11 +286,69 @@ where
     Ok(entry.version.clone())
 }
 
+/// Copy a locally-staged backend into `dst`, taking only what the install
+/// needs.
+///
+/// A `wasm` install *is* its manifest and its component — the two files [`run`]
+/// writes for a registry install of that kind — so an import takes those and
+/// ignores whatever sits beside them. That matters because the natural thing to
+/// point `local_path` at is a source checkout, where the build tree and the
+/// repository history dwarf the component by orders of magnitude and none of it
+/// is ever read again.
+///
+/// A `subprocess` executable is not self-contained in the same way: it may need
+/// siblings no manifest field declares — a bundled interpreter, shared
+/// libraries — and the registry equivalent is an opaque tarball, so its tree is
+/// copied whole. Only VCS metadata is dropped, being the one thing that cannot
+/// be a runtime dependency.
+fn copy_staged_backend(
+    src: &Path,
+    dst: &Path,
+    kind: &str,
+    entrypoint: &str,
+) -> std::io::Result<()> {
+    if kind == "subprocess" {
+        return copy_dir_recursive(src, dst);
+    }
+    // Joined onto a destination below, so it may not climb out of it. The
+    // manifest parser guards `[[models.files]].destination` this way; the
+    // entrypoint reaches the same join and gets the same guard.
+    if !super_stt_registry_types::is_safe_relative_path(entrypoint) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("refusing to import unsafe entrypoint path: {entrypoint}"),
+        ));
+    }
+    std::fs::create_dir_all(dst)?;
+    for name in ["backend.toml", entrypoint] {
+        let from = src.join(name);
+        let to = dst.join(name);
+        // Same policy as the tree copy: a link here would pull the target's
+        // bytes into the install dir.
+        if from.symlink_metadata()?.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("refusing to import symlink entry: {}", from.display()),
+            ));
+        }
+        if let Some(parent) = to.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&from, &to)?;
+    }
+    Ok(())
+}
+
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let from = entry.path();
+        // Repository history is never a runtime dependency, and it is the
+        // bulkiest thing a staged checkout carries after the build tree.
+        if entry.file_name() == ".git" {
+            continue;
+        }
         let to = dst.join(entry.file_name());
         // `read_dir`'s file_type does not follow links, so this detects the
         // link itself. Reject it: copying would follow the link and pull the
@@ -739,6 +799,100 @@ supported_devices = ["cpu"]
         std::os::unix::fs::symlink("/etc/hostname", src.path().join("link")).unwrap();
         let dst = tempfile::tempdir().unwrap();
         let err = copy_dir_recursive(src.path(), &dst.path().join("out")).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    /// Lay out the shape an operator actually points `local_path` at: a source
+    /// checkout, where the component sits beside a build tree and a `.git`.
+    fn staged_checkout() -> tempfile::TempDir {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("backend.toml"), b"stub").unwrap();
+        std::fs::write(src.path().join("y.wasm"), b"component").unwrap();
+        std::fs::write(src.path().join("README.md"), b"docs").unwrap();
+        std::fs::create_dir_all(src.path().join("target/wasm32-wasip2/release")).unwrap();
+        std::fs::write(
+            src.path().join("target/wasm32-wasip2/release/y.wasm"),
+            b"build tree",
+        )
+        .unwrap();
+        std::fs::create_dir_all(src.path().join(".git/objects")).unwrap();
+        std::fs::write(src.path().join(".git/objects/pack"), b"history").unwrap();
+        src
+    }
+
+    /// A wasm install is its manifest and its component; an import copies those
+    /// and nothing else. The build tree and the history beside them are what
+    /// make a naive tree copy orders of magnitude larger than the install.
+    #[test]
+    fn wasm_import_copies_only_the_manifest_and_the_component() {
+        let src = staged_checkout();
+        let dst = tempfile::tempdir().unwrap();
+        let out = dst.path().join("out");
+        copy_staged_backend(src.path(), &out, "wasm", "y.wasm").unwrap();
+
+        assert_eq!(std::fs::read(out.join("y.wasm")).unwrap(), b"component");
+        assert!(out.join("backend.toml").is_file());
+        let mut copied: Vec<_> = std::fs::read_dir(&out)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        copied.sort();
+        assert_eq!(copied, ["backend.toml", "y.wasm"]);
+    }
+
+    /// A subprocess executable may need siblings no manifest field declares, so
+    /// its tree is taken whole — except the history, which cannot be one.
+    #[test]
+    fn subprocess_import_keeps_the_tree_but_drops_vcs_metadata() {
+        let src = staged_checkout();
+        let dst = tempfile::tempdir().unwrap();
+        let out = dst.path().join("out");
+        copy_staged_backend(src.path(), &out, "subprocess", "y.wasm").unwrap();
+
+        assert!(out.join("README.md").is_file());
+        assert!(out.join("target/wasm32-wasip2/release/y.wasm").is_file());
+        assert!(!out.join(".git").exists());
+    }
+
+    /// A nested entrypoint (`bin/qwen3-asr`) needs its parent created.
+    #[test]
+    fn wasm_import_creates_the_entrypoints_parent() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("backend.toml"), b"stub").unwrap();
+        std::fs::create_dir(src.path().join("bin")).unwrap();
+        std::fs::write(src.path().join("bin/y.wasm"), b"component").unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let out = dst.path().join("out");
+        copy_staged_backend(src.path(), &out, "wasm", "bin/y.wasm").unwrap();
+        assert_eq!(std::fs::read(out.join("bin/y.wasm")).unwrap(), b"component");
+    }
+
+    /// The entrypoint is joined onto the destination, so a traversing value
+    /// would write outside the staging dir.
+    #[test]
+    fn wasm_import_rejects_an_escaping_entrypoint() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("backend.toml"), b"stub").unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let err = copy_staged_backend(
+            src.path(),
+            &dst.path().join("out"),
+            "wasm",
+            "../escaped.wasm",
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wasm_import_rejects_a_symlinked_entrypoint() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("backend.toml"), b"stub").unwrap();
+        std::os::unix::fs::symlink("/etc/hostname", src.path().join("y.wasm")).unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        let err =
+            copy_staged_backend(src.path(), &dst.path().join("out"), "wasm", "y.wasm").unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 


### PR DESCRIPTION
Stacked on #354 — review that first; the base retargets to `main` once it merges.

Importing a WASM backend from a source checkout produced a **14 GB** install directory. The copy took the tree verbatim, so `target/` and `.git` came along with the 216 KB component.

## What a backend directory actually needs

Traced every path the daemon opens under a backend dir:

| Read | Where |
|---|---|
| `backend.toml` | discovery (`backends/mod.rs:65`) and load (`Manifest::load`) |
| `[backend].entrypoint` | `instantiate.rs:52` (wasm) / `subprocess/mod.rs:117` (executable) |
| `[[models.files]].destination` | written by the daemon at load time — not part of an install |

Nothing else. And a registry install of a **wasm** backend writes exactly those two files into the staging dir: the downloaded component under the entrypoint name, then the pinned `backend.toml` (`install.rs:127-147`). So for wasm, "manifest + entrypoint" is not a guess — it is what the other install path already produces.

**Subprocess is not the same.** Its registry install extracts an opaque tarball, and the executable may need siblings no manifest field declares. That is not hypothetical: `super-stt-qwen-asr` ships `bin/qwen3-asr` as a launcher that execs a bundled `runtime/python/bin/python3` with `PYTHONPATH` pointing at its own `runtime/site`, plus an `app/` tree. Copying two files there would install a launcher with no interpreter. (`whisper` and `voxtral` tarball a single executable and would have been fine — but the general case is not.)

## Change

`copy_staged_backend` splits on kind:

- **wasm** — copy `backend.toml` and the entrypoint, nothing else.
- **subprocess** — copy the tree, minus `.git`, which cannot be a runtime dependency.

Two guards on the wasm path, both because the entrypoint is now joined onto a destination:

- Symlink rejection, matching the tree copy's existing policy.
- `is_safe_relative_path` on the entrypoint. The manifest parser guards `[[models.files]].destination` this way; the entrypoint reaches the same kind of join and had no equivalent check. A nested entrypoint (`bin/qwen3-asr`) still works — its parent is created.

## A note on the `.gitignore` alternative

Filtering by `.gitignore` was the first idea and it is actively wrong here: a backend repo should gitignore its staged artifact — `super-stt-openai` now ignores `/openai.wasm` so `just stage` output cannot be committed — so a gitignore-respecting copy would skip the entrypoint itself and install a backend that cannot load.

## Verification

`just fmt`, workspace clippy `--all-features --all-targets` pedantic, `just check-features`, and `SUPER_STT_AUTO_APPROVE=1 cargo test --workspace --all-features` — all clean. Five new tests, including the source-checkout shape, the nested entrypoint, and both rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)