### PR TITLE
Say why a recording failed in the notification

### DIFF
--- a/docs/protocol/endpoints/v1/notification_method.md
+++ b/docs/protocol/endpoints/v1/notification_method.md
@@ -25,6 +25,41 @@ failed — logs the failure instead.
 
 The new method takes effect on the next recording.
 
+## What the user sees
+
+The two channels carry different amounts of detail, because they land in
+different places.
+
+A notification has a summary and a body of its own, and its app name and icon
+are supplied separately — so the summary names the failure and the body gives
+the reason:
+
+| Failure                       | Summary                     | Body                             |
+|-------------------------------|-----------------------------|----------------------------------|
+| No model is loaded            | `No model loaded`           | `Load a model and try again.`    |
+| The recorder could not start  | `Could not start recording` | The reason, from the daemon      |
+| Capture died partway          | `Recording failed`          | The reason, from the daemon      |
+| The audio was not transcribed | `Transcription failed`      | The reason, from the backend     |
+
+Reasons authored by a backend are prefixed `Backend error:`, so a failure the
+daemon is only relaying is never mistaken for one of its own. Backend text is
+untrusted: it is flattened to a single line, escaped so a notification server
+that renders markup in the body cannot be driven from it, and clamped to 300
+characters. A failure that arrives with no reason to report falls back to a
+fixed sentence rather than an empty body.
+
+Typing has nowhere to put a reason: the notice lands in whatever window the user
+has focused, in among their own text. It is one fixed, daemon-authored string
+per failure, bracketed so it cannot be read as transcript, and it never carries
+backend text:
+
+```
+[Super STT: no model loaded]
+[Super STT: could not start recording]
+[Super STT: recording failed]
+[Super STT: transcription failed]
+```
+
 ## Auth
 
 - **Required scope:** `settings`.

--- a/docs/protocol/endpoints/v1/transcribe.md
+++ b/docs/protocol/endpoints/v1/transcribe.md
@@ -130,8 +130,9 @@ A failure is also surfaced to the user according to the
 `auto`, the daemon sends a desktop notification; typing a short fixed notice
 into the focused window — for example `[Super STT: no model loaded]` — happens
 only as a fallback when notification delivery fails, and only for a request
-that set `write_mode: true`. The notice is a fixed daemon-authored string;
-backend-supplied error detail is never typed. The failure is still reported
+that set `write_mode: true`. A typed notice is a fixed daemon-authored string
+and never carries error detail; a notification names the failure in its summary
+and gives the reason in its body. The failure is still reported
 normally — as the direct error response (e.g. `409 model_not_loaded`, checked
 and answered before the `202`/SSE envelope for a daemon-mic capture commits)
 or, once an SSE stream has started, via the `error` event — with an empty

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -42,10 +42,15 @@ impl SuperSTTDaemon {
     /// the `error` event; this is the additional human-facing notice. It fires
     /// for every recording, write mode or not — the trigger is the failure, not
     /// the output mode.
-    async fn surface_failure(&self, typer: &mut Typer, notice: &'static str, write_mode: bool) {
+    async fn surface_failure(
+        &self,
+        typer: &mut Typer,
+        failure: &notice::Failure,
+        write_mode: bool,
+    ) {
         let method = self.config.read().await.transcription.notification_method;
         let mut notifier = self.notifier.lock().await;
-        crate::output::notification::deliver(method, &mut notifier, typer, notice, write_mode)
+        crate::output::notification::deliver(method, &mut notifier, typer, failure, write_mode)
             .await;
     }
 
@@ -75,7 +80,7 @@ impl SuperSTTDaemon {
         // reason lands in the field they are actually looking at.
         if self.model.read().await.is_none() {
             warn!("Recording request rejected - no model loaded");
-            self.surface_failure(typer, notice::NO_MODEL_LOADED, write_mode)
+            self.surface_failure(typer, &notice::Failure::no_model_loaded(), write_mode)
                 .await;
             return DaemonResponse::error_with_code(
                 ErrorCode::ModelNotLoaded,
@@ -118,8 +123,12 @@ impl SuperSTTDaemon {
                     let mut guard = self.busy.write().await;
                     *guard = false;
                 }
-                self.surface_failure(typer, notice::COULD_NOT_START_RECORDING, write_mode)
-                    .await;
+                self.surface_failure(
+                    typer,
+                    &notice::Failure::could_not_start_recording(&format!("{e:#}")),
+                    write_mode,
+                )
+                .await;
                 DaemonResponse::error(&format!("Recording failed: {e}"))
             }
         }
@@ -179,8 +188,12 @@ impl SuperSTTDaemon {
                 warn!("Recording capture failed: {e}");
                 self.finalize_recording_session("", false, Some(e.to_string()))
                     .await;
-                self.surface_failure(typer, notice::RECORDING_FAILED, write_mode)
-                    .await;
+                self.surface_failure(
+                    typer,
+                    &notice::Failure::recording_failed(&format!("{e:#}")),
+                    write_mode,
+                )
+                .await;
                 return Ok(Err(format!("recording error: {e}")));
             }
         };
@@ -219,8 +232,15 @@ impl SuperSTTDaemon {
                 warn!("Final transcription failed: {e}");
                 self.finalize_recording_session("", false, Some(e.to_string()))
                     .await;
-                self.surface_failure(typer, notice::TRANSCRIPTION_FAILED, write_mode)
-                    .await;
+                // `e.origin` is why the notice can say whether the daemon or the
+                // backend is the one refusing; the chain form is the reason it
+                // shows.
+                self.surface_failure(
+                    typer,
+                    &notice::Failure::transcription_failed(e.origin, &e.detail()),
+                    write_mode,
+                )
+                .await;
                 return Ok(Err(format!("STT error: {e}")));
             }
         };

--- a/super-stt-daemon/src/daemon/recording/transcribe.rs
+++ b/super-stt-daemon/src/daemon/recording/transcribe.rs
@@ -26,18 +26,26 @@ impl FinalFailure {
         }
     }
 
