### PR TITLE
Read a scheme-less base_url by its host

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -184,8 +184,8 @@ of the box carries it in the component and treats the option as an override.
 That is what the missing `x-stt-option-base_url` header means when the user has
 set nothing.
 
-The value the backend receives is **canonical**, not the string the user typed.
-The daemon parses it once at model-load time and re-serializes it as
+The value the backend receives is **canonical**. The daemon parses it and
+re-serializes it as
 `scheme://host[:port][/path]`: the scheme is lowercased, and supplied when
 absent; userinfo is stripped; a trailing slash is removed; any query or
 fragment is dropped. A port appears only when the user gave one — the daemon
@@ -193,9 +193,18 @@ does not add the scheme's default, which would otherwise travel to the upstream
 in the `Host` header. The path is preserved exactly as written: it plays no part
 in egress, and only the backend knows which path its own API serves.
 
-Normalizing here rather than in each backend keeps every backend working from
-the same value the daemon authorized, and spares each one its own URL parser.
-Config storage is untouched — the settings UI still shows what the user typed.
+Normalizing in the daemon rather than in each backend keeps every backend
+working from the same value the daemon authorized, and spares each one its own
+URL parser.
+
+The same rewrite is applied when the value is **set**, so what
+[`POST /backends/{source}/options/{name}`](../endpoints/v1/backends/options.md)
+stores is already canonical and the settings field reads back the endpoint that
+will be dialed. The scheme is why this is worth doing at the write boundary
+rather than only at load: whether a request is encrypted should not be
+invisible in the field the user is looking at. A value that yields no host is
+the exception — it is stored as typed, so the load-time refusal can name it,
+rather than being dropped.
 
 #### The scheme a value without one is read as
 

--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -186,8 +186,8 @@ set nothing.
 
 The value the backend receives is **canonical**, not the string the user typed.
 The daemon parses it once at model-load time and re-serializes it as
-`scheme://host[:port][/path]`: the scheme is lowercased, and supplied as `https`
-when absent; userinfo is stripped; a trailing slash is removed; any query or
+`scheme://host[:port][/path]`: the scheme is lowercased, and supplied when
+absent; userinfo is stripped; a trailing slash is removed; any query or
 fragment is dropped. A port appears only when the user gave one — the daemon
 does not add the scheme's default, which would otherwise travel to the upstream
 in the `Host` header. The path is preserved exactly as written: it plays no part
@@ -197,6 +197,26 @@ Normalizing here rather than in each backend keeps every backend working from
 the same value the daemon authorized, and spares each one its own URL parser.
 Config storage is untouched — the settings UI still shows what the user typed.
 
+#### The scheme a value without one is read as
+
+A value carrying no scheme is read as `http` when its host is an address the
+daemon can see is local — a loopback or private-range IP literal, or the name
+`localhost` — and as `https` otherwise. A local endpoint is nearly always a
+plaintext one, and reading it as `https` fails every time; a public endpoint is
+the opposite. The choice is logged.
+
+Only a value that names no scheme is decided this way, and it is decided before
+anything connects. A value that says `https` stays `https` however it fails. The
+daemon never retries a failed TLS connection over plaintext: that would let
+anyone able to break the handshake move the user's audio and credentials into
+the clear, and it would look like success.
+
+A host the daemon cannot classify without resolving it — any name other than
+`localhost` — is read as `https`. Guessing `https` for a plaintext endpoint
+costs a failed connection, which is loud and recoverable. Guessing `http` for a
+TLS one discloses whatever the request carries. Where the two are not equally
+wrong, the daemon takes the loud failure.
+
 A value the daemon cannot read as a URL fails the model load, with a message
 naming the option. It is not quietly dropped: falling back to the backend's
 built-in endpoint would send the user's audio and credentials to the very vendor
@@ -204,8 +224,10 @@ they had configured their way out of.
 
 The daemon derives exactly one `host:port` authority from the configured value.
 An explicit port is taken as written; otherwise the scheme's default applies —
