### PR TITLE
Fix new clippy lints from Rust 1.98

### DIFF
--- a/super-stt-cosmic-applet/src/app/subscription.rs
+++ b/super-stt-cosmic-applet/src/app/subscription.rs
@@ -83,10 +83,8 @@ fn b64_to_f32_vec(s: Option<&str>) -> Vec<f32> {
     let Ok(bytes) = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, s) else {
         return Vec::new();
     };
-    bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect()
+    let (samples, _trailing) = bytes.as_chunks::<4>();
+    samples.iter().copied().map(f32::from_le_bytes).collect()
 }
 
 /// Translate one [`WidgetEvent`] into the applet's typed [`Message`]

--- a/super-stt-daemon/src/daemon/device_management.rs
+++ b/super-stt-daemon/src/daemon/device_management.rs
@@ -133,6 +133,10 @@ impl SuperSTTDaemon {
     /// normalized `cpu`/`gpu` preference to thread through the rest of the
     /// switch; `Err` is an early response the caller returns as-is, whether
     /// that is a rejection or an already-satisfied no-op.
+    // `DaemonResponse` is the protocol's response type and is returned by value
+    // throughout the daemon; boxing it in this one helper's `Err` would buy
+    // nothing and read inconsistently against every sibling handler.
+    #[allow(clippy::result_large_err)]
     async fn validate_device_switch_request(&self, device: &str) -> Result<String, DaemonResponse> {
         // Validate and normalize (`cuda`/`metal` → `gpu`). Emit the documented
         // `400 invalid_device` code so clients can distinguish a bad request

--- a/super-stt-daemon/src/stt_models/wasm/ws_host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/ws_host.rs
@@ -195,6 +195,11 @@ impl self::super_stt::realtime::ws::Host for Host {
     }
 }
 
+// Signatures here are dictated by wasmtime's generated trait, so the
+// `async` cannot be dropped from the members that never await (the
+// unimplemented ones, and `drop`). `unknown_lints` keeps the attribute
+// harmless on toolchains predating the lint.
+#[allow(unknown_lints, clippy::unused_async_trait_impl)]
 impl self::super_stt::realtime::ws::HostWsStream for Host {
     async fn send_text(
         &mut self,
@@ -298,6 +303,8 @@ impl self::super_stt::realtime::ws::HostWsStream for Host {
     }
 }
 
+// Same as above: the trait is generated, so these signatures are fixed.
+#[allow(unknown_lints, clippy::unused_async_trait_impl)]
 impl self::super_stt::realtime::ws::HostConsumerStream for Host {
     async fn send_text(
         &mut self,


### PR DESCRIPTION
CI's `rust-toolchain@stable` rolled from 1.95 to **1.98** on 2026-08-18, which added two lints that fire on existing code. `just check` now fails on `main` — every PR opened since then is red through no fault of its own, including empty ones.

Three sites, none of them related to each other beyond the toolchain bump:

**`clippy::slice_as_chunks`** (new) — the applet's base64 → `f32` decoder used `chunks_exact(4)` with a constant size. Rewritten with `as_chunks::<4>()`, which is what the lint suggests and is exactly equivalent: same complete chunks, same discarded remainder.

**`clippy::unused_async_trait_impl`** (new) — fires on seven methods across the two wasmtime `ws` host impls that are `async` but never await (the unimplemented ones plus `drop`). The signatures come from wasmtime's generated trait, so the `async` can't be dropped; allowed at the two impl blocks with the reason recorded.

**`clippy::result_large_err`** — now reaches `async fn validate_device_switch_request`, whose `Err` is `DaemonResponse` at 1280 bytes. That type is the protocol's response struct and is returned by value throughout the daemon, so boxing it in one helper's `Err` would buy nothing and read inconsistently against every sibling handler. Allowed with that rationale.

Both new-lint allows carry `unknown_lints` alongside them, so they stay harmless on toolchains that predate the lint rather than erroring with `unknown lint` under `-D warnings`.

## Verification

Ran against clippy 0.1.98 locally (matching CI): `just check` and `just check-features` both clean, applet tests pass. Note that CI only ever surfaced the applet failure — clippy stops at the first crate that fails, so the daemon's seven were invisible until the whole workspace could be linted at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