-    /// The backend answered and said no.
-    fn backend(error: anyhow::Error) -> Self {
-        Self {
-            origin: Origin::Backend,
-            error,
-        }
-    }
-
     /// The reason, as one string. `{:#}` so an `anyhow` chain reports its causes
     /// and not just the outermost context.
     pub(super) fn detail(&self) -> String {
         format!("{:#}", self.error)
+    }
+}
+
+/// Who authored a dispatch failure's message.
+///
+/// `Failed` is the backend's own answer — it was asked and it refused. The other
+/// two are the daemon never getting as far as asking: an empty model slot, or an
+/// inference task that did not come back.
+///
+/// Separated from [`SuperSTTDaemon::transcribe_final`] because this is the
+/// decision the user-facing notice reads, and that function needs a whole daemon
+/// to call. A decision worth showing the user is worth being able to test.
+fn origin_of(error: &DispatchError) -> Origin {
+    match error {
+        DispatchError::Failed(_) => Origin::Backend,
+        DispatchError::NotLoaded | DispatchError::Join(_) => Origin::Daemon,
     }
 }
 
@@ -132,17 +140,73 @@ impl SuperSTTDaemon {
                 );
                 Ok(text)
             }
-            Err(DispatchError::Failed(e)) => {
-                warn!("Transcription failed: {e}");
-                Err(FinalFailure::backend(e))
+            // One place decides the origin, so the notice cannot disagree with
+            // the variant; the arms below only shape the message and log it.
+            Err(e) => {
+                let origin = origin_of(&e);
+                let error = match e {
+                    DispatchError::Failed(err) => {
+                        warn!("Transcription failed: {err}");
+                        err
+                    }
+                    DispatchError::NotLoaded => {
+                        error!("Model not loaded");
+                        anyhow::anyhow!("Model not loaded")
+                    }
+                    DispatchError::Join(err) => {
+                        anyhow::anyhow!("Transcription task failed: {err}")
+                    }
+                };
+                Err(FinalFailure { origin, error })
             }
-            Err(DispatchError::NotLoaded) => {
-                error!("Model not loaded");
-                Err(FinalFailure::daemon(anyhow::anyhow!("Model not loaded")))
-            }
-            Err(DispatchError::Join(e)) => Err(FinalFailure::daemon(anyhow::anyhow!(
-                "Transcription task failed: {e}"
-            ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FinalFailure, origin_of};
+    use crate::output::notice::Origin;
+    use crate::stt_models::dispatch::DispatchError;
+
+    /// The backend was asked and refused, so its message is its own and the
+    /// notice says so.
+    #[test]
+    fn a_backend_refusal_is_the_backends_own() {
+        let e = DispatchError::Failed(anyhow::anyhow!("write_failed"));
+        assert_eq!(origin_of(&e), Origin::Backend);
+    }
+
+    /// Nothing was asked: there was no model to ask. Labelling this as the
+    /// backend's would blame a backend for the daemon's own state.
+    #[test]
+    fn an_empty_model_slot_is_the_daemons() {
+        assert_eq!(origin_of(&DispatchError::NotLoaded), Origin::Daemon);
+    }
+
+    /// The inference task died, so whatever the backend would have said never
+    /// arrived. The message here is the daemon's own description of the crash.
+    #[tokio::test]
+    async fn a_dead_inference_task_is_the_daemons() {
+        let handle = tokio::spawn(std::future::pending::<()>());
+        handle.abort();
+        let join_error = handle.await.expect_err("an aborted task fails to join");
+        assert_eq!(origin_of(&DispatchError::Join(join_error)), Origin::Daemon);
+    }
+
+    /// The reason shown to the user expands the whole `anyhow` chain. With the
+    /// plain `{}` form the user would get "Failed to process audio" and no clue
+    /// what about it failed.
+    #[test]
+    fn the_reason_expands_the_cause_chain() {
+        let e = FinalFailure::daemon(
+            anyhow::anyhow!("rate mismatch").context("Failed to process audio"),
+        );
+        assert_eq!(e.detail(), "Failed to process audio: rate mismatch");
+        assert_eq!(
+            e.to_string(),
+            "Failed to process audio",
+            "the plain form is what the existing error text keeps using"
+        );
     }
 }

--- a/super-stt-daemon/src/daemon/recording/transcribe.rs
+++ b/super-stt-daemon/src/daemon/recording/transcribe.rs
@@ -1,9 +1,53 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::daemon::types::SuperSTTDaemon;
+use crate::output::notice::Origin;
 use crate::stt_models::dispatch::{DispatchError, dispatch_transcription};
 use anyhow::{Context, Result};
 use log::{debug, error, info, warn};
+
+/// A final-transcription failure, tagged with who authored the message.
+///
+/// The error alone cannot answer that: a backend refusing the audio and the
+/// daemon failing to resample it arrive at the same `Err`, and the notice the
+/// user sees says which it was.
+pub(super) struct FinalFailure {
+    pub(super) origin: Origin,
+    pub(super) error: anyhow::Error,
+}
+
+impl FinalFailure {
+    /// The daemon's own doing: audio processing, an empty model slot, a task
+    /// that did not come back.
+    fn daemon(error: anyhow::Error) -> Self {
+        Self {
+            origin: Origin::Daemon,
+            error,
+        }
+    }
+
+    /// The backend answered and said no.
+    fn backend(error: anyhow::Error) -> Self {
+        Self {
+            origin: Origin::Backend,
+            error,
+        }
+    }
+
+    /// The reason, as one string. `{:#}` so an `anyhow` chain reports its causes
+    /// and not just the outermost context.
+    pub(super) fn detail(&self) -> String {
+        format!("{:#}", self.error)
+    }
+}
+
+impl std::fmt::Display for FinalFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The caller's existing error text is the plain form; `detail()` is the
+        // one that expands the chain.
+        write!(f, "{}", self.error)
+    }
+}
 
 impl SuperSTTDaemon {
     /// Transcribe a chunk of audio data for preview
@@ -70,11 +114,12 @@ impl SuperSTTDaemon {
         &self,
         audio_data: &[f32],
         request_language: Option<&str>,
-    ) -> Result<String> {
+    ) -> std::result::Result<String, FinalFailure> {
         let processed_audio = self
             .audio_processor
             .process_audio(audio_data, 16000)
-            .context("Failed to process audio")?;
+            .context("Failed to process audio")
+            .map_err(FinalFailure::daemon)?;
 
         let language = self.resolve_active_language(request_language).await;
         let start_time = std::time::Instant::now();
@@ -89,13 +134,15 @@ impl SuperSTTDaemon {
             }
             Err(DispatchError::Failed(e)) => {
                 warn!("Transcription failed: {e}");
-                Err(e)
+                Err(FinalFailure::backend(e))
             }
             Err(DispatchError::NotLoaded) => {
                 error!("Model not loaded");
-                Err(anyhow::anyhow!("Model not loaded"))
+                Err(FinalFailure::daemon(anyhow::anyhow!("Model not loaded")))
             }
-            Err(DispatchError::Join(e)) => Err(anyhow::anyhow!("Transcription task failed: {e}")),
+            Err(DispatchError::Join(e)) => Err(FinalFailure::daemon(anyhow::anyhow!(
+                "Transcription task failed: {e}"
+            ))),
         }
     }
 }