-`http` and `ws` ⇒ 80, `https` and `wss` ⇒ 443 — and a value carrying no scheme
-is read as `https`. Any path, query, or userinfo in the value plays no part in
+`http` and `ws` ⇒ 80, `https` and `wss` ⇒ 443 — over the scheme the value names
+or the one it is [read as](#the-scheme-a-value-without-one-is-read-as), so the
+port the daemon authorizes is the one the backend dials. Any path, query, or
+userinfo in the value plays no part in
 this derivation, and a value that yields no host contributes nothing: the
 backend keeps whatever egress its manifest declares.
 

--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -184,12 +184,30 @@ of the box carries it in the component and treats the option as an override.
 That is what the missing `x-stt-option-base_url` header means when the user has
 set nothing.
 
+The value the backend receives is **canonical**, not the string the user typed.
+The daemon parses it once at model-load time and re-serializes it as
+`scheme://host[:port][/path]`: the scheme is lowercased, and supplied as `https`
+when absent; userinfo is stripped; a trailing slash is removed; any query or
+fragment is dropped. A port appears only when the user gave one — the daemon
+does not add the scheme's default, which would otherwise travel to the upstream
+in the `Host` header. The path is preserved exactly as written: it plays no part
+in egress, and only the backend knows which path its own API serves.
+
+Normalizing here rather than in each backend keeps every backend working from
+the same value the daemon authorized, and spares each one its own URL parser.
+Config storage is untouched — the settings UI still shows what the user typed.
+
+A value the daemon cannot read as a URL fails the model load, with a message
+naming the option. It is not quietly dropped: falling back to the backend's
+built-in endpoint would send the user's audio and credentials to the very vendor
+they had configured their way out of.
+
 The daemon derives exactly one `host:port` authority from the configured value.
 An explicit port is taken as written; otherwise the scheme's default applies —
 `http` and `ws` ⇒ 80, `https` and `wss` ⇒ 443 — and a value carrying no scheme
-is read as `https`. Any path, query, or userinfo is discarded, and a value that
-yields no host contributes nothing: the backend keeps whatever egress its
-manifest declares.
+is read as `https`. Any path, query, or userinfo in the value plays no part in
+this derivation, and a value that yields no host contributes nothing: the
+backend keeps whatever egress its manifest declares.
 
 The host is authorized on its own as well, so a gateway stays reachable on its
 other ports — but only the derived `host:port` carries the relaxation below.

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -93,6 +93,12 @@ headers — external clients cannot set them.
 - Secrets and options come from the backend's [configuration](./config.md),
   with values set by the user in the settings UI. The header for a secret or
   option the user has not set is omitted.
+- `x-stt-option-base_url` is the one option header the daemon normalizes. It
+  carries a canonical `scheme://host[:port][/path]`: lowercase scheme, no
+  userinfo, no trailing slash, no query or fragment, and a port only when the
+  user set one. A backend can split it at the first `/` after the scheme and
+  needs no further parsing. Every other option is passed through exactly as the
+  user set it. See [config.md — `base_url` and egress](./config.md#base_url-and-egress).
 - **Secret values are sensitive.** The daemon stores them encrypted and
   redacts the `x-stt-secret-*` headers from logs. A backend uses a secret only
   to authenticate its own outbound calls — it must never echo one in a

--- a/docs/protocol/endpoints/v1/backends/options.md
+++ b/docs/protocol/endpoints/v1/backends/options.md
@@ -129,6 +129,16 @@ Content-Type: application/json
 { "status": "success", "value": "https://gateway.example.com" }
 ```
 
+`base_url` is the one option stored in a rewritten form: the value is
+canonicalized to `scheme://host[:port][/path]` — the same form the backend is
+handed at model load — so the `value` returned here, and the one a later `GET`
+reports, is the endpoint that will actually be dialed rather than the string
+that was posted. A value naming no scheme is given the one its host implies, so
+posting `192.168.0.179:8080/v1` stores and returns
+`http://192.168.0.179:8080/v1`. See
+[config.md](../../../backend/config.md#base_url-and-egress) for the full rule.
+Every other option is stored exactly as posted.
+
 ## `DELETE /backends/{source}/options/{name}`
 
 Remove the override, resetting the option to its manifest **default**.

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -93,14 +93,15 @@ async fn set(
     axum::Json(body): axum::Json<OptionBody>,
 ) -> Response {
     let source = decode_source(&source);
-    // `base_url` is normalized at the boundary. The daemon acts on this value
-    // rather than only passing it through — it is injected as a header *and*
-    // parsed into the egress the backend is granted — so storing it padded
-    // would leave `GET`, the component, and the authorized endpoint holding
-    // three different strings, and a whitespace-only value would show in the UI
-    // as an active override that authorizes nothing. Other options keep the
-    // value verbatim: whitespace may carry meaning in one the daemon does not
-    // interpret.
+    // `base_url` is trimmed at the boundary. Model load canonicalizes it again
+    // — the component and the authorized endpoint are derived there, from one
+    // value, so they agree however this was stored — but that rewrite never
+    // reaches config, which deliberately keeps what the user typed so the
+    // settings field reads back as they wrote it. Trimming here is what keeps
+    // that stored value honest: a padded one would read back padded, and a
+    // whitespace-only one would show as an active override that authorizes
+    // nothing. Other options keep the value verbatim: whitespace may carry
+    // meaning in one the daemon does not interpret.
     //
     // Normalized, not validated: this deliberately does not check that the value
     // parses into a host. Doing so would reject garbage but not the mistake that

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -93,27 +93,25 @@ async fn set(
     axum::Json(body): axum::Json<OptionBody>,
 ) -> Response {
     let source = decode_source(&source);
-    // `base_url` is trimmed at the boundary. Model load canonicalizes it again
-    // — the component and the authorized endpoint are derived there, from one
-    // value, so they agree however this was stored — but that rewrite never
-    // reaches config, which deliberately keeps what the user typed so the
-    // settings field reads back as they wrote it. Trimming here is what keeps
-    // that stored value honest: a padded one would read back padded, and a
-    // whitespace-only one would show as an active override that authorizes
-    // nothing. Other options keep the value verbatim: whitespace may carry
-    // meaning in one the daemon does not interpret.
+    // `base_url` is stored canonical — the same rewrite model load applies, run
+    // here so the settings field reads back the endpoint that will actually be
+    // dialed. The scheme is the reason it matters: a value naming none is read
+    // by its host, and whether the request is encrypted is not something to
+    // leave invisible in the field the user is looking at. Other options keep
+    // the value verbatim, whitespace included: it may carry meaning in one the
+    // daemon does not interpret.
     //
-    // Normalized, not validated: this deliberately does not check that the value
-    // parses into a host. Doing so would reject garbage but not the mistake that
-    // actually misleads people — a well-formed URL naming the wrong port — while
-    // a value the daemon cannot read is already logged at model load and shows
-    // up as a failed transcription. Revisit alongside a settings UI that can
-    // surface the error where the user is looking.
+    // Canonicalized, not validated: a value that yields no host is stored as
+    // typed rather than refused. Rejecting it here would catch garbage but not
+    // the mistake that actually misleads people — a well-formed URL naming the
+    // wrong port — and model load already refuses it with a message naming the
+    // option. What this must not do is quietly drop it.
     let value = if name == crate::stt_models::backends::base_url::OPTION_NAME {
-        body.value.trim()
+        canonical_base_url(&body.value)
     } else {
-        body.value.as_str()
+        body.value.clone()
     };
+    let value = value.as_str();
     if value.is_empty() {
         return json_error(StatusCode::BAD_REQUEST, "invalid_request");
     }
@@ -154,6 +152,27 @@ async fn delete_option(
         return (code, [("content-type", "application/json")], body_str).into_response();
     }
     get_one_inner(s, source, name).await
+}
+
+/// The `base_url` form to store: canonical when the value can be read as a
+/// URL, trimmed otherwise.
+///
+/// A value that yields no host is kept as the user typed it so model load can
+/// refuse it by name; dropping it here would leave the backend on its built-in
+/// endpoint, sending the user's audio and credentials to the vendor they had
+/// configured their way out of.
+#[cfg(feature = "wasm-backends")]
+fn canonical_base_url(value: &str) -> String {
+    crate::stt_models::backends::base_url::normalize(value)
+        .unwrap_or_else(|| value.trim().to_string())
+}
+
+/// Without the wasm transport nothing derives an endpoint from this value, so
+/// there is no canonical form to agree on — only the trim that keeps a padded
+/// value from reading back padded.
+#[cfg(not(feature = "wasm-backends"))]
+fn canonical_base_url(value: &str) -> String {
+    value.trim().to_string()
 }
 
 /// Returns an error `Response` when the backend or the named option is missing,

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -47,7 +47,7 @@ impl SuperSTTDaemon {
         // is handed and the egress it is granted: read separately, a config
         // write landing between them would authorize a different endpoint than
         // the one the component is told to use.
-        let overrides = self.backend_option_overrides(&backend.source).await;
+        let overrides = self.backend_option_overrides(backend).await?;
         let headers = self.backend_headers(backend, &overrides).await?;
         let component = backend.dir.join(&backend.entrypoint);
         let info = ModelInfoData::new(
@@ -231,40 +231,64 @@ impl SuperSTTDaemon {
     /// awaits a keyring round-trip, and a read guard spanning that would block
     /// config writers for its duration.
     ///
-    /// `base_url` is normalized on the way out. It is the one value the two
-    /// paths must read *identically* — one dials it, the other authorizes what
-    /// it names — so surrounding whitespace, from a paste into the settings
-    /// field or from a hand-edited config that never passed through the API,
-    /// would otherwise leave them working from different strings. A value that
-    /// is only whitespace is no value at all and is dropped, so it neither
-    /// reaches the component nor authorizes anything. Every other option is
-    /// passed through exactly as the user set it: whitespace may carry meaning
-    /// in a value the daemon does not interpret.
+    /// `base_url` is canonicalized on the way out (see
+    /// [`normalize`](backends::base_url::normalize)). It is the one value the
+    /// two paths must read *identically* — one dials it, the other authorizes
+    /// what it names — and the component is handed it verbatim, so the rewrite
+    /// that keeps the pair consistent is also what spares every backend its own
+    /// URL parser. Every other option is passed through exactly as the user set
+    /// it: whitespace may carry meaning in a value the daemon does not
+    /// interpret.
+    ///
+    /// The two ways a value can fail are not the same failure. One that is only
+    /// whitespace is no value at all: it is dropped, so it neither reaches the
+    /// component nor authorizes anything, and the backend falls back to its
+    /// built-in endpoint exactly as if nothing were set. One the daemon cannot
+    /// read as a URL is a setting the user meant, so it fails the load instead —
+    /// dropping it would fall back to that same built-in endpoint and send the
+    /// user's audio and credentials to the vendor they had configured their way
+    /// out of.
+    ///
+    /// A value stored for an option this backend does not declare is inert —
+    /// nothing injects or authorizes it — so it is left alone rather than
+    /// validated.
+    ///
+    /// # Errors
+    /// Returns an error when a declared, non-empty `base_url` yields no host.
     #[cfg(feature = "wasm-backends")]
     async fn backend_option_overrides(
         &self,
-        source: &str,
-    ) -> std::collections::HashMap<String, String> {
+        backend: &DiscoveredBackend,
+    ) -> Result<std::collections::HashMap<String, String>> {
         let mut overrides: std::collections::HashMap<String, String> = self
             .config
             .read()
             .await
             .backends
             .options
-            .get(source)
+            .get(&backend.source)
             .cloned()
             .unwrap_or_default();
         let name = backends::base_url::OPTION_NAME;
-        match overrides.get(name).map(|v| v.trim().to_string()) {
-            Some(trimmed) if trimmed.is_empty() => {
-                overrides.remove(name);
-            }
-            Some(trimmed) => {
-                overrides.insert(name.to_string(), trimmed);
-            }
-            None => {}
+        let Some(opt) = backend.options.iter().find(|o| o.name == name) else {
+            return Ok(overrides);
+        };
+        let Some(raw) = overrides.get(name).cloned() else {
+            return Ok(overrides);
+        };
+        if raw.trim().is_empty() {
+            overrides.remove(name);
+        } else if let Some(canonical) = backends::base_url::normalize(&raw) {
+            overrides.insert(name.to_string(), canonical);
+        } else {
+            // Shaped like the missing-secret error above: name the setting the
+            // user can act on, never the internals.
+            bail!(
+                "{} is not a valid URL.",
+                opt.label.as_deref().unwrap_or(&opt.name)
+            );
         }
-        overrides
+        Ok(overrides)
     }
 
     /// What the *user* authorized via a `base_url` option: the `host:port` the
@@ -365,7 +389,10 @@ mod tests {
 
         // No override → nothing, even though the option carries a default: a
         // value the backend author wrote must not authorize egress.
-        let overrides = daemon.backend_option_overrides(source).await;
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
         assert!(SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides).is_empty());
 
         // Config override pointing at a local gateway → that endpoint, port kept.
@@ -380,7 +407,10 @@ mod tests {
             .entry(source.to_string())
             .or_default()
             .insert("base_url".to_string(), "http://localhost:8080".to_string());
-        let overrides = daemon.backend_option_overrides(source).await;
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
         assert_eq!(
             SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides),
             vec!["localhost:8080", "localhost"]
@@ -429,7 +459,10 @@ mod tests {
                 .or_default()
                 .insert("base_url".to_string(), stored.to_string());
 
-            let overrides = daemon.backend_option_overrides(source).await;
+            let overrides = daemon
+                .backend_option_overrides(&backend)
+                .await
+                .expect("a valid base_url");
             let headers = daemon
                 .backend_headers(&backend, &overrides)
                 .await
@@ -445,6 +478,98 @@ mod tests {
                 None => assert!(egress.is_empty(), "egress for {stored:?}"),
             }
         }
+    }
+
+    /// The component is handed the canonical form, not the string the user
+    /// typed. A backend dials this value directly, so the rewrite and the
+    /// authorization have to describe one endpoint — and a backend reading it
+    /// can split at the first `/` rather than carry a URL parser of its own.
+    #[tokio::test]
+    async fn the_injected_base_url_is_canonical() {
+        use crate::daemon::test_fixtures::openai_backend;
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        // No secrets: this drives the real header path, which would otherwise
+        // reach the keyring for the fixture's required key.
+        let backend = DiscoveredBackend {
+            secrets: Vec::new(),
+            ..openai_backend(source, Vec::new(), None)
+        };
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert(
+                "base_url".to_string(),
+                "  HTTPS://user:pass@gw.example.com:8443/v1/?k=v  ".to_string(),
+            );
+
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
+        let headers = daemon
+            .backend_headers(&backend, &overrides)
+            .await
+            .expect("headers for a secret-free backend");
+        let injected = headers
+            .iter()
+            .find(|(k, _)| k == "x-stt-option-base_url")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(injected, Some("https://gw.example.com:8443/v1"));
+        assert_eq!(
+            SuperSTTDaemon::base_url_egress_hosts(&backend, &overrides),
+            vec!["gw.example.com:8443", "gw.example.com"]
+        );
+    }
+
+    /// A value the daemon cannot read fails the load rather than being dropped:
+    /// dropping it would fall back to the backend's built-in endpoint and send
+    /// the user's audio and credentials to the vendor they had configured their
+    /// way out of. The error names the setting, not the internals.
+    ///
+    /// The same stored value is inert for a backend declaring no such option —
+    /// nothing injects or authorizes it — so it must not block that load.
+    #[tokio::test]
+    async fn an_unreadable_base_url_fails_the_load() {
+        use crate::daemon::test_fixtures::openai_backend;
+        use crate::daemon::types::test_daemon;
+        use crate::stt_models::backends::DiscoveredBackend;
+
+        let daemon = test_daemon().await;
+        let source = "github.com/super-stt/openai";
+        let backend = openai_backend(source, Vec::new(), None);
+        daemon
+            .config
+            .write()
+            .await
+            .backends
+            .options
+            .entry(source.to_string())
+            .or_default()
+            .insert("base_url".to_string(), "http://".to_string());
+
+        let err = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect_err("an unreadable base_url fails the load");
+        assert!(err.to_string().contains("API base URL"), "{err}");
+
+        let undeclared = DiscoveredBackend {
+            options: Vec::new(),
+            ..backend
+        };
+        assert!(
+            daemon.backend_option_overrides(&undeclared).await.is_ok(),
+            "a value for an undeclared option must not block a load"
+        );
     }
 
     /// Headers and egress must describe one config state. Resolving them
@@ -475,7 +600,10 @@ mod tests {
             .or_default()
             .insert("base_url".to_string(), "http://10.0.0.5:8080".to_string());
 
-        let overrides = daemon.backend_option_overrides(source).await;
+        let overrides = daemon
+            .backend_option_overrides(&backend)
+            .await
+            .expect("a valid base_url");
         // A write landing here reaches neither side, which is the point.
         daemon
             .config

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -279,6 +279,16 @@ impl SuperSTTDaemon {
         if raw.trim().is_empty() {
             overrides.remove(name);
         } else if let Some(canonical) = backends::base_url::normalize(&raw) {
+            // The scheme the daemon chose for a value that named none decides
+            // whether the request is encrypted, so an operator asking later why
+            // a gateway was reached in the clear needs it on the record.
+            if !raw.contains("://") {
+                log::info!(
+                    "Backend {}: base_url `{}` names no scheme; reading it as `{canonical}`",
+                    backend.source,
+                    raw.trim()
+                );
+            }
             overrides.insert(name.to_string(), canonical);
         } else {
             // Shaped like the missing-secret error above: name the setting the

--- a/super-stt-daemon/src/stt_models/backends/base_url.rs
+++ b/super-stt-daemon/src/stt_models/backends/base_url.rs
@@ -21,8 +21,9 @@ pub(crate) const OPTION_NAME: &str = super_stt_registry_types::manifest::BASE_UR
 ///
 /// The port is explicit or the scheme's default, never absent: it is what
 /// distinguishes the endpoint the user chose — the one that may be local — from
-/// the rest of the host. A value with no scheme is an authority, read as
-/// `https`. Returns `None` when no host can be read, which authorizes nothing.
+/// the rest of the host. A value with no scheme is an authority, read under the
+/// scheme [`inferred_scheme`] gives its host. Returns `None` when no host can be
+/// read, which authorizes nothing.
 ///
 /// The port a scheme implies when a URI carries none.
 ///
@@ -72,8 +73,40 @@ pub(crate) fn normalize(value: &str) -> Option<String> {
     Some(format!("{scheme}://{host}{port}{path}"))
 }
 
-/// Read a configured value as a [`Uri`], giving a scheme-less one a scheme so
-/// it parses as an authority rather than as `scheme:path`.
+/// The scheme a value carrying none is read as.
+///
+/// A local endpoint is nearly always a plaintext one — the gateways people run
+/// on a private address speak `http`, and reading such a value as `https` fails
+/// every time. A public endpoint is the opposite. So the daemon decides from
+/// the host, using the same classifier the egress guard applies, which is what
+/// keeps "local" from meaning two things in one codebase.
+///
+/// This decides only a value that names no scheme, and decides it before
+/// anything connects; a value that says `https` stays `https` however it fails.
+/// Nothing here retries a failed TLS connection over plaintext — that would let
+/// anyone able to break the handshake move the user's audio and credentials
+/// into the clear, while still looking like success.
+///
+/// A name other than `localhost` cannot be classified without resolving it, and
+/// is read as `https`. The two mistakes are not equally bad: `https` against a
+/// plaintext endpoint costs a failed connection, loud and recoverable, while
+/// `http` against a TLS one discloses whatever the request carries. Where the
+/// choice is uncertain, take the loud failure.
+#[cfg(feature = "wasm-backends")]
+fn inferred_scheme(host: &str) -> &'static str {
+    let local = host.eq_ignore_ascii_case("localhost")
+        || crate::stt_models::wasm::host::ip_literal(host)
+            .is_some_and(|ip| crate::stt_models::wasm::host::is_local_ip(&ip));
+    if local { "http" } else { "https" }
+}
+
+/// Read a configured value as a [`Uri`], giving a scheme-less one the scheme
+/// its host implies so it parses as an authority rather than as `scheme:path`.
+///
+/// The inference lives here rather than in [`normalize`] so that every reader
+/// of a scheme-less value agrees on it: [`authority`] derives the port from the
+/// scheme, so a value inferred `http` in one place and `https` in another would
+/// authorize `:443` while the component dialed `:80`.
 ///
 /// [`Uri`]: hyper::Uri
 #[cfg(feature = "wasm-backends")]
@@ -83,10 +116,13 @@ fn parse(value: &str) -> Option<hyper::Uri> {
         return None;
     }
     if trimmed.contains("://") {
-        trimmed.parse().ok()
-    } else {
-        format!("https://{trimmed}").parse().ok()
+        return trimmed.parse().ok();
     }
+    // Read the host under a placeholder scheme, then re-read under the one that
+    // host implies. `Uri` needs *a* scheme to treat this as an authority at all.
+    let probe: hyper::Uri = format!("https://{trimmed}").parse().ok()?;
+    let scheme = inferred_scheme(probe.host()?);
+    format!("{scheme}://{trimmed}").parse().ok()
 }
 
 /// Egress derivation is meaningful only for the wasm transport, which is the
@@ -159,6 +195,58 @@ mod tests {
         for (input, want) in cases {
             assert_eq!(normalize(input).as_deref(), Some(want), "{input:?}");
         }
+    }
+
+    /// A value naming no scheme is read as `http` when its host is one the
+    /// daemon can see is local, and `https` otherwise. This is the case that
+    /// sent a user chasing a `write_failed`: a private gateway read as `https`
+    /// opens TLS against a plaintext listener, and the connection dies wherever
+    /// the body write happens to notice.
+    #[test]
+    fn a_scheme_less_value_is_read_by_its_host() {
+        for (input, want) in [
+            // Local: plaintext is what is actually listening there.
+            ("192.168.0.179:8080/v1", "http://192.168.0.179:8080/v1"),
+            ("10.0.0.5:8080", "http://10.0.0.5:8080"),
+            ("172.16.3.9", "http://172.16.3.9"),
+            ("127.0.0.1:11434/v1", "http://127.0.0.1:11434/v1"),
+            ("localhost:4000/v1", "http://localhost:4000/v1"),
+            ("LOCALHOST:4000", "http://LOCALHOST:4000"),
+            ("[::1]:8080", "http://[::1]:8080"),
+            ("[fd00::1]:8080", "http://[fd00::1]:8080"),
+            // Public, and any name the daemon cannot classify without
+            // resolving it: https, because that mistake is the recoverable one.
+            ("api.openai.com/v1", "https://api.openai.com/v1"),
+            ("gw.internal:8443", "https://gw.internal:8443"),
+            ("140.82.121.4", "https://140.82.121.4"),
+        ] {
+            assert_eq!(normalize(input).as_deref(), Some(want), "{input:?}");
+        }
+    }
+
+    /// Inference must not split the two readers. `authority` derives the port
+    /// from the scheme, so a value read as `http` here and `https` there would
+    /// authorize `:443` while the component dialed `:80`, and every request
+    /// would be refused.
+    #[test]
+    fn the_inferred_scheme_decides_the_authorized_port() {
+        assert_eq!(
+            authority("192.168.0.179"),
+            Some(("192.168.0.179".to_string(), 80))
+        );
+        assert_eq!(
+            authority("api.openai.com"),
+            Some(("api.openai.com".to_string(), 443))
+        );
+        // An explicit scheme is never second-guessed, local host or not.
+        assert_eq!(
+            authority("https://192.168.0.179"),
+            Some(("192.168.0.179".to_string(), 443))
+        );
+        assert_eq!(
+            normalize("https://192.168.0.179").as_deref(),
+            Some("https://192.168.0.179")
+        );
     }
 
     /// A port the user did not write is not invented. `authority` pins the
@@ -262,7 +350,8 @@ mod tests {
             authority("ws://gw.example.com"),
             Some(("gw.example.com".to_string(), 80))
         );
-        // A value with no scheme is an authority, read as https.
+        // A value with no scheme is an authority, read under the scheme its
+        // host implies — a name resolves to https.
         assert_eq!(
             authority("gw.example.com"),
             Some(("gw.example.com".to_string(), 443))

--- a/super-stt-daemon/src/stt_models/backends/base_url.rs
+++ b/super-stt-daemon/src/stt_models/backends/base_url.rs
@@ -32,9 +32,60 @@ pub(crate) const OPTION_NAME: &str = super_stt_registry_types::manifest::BASE_UR
 /// would make them disagree about the very endpoint the user named.
 #[cfg(feature = "wasm-backends")]
 pub(crate) fn default_port(scheme: Option<&str>) -> u16 {
+    // Matched case-insensitively: `Uri` canonicalizes `http` and `https` but
+    // leaves any other scheme's case as written, so `WS://` would otherwise be
+    // ranked with the 443 schemes.
     match scheme {
-        Some("http" | "ws") => 80,
+        Some(s) if s.eq_ignore_ascii_case("http") || s.eq_ignore_ascii_case("ws") => 80,
         _ => 443,
+    }
+}
+
+/// Rewrite a configured value into the canonical form the backend is handed:
+/// `scheme://host[:port][/path]`.
+///
+/// The daemon acts on this value twice — it authorizes an endpoint and it tells
+/// the component which one to dial — and a backend that re-derived the endpoint
+/// from raw text would be writing a second URL parser whose disagreements with
+/// this one surface as a refused request. Normalizing once, here, is what lets
+/// a backend split the value at the first `/` and stop.
+///
+/// The scheme is lowercased and supplied when absent, userinfo is stripped, a
+/// trailing slash is removed, and any query or fragment is dropped. Two things
+/// are deliberately left alone: the port is emitted only when the value carried
+/// one, since a synthesized `:443` would travel to the upstream in the `Host`
+/// header for no gain — [`authority`] already pins the port the egress entry
+/// names — and the path is preserved verbatim, because it does not affect
+/// egress and only the backend knows which path its API serves.
+///
+/// Returns `None` for a value no host can be read from, which is a
+/// misconfiguration the caller reports rather than silently discards.
+#[cfg(feature = "wasm-backends")]
+pub(crate) fn normalize(value: &str) -> Option<String> {
+    let uri = parse(value)?;
+    let host = uri.host().filter(|h| !h.is_empty())?;
+    let scheme = uri.scheme_str().unwrap_or("https").to_ascii_lowercase();
+    let port = uri.port_u16().map(|p| format!(":{p}")).unwrap_or_default();
+    // `path()` is `/` when the value carried none, and already excludes the
+    // query and fragment.
+    let path = uri.path().trim_end_matches('/');
+    Some(format!("{scheme}://{host}{port}{path}"))
+}
+
+/// Read a configured value as a [`Uri`], giving a scheme-less one a scheme so
+/// it parses as an authority rather than as `scheme:path`.
+///
+/// [`Uri`]: hyper::Uri
+#[cfg(feature = "wasm-backends")]
+fn parse(value: &str) -> Option<hyper::Uri> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.contains("://") {
+        trimmed.parse().ok()
+    } else {
+        format!("https://{trimmed}").parse().ok()
     }
 }
 
@@ -45,21 +96,8 @@ pub(crate) fn default_port(scheme: Option<&str>) -> u16 {
 /// [`Uri`]: hyper::Uri
 #[cfg(feature = "wasm-backends")]
 pub(crate) fn authority(value: &str) -> Option<(String, u16)> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    // Give a scheme-less value one, so `Uri` reads it as an authority rather
-    // than as `scheme:path`.
-    let uri: hyper::Uri = if trimmed.contains("://") {
-        trimmed.parse().ok()?
-    } else {
-        format!("https://{trimmed}").parse().ok()?
-    };
-    let host = uri.host()?;
-    if host.is_empty() {
-        return None;
-    }
+    let uri = parse(value)?;
+    let host = uri.host().filter(|h| !h.is_empty())?;
     let port = uri
         .port_u16()
         .unwrap_or_else(|| default_port(uri.scheme_str()));
@@ -79,7 +117,120 @@ pub(crate) fn egress_entries(value: &str) -> Vec<String> {
 
 #[cfg(all(test, feature = "wasm-backends"))]
 mod tests {
-    use super::{authority, default_port, egress_entries};
+    use super::{authority, default_port, egress_entries, normalize};
+
+    /// The form a backend is handed. Everything it may stop parsing for is
+    /// asserted here, since a backend reading the value has only this
+    /// guarantee to lean on.
+    #[test]
+    fn canonicalizes_what_the_backend_is_handed() {
+        let cases = [
+            // Already canonical — unchanged.
+            ("https://api.openai.com", "https://api.openai.com"),
+            ("https://api.openai.com/v1", "https://api.openai.com/v1"),
+            ("http://localhost:11434/v1", "http://localhost:11434/v1"),
+            // Scheme lowercased, and supplied when absent.
+            ("HTTPS://api.openai.com", "https://api.openai.com"),
+            ("WSS://gw.example.com/rt", "wss://gw.example.com/rt"),
+            ("gw.example.com:8080", "https://gw.example.com:8080"),
+            // Userinfo never reaches the component.
+            (
+                "https://user:pass@gw.example.com/v1",
+                "https://gw.example.com/v1",
+            ),
+            // One trailing slash, so a backend can append a suffix blindly.
+            ("https://api.openai.com/", "https://api.openai.com"),
+            ("https://gw.example.com/v1/", "https://gw.example.com/v1"),
+            // A query or fragment cannot compose with a path suffix.
+            (
+                "https://gw.example.com/v1?key=v#frag",
+                "https://gw.example.com/v1",
+            ),
+            // Surrounding whitespace from a paste.
+            ("  https://gw.example.com/v1  ", "https://gw.example.com/v1"),
+            // The bracketed IPv6 form survives as the component must send it.
+            ("http://[::1]:8080/v1", "http://[::1]:8080/v1"),
+            // A path is preserved verbatim: only the backend knows its API's shape.
+            (
+                "https://api.groq.com/openai/v1",
+                "https://api.groq.com/openai/v1",
+            ),
+        ];
+        for (input, want) in cases {
+            assert_eq!(normalize(input).as_deref(), Some(want), "{input:?}");
+        }
+    }
+
+    /// A port the user did not write is not invented. `authority` pins the
+    /// egress entry's port regardless, and a synthesized one would reach the
+    /// upstream in the `Host` header.
+    #[test]
+    fn keeps_the_port_the_user_wrote_and_no_other() {
+        assert_eq!(
+            normalize("https://gw.example.com").as_deref(),
+            Some("https://gw.example.com")
+        );
+        assert_eq!(
+            normalize("https://gw.example.com:443").as_deref(),
+            Some("https://gw.example.com:443")
+        );
+        assert_eq!(
+            authority("https://gw.example.com"),
+            authority("https://gw.example.com:443")
+        );
+    }
+
+    /// Re-normalizing is a no-op. The value is stored raw and canonicalized on
+    /// every load, so a value that changed on each pass would make the entry
+    /// authorized and the endpoint dialed drift apart across reloads.
+    #[test]
+    fn normalizing_is_idempotent() {
+        for value in [
+            "HTTPS://user:pass@gw.example.com:8443/v1/?k=v",
+            "gw.example.com",
+            "http://[::1]:8080/",
+            "https://api.groq.com/openai/v1",
+        ] {
+            let once = normalize(value).expect("parses");
+            assert_eq!(
+                normalize(&once).as_deref(),
+                Some(once.as_str()),
+                "{value:?}"
+            );
+        }
+    }
+
+    /// Normalization must not move the endpoint: the entry the guard enforces
+    /// is derived from the same value the component is told to dial, so the two
+    /// have to agree before and after.
+    #[test]
+    fn normalizing_preserves_the_authorized_endpoint() {
+        for value in [
+            "HTTPS://user:pass@gw.example.com:8443/v1?k=v",
+            "gw.example.com",
+            "WS://gw.example.com/rt",
+            "http://[::1]:8080/",
+            "http://192.168.1.50/v1",
+        ] {
+            let canonical = normalize(value).expect("parses");
+            assert_eq!(authority(value), authority(&canonical), "{value:?}");
+            assert_eq!(
+                egress_entries(value),
+                egress_entries(&canonical),
+                "{value:?}"
+            );
+        }
+    }
+
+    /// The caller reports these rather than dropping them: falling back to the
+    /// backend's built-in endpoint would send the user's audio and credentials
+    /// to the vendor they configured their way out of.
+    #[test]
+    fn normalize_rejects_what_yields_no_host() {
+        for value in ["", "   ", "https://", "/", "https:///path", "http://:8080"] {
+            assert_eq!(normalize(value), None, "{value:?}");
+        }
+    }
 
     #[test]
     fn derives_the_authority_port() {

--- a/super-stt-daemon/src/stt_models/wasm/host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/host.rs
@@ -197,7 +197,7 @@ fn guard_egress_host(
 /// Parse a host that is an IP literal, accepting the bracketed IPv6 form
 /// (`[::1]`) a URI authority carries. `None` for a hostname, which is resolved
 /// instead.
-fn ip_literal(host: &str) -> Option<IpAddr> {
+pub(crate) fn ip_literal(host: &str) -> Option<IpAddr> {
     host.strip_prefix('[')
         .and_then(|inner| inner.strip_suffix(']'))
         .unwrap_or(host)
@@ -308,7 +308,7 @@ fn is_never_routable_v4(v4: Ipv4Addr) -> bool {
 
 /// Loopback and private addresses: off-limits to a manifest-declared
 /// destination, reachable for the endpoint the user named.
-fn is_local_ip(ip: &IpAddr) -> bool {
+pub(crate) fn is_local_ip(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => is_local_v4(*v4),
         IpAddr::V6(v6) => {

--- a/super-stt-daemon/tests/http_smoke_backend_options.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_options.rs
@@ -290,6 +290,55 @@ async fn base_url_round_trips_through_unset() {
     );
 }
 
+/// `base_url` is stored canonical, so the settings field reads back the
+/// endpoint that will be dialed rather than the string that was posted. The
+/// scheme is why it matters: a value naming none is read by its host, and
+/// whether the request is encrypted must not be invisible in the field.
+#[tokio::test]
+async fn base_url_is_stored_canonical() {
+    let (_guard, sock, token) = start_daemon(&["settings"]).await;
+    let opt_path = format!("/backends/{FIXTURE_SOURCE_ENC}/options/base_url");
+
+    for (posted, want) in [
+        // A private gateway named without a scheme is plaintext.
+        ("192.168.0.179:8080/v1", "http://192.168.0.179:8080/v1"),
+        ("localhost:4000/v1", "http://localhost:4000/v1"),
+        // A name the daemon cannot classify keeps https.
+        ("gw.example.com/v1", "https://gw.example.com/v1"),
+        // The rest of the canonical form travels with it.
+        (
+            "  HTTPS://user:pass@gw.example.com/v1/?k=v  ",
+            "https://gw.example.com/v1",
+        ),
+    ] {
+        let (s, body) = post_req(
+            &sock,
+            &opt_path,
+            &token,
+            serde_json::json!({ "value": posted }),
+        )
+        .await;
+        assert_eq!(s, StatusCode::OK, "POST {posted:?}: {body}");
+        assert_eq!(body["value"], want, "POST {posted:?} stored: {body}");
+
+        let (s, body) = get(&sock, &opt_path, &token).await;
+        assert_eq!(s, StatusCode::OK, "GET after {posted:?}: {body}");
+        assert_eq!(body["value"], want, "GET after {posted:?}: {body}");
+    }
+
+    // A value yielding no host is kept as typed rather than dropped, so the
+    // model load can refuse it by name.
+    let (s, body) = post_req(
+        &sock,
+        &opt_path,
+        &token,
+        serde_json::json!({ "value": "http://" }),
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "POST unreadable: {body}");
+    assert_eq!(body["value"], "http://", "kept as typed: {body}");
+}
+
 /// Listing all options for the backend.
 #[tokio::test]
 async fn option_list_returns_declared_options() {


### PR DESCRIPTION
## First: #353 never reached `main`

Its base was `base-url-default-docs` (the stacked branch), and `main` took #352 before that branch was merged onward — so #353 shows MERGED on GitHub while `normalize()` is absent from `main`. The first commit here is a cherry-pick of `d3f83758` restoring it. **That is why this diff is larger than the change it is named for.** No stacking this time; one branch, straight to `main`.

## The incident

A local backend pointed at `192.168.0.179:8080/v1` failed every transcription with `write_failed`. The stored value carried no scheme, both sides read a scheme-less value as `https`, and the component opened TLS against a plaintext listener. Reproduced through the wasmtime harness:

```
no scheme, 41983 samples (the user's recording) => Err(write_failed)
no scheme,  1600 samples                        => Err(http: ErrorCode::TlsProtocolError)
http://,   41983 samples                        => Ok(ok)
```

Same cause in both scheme-less rows — the dead connection is noticed at different points. An 84 KB body dies mid-write, which is why the error named the write and not the scheme. The server itself was verified fine end to end: plain HTTP, `/v1/audio/transcriptions`, `whisper-tiny`, 200 with real speech.

## Change

**A scheme-less value is read by its host.** `http` when the host is one the daemon can see is local — a loopback or private-range IP literal, or the name `localhost` — `https` otherwise. Local endpoints are plaintext in practice, so `https` fails every time there; public endpoints are the reverse.

It reuses the egress guard's own `is_local_ip`/`ip_literal` rather than adding a second classifier, so "local" cannot come to mean two things in one codebase.

**What this deliberately is not:** a fallback. The scheme is decided before anything connects, and a value that says `https` stays `https` however it fails. Retrying a failed TLS connection over plaintext would let anyone able to break the handshake move audio and credentials into the clear while still looking like success.

**An unresolvable name stays `https`.** The two mistakes are not symmetric: `https` against a plaintext endpoint costs a failed connection, loud and recoverable; `http` against a TLS one discloses what the request carries.

The inference sits in `parse()`, so `normalize()` and `authority()` cannot disagree — `authority()` derives the port from the scheme, so a value read as `http` in one place and `https` in the other would authorize `:443` while the component dialed `:80`. There is a test pinning exactly that.

**`base_url` is now stored canonical** (`POST …/options/base_url` applies the same rewrite), so the settings field reads back the endpoint that will be dialed — posting `192.168.0.179:8080/v1` stores `http://192.168.0.179:8080/v1`. This is the UI half of the fix, done in the daemon rather than the app so the field cannot drift from what is actually reached. It reverses #353's "store what the user typed": whether a request is encrypted should not be invisible in the field the user is looking at. A value yielding no host is still stored as typed, so the load-time refusal can name it.

The chosen scheme is logged at model load.

## Verification

`just fmt`, workspace clippy `--all-features --all-targets` pedantic, `just check-features`, `just doctest`, and `SUPER_STT_AUTO_APPROVE=1 cargo test --workspace --all-features` — all clean. New coverage: the inference table, the port-agreement invariant, and an HTTP round-trip asserting what `POST` stores and `GET` returns.

Docs updated ahead of the code in `backend/config.md` and `endpoints/v1/backends/options.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)