--- a/super-stt-daemon/src/output/notice.rs
+++ b/super-stt-daemon/src/output/notice.rs
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! Fixed notices typed into the focused window or placed in a desktop
-//! notification body when a recording fails, regardless of `write_mode`.
+//! What a recording failure looks like to the user.
 //!
-//! These are compile-time constants rather than formatted error text on
-//! purpose. Backends are explicitly untrusted (audit 2 Tier 3 #8) and most
-//! failure detail originates in one, so surfacing it verbatim would put
-//! attacker-influencable text into whatever the user has focused or into a
-//! notification body. The detail goes to the log and the error response;
-//! only these fixed strings ever reach the user.
+//! A failure reaches the user through one of two channels, and they carry
+//! different amounts of detail because they land in different places.
+//!
+//! A desktop notification has a summary and a body of its own, and its app name
+//! and icon are supplied separately — so the summary names the failure and the
+//! body gives the reason, including the reasons a backend authored, which is
+//! where most of them come from. Backends are explicitly untrusted (audit 2
+//! Tier 3 #8) and a notification server may render limited markup in the body,
+//! so that text is flattened, escaped, and clamped by [`sanitize`] before it is
+//! handed over, and labelled so a relayed failure is never read as one of the
+//! daemon's own.
+//!
+//! Typing has nowhere to put a reason: the notice goes into whatever window the
+//! user has focused, in among their own text. It stays one fixed, bracketed,
+//! daemon-authored string per failure and never carries backend text.
 
 /// No model is loaded, so the cycle cannot produce text. Caught before capture.
 pub(crate) const NO_MODEL_LOADED: &str = "[Super STT: no model loaded]";
@@ -28,3 +36,233 @@ pub(crate) const ALL: &[&str] = &[
     RECORDING_FAILED,
     TRANSCRIPTION_FAILED,
 ];
+
+/// Who authored a failure's detail, which decides how the notification body
+/// labels it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Origin {
+    /// The daemon itself: its own preconditions, the audio device, the recorder.
+    Daemon,
+    /// The backend serving the model.
+    Backend,
+}
+
+/// Longest reason a notification body carries. A bubble is not a log view, and
+/// a backend chooses its own message length.
+const MAX_DETAIL: usize = 300;
+
+/// One recording failure, rendered for both channels.
+pub(crate) struct Failure {
+    /// The fixed string the typed channel uses. Never carries detail.
+    pub(crate) typed: &'static str,
+    /// Notification summary: what failed. It deliberately omits the app name —
+    /// the notification already carries `Super STT` as its app name and icon,
+    /// and repeating it costs the user the only line they are certain to read.
+    pub(crate) summary: &'static str,
+    /// Notification body: why it failed.
+    pub(crate) body: String,
+}
+
+impl Failure {
+    /// No model is loaded. There is no reason to report beyond the fact itself,
+    /// so the body says what to do about it.
+    pub(crate) fn no_model_loaded() -> Self {
+        Self {
+            typed: NO_MODEL_LOADED,
+            summary: "No model loaded",
+            body: "Load a model and try again.".to_string(),
+        }
+    }
+
+    /// The recorder could not be spawned.
+    pub(crate) fn could_not_start_recording(detail: &str) -> Self {
+        Self {
+            typed: COULD_NOT_START_RECORDING,
+            summary: "Could not start recording",
+            body: body(
+                Origin::Daemon,
+                detail,
+                "The microphone could not be opened.",
+            ),
+        }
+    }
+
+    /// Capture began and then died.
+    pub(crate) fn recording_failed(detail: &str) -> Self {
+        Self {
+            typed: RECORDING_FAILED,
+            summary: "Recording failed",
+            body: body(
+                Origin::Daemon,
+                detail,
+                "Audio capture stopped before the recording finished.",
+            ),
+        }
+    }
+
+    /// The audio was captured but not transcribed. `origin` is a parameter here
+    /// and fixed in every other constructor because this is the one failure the
+    /// daemon usually did not cause: the backend answered, and said no.
+    pub(crate) fn transcription_failed(origin: Origin, detail: &str) -> Self {
+        Self {
+            typed: TRANSCRIPTION_FAILED,
+            summary: "Transcription failed",
+            body: body(origin, detail, "The recording could not be transcribed."),
+        }
+    }
+}
+
+/// Render a reason into a notification body: labelled by origin, or replaced by
+/// `fallback` when there is nothing left to say after sanitizing.
+fn body(origin: Origin, detail: &str, fallback: &str) -> String {
+    let detail = sanitize(detail);
+    if detail.is_empty() {
+        return fallback.to_string();
+    }
+    match origin {
+        Origin::Backend => format!("Backend error: {detail}"),
+        Origin::Daemon => detail,
+    }
+}
+
+/// Reduce a reason to one line of inert plain text.
+///
+/// Three things happen here, in order:
+///
+/// - Control characters — including the newlines an error chain is full of —
+///   become spaces, and runs of whitespace collapse. A body cannot fake extra
+///   lines, and cannot smuggle terminal escapes into a server that logs it.
+/// - The result is clamped to [`MAX_DETAIL`] characters, marked with an ellipsis
+///   so the user can tell it was cut.
+/// - `&`, `<`, and `>` are escaped last, so a clamp can never sever an entity.
+///   Servers that advertise `body-markup` render the body as markup, and some
+///   render anchors: unescaped, a backend could put a clickable link of its
+///   choosing inside a notification wearing this daemon's name and icon. The
+///   cost is that a literal `&` in a URL shows as `&amp;` on the servers that
+///   do not render markup, which is the cheaper of the two failures.
+fn sanitize(detail: &str) -> String {
+    let flattened: String = detail
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    let mut one_line = flattened.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if one_line.chars().count() > MAX_DETAIL {
+        one_line = one_line.chars().take(MAX_DETAIL - 1).collect::<String>();
+        one_line.push('…');
+    }
+
+    one_line
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Failure, MAX_DETAIL, Origin, sanitize};
+
+    /// The reason the user reported: a backend failure the log had in full
+    /// showed up as a fixed marker. The body must carry the reason, and must say
+    /// whose it is.
+    #[test]
+    fn a_backend_reason_reaches_the_body_labelled() {
+        let f = Failure::transcription_failed(
+            Origin::Backend,
+            "Could not reach http://192.168.0.172/v1/audio/transcriptions (write_failed).",
+        );
+        assert_eq!(f.summary, "Transcription failed");
+        assert_eq!(
+            f.body,
+            "Backend error: Could not reach http://192.168.0.172/v1/audio/transcriptions (write_failed)."
+        );
+    }
+
+    /// The daemon's own reasons are not relayed from anywhere, so labelling them
+    /// would be noise.
+    #[test]
+    fn a_daemon_reason_is_not_labelled() {
+        let f = Failure::recording_failed("Audio device disappeared mid-take");
+        assert_eq!(f.body, "Audio device disappeared mid-take");
+    }
+
+    /// A failure that arrives with nothing to report still says something.
+    #[test]
+    fn an_empty_reason_falls_back_to_a_fixed_sentence() {
+        assert_eq!(
+            Failure::transcription_failed(Origin::Backend, "   ").body,
+            "The recording could not be transcribed."
+        );
+        assert_eq!(
+            Failure::could_not_start_recording("").body,
+            "The microphone could not be opened."
+        );
+    }
+
+    /// No summary repeats the app name: the notification carries it already, and
+    /// the summary is the line the user actually reads.
+    #[test]
+    fn no_summary_repeats_the_app_name() {
+        let all = [
+            Failure::no_model_loaded(),
+            Failure::could_not_start_recording("d"),
+            Failure::recording_failed("d"),
+            Failure::transcription_failed(Origin::Daemon, "d"),
+        ];
+        for f in all {
+            assert!(
+                !f.summary.contains("Super STT"),
+                "summary repeats the app name: {:?}",
+                f.summary
+            );
+            assert!(
+                f.typed.starts_with("[Super STT: "),
+                "a typed notice must stay bracketed and attributed: {:?}",
+                f.typed
+            );
+        }
+    }
+
+    /// An anyhow chain arrives with newlines in it; a bubble gets one line.
+    #[test]
+    fn a_multi_line_reason_collapses_to_one_line() {
+        assert_eq!(
+            sanitize("Failed to process audio\n\nCaused by:\n    rate mismatch"),
+            "Failed to process audio Caused by: rate mismatch"
+        );
+    }
+
+    /// Terminal escapes and other C0/C1 controls do not survive.
+    #[test]
+    fn control_characters_do_not_survive() {
+        let s = sanitize("before\u{1b}[31m\u{7}after\u{85}end");
+        assert_eq!(s, "before [31m after end");
+        assert!(!s.chars().any(char::is_control));
+    }
+
+    /// The three markup characters are escaped, so a `body-markup` server
+    /// renders a backend's text as text — not as a link of its choosing.
+    #[test]
+    fn markup_is_escaped() {
+        assert_eq!(
+            sanitize("<a href=\"http://evil.test\">Click to fix</a> & wait"),
+            "&lt;a href=\"http://evil.test\"&gt;Click to fix&lt;/a&gt; &amp; wait"
+        );
+    }
+
+    /// A long reason is cut, and visibly so. The clamp runs before escaping, so
+    /// it can never leave half an entity behind.
+    #[test]
+    fn a_long_reason_is_clamped_without_severing_an_entity() {
+        let s = sanitize(&"&".repeat(MAX_DETAIL * 2));
+        assert!(
+            s.ends_with('…'),
+            "a cut reason must show that it was cut: {s}"
+        );
+        assert_eq!(
+            s.trim_end_matches('…'),
+            "&amp;".repeat(MAX_DETAIL - 1),
+            "the clamp left a partial entity behind"
+        );
+    }
+}

--- a/super-stt-daemon/src/output/notice.rs
+++ b/super-stt-daemon/src/output/notice.rs
@@ -160,7 +160,19 @@ fn sanitize(detail: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{Failure, MAX_DETAIL, Origin, sanitize};
+    use super::{ALL, Failure, MAX_DETAIL, Origin, sanitize};
+
+    /// Every failure the daemon can raise, for the invariants that must hold
+    /// across all of them.
+    fn every_failure() -> Vec<Failure> {
+        vec![
+            Failure::no_model_loaded(),
+            Failure::could_not_start_recording("d"),
+            Failure::recording_failed("d"),
+            Failure::transcription_failed(Origin::Daemon, "d"),
+            Failure::transcription_failed(Origin::Backend, "d"),
+        ]
+    }
 
     /// The reason the user reported: a backend failure the log had in full
     /// showed up as a fixed marker. The body must carry the reason, and must say
@@ -203,13 +215,7 @@ mod tests {
     /// the summary is the line the user actually reads.
     #[test]
     fn no_summary_repeats_the_app_name() {
-        let all = [
-            Failure::no_model_loaded(),
-            Failure::could_not_start_recording("d"),
-            Failure::recording_failed("d"),
-            Failure::transcription_failed(Origin::Daemon, "d"),
-        ];
-        for f in all {
+        for f in every_failure() {
             assert!(
                 !f.summary.contains("Super STT"),
                 "summary repeats the app name: {:?}",
@@ -219,6 +225,42 @@ mod tests {
                 f.typed.starts_with("[Super STT: "),
                 "a typed notice must stay bracketed and attributed: {:?}",
                 f.typed
+            );
+        }
+    }
+
+    /// [`ALL`] is what the typer's sanitizer test checks every notice against, so
+    /// a failure whose typed string is not in it would be typed without anything
+    /// ever having verified it is safe to type. Fails when a new failure is added
+    /// with a string of its own.
+    #[test]
+    fn every_typed_notice_is_in_the_catalogue() {
+        for f in every_failure() {
+            assert!(
+                ALL.contains(&f.typed),
+                "a typed notice outside the catalogue is typed unchecked: {:?}",
+                f.typed
+            );
+        }
+    }
+
+    /// No failure reaches the user with an empty body. Every constructor either
+    /// carries a reason or substitutes a sentence, and a bubble whose body is
+    /// blank tells the user only that something is broken.
+    #[test]
+    fn no_failure_has_an_empty_body() {
+        for f in every_failure() {
+            assert!(!f.body.is_empty(), "empty body for {:?}", f.summary);
+        }
+        for f in [
+            Failure::could_not_start_recording(""),
+            Failure::recording_failed("\n\t "),
+            Failure::transcription_failed(Origin::Backend, "\u{1b}"),
+        ] {
+            assert!(
+                !f.body.is_empty(),
+                "a reason that sanitized away left an empty body: {:?}",
+                f.summary
             );
         }
     }

--- a/super-stt-daemon/src/output/notification.rs
+++ b/super-stt-daemon/src/output/notification.rs
@@ -7,11 +7,11 @@
 //! standalone servers used on bare compositors (mako, dunst, swaync). One code
 //! path covers all of them; nothing here is desktop-specific.
 //!
-//! Notification bodies carry only the fixed constants from [`crate::output::notice`],
-//! never backend error text. Backends are explicitly untrusted (audit 2 Tier 3
-//! #8) and notification servers may render limited markup in the body, so the
-//! same rule that governs typing governs this channel.
+//! What a bubble says is decided in [`crate::output::notice`], including how
+//! backend-authored text is made safe to put in a body; this module only carries
+//! it to the bus.
 
+use crate::output::notice::Failure;
 use crate::output::typer::Typer;
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
@@ -24,10 +24,11 @@ const NOTIFY_BUS: &str = "org.freedesktop.Notifications";
 const NOTIFY_PATH: &str = "/org/freedesktop/Notifications";
 const NOTIFY_IFACE: &str = "org.freedesktop.Notifications";
 
+/// Sent as the notification's `app_name`, which is where the user learns who
+/// this bubble is from. The summary is free to name the failure instead.
 const APP_NAME: &str = "Super STT";
 /// Installed into `share/icons/hicolor/scalable/apps` by the justfile.
 const APP_ICON: &str = "super-stt-app";
-const SUMMARY: &str = "Super STT";
 /// 0 = low, 1 = normal, 2 = critical.
 const URGENCY_NORMAL: u8 = 1;
 /// Let the notification server pick the timeout.
@@ -45,14 +46,15 @@ pub struct Notifier {
     last_id: u32,
 }
 
+/// Every `(summary, body)` a [`Notifier::fake`] was asked to send.
+#[cfg(test)]
+type Sent = std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>;
+
 enum Inner {
     /// Session-bus connection, established on first send and cached.
     Dbus(Option<Connection>),
     #[cfg(test)]
-    Fake {
-        fail: bool,
-        sent: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    },
+    Fake { fail: bool, sent: Sent },
 }
 
 impl Notifier {
@@ -64,7 +66,7 @@ impl Notifier {
         }
     }
 
-    /// Deliver `body` as a desktop notification.
+    /// Deliver `summary` and `body` as a desktop notification.
     ///
     /// # Errors
     /// Returns an error when no session bus is reachable, or when no
@@ -74,7 +76,7 @@ impl Notifier {
     /// # Panics
     /// Never in practice: the `expect` below only unwraps the connection slot
     /// this same call just populated a few lines above.
-    pub async fn send(&mut self, body: &str) -> Result<()> {
+    pub async fn send(&mut self, summary: &str, body: &str) -> Result<()> {
         match &mut self.inner {
             Inner::Dbus(slot) => {
                 if slot.is_none() {
@@ -102,7 +104,7 @@ impl Notifier {
                             APP_NAME,
                             self.last_id,
                             APP_ICON,
-                            SUMMARY,
+                            summary,
                             body,
                             actions,
                             hints,
@@ -121,16 +123,18 @@ impl Notifier {
                 if *fail {
                     anyhow::bail!("fake notifier: delivery failed");
                 }
-                sent.lock().unwrap().push(body.to_string());
+                sent.lock()
+                    .unwrap()
+                    .push((summary.to_string(), body.to_string()));
                 Ok(())
             }
         }
     }
 
-    /// A notifier that records what it was asked to send, or fails every send
-    /// when `fail` is true.
+    /// A notifier that records the `(summary, body)` of what it was asked to
+    /// send, or fails every send when `fail` is true.
     #[cfg(test)]
-    pub(crate) fn fake(fail: bool) -> (Self, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+    pub(crate) fn fake(fail: bool) -> (Self, Sent) {
         let sent = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         (
             Self {
@@ -154,23 +158,29 @@ pub(crate) async fn deliver(
     method: NotificationMethod,
     notifier: &mut Notifier,
     typer: &mut Typer,
-    notice: &'static str,
+    failure: &Failure,
     write_mode: bool,
 ) {
     match method {
         NotificationMethod::Off => {
-            info!("Recording failure: {notice} (surfacing disabled)");
+            info!(
+                "Recording failure: {} — {} (surfacing disabled)",
+                failure.summary, failure.body
+            );
         }
-        NotificationMethod::Typed => type_or_log(typer, notice, write_mode).await,
+        NotificationMethod::Typed => type_or_log(typer, failure.typed, write_mode).await,
         NotificationMethod::Dbus => {
-            if let Err(e) = notifier.send(notice).await {
-                warn!("Could not deliver failure notification ({notice}): {e}");
+            if let Err(e) = notifier.send(failure.summary, &failure.body).await {
+                warn!(
+                    "Could not deliver failure notification ({}): {e}",
+                    failure.summary
+                );
             }
         }
         NotificationMethod::Auto => {
-            if let Err(e) = notifier.send(notice).await {
+            if let Err(e) = notifier.send(failure.summary, &failure.body).await {
                 warn!("Notification delivery failed ({e}); falling back to typing");
-                type_or_log(typer, notice, write_mode).await;
+                type_or_log(typer, failure.typed, write_mode).await;
             }
         }
     }
@@ -188,12 +198,18 @@ async fn type_or_log(typer: &mut Typer, notice: &'static str, write_mode: bool) 
 mod tests {
     use super::*;
     use crate::output::keyboard::Simulator;
-    use crate::output::notice;
+    use crate::output::notice::{self, Origin};
 
     /// Build a typer whose keystrokes land in a buffer we can assert on.
     fn typer() -> (Typer, std::sync::Arc<std::sync::Mutex<String>>) {
         let (sim, buf) = Simulator::capture();
         (Typer::new(sim), buf)
+    }
+
+    /// A transcription failure carrying a backend's reason — the shape the user
+    /// hits most often, and the one that has both a summary and a body to check.
+    fn backend_failure() -> Failure {
+        Failure::transcription_failed(Origin::Backend, "Could not reach the server (write_failed)")
     }
 
     #[tokio::test(start_paused = true)]
@@ -205,7 +221,7 @@ mod tests {
             NotificationMethod::Off,
             &mut n,
             &mut t,
-            notice::TRANSCRIPTION_FAILED,
+            &backend_failure(),
             true,
         )
         .await;
@@ -223,7 +239,7 @@ mod tests {
             NotificationMethod::Typed,
             &mut n,
             &mut t,
-            notice::TRANSCRIPTION_FAILED,
+            &backend_failure(),
             true,
         )
         .await;
@@ -232,8 +248,33 @@ mod tests {
         assert_eq!(*typed.lock().unwrap(), notice::TRANSCRIPTION_FAILED);
     }
 
+    /// The rule the notification channel relaxed and this one did not: what goes
+    /// into the user's focused window is the fixed marker, never the backend's
+    /// reason, however much of it the bubble would have shown.
     #[tokio::test(start_paused = true)]
-    async fn dbus_sends_the_notice_and_types_nothing() {
+    async fn typing_never_carries_the_reason() {
+        let (mut n, _sent) = Notifier::fake(true);
+        let (mut t, typed) = typer();
+
+        deliver(
+            NotificationMethod::Auto,
+            &mut n,
+            &mut t,
+            &backend_failure(),
+            true,
+        )
+        .await;
+
+        let typed = typed.lock().unwrap().clone();
+        assert_eq!(typed, notice::TRANSCRIPTION_FAILED);
+        assert!(
+            !typed.contains("write_failed"),
+            "backend text was typed into the focused window: {typed}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dbus_sends_the_summary_and_body_and_types_nothing() {
         let (mut n, sent) = Notifier::fake(false);
         let (mut t, typed) = typer();
 
@@ -241,13 +282,48 @@ mod tests {
             NotificationMethod::Dbus,
             &mut n,
             &mut t,
-            notice::RECORDING_FAILED,
+            &Failure::recording_failed("Audio device disappeared mid-take"),
             true,
         )
         .await;
 
-        assert_eq!(*sent.lock().unwrap(), vec![notice::RECORDING_FAILED]);
+        assert_eq!(
+            *sent.lock().unwrap(),
+            vec![(
+                "Recording failed".to_string(),
+                "Audio device disappeared mid-take".to_string()
+            )]
+        );
         assert_eq!(*typed.lock().unwrap(), "");
+    }
+
+    /// The bug this replaced: a bubble that named the app twice and the reason
+    /// not at all.
+    #[tokio::test(start_paused = true)]
+    async fn the_bubble_carries_the_reason_and_not_a_second_app_name() {
+        let (mut n, sent) = Notifier::fake(false);
+        let (mut t, _typed) = typer();
+
+        deliver(
+            NotificationMethod::Dbus,
+            &mut n,
+            &mut t,
+            &backend_failure(),
+            false,
+        )
+        .await;
+
+        let sent = sent.lock().unwrap().clone();
+        let (summary, body) = sent.first().expect("one notification");
+        assert_eq!(summary, "Transcription failed");
+        assert_eq!(
+            body,
+            "Backend error: Could not reach the server (write_failed)"
+        );
+        assert!(
+            !summary.contains(APP_NAME) && !body.contains(APP_NAME),
+            "the app name is the notification's own field, not text"
+        );
     }
 
     /// `dbus` is the deliberate "notification or nothing" choice — a failed
@@ -261,7 +337,7 @@ mod tests {
             NotificationMethod::Dbus,
             &mut n,
             &mut t,
-            notice::RECORDING_FAILED,
+            &Failure::recording_failed("d"),
             true,
         )
         .await;
@@ -278,12 +354,18 @@ mod tests {
             NotificationMethod::Auto,
             &mut n,
             &mut t,
-            notice::NO_MODEL_LOADED,
+            &Failure::no_model_loaded(),
             true,
         )
         .await;
 
-        assert_eq!(*sent.lock().unwrap(), vec![notice::NO_MODEL_LOADED]);
+        assert_eq!(
+            *sent.lock().unwrap(),
+            vec![(
+                "No model loaded".to_string(),
+                "Load a model and try again.".to_string()
+            )]
+        );
         assert_eq!(*typed.lock().unwrap(), "");
     }
 
@@ -298,7 +380,7 @@ mod tests {
             NotificationMethod::Auto,
             &mut n,
             &mut t,
-            notice::NO_MODEL_LOADED,
+            &Failure::no_model_loaded(),
             true,
         )
         .await;
@@ -316,7 +398,7 @@ mod tests {
             NotificationMethod::Typed,
             &mut n,
             &mut t,
-            notice::TRANSCRIPTION_FAILED,
+            &backend_failure(),
             false,
         )
         .await;
@@ -334,12 +416,12 @@ mod tests {
             NotificationMethod::Auto,
             &mut n,
             &mut t,
-            notice::TRANSCRIPTION_FAILED,
+            &backend_failure(),
             false,
         )
         .await;
 
-        assert_eq!(*sent.lock().unwrap(), vec![notice::TRANSCRIPTION_FAILED]);
+        assert_eq!(sent.lock().unwrap().len(), 1);
         assert_eq!(*typed.lock().unwrap(), "");
     }
 
@@ -353,7 +435,7 @@ mod tests {
             NotificationMethod::Auto,
             &mut n,
             &mut t,
-            notice::TRANSCRIPTION_FAILED,
+            &backend_failure(),
             false,
         )
         .await;


### PR DESCRIPTION
A recording that failed produced a notification saying nothing about why:

```
[Super STT] Transcription failed
```

while the log had the whole reason:

```
WARN Transcription failed: Could not reach http://192.168.0.172/v1/audio/transcriptions
     (write_failed). Check the server is running and reachable on that port.
```

Two problems in one bubble. The reason never left the log, and `Super STT`
appeared twice — once as the summary and once inside the body — spending the
only line the user is certain to read on branding they already had from the app
name and icon.

## What it says now

| | Summary | Body |
|---|---|---|
| **Notification** | `Transcription failed` | `Backend error: Could not reach http://192.168.0.172/v1/audio/transcriptions (write_failed). Check the server is running and reachable on that port.` |
| **Typed** | — | `[Super STT: transcription failed]` (unchanged) |

`Super STT` stays in the notification's own `app_name` and icon fields, which is
where the user learns who the bubble is from.

Reasons the daemon authored are not labelled — there is nothing to relay, so a
prefix would be noise. A failure that arrives with no reason at all falls back to
a fixed sentence rather than an empty body: `No model loaded` has nothing to
report beyond the fact, so its body says `Load a model and try again.`

## Why typing did not change

`notice.rs` withheld this detail deliberately: backends are untrusted (audit 2
Tier 3 #8), so nothing they author reached the user. Relaxing that for one
channel is only defensible if the reason it existed is answered, not deleted.

Typing keeps the fixed bracketed constant. It lands in whatever window the user
has focused, in among their own text, where there is nothing to hang a reason on
and where injected text is a genuine problem. A test asserts the typed fallback
still refuses the reason even in the case where the bubble would have shown it.

The notification body takes backend text only after `sanitize`:

- Control characters — including the newlines an `anyhow` chain is full of —
  become spaces and runs of whitespace collapse, so a body cannot fake extra
  lines or smuggle terminal escapes into a server that logs it.
- Clamped to 300 characters with an ellipsis, because a bubble is not a log view
  and a backend chooses its own message length.
- `&`, `<`, `>` escaped last, so the clamp can never sever an entity.

The escaping is the load-bearing part. Servers advertising `body-markup` render
the body as markup and some render anchors, so unescaped a backend could put a
clickable link of its choosing inside a notification wearing this daemon's name
and icon. The cost is a literal `&` in a URL showing as `&amp;` on servers that
do not render markup — the cheaper of the two failures.

## Making the origin knowable

`Backend error:` can only be applied if the daemon knows the answer rather than
guessing at it, and it did not: a backend refusing the audio and the daemon
failing to resample it arrived at the call site as the same `anyhow::Error`.

`transcribe_final` now returns `FinalFailure { origin, error }`, so the label
follows from where the error was constructed — `DispatchError::Failed` is the
backend's, while an empty model slot, a dead task, and audio processing are the
daemon's.

## Tests

16 new tests, in the three places the behaviour lives.

`transcribe.rs` — the origin decision. It used to sit inside `transcribe_final`,
which needs a whole `SuperSTTDaemon` to call, so nothing could reach the one
choice the label depends on. It is now `origin_of`, and each dispatch variant is
pinned:

- a backend refusal is the backend's own (`Failed` → `Backend`)
- an empty model slot is the daemon's — nothing was asked, so nothing can be
  blamed on a backend
- a dead inference task is the daemon's, asserted against a real `JoinError`
  from an aborted task
- the reason expands the whole `anyhow` chain, so `Failed to process audio`
  arrives as `Failed to process audio: rate mismatch` rather than a context line
  with the cause dropped

`notice.rs` — the rendering and the sanitizer:

- a backend reason reaches the body, labelled (the reported bug, verbatim)
- a daemon reason is not labelled
- an empty reason falls back to a fixed sentence
- no summary repeats the app name, and every typed notice stays bracketed
- every typed notice is in `notice::ALL` — the catalogue the typer's sanitizer
  test checks each string against, so a new failure carrying a string of its own
  cannot be typed without anything having verified it is safe to type
- no failure has an empty body, including when the reason sanitizes away to
  nothing
- a multi-line chain collapses to one line
- control characters do not survive
- markup is escaped, asserted against an anchor
- a long reason is clamped without severing an entity

`notification.rs` — the routing, now that summary and body are separate:

- typing never carries the reason, even when notification delivery failed and
  the typed fallback is what the user gets
- the bubble carries the reason and not a second app name
- the `dbus`/`auto`/`typed`/`off` assertions are updated to the `(summary, body)`
  pair the notifier now records

### What is not tested, and why

- **Which `Failure` each of the four call sites raises.** `surface_failure` hangs
  off `SuperSTTDaemon`, which no unit test can construct, and the integration
  tests drive the real daemon binary — where reaching these means a real
  microphone and a backend made to fail mid-cycle. The constructors and the
  routing are covered on their own; the two lines that pair them are not.
- **Real D-Bus delivery.** It needs a session bus with a notification server, so
  the tests assert through a fake notifier. Checked by hand instead: the exact
  `Notify` call the daemon now makes was sent to a live session bus and rendered
  as intended.
- **How a given server draws summary against body.** That is the server's
  business, not this daemon's.

`just fmt`, workspace clippy pedantic `--all-targets`, `just check-features`,
`just doctest`, and `cargo test --workspace --all-features` are green.

## Protocol

No wire change. `notification_method.md` gains a **What the user sees** section
specifying both channels' content — the summary and body per failure, the
`Backend error:` label, the sanitizing rules, and the four typed strings —
and `transcribe.md`'s failure paragraph now distinguishes the two channels
instead of describing only the typed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
