### PR TITLE
Fix backend updates, preserve weights, reconcile duplicates

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -60,6 +60,7 @@ description = "Local Whisper speech-to-text."
 
 | Field        | Type   | Required        | Notes                                                                 |
 |--------------|--------|-----------------|-----------------------------------------------------------------------|
+| `id`         | string | for publication | Globally unique reverse-DNS identifier for the backend, e.g. `app.super-stt.voxtral`. Names the directory the backend is installed into. Required for a backend to be listed in the registry. |
 | `source`     | string | yes             | Canonical repository id for this backend. Becomes the `source` of every model it provides (see [identity](./contract.md#model-identity)). Must be unique across installed backends. |
 | `name`       | string | yes             | Human-readable display name.                                          |
 | `version`    | string | yes             | Backend version (semver).                                            |
@@ -76,6 +77,21 @@ literal `other`. License *expressions* (`MIT OR Apache-2.0`) are not accepted;
 declare a single identifier or `other`. A backend declaring `other` is still
 published — the app surfaces its license as "Other" — so the value is a
 conscious declaration, not an omission.
+
+#### `id` format
+
+- Lowercase ASCII letters, digits, `-`, and `.` only.
+- At least three `.`-separated segments.
+- Each segment is non-empty, begins with a letter, and does not end with `-`.
+- No leading, trailing, or consecutive dots.
+- At most 255 bytes.
+
+The reverse-DNS form namespaces a backend under a domain its author
+controls, so two unrelated authors may both publish a backend named
+`voxtral`: `app.super-stt.voxtral` and `com.example.voxtral` coexist.
+
+`id` names the install directory. It is not part of model identity, which is
+the `(name, source)` pair described in [contract.md](./contract.md).
 
 ## `[network]`
 

--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -616,8 +616,27 @@ supported_devices   = ["none"]
   `label` is the human-readable text shown beside the input in the settings
   UI. Secret values are stored encrypted; option values are stored as
   plaintext.
-- `[backend].source` must be unique across installed backends; a collision
-  is a discovery error for the later backend.
+- `[backend].id`, when present, must match the [`id` format](#id-format)
+  above; a manifest declaring a malformed `id` fails to parse, and the
+  backend is skipped during discovery. It must also be unique across
+  installed backends, since it names the install directory: the registry
+  indexer refuses to publish an index in which two entries declare the same
+  `id`, and an install whose target directory already holds a backend
+  declaring a different `[backend].source` is refused rather than allowed to
+  replace it.
+- `[backend].source` must be unique across installed backends. When two
+  installed directories declare the same `source`, the daemon serves exactly
+  one of them and removes the other. The survivor is chosen in this order:
+  highest `[backend].version`; then the directory named after the backend's
+  own `[backend].id`, its canonical location; then the lexicographically
+  first directory name, so the outcome is stable across scans. Version leads
+  because a backend updated in place is the newer install whatever its
+  directory happens to be called. Before the other directory is removed,
+  every model file it holds that the survivor's manifest still declares at
+  the same `destination` *and* the same `url` is moved across, so resolving a
+  duplicate never costs a re-download. A directory whose `backend.toml` does
+  not parse is never a candidate — neither to survive nor to be removed:
+  without a readable `source` there is no evidence it is the same backend.
 - `[backend].description` is required: a one-line, human-readable summary
   shown in the registry/Browse listing. A manifest that omits it fails to
   parse, and the backend is skipped during discovery.

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -43,6 +43,9 @@ disambiguated by `source`. The daemon derives a model's `source` from the
 > [active_model.md](../endpoints/v1/active_model.md) and
 > [models.md](../endpoints/v1/models.md) are reconciled with this definition.
 
+> `[backend].id` is a separate identifier that names a backend's install
+> directory. It is not part of model identity.
+
 ## Transports
 
 | Concern             | WASM backend                            | Subprocess backend                       |

--- a/docs/protocol/endpoints/v1/registry/backends.md
+++ b/docs/protocol/endpoints/v1/registry/backends.md
@@ -75,11 +75,15 @@ GET /registry/backends?include_incompatible=false&kind=wasm&online=true&q=openai
 }
 ```
 
-`id` is the registry key from `registry.toml`; it names the directory an
-installed backend lives in. `backend_id` is the backend's reverse-DNS
-identifier, declared by `[backend].id` in its release manifest — `null` for
-an entry that predates the field. The two are maintained independently:
-neither is derived from the other.
+`id` is the registry key from `registry.toml`. `backend_id` is the backend's
+reverse-DNS identifier, declared by `[backend].id` in its release manifest —
+`null` for an entry that predates the field. The two are maintained
+independently: neither is derived from the other.
+
+The install directory is named by `backend_id`, falling back to `id` when
+`backend_id` is `null` — see
+[`POST /registry/install`](./install.md#request) for the full rule. A client
+computing the path must apply that fallback rather than assume either field.
 
 `models[].provider` is always an empty string. It is emitted so clients that
 require the key can still parse the response, and carries no information —

--- a/docs/protocol/endpoints/v1/registry/backends.md
+++ b/docs/protocol/endpoints/v1/registry/backends.md
@@ -40,6 +40,7 @@ GET /registry/backends?include_incompatible=false&kind=wasm&online=true&q=openai
   "backends": [
     {
       "id": "voxtral",
+      "backend_id": "app.super-stt.voxtral",
       "source": "github.com/jorge-menjivar/super-stt",
       "version": "0.2.0",
       "name": "Voxtral",
@@ -73,6 +74,12 @@ GET /registry/backends?include_incompatible=false&kind=wasm&online=true&q=openai
   ]
 }
 ```
+
+`id` is the registry key from `registry.toml`; it names the directory an
+installed backend lives in. `backend_id` is the backend's reverse-DNS
+identifier, declared by `[backend].id` in its release manifest — `null` for
+an entry that predates the field. The two are maintained independently:
+neither is derived from the other.
 
 `models[].provider` is always an empty string. It is emitted so clients that
 require the key can still parse the response, and carries no information —

--- a/docs/protocol/endpoints/v1/registry/backends.md
+++ b/docs/protocol/endpoints/v1/registry/backends.md
@@ -102,10 +102,12 @@ Per-entry fields beyond what `index.json` carries:
   compared as semver. The daemon decides this rather than leaving each client
   to re-derive it: the daemon is the side that reads the installed manifest and
   owns the index, so it is the only one that can answer without duplicating
-  both. `false` when nothing is installed, when the installed version is at or
-  ahead of the index's, or when either version does not parse — so a stale or
-  older index never advertises a downgrade. Clients that want to *show* the
-  versions still have both fields.
+  both. The daemon matches an installed backend to this entry by `source`, so
+  a backend installed from a custom repository or a local directory is matched
+  the same way one installed from the registry is. `false` when nothing is
+  installed, when the installed version is at or ahead of the index's, or when
+  either version does not parse — so a stale or older index never advertises a
+  downgrade. Clients that want to *show* the versions still have both fields.
 
 ## Failure modes
 

--- a/docs/protocol/endpoints/v1/registry/install.md
+++ b/docs/protocol/endpoints/v1/registry/install.md
@@ -95,6 +95,15 @@ repository, or a local directory. A backend whose manifest declares no `id`
 is installed under the registry key instead, so installs that predate the
 identifier keep their directory.
 
+That directory must be free for this backend to take. An install whose target
+directory already holds a backend declaring a different `[backend].source`
+fails with `install_dir_conflict`; both directories are left exactly as they
+were, and no model files are moved. Completing such an install would replace
+the backend already there and delete the model files downloaded under it.
+`source` is the identity this is judged on, so re-installing or updating the
+same backend is unaffected, as is replacing an install whose `backend.toml`
+no longer parses.
+
 **Integrity & limits.** Operator base-URL overrides (`GITHUB_API_BASE`,
 `SUPER_STT_REGISTRY_URL`) must be `https://` (loopback `http://` is allowed for
 testing); insecure values are ignored and the secure default is used. Downloads
@@ -166,6 +175,8 @@ Typed `error` values:
 - `manifest_invalid` — the `backend.toml` asset was absent or failed
   verification: no `manifest` pin, unparseable, failed runtime validation, over
   the size cap, or a `source`/`entrypoint` inconsistent with the index entry
+- `install_dir_conflict` — the install directory already holds a backend
+  declaring a different `[backend].source`; nothing on disk was changed
 
 ## Failure modes (synchronous)
 

--- a/docs/protocol/endpoints/v1/registry/install.md
+++ b/docs/protocol/endpoints/v1/registry/install.md
@@ -89,6 +89,12 @@ fail at model load with a read error naming a path, long after the operator
 could connect it to what they staged. A source checkout is the usual cause: a
 build tree names its artifact after the crate, not after the entrypoint.
 
+**Install directory.** A backend is installed into a directory named by its
+`[backend].id`, whichever route installed it — the registry, a custom
+repository, or a local directory. A backend whose manifest declares no `id`
+is installed under the registry key instead, so installs that predate the
+identifier keep their directory.
+
 **Integrity & limits.** Operator base-URL overrides (`GITHUB_API_BASE`,
 `SUPER_STT_REGISTRY_URL`) must be `https://` (loopback `http://` is allowed for
 testing); insecure values are ignored and the secure default is used. Downloads

--- a/registry/README.md
+++ b/registry/README.md
@@ -47,6 +47,20 @@ End users do not interact with this directory.
    release without the `backend.toml` asset is not installable and the indexer
    fails that entry.
 
+### `id`
+
+Every new entry must declare an `id`: a reverse-DNS identifier under a domain
+you control, e.g. `com.example.voxtral`. See
+[backend/config.md](../docs/protocol/backend/config.md) for the format.
+
+- It must be unique across the registry.
+- It must be identical to the `[backend].id` in the `backend.toml` published
+  by the release the entry points at. A release whose manifest declares a
+  different id, or none, is rejected.
+
+Entries that predate this requirement are accepted without an `id`. They stop
+being exempt as soon as they declare one.
+
 ## Removing or yanking
 
 - **Yank a specific bad version** without removing the backend: add

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -831,6 +831,7 @@ mod update_offer_tests {
             .is_some_and(|i| super_stt_registry_types::version::update_available(i, latest));
         RegistryBackend {
             id: "y".to_string(),
+            backend_id: None,
             source: "github.com/x/y".to_string(),
             version: latest.to_string(),
             name: "Y".to_string(),

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -367,6 +367,21 @@ impl DaemonConfig {
         self.transcription.preferred_provider = String::new();
     }
 
+    /// Repoint the active backend to `new_dir` without touching the loaded
+    /// model preference.
+    ///
+    /// Deliberately narrower than [`update_active_backend`]: that method
+    /// clears `preferred_model`/`preferred_provider` because it models the
+    /// user *choosing a different backend*, where any previously loaded
+    /// model no longer applies. This method models an install-time directory
+    /// rename of the *same* backend — its identity, models, and selection are
+    /// unchanged, only the on-disk directory name moved. Using
+    /// `update_active_backend` here would silently wipe the user's model
+    /// choice as a side effect of an update. Do not merge the two.
+    pub fn rename_active_backend(&mut self, new_dir: String) {
+        self.transcription.active_backend = Some(new_dir);
+    }
+
     /// Clear the active backend and the loaded-model preference (→ idle).
     pub fn clear_active_backend(&mut self) {
         self.transcription.active_backend = None;

--- a/super-stt-daemon/src/config_tests.rs
+++ b/super-stt-daemon/src/config_tests.rs
@@ -804,3 +804,27 @@ fn clearing_the_model_preference_clears_the_provider() {
     c.clear_active_backend();
     assert_eq!(c.transcription.preferred_provider, "");
 }
+
+/// `rename_active_backend` (an install-time directory migration of the *same*
+/// backend) must not disturb the loaded-model preference the way
+/// `update_active_backend` (a user picking a *different* backend) does —
+/// otherwise updating a backend silently forgets the user's selected model.
+#[test]
+fn rename_active_backend_preserves_the_model_preference() {
+    let mut c = DaemonConfig::default();
+    c.transcription.active_backend = Some("super-stt-voxtral".to_string());
+    c.update_preferred_model(
+        "voxtral-mini".to_string(),
+        "github.com/super-stt/voxtral".to_string(),
+        Some("local_voxtral".to_string()),
+    );
+
+    c.rename_active_backend("app.super-stt.voxtral".to_string());
+
+    assert_eq!(
+        c.transcription.active_backend.as_deref(),
+        Some("app.super-stt.voxtral")
+    );
+    assert_eq!(c.transcription.preferred_model, "voxtral-mini");
+    assert_eq!(c.transcription.preferred_provider, "local_voxtral");
+}

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -887,6 +887,7 @@ fn fixture_backend_devices(
     DiscoveredBackend {
         dir: std::path::PathBuf::from("/tmp").join(dir_name),
         source: source.to_string(),
+        id: None,
         name: name.to_string(),
         version: "1.0.0".to_string(),
         kind: "wasm".to_string(),

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -96,6 +96,7 @@ fn map_entry(
 ) -> RegistryBackend {
     RegistryBackend {
         id: entry.id.clone(),
+        backend_id: entry.backend_id.clone(),
         source: entry.source.clone(),
         version: entry.version.clone(),
         name: entry.name.clone(),

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -4,7 +4,6 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Deserialize;
-use std::path::PathBuf;
 use super_stt_shared::registry::{
     Compatibility, RegistryBackend, RegistryListResponse, RegistryModel, RegistryOption,
     RegistrySecret,
@@ -18,15 +17,6 @@ pub(crate) struct RegistryBackendsQuery {
     pub(crate) kind: Option<String>,
     pub(crate) online: Option<bool>,
     pub(crate) q: Option<String>,
-}
-
-/// Resolve the backends directory from app state.
-async fn backends_dir(s: &AppState) -> PathBuf {
-    let c = s.daemon.config.read().await;
-    c.transcription.backends_dir.clone().map_or_else(
-        crate::stt_models::backends::default_backends_dir,
-        PathBuf::from,
-    )
 }
 
 /// Return `true` if `entry` should be included given the query filters.
@@ -60,10 +50,26 @@ fn entry_passes_filters(
     true
 }
 
-/// Read the installed version for a backend from its `backend.toml`, if present.
-/// `None` marks a backend that is not installed here.
-fn installed_version(backends_dir: &std::path::Path, backend_id: &str) -> Option<String> {
-    crate::stt_models::backends::installed_version(&backends_dir.join(backend_id))
+/// The installed version of the backend serving `source`, or `None` when no
+/// installed backend claims it.
+///
+/// The catalog is keyed by `source` because that is the only identifier both
+/// sides always carry: the index always has one, and every `backend.toml` must
+/// declare one. A directory name does not qualify — it is derived differently
+/// depending on which install path produced it, so keying on it silently
+/// failed to match anything installed from a custom repo or a local path.
+///
+/// Re-reads the manifest off disk rather than trusting the cached
+/// `DiscoveredBackend::version`, so a version bumped since the last scan is
+/// reported; the cached value stands in when that read fails.
+fn installed_version_for_source(
+    backends: &[crate::stt_models::backends::DiscoveredBackend],
+    source: &str,
+) -> Option<String> {
+    let b = backends.iter().find(|b| b.source == source)?;
+    Some(
+        crate::stt_models::backends::installed_version(&b.dir).unwrap_or_else(|| b.version.clone()),
+    )
 }
 
 /// Whether the index offers something newer than what is installed.
@@ -155,7 +161,7 @@ pub(crate) async fn list_registry_backends(
     };
 
     let host = host_detect::detect();
-    let bdir = backends_dir(&s).await;
+    let backends = s.daemon.backends.read().await;
 
     let mut result = Vec::new();
     for entry in &index.backends {
@@ -186,7 +192,7 @@ pub(crate) async fn list_registry_backends(
         result.push(map_entry(
             entry,
             compat_field,
-            installed_version(&bdir, &entry.id),
+            installed_version_for_source(&backends, &entry.source),
         ));
     }
 
@@ -225,5 +231,56 @@ mod tests {
         // Neither side is guessed at when it cannot be parsed.
         assert!(!update_available(Some("1.0.0"), "nightly"));
         assert!(!update_available(Some(""), "1.0.0"));
+    }
+
+    use crate::stt_models::backends::DiscoveredBackend;
+    use std::path::PathBuf;
+
+    fn discovered(dir: &str, source: &str, version: &str) -> DiscoveredBackend {
+        DiscoveredBackend {
+            dir: PathBuf::from("/backends").join(dir),
+            source: source.to_string(),
+            name: "Voxtral".to_string(),
+            version: version.to_string(),
+            kind: "subprocess".to_string(),
+            entrypoint: "super-stt-backend-voxtral".to_string(),
+            allowed_hosts: Vec::new(),
+            secrets: Vec::new(),
+            options: Vec::new(),
+            models: Vec::new(),
+        }
+    }
+
+    /// The regression this task exists for: the install directory is named
+    /// after the repo, the index id is `voxtral`, and the two never matched.
+    /// Matching on `source` is what makes a custom-path install updatable.
+    #[test]
+    fn a_directory_not_named_after_the_index_id_still_reports_its_version() {
+        let catalog = vec![discovered(
+            "super-stt-voxtral",
+            "github.com/jorge-menjivar/super-stt-voxtral",
+            "0.1.0",
+        )];
+        assert_eq!(
+            super::installed_version_for_source(
+                &catalog,
+                "github.com/jorge-menjivar/super-stt-voxtral"
+            ),
+            Some("0.1.0".to_string())
+        );
+        assert!(update_available(Some("0.1.0"), "0.1.1"));
+    }
+
+    #[test]
+    fn a_source_absent_from_the_catalog_has_no_installed_version() {
+        let catalog = vec![discovered(
+            "whisper",
+            "github.com/x/super-stt-whisper",
+            "0.1.0",
+        )];
+        assert_eq!(
+            super::installed_version_for_source(&catalog, "github.com/x/super-stt-voxtral"),
+            None
+        );
     }
 }

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -62,7 +62,10 @@ fn entry_passes_filters(
 /// Re-reads the manifest off disk rather than trusting the cached
 /// `DiscoveredBackend::version`, so a version bumped since the last scan is
 /// reported; the cached value stands in when that read fails.
-fn installed_version_for_source(
+///
+/// `pub(super)` so `update.rs` shares this instead of re-implementing the same
+/// match-by-`source` + fresh-read-with-fallback rule.
+pub(super) fn installed_version_for_source(
     backends: &[crate::stt_models::backends::DiscoveredBackend],
     source: &str,
 ) -> Option<String> {

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -244,6 +244,7 @@ mod tests {
         DiscoveredBackend {
             dir: PathBuf::from("/backends").join(dir),
             source: source.to_string(),
+            id: None,
             name: "Voxtral".to_string(),
             version: version.to_string(),
             kind: "subprocess".to_string(),

--- a/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
@@ -189,6 +189,46 @@ pub(super) fn spawn_install_pipeline(
         };
         match outcome {
             Ok(version) => {
+                // An update that installs a version declaring an `id` may
+                // land at a new directory name while the backend is still
+                // installed under its old one — retire the predecessor and
+                // move the active-backend pointer with it before the catalog
+                // is rescanned.
+                let dir_name = crate::registry::install_dir_name(&entry);
+                let installed_at = pipeline.backends_dir.join(dir_name);
+                if let Some(old) = crate::registry::install::retire_previous_dir(
+                    &pipeline.backends_dir,
+                    &entry.source,
+                    &installed_at,
+                )
+                .await
+                {
+                    // `transcription.active_backend` stores the install
+                    // directory name, so a migration that renames the
+                    // directory has to move the pointer with it or the
+                    // backend reads as deselected. `rename_active_backend`
+                    // (not `update_active_backend`) is deliberate: this is
+                    // the same backend, same models, only the directory name
+                    // changed — the user's model selection must survive.
+                    let old_name = old
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let mut cfg = daemon.config.write().await;
+                    if cfg.transcription.active_backend.as_deref() == Some(old_name.as_str()) {
+                        cfg.rename_active_backend(dir_name.to_string());
+                        drop(cfg);
+                        *daemon.active_backend.write().await = Some(dir_name.to_string());
+                        if let Err(e) = daemon.persist_config().await {
+                            log::warn!(
+                                "Failed to persist config after backend migration rename: {e}"
+                            );
+                        }
+                        log::info!("Repointed active_backend from {old_name} to {dir_name}");
+                    }
+                }
+
                 // Refresh the daemon's in-memory backend catalog.
                 daemon.refresh_backends().await;
 

--- a/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
@@ -116,6 +116,49 @@ impl Drop for InflightMarker {
     }
 }
 
+/// After a successful install/update, retire the directory that used to
+/// serve `source` (if the install just migrated to a new directory name) and
+/// move `active_backend` — both the persisted config and the runtime mirror —
+/// to follow it.
+///
+/// A no-op unless [`crate::registry::install::retire_previous_dir`] actually
+/// removed a predecessor, and even then repoints `active_backend` only when
+/// it named exactly the directory just retired: installing/updating a
+/// backend that is not the one currently selected must never touch the
+/// pointer. `rename_active_backend` (not `update_active_backend`) is
+/// deliberate — this is the same backend, same models, only the directory
+/// name changed, so the user's model selection must survive.
+async fn retire_and_repoint(
+    daemon: &crate::daemon::types::SuperSTTDaemon,
+    backends_dir: &std::path::Path,
+    source: &str,
+    dir_name: &str,
+) {
+    let installed_at = backends_dir.join(dir_name);
+    let Some(old) =
+        crate::registry::install::retire_previous_dir(backends_dir, source, &installed_at).await
+    else {
+        return;
+    };
+    let old_name = old
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_string();
+
+    let mut cfg = daemon.config.write().await;
+    if cfg.transcription.active_backend.as_deref() != Some(old_name.as_str()) {
+        return;
+    }
+    cfg.rename_active_backend(dir_name.to_string());
+    drop(cfg);
+    *daemon.active_backend.write().await = Some(dir_name.to_string());
+    if let Err(e) = daemon.persist_config().await {
+        log::warn!("Failed to persist config after backend migration rename: {e}");
+    }
+    log::info!("Repointed active_backend from {old_name} to {dir_name}");
+}
+
 /// Shared background pipeline spawner used by both the install and update
 /// handlers. The caller has already inserted `source_bg` into the inflight
 /// set; this function takes ownership of that responsibility via
@@ -195,39 +238,7 @@ pub(super) fn spawn_install_pipeline(
                 // move the active-backend pointer with it before the catalog
                 // is rescanned.
                 let dir_name = crate::registry::install_dir_name(&entry);
-                let installed_at = pipeline.backends_dir.join(dir_name);
-                if let Some(old) = crate::registry::install::retire_previous_dir(
-                    &pipeline.backends_dir,
-                    &entry.source,
-                    &installed_at,
-                )
-                .await
-                {
-                    // `transcription.active_backend` stores the install
-                    // directory name, so a migration that renames the
-                    // directory has to move the pointer with it or the
-                    // backend reads as deselected. `rename_active_backend`
-                    // (not `update_active_backend`) is deliberate: this is
-                    // the same backend, same models, only the directory name
-                    // changed — the user's model selection must survive.
-                    let old_name = old
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let mut cfg = daemon.config.write().await;
-                    if cfg.transcription.active_backend.as_deref() == Some(old_name.as_str()) {
-                        cfg.rename_active_backend(dir_name.to_string());
-                        drop(cfg);
-                        *daemon.active_backend.write().await = Some(dir_name.to_string());
-                        if let Err(e) = daemon.persist_config().await {
-                            log::warn!(
-                                "Failed to persist config after backend migration rename: {e}"
-                            );
-                        }
-                        log::info!("Repointed active_backend from {old_name} to {dir_name}");
-                    }
-                }
+                retire_and_repoint(&daemon, &pipeline.backends_dir, &entry.source, dir_name).await;
 
                 // Refresh the daemon's in-memory backend catalog.
                 daemon.refresh_backends().await;
@@ -252,4 +263,116 @@ pub(super) fn spawn_install_pipeline(
 
         guard.disarm();
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retire_and_repoint;
+    use crate::daemon::types::test_daemon;
+
+    /// Lay out an old directory serving `source` and a new one already
+    /// installed at `new_dir_name`, matching what `run`/`run_local` leave on
+    /// disk right before this function runs in production.
+    fn migrated_layout(root: &std::path::Path, old_dir_name: &str, new_dir_name: &str) {
+        let old = root.join(old_dir_name);
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::write(
+            old.join("backend.toml"),
+            r#"
+[backend]
+source = "github.com/x/voxtral"
+name = "Voxtral"
+version = "1.0.0"
+kind = "subprocess"
+entrypoint = "voxtral"
+contract = "v1"
+description = "Test backend."
+"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join(new_dir_name)).unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_migration_repoints_active_backend_when_it_named_the_retired_directory() {
+        let root = tempfile::tempdir().unwrap();
+        migrated_layout(root.path(), "super-stt-voxtral", "app.super-stt.voxtral");
+
+        let daemon = test_daemon().await;
+        daemon.config.write().await.transcription.active_backend =
+            Some("super-stt-voxtral".to_string());
+        daemon.config.write().await.update_preferred_model(
+            "voxtral-mini".to_string(),
+            "github.com/x/voxtral".to_string(),
+            Some("local_voxtral".to_string()),
+        );
+
+        retire_and_repoint(
+            &daemon,
+            root.path(),
+            "github.com/x/voxtral",
+            "app.super-stt.voxtral",
+        )
+        .await;
+
+        assert!(!root.path().join("super-stt-voxtral").exists());
+        let cfg = daemon.config.read().await;
+        assert_eq!(
+            cfg.transcription.active_backend.as_deref(),
+            Some("app.super-stt.voxtral"),
+            "the pointer must follow the migration"
+        );
+        assert_eq!(
+            cfg.transcription.preferred_model, "voxtral-mini",
+            "the model preference must survive the rename"
+        );
+        assert_eq!(cfg.transcription.preferred_provider, "local_voxtral");
+        drop(cfg);
+        assert_eq!(
+            daemon.active_backend.read().await.as_deref(),
+            Some("app.super-stt.voxtral"),
+            "the runtime mirror must agree with the persisted config"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_migration_leaves_a_different_active_backend_untouched() {
+        let root = tempfile::tempdir().unwrap();
+        migrated_layout(root.path(), "super-stt-voxtral", "app.super-stt.voxtral");
+
+        let daemon = test_daemon().await;
+        daemon.config.write().await.transcription.active_backend =
+            Some("some-other-backend".to_string());
+        daemon.config.write().await.update_preferred_model(
+            "other-model".to_string(),
+            "github.com/x/other".to_string(),
+            Some("local_other".to_string()),
+        );
+
+        retire_and_repoint(
+            &daemon,
+            root.path(),
+            "github.com/x/voxtral",
+            "app.super-stt.voxtral",
+        )
+        .await;
+
+        // The stale directory is still retired — that part is unconditional —
+        // but the pointer, which names a different backend entirely, must not
+        // move.
+        assert!(
+            !root.path().join("super-stt-voxtral").exists(),
+            "the predecessor is retired regardless of what's active"
+        );
+        let cfg = daemon.config.read().await;
+        assert_eq!(
+            cfg.transcription.active_backend.as_deref(),
+            Some("some-other-backend"),
+            "an unrelated active backend must not be repointed"
+        );
+        assert_eq!(cfg.transcription.preferred_model, "other-model");
+        assert_eq!(cfg.transcription.preferred_provider, "local_other");
+        drop(cfg);
+        assert_eq!(daemon.active_backend.read().await.as_deref(), None);
+    }
 }

--- a/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/pipeline.rs
@@ -121,13 +121,20 @@ impl Drop for InflightMarker {
 /// move `active_backend` — both the persisted config and the runtime mirror —
 /// to follow it.
 ///
-/// A no-op unless [`crate::registry::install::retire_previous_dir`] actually
-/// removed a predecessor, and even then repoints `active_backend` only when
-/// it named exactly the directory just retired: installing/updating a
-/// backend that is not the one currently selected must never touch the
-/// pointer. `rename_active_backend` (not `update_active_backend`) is
-/// deliberate — this is the same backend, same models, only the directory
-/// name changed, so the user's model selection must survive.
+/// A no-op unless [`crate::registry::install::retire_previous_dir`] found a
+/// predecessor, and even then repoints `active_backend` only when it named
+/// exactly that directory: installing/updating a backend that is not the one
+/// currently selected must never touch the pointer.
+/// `rename_active_backend` (not `update_active_backend`) is deliberate — this
+/// is the same backend, same models, only the directory name changed, so the
+/// user's model selection must survive.
+///
+/// The repoint follows the predecessor being *found*, not its removal
+/// succeeding: `installed_at` is the live directory either way. Should this
+/// path be skipped entirely — a concurrent refresh reconciled the predecessor
+/// away first, so there is nothing left to find — the pointer is repaired by
+/// [`crate::registry::reconcile::reconcile`], which repoints whatever it
+/// removes.
 async fn retire_and_repoint(
     daemon: &crate::daemon::types::SuperSTTDaemon,
     backends_dir: &std::path::Path,

--- a/super-stt-daemon/src/daemon/http/v1/registry/update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/update.rs
@@ -75,14 +75,10 @@ async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, Er
     };
 
     // Matched by `source`, the same key `GET /registry/backends` uses to
-    // decide `update_available`. Keying on the install directory name instead
-    // made this 404 for anything installed from a custom repo or local path.
+    // decide `update_available` — and the same helper, so the two never drift.
     let installed_version: Option<String> = {
         let backends = s.daemon.backends.read().await;
-        backends.iter().find(|b| b.source == entry.source).map(|b| {
-            crate::stt_models::backends::installed_version(&b.dir)
-                .unwrap_or_else(|| b.version.clone())
-        })
+        super::list::installed_version_for_source(&backends, &entry.source)
     };
 
     let Some(from_version) = installed_version else {

--- a/super-stt-daemon/src/daemon/http/v1/registry/update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/update.rs
@@ -5,7 +5,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Deserialize;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Request body for `POST /registry/backends/update`.
@@ -61,14 +60,6 @@ struct VersionLookup {
 /// index, not installed on disk); the caller's [`InflightMarker`] cleans up the
 /// inflight set.
 async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, ErrResp> {
-    let backends_dir = {
-        let c = s.daemon.config.read().await;
-        c.transcription.backends_dir.clone().map_or_else(
-            crate::stt_models::backends::default_backends_dir,
-            PathBuf::from,
-        )
-    };
-
     let Ok(index) = s.registry_client.get().await else {
         return Err(Box::new(super::registry_error(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -83,16 +74,15 @@ async fn lookup_versions(s: &AppState, source: &str) -> Result<VersionLookup, Er
         )));
     };
 
-    // Determine installed version from disk.
+    // Matched by `source`, the same key `GET /registry/backends` uses to
+    // decide `update_available`. Keying on the install directory name instead
+    // made this 404 for anything installed from a custom repo or local path.
     let installed_version: Option<String> = {
-        let candidate = backends_dir.join(&entry.id).join("backend.toml");
-        if candidate.exists() {
-            crate::stt_models::backends::manifest::Manifest::load(&backends_dir.join(&entry.id))
-                .ok()
-                .map(|m| m.backend.version)
-        } else {
-            None
-        }
+        let backends = s.daemon.backends.read().await;
+        backends.iter().find(|b| b.source == entry.source).map(|b| {
+            crate::stt_models::backends::installed_version(&b.dir)
+                .unwrap_or_else(|| b.version.clone())
+        })
     };
 
     let Some(from_version) = installed_version else {

--- a/super-stt-daemon/src/daemon/model_management/discovery.rs
+++ b/super-stt-daemon/src/daemon/model_management/discovery.rs
@@ -12,13 +12,31 @@ impl SuperSTTDaemon {
             c.transcription.backends_dir.clone()
         };
         let dir = configured.map_or_else(backends::default_backends_dir, PathBuf::from);
-        let discovered = backends::discover(&dir);
+        let (winners, losers) = backends::discover(&dir);
         info!(
             "Backend registry: {} backend(s) from {}",
-            discovered.len(),
+            winners.len(),
             dir.display()
         );
-        *self.backends.write().await = discovered;
+
+        // Skipped while a session holds the switch guard: removing a
+        // directory under an in-flight recording would strand state it
+        // still depends on, the same reason uninstall refuses. The
+        // duplicate is harmless until the next refresh.
+        if !losers.is_empty() {
+            if self.switch_guard().await.is_some() {
+                log::warn!(
+                    "{} duplicate backend director(ies) left for a later refresh: \
+                     a backend is busy",
+                    losers.len()
+                );
+            } else {
+                let bytes = crate::registry::reconcile::reconcile(&losers, &winners).await;
+                log::info!("Reconciled duplicate backends, reclaiming {bytes} bytes");
+            }
+        }
+
+        *self.backends.write().await = winners;
     }
 
     /// Choose the model to load at startup: the configured preference, but only
@@ -77,5 +95,95 @@ impl SuperSTTDaemon {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::daemon::types::test_daemon;
+
+    /// A minimal backend manifest at `dir`, sharing `source` with whatever
+    /// else is written under the same backends root, at the given `version`.
+    fn write_backend(dir: &std::path::Path, version: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("backend.toml"),
+            format!(
+                r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "{version}"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    description = "Test backend."
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Reconciliation must not touch the filesystem while a session holds the
+    /// switch guard: removing a directory under an in-flight recording would
+    /// strand state it still depends on. The duplicate stays in place — only
+    /// the winner is served — until a later, idle refresh cleans it up.
+    #[tokio::test]
+    async fn reconciliation_is_skipped_while_a_backend_is_busy() {
+        let root = tempfile::tempdir().unwrap();
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("super-stt-y");
+        write_backend(&winner, "1.0.1");
+        write_backend(&loser, "1.0.0");
+
+        let daemon = test_daemon().await;
+        *daemon.busy.write().await = true;
+        daemon.config.write().await.transcription.backends_dir =
+            Some(root.path().to_string_lossy().into_owned());
+
+        daemon.refresh_backends().await;
+
+        assert!(
+            loser.exists(),
+            "a duplicate must not be removed while a backend is busy"
+        );
+        assert!(winner.exists());
+        let backends = daemon.backends.read().await;
+        assert_eq!(
+            backends.len(),
+            1,
+            "the winner is still the only one served, even though the \
+             duplicate was left in place"
+        );
+    }
+
+    /// The mirror case: once idle, a refresh reconciles the duplicate away.
+    #[tokio::test]
+    async fn reconciliation_runs_and_removes_the_loser_when_idle() {
+        let root = tempfile::tempdir().unwrap();
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("super-stt-y");
+        write_backend(&winner, "1.0.1");
+        write_backend(&loser, "1.0.0");
+
+        let daemon = test_daemon().await;
+        daemon.config.write().await.transcription.backends_dir =
+            Some(root.path().to_string_lossy().into_owned());
+
+        daemon.refresh_backends().await;
+
+        assert!(
+            !loser.exists(),
+            "an idle refresh must reconcile the duplicate away"
+        );
+        assert!(winner.exists());
+        let backends = daemon.backends.read().await;
+        assert_eq!(backends.len(), 1);
     }
 }

--- a/super-stt-daemon/src/daemon/model_management/discovery.rs
+++ b/super-stt-daemon/src/daemon/model_management/discovery.rs
@@ -31,7 +31,7 @@ impl SuperSTTDaemon {
                     losers.len()
                 );
             } else {
-                let bytes = crate::registry::reconcile::reconcile(&losers, &winners).await;
+                let bytes = crate::registry::reconcile::reconcile(self, &losers, &winners).await;
                 log::info!("Reconciled duplicate backends, reclaiming {bytes} bytes");
             }
         }
@@ -185,5 +185,49 @@ mod tests {
         assert!(winner.exists());
         let backends = daemon.backends.read().await;
         assert_eq!(backends.len(), 1);
+    }
+
+    /// The upgrade path, end to end: a user who already has two directories
+    /// for one source gets them reconciled on the first refresh after the
+    /// daemon starts. If `active_backend` named the loser, that refresh
+    /// deletes the directory the pointer names — so the refresh has to move
+    /// the pointer with it, or the daemon comes up reporting no active
+    /// backend and no models while the backend sits installed next door.
+    #[tokio::test]
+    async fn a_refresh_that_reconciles_the_active_directory_repoints_it() {
+        let root = tempfile::tempdir().unwrap();
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("super-stt-y");
+        write_backend(&winner, "1.0.1");
+        write_backend(&loser, "1.0.0");
+
+        let daemon = test_daemon().await;
+        {
+            let mut cfg = daemon.config.write().await;
+            cfg.transcription.backends_dir = Some(root.path().to_string_lossy().into_owned());
+            cfg.transcription.active_backend = Some("super-stt-y".to_string());
+            cfg.update_preferred_model(
+                "m".to_string(),
+                "github.com/x/y".to_string(),
+                Some("local_y".to_string()),
+            );
+        }
+        *daemon.active_backend.write().await = Some("super-stt-y".to_string());
+
+        daemon.refresh_backends().await;
+
+        assert!(!loser.exists());
+        let cfg = daemon.config.read().await;
+        assert_eq!(
+            cfg.transcription.active_backend.as_deref(),
+            Some("app.super-stt.y"),
+            "the pointer must never be left naming a directory the refresh deleted"
+        );
+        assert_eq!(cfg.transcription.preferred_model, "m");
+        drop(cfg);
+        assert_eq!(
+            daemon.active_backend.read().await.as_deref(),
+            Some("app.super-stt.y")
+        );
     }
 }

--- a/super-stt-daemon/src/daemon/startup_tests.rs
+++ b/super-stt-daemon/src/daemon/startup_tests.rs
@@ -24,6 +24,7 @@ fn discovered(dir: &str, source: &str) -> DiscoveredBackend {
     DiscoveredBackend {
         dir: PathBuf::from("/var/lib/super-stt/backends").join(dir),
         source: source.to_string(),
+        id: None,
         name: "Whisper (local)".to_string(),
         version: "1.0.0".to_string(),
         kind: "subprocess".to_string(),

--- a/super-stt-daemon/src/daemon/test_fixtures.rs
+++ b/super-stt-daemon/src/daemon/test_fixtures.rs
@@ -27,6 +27,7 @@ pub(crate) fn openai_backend(
     DiscoveredBackend {
         dir: std::path::PathBuf::from("/tmp/openai"),
         source: source.to_string(),
+        id: None,
         name: "OpenAI".to_string(),
         version: "1.0.0".to_string(),
         kind: "wasm".to_string(),

--- a/super-stt-daemon/src/registry/carry_over.rs
+++ b/super-stt-daemon/src/registry/carry_over.rs
@@ -85,9 +85,23 @@ pub fn survivors(old: &Manifest, new: &Manifest) -> Vec<String> {
 /// Both directories live under the backends directory, so these are
 /// same-filesystem renames: constant-time, with no multi-gigabyte copy.
 ///
+/// Destinations are moved one at a time with no rollback. If an error occurs
+/// partway through — a permissions failure, a full disk — the destinations
+/// already processed stay moved; the caller must not assume `from_dir` is
+/// still intact after an `Err`. This is safe for `install`'s caller
+/// (`preserve_models`) because a file this leaves behind under `from_dir` is
+/// simply re-downloaded the next time it is provisioned
+/// (`stt_models::download::usable_existing` re-verifies every file's hash
+/// before trusting it), so the end state is always correct content — it is
+/// only ever less carry-over than intended, never wrong bytes served. See
+/// `preserve_models`'s doc comment for the one place that safety net does not
+/// fully cover: a same-version retry after a partial failure.
+///
 /// # Errors
 /// Returns an `io::Error` if a destination is not a safe relative path, a
-/// directory cannot be created, or a rename fails.
+/// directory cannot be created, or a rename fails. The error is wrapped with
+/// the source and destination paths so a failure log line names which of
+/// potentially dozens of model files it was.
 pub async fn carry(
     from_dir: &Path,
     to_dir: &Path,
@@ -116,9 +130,27 @@ pub async fn carry(
             continue;
         }
         if let Some(parent) = dst.parent() {
-            fs::create_dir_all(parent).await?;
+            fs::create_dir_all(parent).await.map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "carry_over: creating parent of `{}` ({}): {e}",
+                        dst.display(),
+                        parent.display()
+                    ),
+                )
+            })?;
         }
-        fs::rename(&src, &dst).await?;
+        fs::rename(&src, &dst).await.map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!(
+                    "carry_over: renaming `{}` to `{}`: {e}",
+                    src.display(),
+                    dst.display()
+                ),
+            )
+        })?;
         moved += meta.len();
     }
     Ok(moved)
@@ -308,6 +340,57 @@ mod tests {
         assert!(
             !from.path().join("models/m/a.bin").exists(),
             "moved, not copied"
+        );
+    }
+
+    /// `carry` has no rollback: a failure partway through must leave earlier
+    /// destinations moved and later ones untouched, never straddling both
+    /// directories or silently losing bytes. Pins the documented
+    /// no-rollback behaviour (see `carry`'s doc comment) so it cannot erode
+    /// silently.
+    ///
+    /// The failure is triggered portably, without platform-specific
+    /// permission tricks: the second destination's parent directory
+    /// (`sub/`) already exists under `to_dir` as a plain *file*, so
+    /// `create_dir_all` cannot turn it into a directory.
+    #[tokio::test]
+    async fn a_partial_failure_leaves_earlier_moves_in_place_and_later_ones_untouched() {
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+
+        std::fs::write(from.path().join("a.bin"), b"aaaa").unwrap();
+        std::fs::create_dir_all(from.path().join("sub")).unwrap();
+        std::fs::write(from.path().join("sub/b.bin"), b"bb").unwrap();
+        // Blocks `create_dir_all(to_dir.join("sub"))` for the second
+        // destination: "sub" already exists under `to_dir`, but as a file.
+        std::fs::write(to.path().join("sub"), b"blocking file").unwrap();
+
+        let err = carry(
+            from.path(),
+            to.path(),
+            &["a.bin".to_string(), "sub/b.bin".to_string()],
+        )
+        .await
+        .expect_err("the second destination's parent cannot be created");
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+
+        assert!(
+            !from.path().join("a.bin").exists(),
+            "the first destination genuinely moved out of from_dir"
+        );
+        assert_eq!(
+            std::fs::read(to.path().join("a.bin")).unwrap(),
+            b"aaaa",
+            "the first destination genuinely moved into to_dir"
+        );
+        assert!(
+            from.path().join("sub/b.bin").exists(),
+            "the second destination is untouched by the failed move"
+        );
+        assert_eq!(
+            std::fs::read(to.path().join("sub")).unwrap(),
+            b"blocking file",
+            "the blocking file itself must be untouched"
         );
     }
 }

--- a/super-stt-daemon/src/registry/carry_over.rs
+++ b/super-stt-daemon/src/registry/carry_over.rs
@@ -19,26 +19,52 @@ use super_stt_registry_types::manifest::Manifest;
 use tokio::fs;
 
 /// Map every declared file destination to its download URL.
-fn declared(m: &Manifest) -> HashMap<&str, &str> {
-    m.models
-        .iter()
-        .flat_map(|model| &model.files)
-        .map(|f| (f.destination.as_str(), f.url.as_str()))
-        .collect()
+///
+/// `Manifest::parse` does not enforce destination uniqueness across models,
+/// so the same destination can legally appear more than once. When it does
+/// with conflicting URLs, the destination maps to `None`: we cannot tell
+/// which URL a file on disk (if any) actually came from, so treating it as
+/// unrecognized forces a re-download rather than risking the wrong file
+/// being carried over silently. The same destination declared twice with the
+/// *same* URL is not a conflict and still maps to `Some(url)`.
+fn declared(m: &Manifest) -> HashMap<&str, Option<&str>> {
+    let mut out: HashMap<&str, Option<&str>> = HashMap::new();
+    for model in &m.models {
+        for f in &model.files {
+            let dest = f.destination.as_str();
+            let url = f.url.as_str();
+            out.entry(dest)
+                .and_modify(|existing| {
+                    if *existing != Some(url) {
+                        *existing = None;
+                    }
+                })
+                .or_insert(Some(url));
+        }
+    }
+    out
 }
 
-/// Destinations declared by both manifests with the same URL, sorted so the
-/// result is stable for logging and tests.
+/// Destinations declared unambiguously by both manifests with the same URL,
+/// sorted so the result is stable for logging and tests.
+///
+/// A destination whose declaration is ambiguous in either manifest (see
+/// [`declared`]) never survives, even if one of its conflicting URLs happens
+/// to match.
 ///
 /// Every destination is validated as a safe relative path by `Manifest::parse`,
-/// so callers may join these onto a directory without escaping it.
+/// so callers may join these onto a directory without escaping it — `carry`
+/// re-validates anyway, since it is not limited to receiving this function's
+/// output.
 #[must_use]
 pub fn survivors(old: &Manifest, new: &Manifest) -> Vec<String> {
     let old_files = declared(old);
     let mut out: Vec<String> = declared(new)
         .into_iter()
-        .filter(|(dest, url)| old_files.get(dest) == Some(url))
-        .map(|(dest, _)| dest.to_string())
+        .filter_map(|(dest, url)| {
+            let url = url?;
+            (old_files.get(dest) == Some(&Some(url))).then(|| dest.to_string())
+        })
         .collect();
     out.sort();
     out
@@ -47,18 +73,38 @@ pub fn survivors(old: &Manifest, new: &Manifest) -> Vec<String> {
 /// Move each of `destinations` from `from_dir` into `to_dir`, returning the
 /// total bytes moved.
 ///
+/// Each destination must be a safe relative path: it is joined onto both
+/// `from_dir` and `to_dir` below, so a `..` component would let it climb out
+/// of either. `survivors` only ever returns manifest-declared destinations,
+/// which `Manifest::parse` already validates this way, but `carry` is not
+/// limited to that input, so it re-checks every destination itself before
+/// touching the filesystem.
+///
 /// A destination missing under `from_dir` is skipped, and one that already
 /// exists under `to_dir` is left alone — the staged copy is the newer one.
 /// Both directories live under the backends directory, so these are
 /// same-filesystem renames: constant-time, with no multi-gigabyte copy.
 ///
 /// # Errors
-/// Returns an `io::Error` if a directory cannot be created or a rename fails.
+/// Returns an `io::Error` if a destination is not a safe relative path, a
+/// directory cannot be created, or a rename fails.
 pub async fn carry(
     from_dir: &Path,
     to_dir: &Path,
     destinations: &[String],
 ) -> std::io::Result<u64> {
+    // Joined onto both directories below, so none may climb out of either.
+    // The manifest parser guards `[[models.files]].destination` this way;
+    // `carry` reaches the same join and gets the same guard, checked for
+    // every destination up front so a bad entry mutates nothing.
+    for dest in destinations {
+        if !super_stt_registry_types::is_safe_relative_path(dest) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("refusing to carry over unsafe destination: {dest}"),
+            ));
+        }
+    }
     let mut moved = 0u64;
     for dest in destinations {
         let src = from_dir.join(dest);
@@ -84,11 +130,37 @@ mod tests {
     use super_stt_registry_types::manifest::Manifest;
 
     fn manifest_with(files: &[(&str, &str)]) -> Manifest {
-        let entries = files
+        manifest_with_models(&[files])
+    }
+
+    /// Like `manifest_with`, but emits one `[[models]]` block per entry in
+    /// `models`, so a destination can be declared more than once across
+    /// separate models (to exercise the conflicting-URL case).
+    fn manifest_with_models(models: &[&[(&str, &str)]]) -> Manifest {
+        let blocks = models
             .iter()
-            .map(|(url, dest)| format!("{{ url = \"{url}\", destination = \"{dest}\" }}"))
+            .enumerate()
+            .map(|(i, files)| {
+                let entries = files
+                    .iter()
+                    .map(|(url, dest)| format!("{{ url = \"{url}\", destination = \"{dest}\" }}"))
+                    .collect::<Vec<_>>()
+                    .join(",\n            ");
+                format!(
+                    r#"
+[[models]]
+    name               = "m{i}"
+    primary_language   = "en"
+    supported_languages = ["en"]
+    supported_devices  = ["cpu"]
+    files = [
+            {entries}
+    ]
+"#
+                )
+            })
             .collect::<Vec<_>>()
-            .join(",\n            ");
+            .join("\n");
         let text = format!(
             r#"
 [backend]
@@ -105,15 +177,7 @@ mod tests {
     file   = "y.tar.gz"
     target = "x86_64-unknown-linux-gnu"
     accel  = ["cpu"]
-
-[[models]]
-    name               = "m"
-    primary_language   = "en"
-    supported_languages = ["en"]
-    supported_devices  = ["cpu"]
-    files = [
-            {entries}
-    ]
+{blocks}
 "#
         );
         Manifest::parse(&text).expect("fixture manifest parses")
@@ -138,6 +202,73 @@ mod tests {
         let old = manifest_with(&[("https://h/a.bin", "models/m/a.bin")]);
         let new = manifest_with(&[("https://h/b.bin", "models/m/b.bin")]);
         assert!(survivors(&old, &new).is_empty());
+    }
+
+    #[test]
+    fn a_destination_declared_twice_with_conflicting_urls_does_not_survive() {
+        // The old manifest ambiguously declares "shared.bin" across two
+        // models with different URLs, and unambiguously declares "z.bin";
+        // the new manifest declares both destinations unambiguously,
+        // "shared.bin" matching one of the two old URLs. The ambiguous old
+        // declaration must still block "shared.bin", while "z.bin" — an
+        // ordinary, unambiguous match — survives.
+        let old = manifest_with_models(&[
+            &[
+                ("https://h/shared-v1.bin", "models/m/shared.bin"),
+                ("https://h/z.bin", "models/m/z.bin"),
+            ],
+            &[("https://h/shared-v2.bin", "models/m/shared.bin")],
+        ]);
+        let new = manifest_with_models(&[&[
+            ("https://h/shared-v1.bin", "models/m/shared.bin"),
+            ("https://h/z.bin", "models/m/z.bin"),
+        ]]);
+        assert_eq!(
+            survivors(&old, &new),
+            vec!["models/m/z.bin".to_string()],
+            "shared.bin's old declaration is ambiguous, so it cannot survive"
+        );
+    }
+
+    #[test]
+    fn a_destination_declared_twice_with_the_same_url_is_not_a_conflict() {
+        let files: &[(&str, &str)] = &[
+            ("https://h/z.bin", "models/m/z.bin"),
+            ("https://h/a.bin", "models/m/a.bin"),
+        ];
+        // "a.bin" and "z.bin" are each declared identically by two separate
+        // models in both manifests; the repeat must not read as a conflict.
+        let repeat: &[(&str, &str)] = &[("https://h/a.bin", "models/m/a.bin")];
+        let old = manifest_with_models(&[files, repeat]);
+        let new = manifest_with_models(&[files, repeat]);
+        assert_eq!(
+            survivors(&old, &new),
+            vec!["models/m/a.bin".to_string(), "models/m/z.bin".to_string()],
+            "both destinations survive, sorted, pinning `survivors`' sort"
+        );
+    }
+
+    #[tokio::test]
+    async fn carry_refuses_a_traversing_destination() {
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+        let from_nested = from.path().join("nested");
+        std::fs::create_dir_all(&from_nested).unwrap();
+        // If the guard were missing, `from_nested.join("../escaped.bin")`
+        // would resolve to this path — still inside our sandbox, so we can
+        // assert it was never touched.
+        std::fs::write(from.path().join("escaped.bin"), b"secret").unwrap();
+
+        let err = carry(&from_nested, to.path(), &["../escaped.bin".to_string()])
+            .await
+            .expect_err("a traversing destination must be refused, not joined");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            from.path().join("escaped.bin").exists(),
+            "the file outside `from_nested` must be untouched, not moved"
+        );
+        assert!(!to.path().join("escaped.bin").exists());
     }
 
     #[tokio::test]

--- a/super-stt-daemon/src/registry/carry_over.rs
+++ b/super-stt-daemon/src/registry/carry_over.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Which downloaded model files survive a backend directory being replaced.
+//!
+//! Replacing a backend directory used to take its `models/` subtree with it,
+//! so an update discarded gigabytes of weights that immediately re-downloaded.
+//! A file is still valid when both manifests declare the same `destination`
+//! with the same `url`: a destination the new manifest no longer declares is a
+//! deleted file, and a changed `url` at the same destination is a changed one.
+//!
+//! `sha256` is deliberately not part of the predicate. `download::usable_existing`
+//! re-verifies every carried file against the new manifest's hash at provision
+//! time and re-downloads on mismatch, so a stale hash cannot survive; checking
+//! it here would only duplicate that.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use super_stt_registry_types::manifest::Manifest;
+use tokio::fs;
+
+/// Map every declared file destination to its download URL.
+fn declared(m: &Manifest) -> HashMap<&str, &str> {
+    m.models
+        .iter()
+        .flat_map(|model| &model.files)
+        .map(|f| (f.destination.as_str(), f.url.as_str()))
+        .collect()
+}
+
+/// Destinations declared by both manifests with the same URL, sorted so the
+/// result is stable for logging and tests.
+///
+/// Every destination is validated as a safe relative path by `Manifest::parse`,
+/// so callers may join these onto a directory without escaping it.
+#[must_use]
+pub fn survivors(old: &Manifest, new: &Manifest) -> Vec<String> {
+    let old_files = declared(old);
+    let mut out: Vec<String> = declared(new)
+        .into_iter()
+        .filter(|(dest, url)| old_files.get(dest) == Some(url))
+        .map(|(dest, _)| dest.to_string())
+        .collect();
+    out.sort();
+    out
+}
+
+/// Move each of `destinations` from `from_dir` into `to_dir`, returning the
+/// total bytes moved.
+///
+/// A destination missing under `from_dir` is skipped, and one that already
+/// exists under `to_dir` is left alone — the staged copy is the newer one.
+/// Both directories live under the backends directory, so these are
+/// same-filesystem renames: constant-time, with no multi-gigabyte copy.
+///
+/// # Errors
+/// Returns an `io::Error` if a directory cannot be created or a rename fails.
+pub async fn carry(
+    from_dir: &Path,
+    to_dir: &Path,
+    destinations: &[String],
+) -> std::io::Result<u64> {
+    let mut moved = 0u64;
+    for dest in destinations {
+        let src = from_dir.join(dest);
+        let dst = to_dir.join(dest);
+        let Ok(meta) = fs::metadata(&src).await else {
+            continue;
+        };
+        if fs::metadata(&dst).await.is_ok() {
+            continue;
+        }
+        if let Some(parent) = dst.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::rename(&src, &dst).await?;
+        moved += meta.len();
+    }
+    Ok(moved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{carry, survivors};
+    use super_stt_registry_types::manifest::Manifest;
+
+    fn manifest_with(files: &[(&str, &str)]) -> Manifest {
+        let entries = files
+            .iter()
+            .map(|(url, dest)| format!("{{ url = \"{url}\", destination = \"{dest}\" }}"))
+            .collect::<Vec<_>>()
+            .join(",\n            ");
+        let text = format!(
+            r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "1.0.0"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    license    = "Apache-2.0"
+    description = "Test backend."
+
+[[assets.subprocess]]
+    file   = "y.tar.gz"
+    target = "x86_64-unknown-linux-gnu"
+    accel  = ["cpu"]
+
+[[models]]
+    name               = "m"
+    primary_language   = "en"
+    supported_languages = ["en"]
+    supported_devices  = ["cpu"]
+    files = [
+            {entries}
+    ]
+"#
+        );
+        Manifest::parse(&text).expect("fixture manifest parses")
+    }
+
+    #[test]
+    fn an_unchanged_url_at_the_same_destination_survives() {
+        let old = manifest_with(&[("https://h/a.bin", "models/m/a.bin")]);
+        let new = manifest_with(&[("https://h/a.bin", "models/m/a.bin")]);
+        assert_eq!(survivors(&old, &new), vec!["models/m/a.bin".to_string()]);
+    }
+
+    #[test]
+    fn a_changed_url_does_not_survive() {
+        let old = manifest_with(&[("https://h/a.bin", "models/m/a.bin")]);
+        let new = manifest_with(&[("https://h/a-v2.bin", "models/m/a.bin")]);
+        assert!(survivors(&old, &new).is_empty());
+    }
+
+    #[test]
+    fn a_destination_the_new_manifest_drops_does_not_survive() {
+        let old = manifest_with(&[("https://h/a.bin", "models/m/a.bin")]);
+        let new = manifest_with(&[("https://h/b.bin", "models/m/b.bin")]);
+        assert!(survivors(&old, &new).is_empty());
+    }
+
+    #[tokio::test]
+    async fn carry_moves_only_what_is_present_and_absent_at_the_destination() {
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+
+        std::fs::create_dir_all(from.path().join("models/m")).unwrap();
+        std::fs::write(from.path().join("models/m/a.bin"), b"aaaa").unwrap();
+        std::fs::write(from.path().join("models/m/b.bin"), b"bb").unwrap();
+        // Already staged: must not be overwritten by the older copy.
+        std::fs::create_dir_all(to.path().join("models/m")).unwrap();
+        std::fs::write(to.path().join("models/m/b.bin"), b"NEW").unwrap();
+
+        let moved = carry(
+            from.path(),
+            to.path(),
+            &[
+                "models/m/a.bin".to_string(),
+                "models/m/b.bin".to_string(),
+                "models/m/missing.bin".to_string(),
+            ],
+        )
+        .await
+        .expect("carry succeeds");
+
+        assert_eq!(moved, 4, "only a.bin's bytes are counted");
+        assert_eq!(
+            std::fs::read(to.path().join("models/m/a.bin")).unwrap(),
+            b"aaaa"
+        );
+        assert_eq!(
+            std::fs::read(to.path().join("models/m/b.bin")).unwrap(),
+            b"NEW",
+            "an existing staged file wins"
+        );
+        assert!(
+            !from.path().join("models/m/a.bin").exists(),
+            "moved, not copied"
+        );
+    }
+}

--- a/super-stt-daemon/src/registry/compat.rs
+++ b/super-stt-daemon/src/registry/compat.rs
@@ -291,6 +291,7 @@ mod tests {
     fn entry(kind: &str, subprocess: Vec<IndexSubprocessAsset>) -> IndexBackend {
         IndexBackend {
             id: "t".into(),
+            backend_id: None,
             source: "x".into(),
             version: "1.0.0".into(),
             tag: "v1.0.0".into(),

--- a/super-stt-daemon/src/registry/index_schema.rs
+++ b/super-stt-daemon/src/registry/index_schema.rs
@@ -63,14 +63,33 @@ pub fn warn_if_client_too_old(index: &Index) {
     }
 }
 
-/// Drop backends whose `id` or `entrypoint` is not a safe path component.
-/// These values become directory names / are joined onto the backends dir
-/// at install time; an absolute or traversing value would escape it. A
-/// well-formed index (the indexer rejects them) never contains such a
-/// backend, so a stray one — e.g. from a poisoned `SUPER_STT_REGISTRY_URL`
-/// — is dropped with a warning rather than failing the whole index.
+/// Sanitize backends fetched from `index.json` before anything downstream
+/// (in particular [`super::install_dir_name`]) can join them onto the
+/// backends directory. These values become directory names / are joined onto
+/// the backends dir at install time; an absolute or traversing value would
+/// escape it. A well-formed index (the indexer rejects them) never contains
+/// such values, so a stray one — e.g. from a poisoned
+/// `SUPER_STT_REGISTRY_URL` — is sanitized here rather than failing the
+/// whole index.
+///
+/// `backend_id` is optional and its absence has a well-defined meaning (fall
+/// back to the registry key), so an unsafe value is cleared to `None` rather
+/// than dropping the backend over it. `id` and `entrypoint` are required and
+/// have no such fallback, so an entry with an unsafe one of those is dropped
+/// outright, same as before this function also looked at `backend_id`.
 pub fn retain_safe_backends(index: &mut Index) {
     use super_stt_shared::registry::{is_safe_component, is_safe_relative_path};
+    for b in &mut index.backends {
+        if let Some(id) = b.backend_id.as_deref()
+            && !is_safe_component(id)
+        {
+            log::warn!(
+                "registry: clearing backend `{}` unsafe backend_id {id:?}",
+                b.id
+            );
+            b.backend_id = None;
+        }
+    }
     index.backends.retain(|b| {
         let ok = is_safe_component(&b.id) && is_safe_relative_path(&b.entrypoint);
         if !ok {
@@ -227,6 +246,86 @@ mod tests {
             check_min_client(CLIENT_VERSION, "0.1.0"),
             MinClientStatus::Compatible
         );
+    }
+
+    /// A minimal-but-safe backend entry, for exercising `retain_safe_backends`
+    /// without constructing the full field list every time.
+    fn safe_backend(id: &str, backend_id: Option<&str>) -> IndexBackend {
+        IndexBackend {
+            id: id.into(),
+            backend_id: backend_id.map(String::from),
+            source: "github.com/x/y".into(),
+            version: "1.0.0".into(),
+            tag: "v1.0.0".into(),
+            name: "X".into(),
+            description: None,
+            license: String::new(),
+            kind: "subprocess".into(),
+            contract: "v1".into(),
+            entrypoint: "x".into(),
+            allowed_hosts: vec![],
+            online: false,
+            supports_gpu: false,
+            supports_cpu: true,
+            models: vec![],
+            secrets: vec![],
+            options: vec![],
+            assets: IndexAssets::default(),
+            index_stale: None,
+            manifest: None,
+        }
+    }
+
+    /// `backend_id` arrives over the network via `index.json`. An unsafe value
+    /// (here, path traversal) must not survive to reach the install pipeline —
+    /// but the entry itself, whose required `id`/`entrypoint` are fine, must
+    /// not be dropped over it: the field is optional and clearing it just
+    /// falls back to the registry key.
+    #[test]
+    fn retain_safe_backends_clears_an_unsafe_backend_id_but_keeps_the_entry() {
+        let mut index = Index {
+            schema_version: 1,
+            generated_at: "now".into(),
+            min_client: "0.1.0".into(),
+            backends: vec![safe_backend("voxtral", Some("../../../../home/jorge/.ssh"))],
+        };
+        retain_safe_backends(&mut index);
+        assert_eq!(index.backends.len(), 1, "the entry itself must survive");
+        assert_eq!(index.backends[0].id, "voxtral");
+        assert!(
+            index.backends[0].backend_id.is_none(),
+            "an unsafe backend_id must be cleared, not passed through"
+        );
+    }
+
+    #[test]
+    fn retain_safe_backends_keeps_a_safe_backend_id() {
+        let mut index = Index {
+            schema_version: 1,
+            generated_at: "now".into(),
+            min_client: "0.1.0".into(),
+            backends: vec![safe_backend("voxtral", Some("app.super-stt.voxtral"))],
+        };
+        retain_safe_backends(&mut index);
+        assert_eq!(
+            index.backends[0].backend_id.as_deref(),
+            Some("app.super-stt.voxtral")
+        );
+    }
+
+    /// Pre-existing behavior, now under explicit test: an unsafe `id` or
+    /// `entrypoint` drops the whole entry, since `id` is required and has no
+    /// well-defined fallback the way `backend_id` does.
+    #[test]
+    fn retain_safe_backends_still_drops_an_entry_with_an_unsafe_id() {
+        let mut index = Index {
+            schema_version: 1,
+            generated_at: "now".into(),
+            min_client: "0.1.0".into(),
+            backends: vec![safe_backend("../evil", None)],
+        };
+        retain_safe_backends(&mut index);
+        assert!(index.backends.is_empty());
     }
 
     #[test]

--- a/super-stt-daemon/src/registry/index_schema.rs
+++ b/super-stt-daemon/src/registry/index_schema.rs
@@ -73,18 +73,27 @@ pub fn warn_if_client_too_old(index: &Index) {
 /// whole index.
 ///
 /// `backend_id` is optional and its absence has a well-defined meaning (fall
-/// back to the registry key), so an unsafe value is cleared to `None` rather
+/// back to the registry key), so a rejected value is cleared to `None` rather
 /// than dropping the backend over it. `id` and `entrypoint` are required and
 /// have no such fallback, so an entry with an unsafe one of those is dropped
-/// outright, same as before this function also looked at `backend_id`.
+/// outright.
+///
+/// `backend_id` is held to the full `[backend].id` format rule
+/// ([`super_stt_registry_types::backend_id::is_valid`]) rather than to
+/// `is_safe_component`. Every other route into an install directory name goes
+/// through `Manifest::parse`, which enforces exactly that rule, so a looser
+/// check here would make `index.json` the one input the daemon accepts below
+/// its own contract. `.staging` shows why that matters: it is a legal path
+/// component, so a component-level check passes it, but it names the shared
+/// staging root every install stages through.
 pub fn retain_safe_backends(index: &mut Index) {
     use super_stt_shared::registry::{is_safe_component, is_safe_relative_path};
     for b in &mut index.backends {
         if let Some(id) = b.backend_id.as_deref()
-            && !is_safe_component(id)
+            && !super_stt_registry_types::backend_id::is_valid(id)
         {
             log::warn!(
-                "registry: clearing backend `{}` unsafe backend_id {id:?}",
+                "registry: clearing backend `{}` malformed backend_id {id:?}",
                 b.id
             );
             b.backend_id = None;
@@ -296,6 +305,52 @@ mod tests {
             index.backends[0].backend_id.is_none(),
             "an unsafe backend_id must be cleared, not passed through"
         );
+    }
+
+    /// `.staging` passes a component-level safety check but names the shared
+    /// staging root every install stages through, so an index that published
+    /// it would resolve an install directory onto that root. The boundary
+    /// holds `backend_id` to the `[backend].id` format rule, which rejects
+    /// it — and the entry itself still survives, falling back to its
+    /// registry key.
+    #[test]
+    fn retain_safe_backends_clears_the_shared_staging_root_as_a_backend_id() {
+        assert!(
+            super_stt_shared::registry::is_safe_component(".staging"),
+            "the premise: a component-level check accepts .staging"
+        );
+        let mut index = Index {
+            schema_version: 1,
+            generated_at: "now".into(),
+            min_client: "0.1.0".into(),
+            backends: vec![safe_backend("voxtral", Some(".staging"))],
+        };
+        retain_safe_backends(&mut index);
+        assert_eq!(index.backends.len(), 1, "the entry itself must survive");
+        assert!(
+            index.backends[0].backend_id.is_none(),
+            ".staging must never reach the install pipeline as a directory name"
+        );
+    }
+
+    /// Every other route into an install directory name goes through
+    /// `Manifest::parse`, which enforces the `[backend].id` format. This
+    /// boundary must not be more lenient than the daemon's own contract.
+    #[test]
+    fn retain_safe_backends_clears_a_malformed_backend_id() {
+        for malformed in ["voxtral", "app.voxtral", "app.super_stt.voxtral", "APP.X.Y"] {
+            let mut index = Index {
+                schema_version: 1,
+                generated_at: "now".into(),
+                min_client: "0.1.0".into(),
+                backends: vec![safe_backend("voxtral", Some(malformed))],
+            };
+            retain_safe_backends(&mut index);
+            assert!(
+                index.backends[0].backend_id.is_none(),
+                "malformed backend_id {malformed:?} must be cleared"
+            );
+        }
     }
 
     #[test]

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -158,7 +158,10 @@ where
     let final_path = p
         .backends_dir
         .join(crate::registry::install_dir_name(entry));
-    preserve_models(&staging, &final_path)
+    let inherit_from = previous_dir_for(&p.backends_dir, &entry.source)
+        .await
+        .unwrap_or_else(|| final_path.clone());
+    preserve_models(&staging, &inherit_from)
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
     swap_into_place(&staging, &final_path)
@@ -294,7 +297,10 @@ where
     let final_path = p
         .backends_dir
         .join(crate::registry::install_dir_name(entry));
-    preserve_models(&staging, &final_path)
+    let inherit_from = previous_dir_for(&p.backends_dir, &entry.source)
+        .await
+        .unwrap_or_else(|| final_path.clone());
+    preserve_models(&staging, &inherit_from)
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
     swap_into_place(&staging, &final_path)
@@ -401,6 +407,69 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// The directory currently serving `source`, if any — the one whose model
+/// files a migrating install should inherit. Equals `final_path` for an
+/// ordinary in-place update, where `final_path` is itself the directory
+/// already serving `source`.
+async fn previous_dir_for(backends_dir: &Path, source: &str) -> Option<PathBuf> {
+    use super_stt_registry_types::manifest::Manifest;
+
+    let mut entries = tokio::fs::read_dir(backends_dir).await.ok()?;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        if Manifest::load(&dir).is_ok_and(|m| m.backend.source == source) {
+            return Some(dir);
+        }
+    }
+    None
+}
+
+/// Remove the directory that used to serve `source`, when the install just
+/// landed somewhere else (a migration).
+///
+/// Called only after a successful swap, so the backend is already being
+/// served from `keep` and removing the predecessor cannot take the last copy.
+/// Returns the path removed, or `None` when there was nothing to retire.
+///
+/// A directory whose manifest will not parse is never a candidate: without a
+/// readable `source` there is no evidence it is the same backend.
+pub async fn retire_previous_dir(
+    backends_dir: &Path,
+    source: &str,
+    keep: &Path,
+) -> Option<PathBuf> {
+    use super_stt_registry_types::manifest::Manifest;
+
+    let mut entries = tokio::fs::read_dir(backends_dir).await.ok()?;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let dir = entry.path();
+        if dir == keep || !dir.is_dir() {
+            continue;
+        }
+        let Ok(installed) = Manifest::load(&dir) else {
+            continue;
+        };
+        if installed.backend.source != source {
+            continue;
+        }
+        match tokio::fs::remove_dir_all(&dir).await {
+            Ok(()) => {
+                log::info!(
+                    "Retired {} after installing {source} into {}",
+                    dir.display(),
+                    keep.display()
+                );
+                return Some(dir);
+            }
+            Err(e) => log::error!("Failed to retire {}: {e}", dir.display()),
+        }
+    }
+    None
 }
 
 /// Move model files that survive the replacement from the installed directory
@@ -1176,6 +1245,184 @@ supported_devices = ["cpu"]
             "the old file must stay put so the daemon re-downloads the new URL"
         );
         assert!(!staging.join("models/m/a.bin").exists());
+    }
+
+    #[tokio::test]
+    async fn retire_previous_dir_removes_the_superseded_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let old = root.path().join("super-stt-voxtral");
+        let new = root.path().join("app.super-stt.voxtral");
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::create_dir_all(&new).unwrap();
+        std::fs::write(
+            old.join("backend.toml"),
+            r#"
+[backend]
+source = "github.com/x/super-stt-voxtral"
+name = "Voxtral"
+version = "1.0.0"
+kind = "subprocess"
+entrypoint = "voxtral"
+contract = "v1"
+description = "Test backend."
+"#,
+        )
+        .unwrap();
+
+        let removed =
+            super::retire_previous_dir(root.path(), "github.com/x/super-stt-voxtral", &new).await;
+
+        assert_eq!(removed.as_deref(), Some(old.as_path()));
+        assert!(!old.exists(), "the superseded directory is gone");
+        assert!(new.exists(), "the new directory survives");
+    }
+
+    #[tokio::test]
+    async fn retire_previous_dir_never_removes_the_directory_it_was_told_to_keep() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("app.super-stt.voxtral");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("backend.toml"),
+            r#"
+[backend]
+source = "github.com/x/super-stt-voxtral"
+name = "Voxtral"
+version = "1.0.0"
+kind = "subprocess"
+entrypoint = "voxtral"
+contract = "v1"
+description = "Test backend."
+"#,
+        )
+        .unwrap();
+
+        let removed =
+            super::retire_previous_dir(root.path(), "github.com/x/super-stt-voxtral", &dir).await;
+
+        assert!(removed.is_none());
+        assert!(dir.exists());
+    }
+
+    /// A directory whose manifest fails to parse carries no evidence it is the
+    /// same backend, so it must never be treated as a retirement candidate —
+    /// even if it happens to sit alongside `keep` and nothing else claims the
+    /// source.
+    #[tokio::test]
+    async fn retire_previous_dir_skips_a_directory_whose_manifest_does_not_parse() {
+        let root = tempfile::tempdir().unwrap();
+        let unparseable = root.path().join("mystery-dir");
+        let keep = root.path().join("app.super-stt.voxtral");
+        std::fs::create_dir_all(&unparseable).unwrap();
+        std::fs::create_dir_all(&keep).unwrap();
+        std::fs::write(unparseable.join("backend.toml"), "this is not toml = = =").unwrap();
+
+        let removed =
+            super::retire_previous_dir(root.path(), "github.com/x/super-stt-voxtral", &keep).await;
+
+        assert!(removed.is_none());
+        assert!(
+            unparseable.exists(),
+            "a directory with an unparseable manifest must never be retired"
+        );
+    }
+
+    #[tokio::test]
+    async fn previous_dir_for_finds_the_directory_serving_a_source() {
+        let root = tempfile::tempdir().unwrap();
+        let old = root.path().join("super-stt-voxtral");
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::write(
+            old.join("backend.toml"),
+            r#"
+[backend]
+source = "github.com/x/super-stt-voxtral"
+name = "Voxtral"
+version = "1.0.0"
+kind = "subprocess"
+entrypoint = "voxtral"
+contract = "v1"
+description = "Test backend."
+"#,
+        )
+        .unwrap();
+
+        let found = super::previous_dir_for(root.path(), "github.com/x/super-stt-voxtral").await;
+
+        assert_eq!(found.as_deref(), Some(old.as_path()));
+    }
+
+    #[tokio::test]
+    async fn previous_dir_for_is_none_when_no_directory_serves_the_source() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("something-else")).unwrap();
+
+        let found = super::previous_dir_for(root.path(), "github.com/x/super-stt-voxtral").await;
+
+        assert!(found.is_none());
+    }
+
+    /// The 8.8 GB case: a migration where `final_path` does not exist yet must
+    /// still carry the old directory's unchanged model files into staging, by
+    /// resolving the inherit-from directory through `previous_dir_for` rather
+    /// than comparing straight against `final_path`.
+    #[tokio::test]
+    async fn a_migration_preserves_model_files_via_previous_dir_for() {
+        let root = tempfile::tempdir().unwrap();
+        let old_dir = root.path().join("super-stt-voxtral");
+        let staging = root.path().join(".staging/app.super-stt.voxtral-1.0.1");
+        let final_path = root.path().join("app.super-stt.voxtral");
+        std::fs::create_dir_all(old_dir.join("models/m")).unwrap();
+        std::fs::create_dir_all(&staging).unwrap();
+        assert!(!final_path.exists(), "final_path must not exist yet");
+
+        let toml = |version: &str| {
+            format!(
+                r#"
+[backend]
+    source     = "github.com/x/voxtral"
+    name       = "Voxtral"
+    version    = "{version}"
+    kind       = "subprocess"
+    entrypoint = "voxtral"
+    contract   = "v1"
+    license    = "Apache-2.0"
+    description = "Test backend."
+
+[[assets.subprocess]]
+    file   = "voxtral.tar.gz"
+    target = "x86_64-unknown-linux-gnu"
+    accel  = ["cpu"]
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+    files = [
+        {{ url = "https://h/a.bin", destination = "models/m/a.bin" }},
+    ]
+"#
+            )
+        };
+        std::fs::write(old_dir.join("backend.toml"), toml("1.0.0")).unwrap();
+        std::fs::write(staging.join("backend.toml"), toml("1.0.1")).unwrap();
+        std::fs::write(old_dir.join("models/m/a.bin"), b"weights").unwrap();
+
+        let inherit_from = super::previous_dir_for(root.path(), "github.com/x/voxtral")
+            .await
+            .unwrap_or_else(|| final_path.clone());
+        assert_eq!(inherit_from, old_dir, "must inherit from the old directory");
+
+        let moved = super::preserve_models(&staging, &inherit_from)
+            .await
+            .unwrap();
+
+        assert_eq!(moved, 7);
+        assert!(
+            staging.join("models/m/a.bin").exists(),
+            "the model file must survive the migration"
+        );
     }
 
     #[tokio::test]

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -23,6 +23,14 @@ use super_stt_registry_types::verify::{
 const MAX_DOWNLOAD_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 /// Slack allowed over a declared asset size before a download is rejected.
 const DOWNLOAD_SIZE_MARGIN: u64 = 1024 * 1024;
+/// The name of the shared staging root every install/update stages into
+/// before the atomic swap: `<backends_dir>/.staging/<id>-<version>`. It is
+/// a direct child of `backends_dir`, exactly like a backend's own install
+/// directory, but it is never one itself — a directory scan over
+/// `backends_dir` must always skip it explicitly rather than rely on its
+/// manifest lookup happening to fail one level too shallow.
+const STAGING_DIR_NAME: &str = ".staging";
+
 /// The byte ceiling for a download given the index-declared `expected_size`
 /// (0 when unknown).
 fn download_cap(expected_size: u64) -> u64 {
@@ -114,7 +122,7 @@ where
     download_and_verify(p, entry, selection, &partial_path).await?;
 
     (p.on_progress)(P::Extracting, None);
-    let staging = p.backends_dir.join(".staging").join(format!(
+    let staging = p.backends_dir.join(STAGING_DIR_NAME).join(format!(
         "{}-{}",
         crate::registry::install_dir_name(entry),
         entry.version
@@ -269,7 +277,7 @@ where
 
     (p.on_progress)(P::Resolving, None);
 
-    let staging = p.backends_dir.join(".staging").join(format!(
+    let staging = p.backends_dir.join(STAGING_DIR_NAME).join(format!(
         "{}-{}",
         crate::registry::install_dir_name(entry),
         entry.version
@@ -409,17 +417,35 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// The directory currently serving `source`, if any — the one whose model
-/// files a migrating install should inherit. Equals `final_path` for an
-/// ordinary in-place update, where `final_path` is itself the directory
-/// already serving `source`.
-async fn previous_dir_for(backends_dir: &Path, source: &str) -> Option<PathBuf> {
+/// Scan the immediate children of `backends_dir` for the one whose manifest
+/// declares `source`, skipping `exclude` (when given) and always skipping
+/// [`STAGING_DIR_NAME`].
+///
+/// The `.staging` skip is an explicit rule, not an accident of directory
+/// depth: a real staged install's manifest lives one level *deeper*
+/// (`.staging/<id>-<version>/backend.toml`), so a naive scan happens to be
+/// safe today only because `Manifest::load(backends_dir/.staging)` fails.
+/// Callers that only read (like this one) would silently no-op if that
+/// stopped being true; [`retire_previous_dir`], which calls `remove_dir_all`
+/// on what this returns, would destroy the shared staging root instead. One
+/// scan with one skip rule means there is nowhere for the two to drift apart.
+///
+/// A directory whose manifest will not parse is never a match: without a
+/// readable `source` there is no evidence it is the same backend.
+async fn find_serving(
+    backends_dir: &Path,
+    source: &str,
+    exclude: Option<&Path>,
+) -> Option<PathBuf> {
     use super_stt_registry_types::manifest::Manifest;
 
     let mut entries = tokio::fs::read_dir(backends_dir).await.ok()?;
     while let Ok(Some(entry)) = entries.next_entry().await {
         let dir = entry.path();
-        if !dir.is_dir() {
+        if dir.file_name().is_some_and(|n| n == STAGING_DIR_NAME) {
+            continue;
+        }
+        if exclude.is_some_and(|e| dir == e) || !dir.is_dir() {
             continue;
         }
         if Manifest::load(&dir).is_ok_and(|m| m.backend.source == source) {
@@ -429,47 +455,40 @@ async fn previous_dir_for(backends_dir: &Path, source: &str) -> Option<PathBuf> 
     None
 }
 
+/// The directory currently serving `source`, if any — the one whose model
+/// files a migrating install should inherit. Equals `final_path` for an
+/// ordinary in-place update, where `final_path` is itself the directory
+/// already serving `source`.
+async fn previous_dir_for(backends_dir: &Path, source: &str) -> Option<PathBuf> {
+    find_serving(backends_dir, source, None).await
+}
+
 /// Remove the directory that used to serve `source`, when the install just
 /// landed somewhere else (a migration).
 ///
 /// Called only after a successful swap, so the backend is already being
 /// served from `keep` and removing the predecessor cannot take the last copy.
 /// Returns the path removed, or `None` when there was nothing to retire.
-///
-/// A directory whose manifest will not parse is never a candidate: without a
-/// readable `source` there is no evidence it is the same backend.
 pub async fn retire_previous_dir(
     backends_dir: &Path,
     source: &str,
     keep: &Path,
 ) -> Option<PathBuf> {
-    use super_stt_registry_types::manifest::Manifest;
-
-    let mut entries = tokio::fs::read_dir(backends_dir).await.ok()?;
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        let dir = entry.path();
-        if dir == keep || !dir.is_dir() {
-            continue;
+    let dir = find_serving(backends_dir, source, Some(keep)).await?;
+    match tokio::fs::remove_dir_all(&dir).await {
+        Ok(()) => {
+            log::info!(
+                "Retired {} after installing {source} into {}",
+                dir.display(),
+                keep.display()
+            );
+            Some(dir)
         }
-        let Ok(installed) = Manifest::load(&dir) else {
-            continue;
-        };
-        if installed.backend.source != source {
-            continue;
-        }
-        match tokio::fs::remove_dir_all(&dir).await {
-            Ok(()) => {
-                log::info!(
-                    "Retired {} after installing {source} into {}",
-                    dir.display(),
-                    keep.display()
-                );
-                return Some(dir);
-            }
-            Err(e) => log::error!("Failed to retire {}: {e}", dir.display()),
+        Err(e) => {
+            log::error!("Failed to retire {}: {e}", dir.display());
+            None
         }
     }
-    None
 }
 
 /// Move model files that survive the replacement from the installed directory
@@ -1362,6 +1381,53 @@ description = "Test backend."
         assert!(found.is_none());
     }
 
+    /// `.staging` (the shared root every install/update stages into) sits one
+    /// level inside `backends_dir`, exactly where a real backend directory
+    /// would. Both scans are safe today only because a real staged install's
+    /// manifest lives one level *deeper* (`.staging/<id>-<version>/backend.toml`),
+    /// so a plain `Manifest::load(backends_dir/.staging)` fails. Nothing
+    /// enforces that shape, so this proves `.staging` is skipped by an
+    /// explicit rule rather than by accident — a manifest ever placed one
+    /// level shallower (a bug, a manual recovery) must never turn into
+    /// `retire_previous_dir` calling `remove_dir_all` on the shared staging
+    /// root out from under every in-flight install.
+    #[tokio::test]
+    async fn the_staging_root_is_never_matched_as_a_backend_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let staging_root = root.path().join(super::STAGING_DIR_NAME);
+        std::fs::create_dir_all(&staging_root).unwrap();
+        std::fs::write(
+            staging_root.join("backend.toml"),
+            r#"
+[backend]
+source = "github.com/x/super-stt-voxtral"
+name = "Voxtral"
+version = "1.0.0"
+kind = "subprocess"
+entrypoint = "voxtral"
+contract = "v1"
+description = "Test backend."
+"#,
+        )
+        .unwrap();
+        let keep = root.path().join("app.super-stt.voxtral");
+        std::fs::create_dir_all(&keep).unwrap();
+
+        let found = super::previous_dir_for(root.path(), "github.com/x/super-stt-voxtral").await;
+        assert!(
+            found.is_none(),
+            ".staging must never be matched as a backend directory"
+        );
+
+        let removed =
+            super::retire_previous_dir(root.path(), "github.com/x/super-stt-voxtral", &keep).await;
+        assert!(removed.is_none());
+        assert!(
+            staging_root.exists(),
+            "the shared staging root must never be removed"
+        );
+    }
+
     /// The 8.8 GB case: a migration where `final_path` does not exist yet must
     /// still carry the old directory's unchanged model files into staging, by
     /// resolving the inherit-from directory through `previous_dir_for` rather
@@ -1422,6 +1488,11 @@ description = "Test backend."
         assert!(
             staging.join("models/m/a.bin").exists(),
             "the model file must survive the migration"
+        );
+        assert_eq!(
+            std::fs::read(staging.join("models/m/a.bin")).unwrap(),
+            b"weights",
+            "the carried file's bytes, not just its existence, must survive"
         );
     }
 

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -765,6 +765,7 @@ supported_devices = ["cpu"]
     fn minimal_entry() -> IndexBackend {
         IndexBackend {
             id: "x".into(),
+            backend_id: None,
             source: "github.com/x/y".into(),
             version: "1.0.0".into(),
             tag: "v1.0.0".into(),

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -114,10 +114,11 @@ where
     download_and_verify(p, entry, selection, &partial_path).await?;
 
     (p.on_progress)(P::Extracting, None);
-    let staging = p
-        .backends_dir
-        .join(".staging")
-        .join(format!("{}-{}", entry.id, entry.version));
+    let staging = p.backends_dir.join(".staging").join(format!(
+        "{}-{}",
+        crate::registry::install_dir_name(entry),
+        entry.version
+    ));
     if staging.exists() {
         let _ = fs::remove_dir_all(&staging).await;
     }
@@ -154,7 +155,9 @@ where
     }
 
     (p.on_progress)(P::Installing, None);
-    let final_path = p.backends_dir.join(&entry.id);
+    let final_path = p
+        .backends_dir
+        .join(crate::registry::install_dir_name(entry));
     preserve_models(&staging, &final_path)
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
@@ -263,10 +266,11 @@ where
 
     (p.on_progress)(P::Resolving, None);
 
-    let staging = p
-        .backends_dir
-        .join(".staging")
-        .join(format!("{}-{}", entry.id, entry.version));
+    let staging = p.backends_dir.join(".staging").join(format!(
+        "{}-{}",
+        crate::registry::install_dir_name(entry),
+        entry.version
+    ));
     if staging.exists() {
         let _ = fs::remove_dir_all(&staging).await;
     }
@@ -287,7 +291,9 @@ where
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
 
     (p.on_progress)(P::Installing, None);
-    let final_path = p.backends_dir.join(&entry.id);
+    let final_path = p
+        .backends_dir
+        .join(crate::registry::install_dir_name(entry));
     preserve_models(&staging, &final_path)
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
@@ -754,6 +760,7 @@ async fn download_manifest_bytes(
 mod tests {
     use super::*;
     use crate::registry::index_schema::*;
+    use crate::registry::install_dir_name;
 
     const PINNED_MANIFEST: &str = r#"
 [backend]
@@ -835,6 +842,64 @@ supported_devices = ["cpu"]
             assets: IndexAssets::default(),
             index_stale: None,
             manifest: None,
+        }
+    }
+
+    fn index_entry(id: &str, backend_id: Option<&str>) -> IndexBackend {
+        let mut e = minimal_entry();
+        e.id = id.to_string();
+        e.backend_id = backend_id.map(str::to_string);
+        e
+    }
+
+    #[test]
+    fn the_install_dir_is_the_backend_id_when_one_is_declared() {
+        let e = index_entry("voxtral", Some("app.super-stt.voxtral"));
+        assert_eq!(install_dir_name(&e), "app.super-stt.voxtral");
+    }
+
+    #[test]
+    fn the_install_dir_falls_back_to_the_registry_key() {
+        let e = index_entry("voxtral", None);
+        assert_eq!(install_dir_name(&e), "voxtral");
+    }
+
+    /// `backend_id` arrives from `index.json` over the network. Even if the
+    /// registry-client boundary (`retain_safe_backends`) failed to sanitize
+    /// it, `install_dir_name` must never hand back a value that would let the
+    /// caller's `backends_dir.join(...)` escape the backends directory.
+    #[test]
+    fn install_dir_name_falls_back_when_backend_id_is_unsafe() {
+        for unsafe_id in [
+            "..",
+            "../../../../home/jorge/.ssh",
+            "/etc/passwd",
+            "a/b",
+            "",
+        ] {
+            let e = index_entry("voxtral", Some(unsafe_id));
+            assert_eq!(
+                install_dir_name(&e),
+                "voxtral",
+                "unsafe backend_id {unsafe_id:?} must not be used"
+            );
+        }
+    }
+
+    /// The same traversal cases, but proving the property that actually
+    /// matters: joining the returned name onto the backends dir never
+    /// produces a path outside it.
+    #[test]
+    fn install_dir_name_never_escapes_the_backends_dir_when_joined() {
+        let backends_dir = Path::new("/var/lib/super-stt/backends");
+        for unsafe_id in ["..", "../../../../home/jorge/.ssh", "/etc/passwd", "a/b"] {
+            let e = index_entry("voxtral", Some(unsafe_id));
+            let joined = backends_dir.join(install_dir_name(&e));
+            assert!(
+                joined.starts_with(backends_dir),
+                "backend_id {unsafe_id:?} escaped: {}",
+                joined.display()
+            );
         }
     }
 

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -407,6 +407,21 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
 /// A missing or unparseable manifest on either side carries nothing: without
 /// both file lists there is no way to tell an unchanged file from a changed
 /// one, and re-downloading is the safe answer.
+///
+/// `carry_over::carry` moves files one at a time with no rollback, so an I/O
+/// error partway through (e.g. file 3 of 5) aborts this function — and the
+/// install, before the swap — with files 1–2 already moved out of
+/// `final_path` and into `staging`. The live directory at `final_path` keeps
+/// serving but is now missing those files; the next model load re-downloads
+/// them via `usable_existing`'s hash check, so nothing wrong is ever served.
+///
+/// The one gap that safety net does not cover: `run`/`run_local` unconditionally
+/// wipe a stale `.staging/<id>-<version>` directory before reusing it, so an
+/// ordinary "retry the same version" after a partial failure destroys the
+/// very files this function already carried into it — a maintainer sees the
+/// update "succeed" having silently re-downloaded weights it should have
+/// preserved. This is a known, accepted gap (end state is still correct
+/// content), not a bug to fix here.
 async fn preserve_models(staging: &Path, final_path: &Path) -> std::io::Result<u64> {
     use super_stt_registry_types::manifest::Manifest;
 

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -155,6 +155,9 @@ where
 
     (p.on_progress)(P::Installing, None);
     let final_path = p.backends_dir.join(&entry.id);
+    preserve_models(&staging, &final_path)
+        .await
+        .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
     swap_into_place(&staging, &final_path)
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
@@ -285,6 +288,9 @@ where
 
     (p.on_progress)(P::Installing, None);
     let final_path = p.backends_dir.join(&entry.id);
+    preserve_models(&staging, &final_path)
+        .await
+        .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
     swap_into_place(&staging, &final_path)
         .await
         .map_err(|e| PipelineError::Io(e).as_typed(P::Installing))?;
@@ -389,6 +395,35 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Move model files that survive the replacement from the installed directory
+/// into `staging`, returning the bytes moved.
+///
+/// Runs before the swap so the directory that lands is already complete and
+/// the swap stays atomic. Both paths live under the backends directory, so the
+/// moves are same-filesystem renames rather than multi-gigabyte copies.
+///
+/// A missing or unparseable manifest on either side carries nothing: without
+/// both file lists there is no way to tell an unchanged file from a changed
+/// one, and re-downloading is the safe answer.
+async fn preserve_models(staging: &Path, final_path: &Path) -> std::io::Result<u64> {
+    use super_stt_registry_types::manifest::Manifest;
+
+    let (Ok(old), Ok(new)) = (Manifest::load(final_path), Manifest::load(staging)) else {
+        return Ok(0);
+    };
+    let keep = crate::registry::carry_over::survivors(&old, &new);
+    if keep.is_empty() {
+        return Ok(0);
+    }
+    let moved = crate::registry::carry_over::carry(final_path, staging, &keep).await?;
+    log::info!(
+        "Preserved {} model file(s) ({moved} bytes) across the update of {}",
+        keep.len(),
+        final_path.display()
+    );
+    Ok(moved)
 }
 
 /// Move `staging` into `final_path` as atomically as the filesystem allows:
@@ -939,6 +974,128 @@ supported_devices = ["cpu"]
         let err =
             copy_staged_backend(src.path(), &dst.path().join("out"), "wasm", "y.wasm").unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    /// Defect 2: replacing a backend directory took its downloaded weights
+    /// with it. The staged manifest declares the same file at the same URL, so
+    /// the bytes move across instead of re-downloading.
+    #[tokio::test]
+    async fn preserve_models_moves_unchanged_weights_into_staging() {
+        let root = tempfile::tempdir().unwrap();
+        let staging = root.path().join(".staging/y-1.0.1");
+        let final_path = root.path().join("y");
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::create_dir_all(final_path.join("models/m")).unwrap();
+
+        let toml = |version: &str| {
+            format!(
+                r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "{version}"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    license    = "Apache-2.0"
+    description = "Test backend."
+
+[[assets.subprocess]]
+    file   = "y.tar.gz"
+    target = "x86_64-unknown-linux-gnu"
+    accel  = ["cpu"]
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+    files = [
+        {{ url = "https://h/a.bin", destination = "models/m/a.bin" }},
+    ]
+"#
+            )
+        };
+        std::fs::write(final_path.join("backend.toml"), toml("1.0.0")).unwrap();
+        std::fs::write(staging.join("backend.toml"), toml("1.0.1")).unwrap();
+        std::fs::write(final_path.join("models/m/a.bin"), b"weights").unwrap();
+
+        let moved = super::preserve_models(&staging, &final_path).await.unwrap();
+        assert_eq!(moved, 7);
+        assert!(staging.join("models/m/a.bin").exists());
+    }
+
+    #[tokio::test]
+    async fn preserve_models_is_a_no_op_without_an_installed_manifest() {
+        let root = tempfile::tempdir().unwrap();
+        let staging = root.path().join("staging");
+        std::fs::create_dir_all(&staging).unwrap();
+        let moved = super::preserve_models(&staging, &root.path().join("absent"))
+            .await
+            .unwrap();
+        assert_eq!(moved, 0);
+    }
+
+    /// The other half of the predicate's contract at this integration layer:
+    /// a file whose `url` changed between the two manifests must be left
+    /// behind under the installed dir, not carried into staging, so the next
+    /// model load re-downloads the new bytes instead of serving stale ones.
+    #[tokio::test]
+    async fn preserve_models_leaves_a_changed_url_behind() {
+        let root = tempfile::tempdir().unwrap();
+        let staging = root.path().join(".staging/y-1.0.1");
+        let final_path = root.path().join("y");
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::create_dir_all(final_path.join("models/m")).unwrap();
+
+        let toml = |version: &str, url: &str| {
+            format!(
+                r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "{version}"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    license    = "Apache-2.0"
+    description = "Test backend."
+
+[[assets.subprocess]]
+    file   = "y.tar.gz"
+    target = "x86_64-unknown-linux-gnu"
+    accel  = ["cpu"]
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+    files = [
+        {{ url = "{url}", destination = "models/m/a.bin" }},
+    ]
+"#
+            )
+        };
+        std::fs::write(
+            final_path.join("backend.toml"),
+            toml("1.0.0", "https://h/a.bin"),
+        )
+        .unwrap();
+        std::fs::write(
+            staging.join("backend.toml"),
+            toml("1.0.1", "https://h/a-v2.bin"),
+        )
+        .unwrap();
+        std::fs::write(final_path.join("models/m/a.bin"), b"weights").unwrap();
+
+        let moved = super::preserve_models(&staging, &final_path).await.unwrap();
+        assert_eq!(moved, 0);
+        assert!(
+            final_path.join("models/m/a.bin").exists(),
+            "the old file must stay put so the daemon re-downloads the new URL"
+        );
+        assert!(!staging.join("models/m/a.bin").exists());
     }
 
     #[tokio::test]

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -166,6 +166,11 @@ where
     let final_path = p
         .backends_dir
         .join(crate::registry::install_dir_name(entry));
+    // Before anything else touches the filesystem outside `staging`: the
+    // swap below replaces whatever sits at `final_path`, and `preserve_models`
+    // moves model files out of the directory currently serving this `source`.
+    // Bailing here leaves both of those untouched.
+    ensure_dir_free_for(&final_path, &entry.source)?;
     let inherit_from = previous_dir_for(&p.backends_dir, &entry.source)
         .await
         .unwrap_or_else(|| final_path.clone());
@@ -305,6 +310,11 @@ where
     let final_path = p
         .backends_dir
         .join(crate::registry::install_dir_name(entry));
+    // Before anything else touches the filesystem outside `staging`: the
+    // swap below replaces whatever sits at `final_path`, and `preserve_models`
+    // moves model files out of the directory currently serving this `source`.
+    // Bailing here leaves both of those untouched.
+    ensure_dir_free_for(&final_path, &entry.source)?;
     let inherit_from = previous_dir_for(&p.backends_dir, &entry.source)
         .await
         .unwrap_or_else(|| final_path.clone());
@@ -468,7 +478,12 @@ async fn previous_dir_for(backends_dir: &Path, source: &str) -> Option<PathBuf> 
 ///
 /// Called only after a successful swap, so the backend is already being
 /// served from `keep` and removing the predecessor cannot take the last copy.
-/// Returns the path removed, or `None` when there was nothing to retire.
+///
+/// Returns the predecessor it found, or `None` when there was nothing to
+/// retire. A failed `remove_dir_all` is logged but still reports the
+/// predecessor: `keep` is the live directory either way, so a caller
+/// repointing at it is right regardless, and the directory left behind is a
+/// duplicate that the next refresh reconciles.
 pub async fn retire_previous_dir(
     backends_dir: &Path,
     source: &str,
@@ -476,19 +491,17 @@ pub async fn retire_previous_dir(
 ) -> Option<PathBuf> {
     let dir = find_serving(backends_dir, source, Some(keep)).await?;
     match tokio::fs::remove_dir_all(&dir).await {
-        Ok(()) => {
-            log::info!(
-                "Retired {} after installing {source} into {}",
-                dir.display(),
-                keep.display()
-            );
-            Some(dir)
-        }
-        Err(e) => {
-            log::error!("Failed to retire {}: {e}", dir.display());
-            None
-        }
+        Ok(()) => log::info!(
+            "Retired {} after installing {source} into {}",
+            dir.display(),
+            keep.display()
+        ),
+        Err(e) => log::error!(
+            "Failed to retire {}: {e}; it will be reconciled on a later refresh",
+            dir.display()
+        ),
     }
+    Some(dir)
 }
 
 /// Move model files that survive the replacement from the installed directory
@@ -533,6 +546,49 @@ async fn preserve_models(staging: &Path, final_path: &Path) -> std::io::Result<u
         final_path.display()
     );
     Ok(moved)
+}
+
+/// Refuse to install over a directory that already serves a *different*
+/// backend.
+///
+/// [`crate::registry::install_dir_name`] names `final_path` from the entry's
+/// `backend_id`, and that value is only ever pinned to the backend it claims
+/// to be on part of one route: the registry pins it for an entry whose
+/// `registry.toml` row declares an `id`. A custom repository, a locally
+/// staged directory, and a registry entry that predates the identifier all
+/// publish whatever `[backend].id` their manifest declares — so any of them
+/// can name a directory another backend is already installed in.
+/// [`swap_into_place`] renames whatever sits there aside and deletes it, so
+/// without this check an install could destroy an unrelated backend and the
+/// multi-gigabyte model files under it. `source` is the identity the daemon
+/// resolves backends and models by, so it is what identity is judged on here.
+///
+/// A directory whose manifest does not parse is not a claim of identity and
+/// does not block the install: replacing a half-written or corrupt install is
+/// the ordinary repair path, and refusing it would leave the user with no way
+/// forward.
+///
+/// # Errors
+/// Returns `(Installing, InstallDirConflict)` when `final_path` holds a
+/// manifest declaring a different `source`.
+fn ensure_dir_free_for(
+    final_path: &Path,
+    source: &str,
+) -> Result<(), (InstallPhase, InstallError)> {
+    use super_stt_registry_types::manifest::Manifest;
+
+    let Ok(occupant) = Manifest::load(final_path) else {
+        return Ok(());
+    };
+    if occupant.backend.source == source {
+        return Ok(());
+    }
+    log::error!(
+        "Refusing to install {source} into {}: that directory already serves {}",
+        final_path.display(),
+        occupant.backend.source
+    );
+    Err((InstallPhase::Installing, InstallError::InstallDirConflict))
 }
 
 /// Move `staging` into `final_path` as atomically as the filesystem allows:
@@ -974,6 +1030,45 @@ supported_devices = ["cpu"]
         }
     }
 
+    /// `.staging` is a legal path component, so a component-level safety
+    /// check waves it through — but it names the shared staging root every
+    /// install writes into, and resolving an install directory to it would
+    /// point the swap at every in-flight install at once. `backend_id` is
+    /// therefore held to the full `[backend].id` format rule, which
+    /// `.staging` fails (a leading dot, and one segment).
+    #[test]
+    fn install_dir_name_rejects_the_shared_staging_root() {
+        assert!(
+            super_stt_shared::registry::is_safe_component(".staging"),
+            "the premise: a component-level check accepts .staging"
+        );
+        let e = index_entry("voxtral", Some(".staging"));
+        assert_eq!(install_dir_name(&e), "voxtral");
+    }
+
+    /// More broadly: `index.json` is the only route into an install directory
+    /// name that does not pass through `Manifest::parse`, so it must apply the
+    /// same `[backend].id` rule rather than a looser one.
+    #[test]
+    fn install_dir_name_rejects_a_malformed_backend_id() {
+        for malformed in [
+            ".staging",
+            "voxtral",
+            "app.voxtral",
+            "App.Super-STT.Voxtral",
+            "app.super_stt.voxtral",
+            "app..voxtral",
+            "app.super-stt.voxtral-",
+        ] {
+            let e = index_entry("registry-key", Some(malformed));
+            assert_eq!(
+                install_dir_name(&e),
+                "registry-key",
+                "malformed backend_id {malformed:?} must not name a directory"
+            );
+        }
+    }
+
     /// The same traversal cases, but proving the property that actually
     /// matters: joining the returned name onto the backends dir never
     /// produces a path outside it.
@@ -1264,6 +1359,219 @@ supported_devices = ["cpu"]
             "the old file must stay put so the daemon re-downloads the new URL"
         );
         assert!(!staging.join("models/m/a.bin").exists());
+    }
+
+    /// A backend directory holding `source`, with one downloaded weight file
+    /// under it — the thing an unguarded swap would delete.
+    fn occupied_backend_dir(dir: &Path, source: &str) {
+        std::fs::create_dir_all(dir.join("models/m")).unwrap();
+        std::fs::write(
+            dir.join("backend.toml"),
+            format!(
+                r#"
+[backend]
+source = "{source}"
+name = "Occupant"
+version = "1.0.0"
+kind = "subprocess"
+entrypoint = "occupant"
+contract = "v1"
+description = "Test backend."
+"#
+            ),
+        )
+        .unwrap();
+        std::fs::write(dir.join("models/m/a.bin"), b"expensive weights").unwrap();
+    }
+
+    #[test]
+    fn ensure_dir_free_for_allows_an_update_of_the_same_backend() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("app.super-stt.voxtral");
+        occupied_backend_dir(&dir, "github.com/x/voxtral");
+        ensure_dir_free_for(&dir, "github.com/x/voxtral").expect("same source is an update");
+    }
+
+    /// Replacing a half-written or corrupt install is the ordinary repair
+    /// path: a directory whose manifest does not parse makes no claim of
+    /// identity, so it must not block an install.
+    #[test]
+    fn ensure_dir_free_for_allows_an_unreadable_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("app.super-stt.voxtral");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("backend.toml"), b"this is not toml = = =").unwrap();
+        ensure_dir_free_for(&dir, "github.com/x/voxtral")
+            .expect("a corrupt install is replaceable");
+
+        let empty = root.path().join("brand-new");
+        ensure_dir_free_for(&empty, "github.com/x/voxtral").expect("a fresh install has no dir");
+    }
+
+    #[test]
+    fn ensure_dir_free_for_refuses_a_directory_serving_another_backend() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("app.super-stt.voxtral");
+        occupied_backend_dir(&dir, "github.com/x/voxtral");
+        let err = ensure_dir_free_for(&dir, "github.com/someone/thing").unwrap_err();
+        assert_eq!(err.1, InstallError::InstallDirConflict);
+    }
+
+    /// The whole reason the guard exists. `install_dir_name` reads
+    /// `backend_id`, which nothing pins to the backend that declares it on
+    /// the local-dir route — an operator-staged `backend.toml` can name any
+    /// `[backend].id` it likes. Landing on another backend's directory must
+    /// fail the install outright, because `swap_into_place` would otherwise
+    /// rename that directory aside and delete it, weights and all.
+    #[tokio::test]
+    async fn run_local_refuses_to_install_over_a_different_backend() {
+        let root = tempfile::tempdir().unwrap();
+        let backends_dir = root.path().join("backends");
+        let victim = backends_dir.join("app.super-stt.voxtral");
+        occupied_backend_dir(&victim, "github.com/x/voxtral");
+        let victim_manifest = std::fs::read(victim.join("backend.toml")).unwrap();
+
+        // The staged import: a different backend, but claiming Voxtral's
+        // install directory via `backend_id`.
+        let staged = root.path().join("staged");
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(
+            staged.join("backend.toml"),
+            r#"
+[backend]
+source = "github.com/someone/thing"
+id = "app.super-stt.voxtral"
+name = "Thing"
+version = "9.9.9"
+kind = "subprocess"
+entrypoint = "thing"
+contract = "v1"
+description = "Test backend."
+"#,
+        )
+        .unwrap();
+        std::fs::write(staged.join("thing"), b"#!/bin/sh\n").unwrap();
+
+        let mut entry = minimal_entry();
+        entry.id = "thing".into();
+        entry.backend_id = Some("app.super-stt.voxtral".into());
+        entry.source = "github.com/someone/thing".into();
+        entry.entrypoint = "thing".into();
+
+        let pipeline = Pipeline {
+            backends_dir: backends_dir.clone(),
+            cache_dir: root.path().join("cache"),
+            http: reqwest::Client::new(),
+            on_progress: Arc::new(|_, _| {}),
+        };
+        let err = run_local(&pipeline, &entry, &staged)
+            .await
+            .expect_err("installing over another backend must be refused");
+
+        assert_eq!(err.1, InstallError::InstallDirConflict);
+        assert_eq!(err.0, InstallPhase::Installing);
+        assert!(
+            victim.join("models/m/a.bin").exists(),
+            "the occupant's downloaded weights must survive untouched"
+        );
+        assert_eq!(
+            std::fs::read(victim.join("backend.toml")).unwrap(),
+            victim_manifest,
+            "the occupant's manifest must be exactly as it was"
+        );
+        let mut sidecar = victim.as_os_str().to_owned();
+        sidecar.push(".old");
+        assert!(
+            !Path::new(&sidecar).exists(),
+            "the swap must not have started"
+        );
+    }
+
+    /// The same guard on the registry/custom-repo route, which reaches the
+    /// swap through [`run`] rather than [`run_local`]. Everything up to the
+    /// install directory is real: the asset and the pinned manifest are
+    /// downloaded and verified before the conflict is detected.
+    #[tokio::test]
+    async fn run_refuses_to_install_over_a_different_backend() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let root = tempfile::tempdir().unwrap();
+        let backends_dir = root.path().join("backends");
+        let victim = backends_dir.join("app.super-stt.voxtral");
+        occupied_backend_dir(&victim, "github.com/x/voxtral");
+
+        let component = b"\0asm-not-really".to_vec();
+        let manifest = r#"
+[backend]
+source = "github.com/someone/thing"
+id = "app.super-stt.voxtral"
+name = "Thing"
+version = "9.9.9"
+kind = "wasm"
+entrypoint = "thing.wasm"
+contract = "v1"
+description = "Test backend."
+
+[[models]]
+name = "m"
+primary_language = "en"
+supported_languages = ["en"]
+supported_devices = ["cpu"]
+"#;
+        let mut server = mockito::Server::new_async().await;
+        let asset_mock = server
+            .mock("GET", "/thing.wasm")
+            .with_status(200)
+            .with_body(component.as_slice())
+            .create_async()
+            .await;
+        let manifest_mock = server
+            .mock("GET", "/backend.toml")
+            .with_status(200)
+            .with_body(manifest)
+            .create_async()
+            .await;
+
+        let mut entry = minimal_entry();
+        entry.id = "thing".into();
+        // The poisoned value: a legitimate `source`, but an `id` naming a
+        // directory that belongs to someone else.
+        entry.backend_id = Some("app.super-stt.voxtral".into());
+        entry.source = "github.com/someone/thing".into();
+        entry.kind = "wasm".into();
+        entry.entrypoint = "thing.wasm".into();
+        entry.version = "9.9.9".into();
+        entry.assets.wasm = Some(IndexAsset {
+            url: format!("{}/thing.wasm", server.url()),
+            size: component.len() as u64,
+            sha256: sha_hex(&component),
+        });
+        entry.manifest = Some(IndexAsset {
+            url: format!("{}/backend.toml", server.url()),
+            size: manifest.len() as u64,
+            sha256: sha_hex(manifest.as_bytes()),
+        });
+
+        let pipeline = Pipeline {
+            backends_dir: backends_dir.clone(),
+            cache_dir: root.path().join("cache"),
+            http: reqwest::Client::new(),
+            on_progress: Arc::new(|_, _| {}),
+        };
+        let err = run(&pipeline, &entry, &Selection::Wasm)
+            .await
+            .expect_err("installing over another backend must be refused");
+
+        asset_mock.assert_async().await;
+        manifest_mock.assert_async().await;
+        assert_eq!(err.1, InstallError::InstallDirConflict);
+        assert!(
+            victim.join("models/m/a.bin").exists(),
+            "the occupant's downloaded weights must survive untouched"
+        );
+        assert!(
+            !victim.join("thing.wasm").exists(),
+            "nothing from the refused install may reach the occupant's directory"
+        );
     }
 
     #[tokio::test]

--- a/super-stt-daemon/src/registry/mod.rs
+++ b/super-stt-daemon/src/registry/mod.rs
@@ -14,3 +14,26 @@ pub mod local_dir;
 /// Re-export the shared operator-base-URL gate from `super-stt-forge` so the
 /// registry client and the forge adapters apply one identical rule.
 pub(crate) use super_stt_forge::accept_base_url;
+
+/// The directory name a backend installs into.
+///
+/// The reverse-DNS `[backend].id` when the entry carries one, so every install
+/// route — registry, custom repository, local directory — lands on the same
+/// path for the same backend. Falls back to the registry key for an entry that
+/// predates the identifier, which is where such a backend is already
+/// installed.
+///
+/// `backend_id` arrives from `index.json` over the network. This function
+/// does not assume the registry-client boundary (`retain_safe_backends`)
+/// already sanitized it: it re-checks `backend_id` itself with
+/// `is_safe_component` and falls back to the registry key whenever
+/// `backend_id` is absent, empty, `.`/`..`, contains a path separator, or
+/// otherwise is not a single safe path component — the same rule `id` is
+/// held to elsewhere.
+#[must_use]
+pub fn install_dir_name(entry: &index_schema::IndexBackend) -> &str {
+    match entry.backend_id.as_deref() {
+        Some(id) if super_stt_shared::registry::is_safe_component(id) => id,
+        _ => &entry.id,
+    }
+}

--- a/super-stt-daemon/src/registry/mod.rs
+++ b/super-stt-daemon/src/registry/mod.rs
@@ -26,15 +26,20 @@ pub(crate) use super_stt_forge::accept_base_url;
 ///
 /// `backend_id` arrives from `index.json` over the network. This function
 /// does not assume the registry-client boundary (`retain_safe_backends`)
-/// already sanitized it: it re-checks `backend_id` itself with
-/// `is_safe_component` and falls back to the registry key whenever
-/// `backend_id` is absent, empty, `.`/`..`, contains a path separator, or
-/// otherwise is not a single safe path component — the same rule `id` is
-/// held to elsewhere.
+/// already sanitized it: it re-checks the value itself and falls back to the
+/// registry key whenever `backend_id` is absent or malformed.
+///
+/// The check is the full `[backend].id` format rule
+/// ([`super_stt_registry_types::backend_id::is_valid`]), not merely "usable
+/// as a path component". `Manifest::parse` already holds every other route
+/// to that rule, so anything looser here would make `index.json` the one
+/// input the daemon accepts below its own contract — and the gap is not
+/// theoretical: `.staging` is a perfectly good path component but names the
+/// shared staging root every install writes through.
 #[must_use]
 pub fn install_dir_name(entry: &index_schema::IndexBackend) -> &str {
     match entry.backend_id.as_deref() {
-        Some(id) if super_stt_shared::registry::is_safe_component(id) => id,
+        Some(id) if super_stt_registry_types::backend_id::is_valid(id) => id,
         _ => &entry.id,
     }
 }

--- a/super-stt-daemon/src/registry/mod.rs
+++ b/super-stt-daemon/src/registry/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //! Daemon-side registry client, compatibility evaluation, and install pipeline.
 
+pub mod carry_over;
 pub mod client;
 pub mod compat;
 pub mod custom_repo;

--- a/super-stt-daemon/src/registry/mod.rs
+++ b/super-stt-daemon/src/registry/mod.rs
@@ -10,6 +10,7 @@ pub mod index_schema;
 pub mod install;
 pub mod installed;
 pub mod local_dir;
+pub mod reconcile;
 
 /// Re-export the shared operator-base-URL gate from `super-stt-forge` so the
 /// registry client and the forge adapters apply one identical rule.

--- a/super-stt-daemon/src/registry/reconcile.rs
+++ b/super-stt-daemon/src/registry/reconcile.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Removing the duplicate directories `dedup_sources` identified.
+//!
+//! Kept separate from discovery: reading a directory and deleting one are
+//! different responsibilities, and destructive work does not belong inside a
+//! function whose job is to scan.
+
+use std::path::Path;
+
+use crate::stt_models::backends::DiscoveredBackend;
+use super_stt_registry_types::manifest::Manifest;
+
+/// Move each loser's still-valid model files into `winner`, then remove it.
+/// Returns the bytes carried across.
+///
+/// A directory whose manifest will not parse is left untouched: without a
+/// readable file list there is no evidence it is the same backend, and that is
+/// exactly the case where deleting would be a guess. A failed carry-over
+/// aborts before the delete, so a partial move never costs the only copy.
+pub async fn reconcile_dirs(losers: &[std::path::PathBuf], winner: &Path) -> u64 {
+    let Ok(new) = Manifest::load(winner) else {
+        log::error!(
+            "Refusing to reconcile into {}: its manifest does not parse",
+            winner.display()
+        );
+        return 0;
+    };
+
+    let mut reclaimed = 0u64;
+    for loser in losers {
+        let Ok(old) = Manifest::load(loser) else {
+            log::error!(
+                "Leaving {} in place: its manifest does not parse, so it cannot be \
+                 confirmed a duplicate",
+                loser.display()
+            );
+            continue;
+        };
+        let keep = crate::registry::carry_over::survivors(&old, &new);
+        let bytes = match crate::registry::carry_over::carry(loser, winner, &keep).await {
+            Ok(bytes) => {
+                reclaimed += bytes;
+                bytes
+            }
+            Err(e) => {
+                log::error!(
+                    "Leaving {} in place: carrying its model files into {} failed: {e}",
+                    loser.display(),
+                    winner.display()
+                );
+                continue;
+            }
+        };
+        match tokio::fs::remove_dir_all(loser).await {
+            Ok(()) => log::info!(
+                "Reconciled duplicate {} ({}) into {} ({}), reclaiming {bytes} bytes",
+                loser.display(),
+                old.backend.version,
+                winner.display(),
+                new.backend.version,
+            ),
+            Err(e) => log::error!("Failed to remove duplicate {}: {e}", loser.display()),
+        }
+    }
+    reclaimed
+}
+
+/// Reconcile every duplicate `dedup_sources` reported, grouping each loser
+/// with the winner that serves its `source`.
+pub async fn reconcile(losers: &[DiscoveredBackend], winners: &[DiscoveredBackend]) -> u64 {
+    let mut reclaimed = 0u64;
+    for w in winners {
+        let dirs: Vec<std::path::PathBuf> = losers
+            .iter()
+            .filter(|l| l.source == w.source)
+            .map(|l| l.dir.clone())
+            .collect();
+        if !dirs.is_empty() {
+            reclaimed += reconcile_dirs(&dirs, &w.dir).await;
+        }
+    }
+    reclaimed
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn a_loser_hands_its_weights_over_before_it_is_removed() {
+        let root = tempfile::tempdir().unwrap();
+        let toml = r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "1.0.0"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    license    = "Apache-2.0"
+    description = "Test backend."
+
+[[assets.subprocess]]
+    file   = "y.tar.gz"
+    target = "x86_64-unknown-linux-gnu"
+    accel  = ["cpu"]
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+    files = [
+        { url = "https://h/a.bin", destination = "models/m/a.bin" },
+    ]
+"#;
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("super-stt-y");
+        for d in [&winner, &loser] {
+            std::fs::create_dir_all(d.join("models/m")).unwrap();
+            std::fs::write(d.join("backend.toml"), toml).unwrap();
+        }
+        std::fs::write(loser.join("models/m/a.bin"), b"weights").unwrap();
+
+        let reclaimed = super::reconcile_dirs(&[loser.clone()], &winner).await;
+
+        assert_eq!(reclaimed, 7);
+        assert!(
+            winner.join("models/m/a.bin").exists(),
+            "weights moved across"
+        );
+        assert!(!loser.exists(), "the duplicate is gone");
+    }
+
+    /// Beyond the byte count: the moved file's actual content must survive
+    /// the carry, byte for byte. This is the case the task exists for — a
+    /// count matching by coincidence would not catch a truncated or
+    /// corrupted move.
+    #[tokio::test]
+    async fn a_losers_weights_genuinely_reach_the_winner_byte_for_byte() {
+        let root = tempfile::tempdir().unwrap();
+        let toml = r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "1.0.0"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    license    = "Apache-2.0"
+    description = "Test backend."
+
+[[assets.subprocess]]
+    file   = "y.tar.gz"
+    target = "x86_64-unknown-linux-gnu"
+    accel  = ["cpu"]
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+    files = [
+        { url = "https://h/a.bin", destination = "models/m/a.bin" },
+    ]
+"#;
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("super-stt-y");
+        for d in [&winner, &loser] {
+            std::fs::create_dir_all(d.join("models/m")).unwrap();
+            std::fs::write(d.join("backend.toml"), toml).unwrap();
+        }
+        // Realistic-shaped content, not just a short literal: several
+        // repeated blocks so a truncation or a swapped chunk would be caught
+        // by the equality check below.
+        let content: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
+        std::fs::write(loser.join("models/m/a.bin"), &content).unwrap();
+
+        let reclaimed = super::reconcile_dirs(&[loser.clone()], &winner).await;
+
+        assert_eq!(reclaimed, content.len() as u64);
+        let carried = std::fs::read(winner.join("models/m/a.bin")).unwrap();
+        assert_eq!(
+            carried, content,
+            "the winner's copy must be byte-for-byte identical to the loser's"
+        );
+        assert!(!loser.exists(), "the duplicate is gone");
+    }
+
+    #[tokio::test]
+    async fn an_unparseable_directory_is_left_alone() {
+        let root = tempfile::tempdir().unwrap();
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("junk");
+        std::fs::create_dir_all(&winner).unwrap();
+        std::fs::create_dir_all(&loser).unwrap();
+        std::fs::write(loser.join("backend.toml"), b"not toml {{{").unwrap();
+
+        let reclaimed = super::reconcile_dirs(&[loser.clone()], &winner).await;
+
+        assert_eq!(reclaimed, 0);
+        assert!(
+            loser.exists(),
+            "a directory we cannot read is never deleted"
+        );
+    }
+}

--- a/super-stt-daemon/src/registry/reconcile.rs
+++ b/super-stt-daemon/src/registry/reconcile.rs
@@ -5,28 +5,43 @@
 //! different responsibilities, and destructive work does not belong inside a
 //! function whose job is to scan.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::stt_models::backends::DiscoveredBackend;
 use super_stt_registry_types::manifest::Manifest;
 
+/// What one reconciliation pass did: the bytes carried across, and the
+/// directories it actually removed.
+///
+/// The removals are reported rather than merely counted because a caller has
+/// to repair anything that pointed at one of them — see
+/// [`repoint_active_backend`]. Basing that on "did the delete happen" rather
+/// than on any one deleter's return value is what keeps the pointer and the
+/// filesystem from disagreeing.
+#[derive(Debug, Default)]
+pub struct Reconciled {
+    /// Bytes of model files moved from the losers into the winner.
+    pub reclaimed: u64,
+    /// The loser directories that no longer exist.
+    pub removed: Vec<PathBuf>,
+}
+
 /// Move each loser's still-valid model files into `winner`, then remove it.
-/// Returns the bytes carried across.
 ///
 /// A directory whose manifest will not parse is left untouched: without a
 /// readable file list there is no evidence it is the same backend, and that is
 /// exactly the case where deleting would be a guess. A failed carry-over
 /// aborts before the delete, so a partial move never costs the only copy.
-pub async fn reconcile_dirs(losers: &[std::path::PathBuf], winner: &Path) -> u64 {
+pub async fn reconcile_dirs(losers: &[PathBuf], winner: &Path) -> Reconciled {
     let Ok(new) = Manifest::load(winner) else {
         log::error!(
             "Refusing to reconcile into {}: its manifest does not parse",
             winner.display()
         );
-        return 0;
+        return Reconciled::default();
     };
 
-    let mut reclaimed = 0u64;
+    let mut out = Reconciled::default();
     for loser in losers {
         let Ok(old) = Manifest::load(loser) else {
             log::error!(
@@ -39,7 +54,7 @@ pub async fn reconcile_dirs(losers: &[std::path::PathBuf], winner: &Path) -> u64
         let keep = crate::registry::carry_over::survivors(&old, &new);
         let bytes = match crate::registry::carry_over::carry(loser, winner, &keep).await {
             Ok(bytes) => {
-                reclaimed += bytes;
+                out.reclaimed += bytes;
                 bytes
             }
             Err(e) => {
@@ -52,34 +67,98 @@ pub async fn reconcile_dirs(losers: &[std::path::PathBuf], winner: &Path) -> u64
             }
         };
         match tokio::fs::remove_dir_all(loser).await {
-            Ok(()) => log::info!(
-                "Reconciled duplicate {} ({}) into {} ({}), reclaiming {bytes} bytes",
-                loser.display(),
-                old.backend.version,
-                winner.display(),
-                new.backend.version,
-            ),
+            Ok(()) => {
+                log::info!(
+                    "Reconciled duplicate {} ({}) into {} ({}), reclaiming {bytes} bytes",
+                    loser.display(),
+                    old.backend.version,
+                    winner.display(),
+                    new.backend.version,
+                );
+                out.removed.push(loser.clone());
+            }
             Err(e) => log::error!("Failed to remove duplicate {}: {e}", loser.display()),
         }
     }
-    reclaimed
+    out
 }
 
 /// Reconcile every duplicate `dedup_sources` reported, grouping each loser
-/// with the winner that serves its `source`.
-pub async fn reconcile(losers: &[DiscoveredBackend], winners: &[DiscoveredBackend]) -> u64 {
+/// with the winner that serves its `source`, and move `active_backend` onto
+/// the winner whenever the directory it named was one of the ones removed.
+///
+/// Returns the bytes carried across.
+pub async fn reconcile(
+    daemon: &crate::daemon::types::SuperSTTDaemon,
+    losers: &[DiscoveredBackend],
+    winners: &[DiscoveredBackend],
+) -> u64 {
     let mut reclaimed = 0u64;
     for w in winners {
-        let dirs: Vec<std::path::PathBuf> = losers
+        let dirs: Vec<PathBuf> = losers
             .iter()
             .filter(|l| l.source == w.source)
             .map(|l| l.dir.clone())
             .collect();
-        if !dirs.is_empty() {
-            reclaimed += reconcile_dirs(&dirs, &w.dir).await;
+        if dirs.is_empty() {
+            continue;
         }
+        let done = reconcile_dirs(&dirs, &w.dir).await;
+        reclaimed += done.reclaimed;
+        repoint_active_backend(daemon, &done.removed, &w.dir).await;
     }
     reclaimed
+}
+
+/// Move `active_backend` — the persisted config and the runtime mirror — onto
+/// `winner` when it named one of the directories just removed.
+///
+/// `active_backend` stores a directory name, and reconciliation is the last
+/// thing standing between that name and a directory that no longer exists.
+/// The pointer does not repair itself: `adopt_active_backend_for` only fills
+/// an *unset* pointer, so a stale name simply resolves to nothing — the
+/// daemon reports no active backend and serves no models, while the backend
+/// itself is installed and healthy one directory over.
+///
+/// Keying this on the removal, rather than on any particular deleter
+/// reporting success, is deliberate. Every route that removes a duplicate —
+/// a first refresh cleaning up two pre-existing directories, an install whose
+/// migration raced a concurrent refresh, a retirement whose `remove_dir_all`
+/// failed and left the duplicate for a later pass — converges here, so there
+/// is one place that has to be right instead of one per deleter.
+///
+/// `rename_active_backend` (not `update_active_backend`) is deliberate too:
+/// the winner serves the same `source` and the same models, so this is a
+/// directory move, not the user choosing a different backend. Clearing
+/// `preferred_model`/`preferred_provider` here would silently discard the
+/// user's model selection as a side effect of housekeeping.
+async fn repoint_active_backend(
+    daemon: &crate::daemon::types::SuperSTTDaemon,
+    removed: &[PathBuf],
+    winner: &Path,
+) {
+    let Some(new_name) = winner.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    let mut cfg = daemon.config.write().await;
+    let Some(active) = cfg.transcription.active_backend.clone() else {
+        return;
+    };
+    // Losers and winner are siblings under the backends directory, so a name
+    // match is an identity match: the pointer named a directory that is gone.
+    let was_removed = removed
+        .iter()
+        .any(|d| d.file_name().and_then(|n| n.to_str()) == Some(active.as_str()));
+    if !was_removed {
+        return;
+    }
+    cfg.rename_active_backend(new_name.to_string());
+    drop(cfg);
+    *daemon.active_backend.write().await = Some(new_name.to_string());
+    if let Err(e) = daemon.persist_config().await {
+        log::warn!("Failed to persist config after reconciling {active}: {e}");
+    }
+    log::info!("Repointed active_backend from {active} to {new_name} after reconciliation");
 }
 
 #[cfg(test)]
@@ -120,9 +199,10 @@ mod tests {
         }
         std::fs::write(loser.join("models/m/a.bin"), b"weights").unwrap();
 
-        let reclaimed = super::reconcile_dirs(&[loser.clone()], &winner).await;
+        let done = super::reconcile_dirs(&[loser.clone()], &winner).await;
 
-        assert_eq!(reclaimed, 7);
+        assert_eq!(done.reclaimed, 7);
+        assert_eq!(done.removed, vec![loser.clone()]);
         assert!(
             winner.join("models/m/a.bin").exists(),
             "weights moved across"
@@ -174,9 +254,10 @@ mod tests {
         let content: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
         std::fs::write(loser.join("models/m/a.bin"), &content).unwrap();
 
-        let reclaimed = super::reconcile_dirs(&[loser.clone()], &winner).await;
+        let done = super::reconcile_dirs(&[loser.clone()], &winner).await;
 
-        assert_eq!(reclaimed, content.len() as u64);
+        assert_eq!(done.reclaimed, content.len() as u64);
+        assert_eq!(done.removed, vec![loser.clone()]);
         let carried = std::fs::read(winner.join("models/m/a.bin")).unwrap();
         assert_eq!(
             carried, content,
@@ -194,12 +275,134 @@ mod tests {
         std::fs::create_dir_all(&loser).unwrap();
         std::fs::write(loser.join("backend.toml"), b"not toml {{{").unwrap();
 
-        let reclaimed = super::reconcile_dirs(&[loser.clone()], &winner).await;
+        let done = super::reconcile_dirs(&[loser.clone()], &winner).await;
 
-        assert_eq!(reclaimed, 0);
+        assert_eq!(done.reclaimed, 0);
+        assert!(
+            done.removed.is_empty(),
+            "nothing was removed, so nothing has to be repointed"
+        );
         assert!(
             loser.exists(),
             "a directory we cannot read is never deleted"
         );
+    }
+
+    /// A backend directory serving `github.com/x/y` at `version`, valid
+    /// enough for `discover` to load it.
+    fn write_backend(dir: &std::path::Path, version: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("backend.toml"),
+            format!(
+                r#"
+[backend]
+    source     = "github.com/x/y"
+    name       = "Y"
+    version    = "{version}"
+    kind       = "subprocess"
+    entrypoint = "y"
+    contract   = "v1"
+    description = "Test backend."
+
+[[models]]
+    name                = "m"
+    primary_language    = "en"
+    supported_languages = ["en"]
+    supported_devices   = ["cpu"]
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// `active_backend` stores a directory name, and reconciliation is the
+    /// only thing that removes a directory out from under it — including on
+    /// the plain upgrade path, where a user who already has two directories
+    /// for one source gets them reconciled on the first refresh. A pointer
+    /// left naming the removed one resolves to nothing at all, and never
+    /// self-heals: the adopt-on-startup path only fills an *unset* pointer.
+    ///
+    /// The model selection must survive: the winner serves the same source
+    /// and the same models, so this is a directory move, not the user
+    /// choosing a different backend.
+    #[tokio::test]
+    async fn reconciling_the_active_directory_repoints_it_and_keeps_the_model_choice() {
+        let root = tempfile::tempdir().unwrap();
+        let winner = root.path().join("app.super-stt.y");
+        let loser = root.path().join("super-stt-y");
+        write_backend(&winner, "1.0.1");
+        write_backend(&loser, "1.0.0");
+
+        let daemon = crate::daemon::types::test_daemon().await;
+        {
+            let mut cfg = daemon.config.write().await;
+            cfg.transcription.active_backend = Some("super-stt-y".to_string());
+            cfg.update_preferred_model(
+                "m".to_string(),
+                "github.com/x/y".to_string(),
+                Some("local_y".to_string()),
+            );
+        }
+        *daemon.active_backend.write().await = Some("super-stt-y".to_string());
+
+        let (winners, losers) = crate::stt_models::backends::discover(root.path());
+        assert_eq!(losers.len(), 1, "the older directory is the loser");
+        super::reconcile(&daemon, &losers, &winners).await;
+
+        assert!(!loser.exists(), "the duplicate is gone");
+        let cfg = daemon.config.read().await;
+        assert_eq!(
+            cfg.transcription.active_backend.as_deref(),
+            Some("app.super-stt.y"),
+            "the pointer must follow the directory that survived"
+        );
+        assert_eq!(
+            cfg.transcription.preferred_model, "m",
+            "the model preference must survive the repoint"
+        );
+        assert_eq!(cfg.transcription.preferred_provider, "local_y");
+        assert_eq!(cfg.transcription.preferred_source, "github.com/x/y");
+        drop(cfg);
+        assert_eq!(
+            daemon.active_backend.read().await.as_deref(),
+            Some("app.super-stt.y"),
+            "the runtime mirror must agree with the persisted config"
+        );
+    }
+
+    /// The mirror case: reconciling a backend the user has not selected must
+    /// not move the pointer onto it.
+    #[tokio::test]
+    async fn reconciling_an_unrelated_directory_leaves_the_pointer_alone() {
+        let root = tempfile::tempdir().unwrap();
+        write_backend(&root.path().join("app.super-stt.y"), "1.0.1");
+        write_backend(&root.path().join("super-stt-y"), "1.0.0");
+
+        let daemon = crate::daemon::types::test_daemon().await;
+        {
+            let mut cfg = daemon.config.write().await;
+            cfg.transcription.active_backend = Some("some-other-backend".to_string());
+            cfg.update_preferred_model(
+                "other-model".to_string(),
+                "github.com/x/other".to_string(),
+                Some("local_other".to_string()),
+            );
+        }
+
+        let (winners, losers) = crate::stt_models::backends::discover(root.path());
+        super::reconcile(&daemon, &losers, &winners).await;
+
+        assert!(
+            !root.path().join("super-stt-y").exists(),
+            "the duplicate is still reconciled away"
+        );
+        let cfg = daemon.config.read().await;
+        assert_eq!(
+            cfg.transcription.active_backend.as_deref(),
+            Some("some-other-backend"),
+            "an unrelated active backend must not be repointed"
+        );
+        assert_eq!(cfg.transcription.preferred_model, "other-model");
     }
 }

--- a/super-stt-daemon/src/stt_models/backends/mod.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod.rs
@@ -10,7 +10,6 @@
 pub(crate) mod base_url;
 pub mod manifest;
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -28,6 +27,9 @@ pub struct DiscoveredBackend {
     pub dir: PathBuf,
     /// Repo id (`[backend].source`); the `source` of every model it serves.
     pub source: String,
+    /// The backend's declared `[backend].id`, when it has one. Used to break a
+    /// duplicate-directory tie in favour of the canonical install path.
+    pub id: Option<String>,
     /// Human-facing backend name (`[backend].name`).
     pub name: String,
     /// The backend's own version (`[backend].version`) as of the last scan.
@@ -75,8 +77,13 @@ pub fn installed_version(dir: &Path) -> Option<String> {
 
 /// Scan `backends_dir` for installed backends. Subdirectories without a
 /// readable, parseable `backend.toml` are skipped with a warning.
+///
+/// A pure scan: it selects the backend that serves each `source` and returns
+/// the duplicates it supersedes alongside it, but performs no filesystem
+/// mutation. Removing a loser is `registry::reconcile`'s job — reading a
+/// directory and deleting one are different responsibilities.
 #[must_use]
-pub fn discover(backends_dir: &Path) -> Vec<DiscoveredBackend> {
+pub fn discover(backends_dir: &Path) -> (Vec<DiscoveredBackend>, Vec<DiscoveredBackend>) {
     let entries = match std::fs::read_dir(backends_dir) {
         Ok(e) => e,
         Err(e) => {
@@ -84,7 +91,7 @@ pub fn discover(backends_dir: &Path) -> Vec<DiscoveredBackend> {
                 "Backends directory {} not readable ({e}); no backends discovered",
                 backends_dir.display()
             );
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         }
     };
 
@@ -111,30 +118,65 @@ pub fn discover(backends_dir: &Path) -> Vec<DiscoveredBackend> {
     dedup_sources(backends)
 }
 
-/// Enforce that each discovered backend has a unique `source`. The `source` is
-/// the stable identity the daemon resolves both models and the *active backend*
-/// by, so a collision would make selection ambiguous — the first match would
-/// silently win (e.g. selecting Voxtral could activate Mistral if both declared
-/// the same source). Keep the first occurrence of each source and drop the rest
-/// with a loud error so the misconfiguration is visible rather than silent.
-fn dedup_sources(backends: Vec<DiscoveredBackend>) -> Vec<DiscoveredBackend> {
-    let mut seen: HashSet<String> = HashSet::with_capacity(backends.len());
-    let mut out = Vec::with_capacity(backends.len());
+/// Split discovered backends into the one that serves each `source` and the
+/// duplicates it supersedes.
+///
+/// `source` is the identity the daemon resolves models and the active backend
+/// by, so two directories claiming one source is ambiguous — and worse, the
+/// loser strands an orphaned `models/` subtree that nothing will ever load.
+/// The winner is chosen deterministically:
+///
+/// 1. highest `version` — a backend updated in place before migration existed
+///    is the newer install, whatever its directory is called;
+/// 2. the directory named after the backend's `id`, the canonical location;
+/// 3. the lexicographically first directory name, so the result is stable.
+///
+/// Selection only. Removing a loser is `registry::reconcile`'s job — reading a
+/// directory and deleting one are different responsibilities.
+fn dedup_sources(
+    backends: Vec<DiscoveredBackend>,
+) -> (Vec<DiscoveredBackend>, Vec<DiscoveredBackend>) {
+    use std::collections::HashMap;
+
+    let mut groups: HashMap<String, Vec<DiscoveredBackend>> = HashMap::new();
     for b in backends {
-        if seen.insert(b.source.clone()) {
-            out.push(b);
-        } else {
-            error!(
-                "Backend '{}' at {} declares source '{}', which is already used by \
-                 another discovered backend; skipping it. Each backend.toml must \
-                 declare a unique [backend].source.",
-                b.name,
-                b.dir.display(),
-                b.source
-            );
-        }
+        groups.entry(b.source.clone()).or_default().push(b);
     }
-    out
+
+    let mut winners = Vec::new();
+    let mut losers = Vec::new();
+    for (source, mut group) in groups {
+        group.sort_by(|a, b| {
+            let av = super_stt_registry_types::version::parse_version(&a.version);
+            let bv = super_stt_registry_types::version::parse_version(&b.version);
+            bv.cmp(&av)
+                .then_with(|| is_id_named(b).cmp(&is_id_named(a)))
+                .then_with(|| a.dir.cmp(&b.dir))
+        });
+        let mut it = group.into_iter();
+        let winner = it.next().expect("a group is never empty");
+        for dup in it {
+            error!(
+                "Backend '{}' at {} duplicates source '{source}', already served from {}; \
+                 it will be reconciled and removed.",
+                dup.name,
+                dup.dir.display(),
+                winner.dir.display()
+            );
+            losers.push(dup);
+        }
+        winners.push(winner);
+    }
+    winners.sort_by(|a, b| a.dir.cmp(&b.dir));
+    (winners, losers)
+}
+
+/// Whether a backend sits in the directory its own `id` names.
+fn is_id_named(b: &DiscoveredBackend) -> bool {
+    match (&b.id, b.dir.file_name().and_then(|n| n.to_str())) {
+        (Some(id), Some(name)) => id == name,
+        _ => false,
+    }
 }
 
 /// Parse one backend directory into a [`DiscoveredBackend`].
@@ -189,6 +231,7 @@ fn load_backend(dir: &Path) -> anyhow::Result<DiscoveredBackend> {
     Ok(DiscoveredBackend {
         dir: dir.to_path_buf(),
         source,
+        id: m.backend.id.clone(),
         name: m.backend.name,
         version: m.backend.version,
         kind: m.backend.kind.to_string(),

--- a/super-stt-daemon/src/stt_models/backends/mod_tests.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod_tests.rs
@@ -80,8 +80,9 @@ processing_interval_ms = 2000
     )
     .unwrap();
 
-    let backends = discover(&root);
+    let (backends, losers) = discover(&root);
     assert_eq!(backends.len(), 2, "expected two backends, got {backends:?}");
+    assert!(losers.is_empty(), "distinct sources are never duplicates");
 
     // Identity + secrets/options carried through.
     let oai = backends
@@ -145,13 +146,13 @@ fn skips_invalid_backend_dirs() {
     fs::create_dir_all(&broken).unwrap();
     fs::write(broken.join("backend.toml"), "this is not valid toml = =\n").unwrap();
 
-    assert!(discover(&root).is_empty());
+    assert!(discover(&root).0.is_empty());
 }
 
 #[test]
 fn missing_dir_is_empty() {
     let path = std::env::temp_dir().join("super-stt-backend-discovery/does-not-exist");
-    assert!(discover(&path).is_empty());
+    assert!(discover(&path).0.is_empty());
 }
 
 /// A backend whose manifest omits `supported_devices` on any model is
@@ -182,7 +183,7 @@ multilingual = true
     .unwrap();
 
     assert!(
-        discover(&root).is_empty(),
+        discover(&root).0.is_empty(),
         "a manifest without supported_devices must be rejected"
     );
 }
@@ -218,7 +219,7 @@ supported_devices = []
     .unwrap();
 
     assert!(
-        discover(&root).is_empty(),
+        discover(&root).0.is_empty(),
         "a manifest with supported_devices = [] must be rejected"
     );
 }
@@ -251,7 +252,7 @@ supported_devices = ["xpu"]
     )
     .unwrap();
 
-    assert!(discover(&root).is_empty());
+    assert!(discover(&root).0.is_empty());
 }
 
 /// `none` (online sentinel) mixed with a local device is rejected — they
@@ -283,7 +284,7 @@ supported_devices = ["none", "cpu"]
     )
     .unwrap();
 
-    assert!(discover(&root).is_empty());
+    assert!(discover(&root).0.is_empty());
 }
 
 /// `dir_name` returns the final path component — the relative install dir
@@ -297,6 +298,7 @@ fn dir_name_returns_final_component() {
         DiscoveredBackend {
             dir,
             source: "github.com/super-stt/openai".to_string(),
+            id: None,
             name: "OpenAI".to_string(),
             version: "1.0.0".to_string(),
             kind: "wasm".to_string(),
@@ -383,8 +385,12 @@ fn distinct_sources_resolve_to_the_right_backend() {
         "Voxtral",
     );
 
-    let backends = discover(&root);
+    let (backends, losers) = discover(&root);
     assert_eq!(backends.len(), 3);
+    assert!(
+        losers.is_empty(),
+        "three distinct sources are never duplicates"
+    );
 
     for (source, want_dir) in [
         ("github.com/jorge-menjivar/super-stt/openai", "openai"),
@@ -403,21 +409,25 @@ fn distinct_sources_resolve_to_the_right_backend() {
     }
 }
 
-/// Two backends sharing a source is a misconfiguration: discovery keeps the
-/// first and drops the rest so resolution is never ambiguous.
+/// Two backends sharing a source is a misconfiguration: discovery keeps one
+/// deterministic winner and reports the rest as duplicates for reconciliation,
+/// so resolution is never ambiguous.
 #[test]
 fn duplicate_sources_are_deduplicated() {
     let root = scratch("dup-sources");
-    // Same source on two different dirs — the pre-fix bug condition.
+    // Same source, same version, neither id-named — the tie falls to the
+    // lexicographically first directory name.
     write_backend(&root, "aaa", "github.com/x/shared", "First");
     write_backend(&root, "bbb", "github.com/x/shared", "Second");
 
-    let backends = discover(&root);
+    let (backends, losers) = discover(&root);
     assert_eq!(
         backends.len(),
         1,
         "duplicate source must be collapsed to one"
     );
+    assert_eq!(losers.len(), 1, "the duplicate is reported, not dropped");
+    assert!(losers[0].dir.ends_with("bbb"));
 
     // Exactly one backend resolves for the shared source — no ambiguity.
     let matches: Vec<_> = backends
@@ -466,8 +476,9 @@ processing_interval_ms = 1500
     )
     .unwrap();
 
-    let backends = discover(&root);
+    let (backends, losers) = discover(&root);
     assert_eq!(backends.len(), 1);
+    assert!(losers.is_empty());
 
     let (b, def) = find_model(
         &backends,
@@ -495,14 +506,17 @@ processing_interval_ms = 1500
     assert_eq!(big.processing_interval, Duration::from_millis(1500));
 }
 
-/// `dedup_sources` keeps first-seen order and drops later duplicates.
+/// At equal (unparseable-as-distinguishing) version and with neither
+/// candidate id-named, `dedup_sources` falls back to the lexicographically
+/// first directory name, so the result is stable across runs.
 #[test]
-fn dedup_sources_keeps_first_occurrence() {
+fn dedup_sources_falls_back_to_lexicographic_order() {
     use crate::stt_models::ModelDefinition;
     fn fake(dir: &str, source: &str) -> DiscoveredBackend {
         DiscoveredBackend {
             dir: PathBuf::from(dir),
             source: source.to_string(),
+            id: None,
             name: dir.to_string(),
             version: "1.0.0".to_string(),
             kind: "wasm".to_string(),
@@ -519,9 +533,11 @@ fn dedup_sources_keeps_first_occurrence() {
         fake("c", "src-1"), // dup of a
         fake("d", "src-3"),
     ];
-    let out = dedup_sources(input);
-    let dirs: Vec<_> = out.iter().filter_map(dir_name).collect();
+    let (winners, losers) = dedup_sources(input);
+    let dirs: Vec<_> = winners.iter().filter_map(dir_name).collect();
     assert_eq!(dirs, vec!["a", "b", "d"]);
+    assert_eq!(losers.len(), 1);
+    assert!(losers[0].dir.ends_with("c"));
 }
 
 /// The regression: `find_model` used to treat an empty `source` as "any
@@ -540,6 +556,7 @@ fn an_empty_source_resolves_nothing() {
         DiscoveredBackend {
             dir: PathBuf::from(dir),
             source: source.to_string(),
+            id: None,
             name: dir.to_string(),
             version: "1.0.0".to_string(),
             kind: "wasm".to_string(),
@@ -633,7 +650,7 @@ supported_devices = ["none"]
     )
     .unwrap();
 
-    let backends = discover(&root);
+    let (backends, _) = discover(&root);
     assert_eq!(
         backends.len(),
         1,
@@ -665,4 +682,81 @@ fn the_catalog_reports_the_installed_accel() {
         .map(|r| r.selected.accel)
         .unwrap_or_default();
     assert_eq!(accel, vec!["cpu".to_string()]);
+}
+
+/// A minimal `DiscoveredBackend` at `/backends/<dir>`, for the
+/// `dedup_sources` selection tests below. No `discovered_fixture`/
+/// `tests_support` helper exists in this crate, so the literal is built
+/// inline here, matching the pattern `write_backend` and `fake` already use
+/// above.
+fn at(dir: &str, source: &str, version: &str, id: Option<&str>) -> DiscoveredBackend {
+    use crate::stt_models::ModelDefinition;
+    DiscoveredBackend {
+        dir: PathBuf::from("/backends").join(dir),
+        source: source.to_string(),
+        name: dir.to_string(),
+        version: version.to_string(),
+        kind: "wasm".to_string(),
+        entrypoint: "x.wasm".to_string(),
+        allowed_hosts: Vec::new(),
+        secrets: Vec::new(),
+        options: Vec::new(),
+        models: Vec::<ModelDefinition>::new(),
+        id: id.map(str::to_string),
+    }
+}
+
+/// Version outranks the id-named directory. A backend updated in place
+/// before migration existed sits at the repo-named directory on the newer
+/// version; preferring the id-named one would delete the newer install and
+/// silently downgrade the user.
+#[test]
+fn the_higher_version_wins_even_against_the_id_named_dir() {
+    let (winners, losers) = dedup_sources(vec![
+        at(
+            "app.super-stt.voxtral",
+            "github.com/x/v",
+            "0.1.0",
+            Some("app.super-stt.voxtral"),
+        ),
+        at(
+            "super-stt-voxtral",
+            "github.com/x/v",
+            "0.1.1",
+            Some("app.super-stt.voxtral"),
+        ),
+    ]);
+    assert_eq!(winners.len(), 1);
+    assert!(winners[0].dir.ends_with("super-stt-voxtral"));
+    assert_eq!(losers.len(), 1);
+}
+
+#[test]
+fn the_id_named_dir_wins_at_equal_versions() {
+    let (winners, losers) = dedup_sources(vec![
+        at(
+            "super-stt-voxtral",
+            "github.com/x/v",
+            "0.1.1",
+            Some("app.super-stt.voxtral"),
+        ),
+        at(
+            "app.super-stt.voxtral",
+            "github.com/x/v",
+            "0.1.1",
+            Some("app.super-stt.voxtral"),
+        ),
+    ]);
+    assert!(winners[0].dir.ends_with("app.super-stt.voxtral"));
+    assert_eq!(losers.len(), 1);
+}
+
+#[test]
+fn distinct_sources_are_never_duplicates() {
+    let (winners, losers) = dedup_sources(vec![
+        at("a", "github.com/x/a", "1.0.0", None),
+        at("b", "github.com/x/b", "1.0.0", None),
+    ]);
+    assert_eq!(winners.len(), 2);
+    assert!(losers.is_empty());
 }

--- a/super-stt-indexer/src/carryforward.rs
+++ b/super-stt-indexer/src/carryforward.rs
@@ -59,6 +59,7 @@ mod tests {
     fn dummy(id: &str) -> IndexBackend {
         IndexBackend {
             id: id.into(),
+            backend_id: None,
             source: "x".into(),
             version: "1.0.0".into(),
             tag: "v1.0.0".into(),

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -350,6 +350,7 @@ mod tests {
     fn backend(id: &str, source: &str) -> index_json::IndexBackend {
         index_json::IndexBackend {
             id: id.into(),
+            backend_id: None,
             source: source.into(),
             version: "1.0.0".into(),
             tag: "v1.0.0".into(),

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -132,6 +132,7 @@ async fn run_build(args: BuildArgs) -> anyhow::Result<()> {
     }
 
     ensure_unique_sources(&out_backends)?;
+    ensure_unique_backend_ids(&out_backends)?;
 
     let index = index_json::Index {
         schema_version: index_json::SCHEMA_VERSION,
@@ -321,9 +322,10 @@ pub(crate) fn into_index_backend(
 }
 
 /// A backend's `source` is its unique identity. Two distinct entries that
-/// collide on `source` would be indistinguishable to every daemon (the
-/// daemon's `dedup_sources` guard silently drops all but the first), so a
-/// collision must never be published — fail the build instead.
+/// collide on `source` would be indistinguishable to every daemon — one of
+/// the two install directories is picked as the winner and the other is
+/// removed from disk — so a collision must never be published: fail the build
+/// instead.
 fn ensure_unique_sources(backends: &[index_json::IndexBackend]) -> anyhow::Result<()> {
     let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
     for b in backends {
@@ -331,6 +333,36 @@ fn ensure_unique_sources(backends: &[index_json::IndexBackend]) -> anyhow::Resul
             anyhow::bail!(
                 "duplicate source `{}` shared by entries `{}` and `{}`; each backend must have a distinct source",
                 b.source,
+                prev_id,
+                b.id,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A backend's `backend_id` names the directory it is installed into, so two
+/// entries publishing the same one would install over each other — the second
+/// install replaces the first, taking its downloaded model files with it.
+///
+/// Per-entry validation cannot see this: each release's manifest declares its
+/// own `id` in isolation, and both are individually well-formed. Like
+/// [`ensure_unique_sources`], the collision is only visible across the
+/// assembled index, so it is checked here and fails the build.
+///
+/// An entry without a `backend_id` installs under its registry key, which
+/// [`ensure_unique_sources`]' own key space already keeps distinct, so those
+/// entries are skipped rather than grouped together under a shared absence.
+fn ensure_unique_backend_ids(backends: &[index_json::IndexBackend]) -> anyhow::Result<()> {
+    let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for b in backends {
+        let Some(backend_id) = b.backend_id.as_deref() else {
+            continue;
+        };
+        if let Some(prev_id) = seen.insert(backend_id, b.id.as_str()) {
+            anyhow::bail!(
+                "duplicate backend id `{}` shared by entries `{}` and `{}`; each backend must declare a distinct [backend].id",
+                backend_id,
                 prev_id,
                 b.id,
             );
@@ -390,5 +422,46 @@ mod tests {
         ];
         let err = ensure_unique_sources(&backends).unwrap_err();
         assert!(err.to_string().contains("duplicate source"));
+    }
+
+    /// `backend_id` names the install directory, so publishing two entries
+    /// that share one would have the second install replace the first —
+    /// including the model files under it. Each entry's own manifest is
+    /// perfectly valid, so only this cross-entry check can catch it.
+    #[test]
+    fn duplicate_backend_ids_are_rejected() {
+        let mut a = backend("mistral", "github.com/x/mistral");
+        a.backend_id = Some("app.super-stt.voxtral".into());
+        let mut b = backend("voxtral", "github.com/x/voxtral");
+        b.backend_id = Some("app.super-stt.voxtral".into());
+
+        let err = ensure_unique_backend_ids(&[a, b]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("duplicate backend id"), "{msg}");
+        assert!(msg.contains("app.super-stt.voxtral"), "{msg}");
+        assert!(msg.contains("mistral") && msg.contains("voxtral"), "{msg}");
+    }
+
+    #[test]
+    fn distinct_backend_ids_pass() {
+        let mut a = backend("mistral", "github.com/x/mistral");
+        a.backend_id = Some("app.super-stt.mistral".into());
+        let mut b = backend("voxtral", "github.com/x/voxtral");
+        b.backend_id = Some("app.super-stt.voxtral".into());
+
+        ensure_unique_backend_ids(&[a, b]).unwrap();
+    }
+
+    /// Entries that predate `[backend].id` install under their registry key,
+    /// which is already unique. Several of them sharing a `None` must not be
+    /// mistaken for a collision.
+    #[test]
+    fn entries_without_a_backend_id_never_collide() {
+        let backends = vec![
+            backend("mistral", "github.com/x/mistral"),
+            backend("voxtral", "github.com/x/voxtral"),
+        ];
+        assert!(backends.iter().all(|b| b.backend_id.is_none()));
+        ensure_unique_backend_ids(&backends).unwrap();
     }
 }

--- a/super-stt-indexer/src/main.rs
+++ b/super-stt-indexer/src/main.rs
@@ -187,7 +187,8 @@ async fn build_entry(
     let text = String::from_utf8(bytes).map_err(|e| fail(&e))?;
     let m = manifest::Manifest::parse(&text).map_err(|e| fail(&e))?;
     let manifest_pin = Some(index_json::IndexAsset { url, size, sha256 });
-    manifest::validate(&m, &resolved.version, &entry.repo).map_err(|e| fail(&e))?;
+    manifest::validate(&m, &resolved.version, &entry.repo, entry.id.as_deref())
+        .map_err(|e| fail(&e))?;
     let idx_assets = resolve_index_assets(http, &m, &resolved.release.assets)
         .await
         .map_err(|e| fail(&e))?;

--- a/super-stt-indexer/src/manifest.rs
+++ b/super-stt-indexer/src/manifest.rs
@@ -17,6 +17,10 @@ pub enum ManifestError {
     VersionMismatch(String, Version),
     #[error("`backend.source = {0:?}` does not match registry entry repo `{1}`")]
     SourceMismatch(String, String),
+    /// The release manifest's `[backend].id` does not equal the `id` declared
+    /// by the `registry.toml` entry that points at this release.
+    #[error("manifest declares `id = {0:?}` but the registry entry declares {1:?}")]
+    IdMismatch(String, String),
     #[error("`backend.kind = \"wasm\"` requires `[assets.wasm]` but it is missing")]
     MissingWasmAsset,
     #[error("`backend.kind = \"subprocess\"` requires `[[assets.subprocess]]` but list is empty")]
@@ -42,6 +46,7 @@ pub fn validate(
     m: &Manifest,
     expected_version: &Version,
     expected_source: &str,
+    expected_id: Option<&str>,
 ) -> Result<(), ManifestError> {
     // Parse via the one shared version parser (v-prefix strip + semver) so the
     // manifest check can't drift from the daemon/app/resolve logic (Tier 1 #31).
@@ -65,6 +70,18 @@ pub fn validate(
         return Err(ManifestError::SourceMismatch(
             m.backend.source.clone(),
             expected_source.into(),
+        ));
+    }
+    // An entry that declares an `id` pins the release to it. This is the same
+    // class of check as `SourceMismatch`: whoever controls the entry controls
+    // which identity the release may claim, so a release cannot rename itself
+    // into another backend's install directory.
+    if let Some(want) = expected_id
+        && m.backend.id.as_deref() != Some(want)
+    {
+        return Err(ManifestError::IdMismatch(
+            m.backend.id.clone().unwrap_or_default(),
+            want.to_string(),
         ));
     }
     match m.backend.kind {
@@ -117,10 +134,61 @@ mod tests {
         wasm = "y.wasm"
     "#;
 
+    fn with_id(id: &str) -> String {
+        VALID.replace("[backend]", &format!("[backend]\n    id = \"{id}\""))
+    }
+
     #[test]
     fn validates_a_correct_wasm_manifest() {
         let m = Manifest::parse(VALID).unwrap();
-        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap();
+    }
+
+    #[test]
+    fn accepts_a_manifest_whose_id_matches_the_entry() {
+        let m = Manifest::parse(&with_id("com.example.y")).unwrap();
+        validate(
+            &m,
+            &Version::new(1, 0, 0),
+            "github.com/x/y",
+            Some("com.example.y"),
+        )
+        .expect("matching ids validate");
+    }
+
+    #[test]
+    fn rejects_a_manifest_whose_id_differs_from_the_entry() {
+        let m = Manifest::parse(&with_id("com.example.other")).unwrap();
+        let err = validate(
+            &m,
+            &Version::new(1, 0, 0),
+            "github.com/x/y",
+            Some("com.example.y"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ManifestError::IdMismatch(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_a_manifest_with_no_id_when_the_entry_declares_one() {
+        let m = Manifest::parse(VALID).unwrap();
+        let err = validate(
+            &m,
+            &Version::new(1, 0, 0),
+            "github.com/x/y",
+            Some("com.example.y"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ManifestError::IdMismatch(_, _)), "{err:?}");
+    }
+
+    /// A grandfathered entry declares no id, so the manifest is not pinned.
+    #[test]
+    fn accepts_any_id_when_the_entry_declares_none() {
+        let m = Manifest::parse(VALID).unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).expect("unpinned");
+        let m = Manifest::parse(&with_id("com.example.y")).unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).expect("unpinned");
     }
 
     /// The indexer fetches `backend.toml` from a backend's release, so it sees
@@ -143,7 +211,7 @@ mod tests {
             "
         );
         let m = Manifest::parse(&t).expect("a manifest declaring `provider` must still parse");
-        validate(&m, &Version::new(1, 0, 0), "github.com/x/y")
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None)
             .expect("`provider` must not fail indexer validation");
         assert_eq!(m.models.len(), 1);
     }
@@ -151,14 +219,14 @@ mod tests {
     #[test]
     fn rejects_version_mismatch() {
         let m = Manifest::parse(VALID).unwrap();
-        let err = validate(&m, &Version::new(2, 0, 0), "github.com/x/y").unwrap_err();
+        let err = validate(&m, &Version::new(2, 0, 0), "github.com/x/y", None).unwrap_err();
         assert!(matches!(err, ManifestError::VersionMismatch(_, _)));
     }
 
     #[test]
     fn rejects_source_mismatch() {
         let m = Manifest::parse(VALID).unwrap();
-        let err = validate(&m, &Version::new(1, 0, 0), "github.com/other/repo").unwrap_err();
+        let err = validate(&m, &Version::new(1, 0, 0), "github.com/other/repo", None).unwrap_err();
         assert!(matches!(err, ManifestError::SourceMismatch(_, _)));
     }
 
@@ -166,14 +234,14 @@ mod tests {
     fn accepts_monorepo_subpath_source() {
         let t = VALID.replace("github.com/x/y", "github.com/x/y/openai");
         let m = Manifest::parse(&t).unwrap();
-        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap();
     }
 
     #[test]
     fn rejects_source_that_only_shares_a_prefix_segment() {
         let t = VALID.replace("github.com/x/y", "github.com/x/yyy");
         let m = Manifest::parse(&t).unwrap();
-        let err = validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap_err();
+        let err = validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap_err();
         assert!(matches!(err, ManifestError::SourceMismatch(_, _)));
     }
 
@@ -253,10 +321,10 @@ mod tests {
             type = "string"
         "#;
         let m = Manifest::parse(BASE).unwrap();
-        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap();
 
         let m = Manifest::parse(&format!("{BASE}\ndefault = \"https://api.y.com\"\n")).unwrap();
-        let err = validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap_err();
+        let err = validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap_err();
         assert!(
             matches!(err, ManifestError::BaseUrlDefault),
             "expected BaseUrlDefault, got {err:?}"
@@ -265,7 +333,7 @@ mod tests {
         // Every other option keeps its default.
         let m =
             Manifest::parse(&BASE.replace(r#"name = "base_url""#, r#"name = "region""#)).unwrap();
-        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap();
     }
 
     #[test]
@@ -288,6 +356,6 @@ mod tests {
             cuda_major = 13
         "#;
         let m = Manifest::parse(t).unwrap();
-        validate(&m, &Version::new(1, 0, 0), "github.com/x/y").unwrap();
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None).unwrap();
     }
 }

--- a/super-stt-indexer/src/registry_toml.rs
+++ b/super-stt-indexer/src/registry_toml.rs
@@ -26,7 +26,25 @@ pub enum ParseError {
         "entries `{a}` and `{b}` share repo `{repo}` and one `tag_prefix` is a prefix of the other"
     )]
     PrefixOverlap { a: String, b: String, repo: String },
+    #[error("entry `{key}` must declare an `id` (see registry/README.md)")]
+    MissingId { key: String },
+    #[error("entry `{key}`: `id = {id:?}` is not a valid reverse-DNS id")]
+    InvalidId { key: String, id: String },
+    #[error("entries `{a}` and `{b}` both declare `id = {id:?}`")]
+    DuplicateId { a: String, b: String, id: String },
 }
+
+/// Entries that predate the `id` requirement. They parse without one; every
+/// other entry must declare one. Remove a key from this list once its entry
+/// declares an `id` — the list is meant to shrink to empty.
+const GRANDFATHERED: &[&str] = &[
+    "deepgram",
+    "mistral",
+    "openai",
+    "qwen3_asr",
+    "voxtral",
+    "whisper",
+];
 
 /// Parsed registry file: id → entry. Backed by a `BTreeMap`, so iteration is in
 /// sorted id order — not the file's declaration order.
@@ -39,24 +57,35 @@ impl Registry {
         for (id, e) in &raw {
             validate_entry(id, e)?;
         }
+        let mut seen: BTreeMap<&str, &str> = BTreeMap::new();
+        for (key, e) in &raw {
+            let Some(id) = e.id.as_deref() else { continue };
+            if let Some(prev) = seen.insert(id, key) {
+                return Err(ParseError::DuplicateId {
+                    a: prev.to_string(),
+                    b: key.clone(),
+                    id: id.to_string(),
+                });
+            }
+        }
         validate_monorepo_groups(&raw)?;
         Ok(Self(raw))
     }
 }
 
-fn validate_entry(id: &str, e: &Entry) -> Result<(), ParseError> {
-    if !id
+fn validate_entry(id_key: &str, e: &Entry) -> Result<(), ParseError> {
+    if !id_key
         .chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
     {
         return Err(ParseError::Entry {
-            id: id.into(),
+            id: id_key.into(),
             reason: "id must be ascii lowercase, digits, `-`, `_`".into(),
         });
     }
     if e.repo.is_empty() {
         return Err(ParseError::Entry {
-            id: id.into(),
+            id: id_key.into(),
             reason: "`repo` is required".into(),
         });
     }
@@ -64,9 +93,21 @@ fn validate_entry(id: &str, e: &Entry) -> Result<(), ParseError> {
         && !super_stt_registry_types::is_safe_relative_path(sd)
     {
         return Err(ParseError::Entry {
-            id: id.into(),
+            id: id_key.into(),
             reason: format!("`subdir = {sd:?}` is not a safe relative path"),
         });
+    }
+    match &e.id {
+        Some(id) if !super_stt_registry_types::backend_id::is_valid(id) => {
+            return Err(ParseError::InvalidId {
+                key: id_key.into(),
+                id: id.clone(),
+            });
+        }
+        None if !GRANDFATHERED.contains(&id_key) => {
+            return Err(ParseError::MissingId { key: id_key.into() });
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -173,7 +214,7 @@ mod tests {
             );
         }
         let ok = Registry::parse(
-            "[good]\nrepo = \"github.com/x/y\"\nforge = \"github\"\nsubdir = \"my..backend/v2\"\n",
+            "[good]\nid = \"com.example.good\"\nrepo = \"github.com/x/y\"\nforge = \"github\"\nsubdir = \"my..backend/v2\"\n",
         )
         .unwrap();
         assert_eq!(
@@ -187,9 +228,11 @@ mod tests {
         let err = Registry::parse(
             r#"
             [a]
+            id = "com.example.a"
             repo = "github.com/x/mono"
             forge = "github"
             [b]
+            id = "com.example.b"
             repo = "github.com/x/mono"
             forge = "github"
         "#,
@@ -203,10 +246,12 @@ mod tests {
         let err = Registry::parse(
             r#"
             [a]
+            id = "com.example.a"
             repo = "github.com/x/mono"
             forge = "github"
             tag_prefix = "v"
             [b]
+            id = "com.example.b"
             repo = "github.com/x/mono"
             forge = "github"
             tag_prefix = "v"
@@ -221,10 +266,12 @@ mod tests {
         let err = Registry::parse(
             r#"
             [a]
+            id = "com.example.a"
             repo = "github.com/x/mono"
             forge = "github"
             tag_prefix = "voxtral-"
             [b]
+            id = "com.example.b"
             repo = "github.com/x/mono"
             forge = "github"
             tag_prefix = "voxtral-mini-"
@@ -239,10 +286,12 @@ mod tests {
         let r = Registry::parse(
             r#"
             [a]
+            id = "com.example.a"
             repo = "github.com/x/mono"
             forge = "github"
             tag_prefix = "a-"
             [b]
+            id = "com.example.b"
             repo = "github.com/x/mono"
             forge = "github"
             tag_prefix = "b-"
@@ -258,9 +307,11 @@ mod tests {
         let r = Registry::parse(
             r#"
             [a]
+            id = "com.example.a"
             repo = "github.com/x/mono"
             forge = "github"
             [b]
+            id = "com.example.b"
             repo = "github.com/x/mono"
             forge = "github"
             removed = true
@@ -268,5 +319,65 @@ mod tests {
         )
         .unwrap();
         assert_eq!(r.0.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::{ParseError, Registry};
+
+    const NEW_ENTRY: &str = r#"
+[brand-new]
+    id    = "com.example.brand-new"
+    repo  = "github.com/example/super-stt-brand-new"
+    forge = "github"
+"#;
+
+    #[test]
+    fn accepts_a_new_entry_with_a_valid_unique_id() {
+        let r = Registry::parse(NEW_ENTRY).expect("parses");
+        assert_eq!(
+            r.0["brand-new"].id.as_deref(),
+            Some("com.example.brand-new")
+        );
+    }
+
+    #[test]
+    fn rejects_a_new_entry_without_an_id() {
+        let text = "[brand-new]\n    repo = \"github.com/example/x\"\n    forge = \"github\"\n";
+        let err = Registry::parse(text).unwrap_err();
+        assert!(matches!(err, ParseError::MissingId { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn accepts_a_grandfathered_entry_without_an_id() {
+        let text = "[voxtral]\n    repo = \"github.com/jorge-menjivar/super-stt-voxtral\"\n    forge = \"github\"\n";
+        Registry::parse(text).expect("existing entries are exempt");
+    }
+
+    #[test]
+    fn rejects_a_malformed_id() {
+        let text = NEW_ENTRY.replace("com.example.brand-new", "brandnew");
+        let err = Registry::parse(&text).unwrap_err();
+        assert!(matches!(err, ParseError::InvalidId { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_two_entries_sharing_an_id() {
+        let text = format!(
+            "{NEW_ENTRY}\n[other]\n    id    = \"com.example.brand-new\"\n    repo  = \"github.com/example/super-stt-other\"\n    forge = \"github\"\n"
+        );
+        let err = Registry::parse(&text).unwrap_err();
+        assert!(matches!(err, ParseError::DuplicateId { .. }), "{err:?}");
+    }
+
+    /// The shipped file must keep parsing as the requirement lands.
+    #[test]
+    fn the_in_repo_registry_parses() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap();
+        let text = std::fs::read_to_string(root.join("registry/registry.toml")).unwrap();
+        Registry::parse(&text).expect("registry.toml parses");
     }
 }

--- a/super-stt-indexer/src/resolve.rs
+++ b/super-stt-indexer/src/resolve.rs
@@ -116,6 +116,7 @@ mod tests {
 
     fn entry(prefix: Option<&str>, max: Option<&str>) -> Entry {
         Entry {
+            id: None,
             repo: "github.com/x/y".into(),
             forge: super_stt_registry_types::forge::Forge::Github,
             subdir: None,

--- a/super-stt-indexer/tests/integration.rs
+++ b/super-stt-indexer/tests/integration.rs
@@ -76,6 +76,7 @@ async fn end_to_end_indexes_a_single_wasm_backend() {
         &registry_path,
         r#"
         [x-y]
+        id = "com.example.x-y"
         repo = "github.com/x/y"
         forge = "github"
     "#,

--- a/super-stt-indexer/tests/integration.rs
+++ b/super-stt-indexer/tests/integration.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 
 const MANIFEST_OK: &str = r#"
 [backend]
+id = "com.example.x-y"
 source = "github.com/x/y/foo"
 name = "Y"
 version = "1.0.0"

--- a/super-stt-registry-types/src/backend_id.rs
+++ b/super-stt-registry-types/src/backend_id.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Format rules for `[backend].id` — the reverse-DNS identifier that names a
+//! backend's install directory.
+
+/// Longest permitted id. A backend id becomes a filesystem path component,
+/// and 255 bytes is the component limit on the filesystems this runs on.
+const MAX_LEN: usize = 255;
+
+/// Whether `s` is a well-formed reverse-DNS backend id.
+///
+/// At least three `.`-separated segments, each beginning with a lowercase
+/// ASCII letter and containing only lowercase letters, digits, and `-`, and
+/// none ending in `-`. Rejects empty, leading, trailing, and consecutive dot
+/// segments implicitly: an empty segment has no leading letter.
+#[must_use]
+pub fn is_valid(s: &str) -> bool {
+    if s.is_empty() || s.len() > MAX_LEN {
+        return false;
+    }
+    let segments: Vec<&str> = s.split('.').collect();
+    if segments.len() < 3 {
+        return false;
+    }
+    segments.iter().all(|seg| {
+        seg.starts_with(|c: char| c.is_ascii_lowercase())
+            && !seg.ends_with('-')
+            && seg
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid;
+
+    #[test]
+    fn accepts_reverse_dns_ids() {
+        assert!(is_valid("app.super-stt.voxtral"));
+        assert!(is_valid("com.example.whisper"));
+        assert!(is_valid("io.a.b.c.d"));
+        assert!(is_valid("org.x.qwen3-asr"));
+    }
+
+    #[test]
+    fn rejects_malformed_ids() {
+        assert!(!is_valid(""), "empty");
+        assert!(!is_valid("voxtral"), "one segment");
+        assert!(!is_valid("app.voxtral"), "two segments");
+        assert!(!is_valid("app..voxtral"), "consecutive dots");
+        assert!(!is_valid(".app.super-stt.voxtral"), "leading dot");
+        assert!(!is_valid("app.super-stt.voxtral."), "trailing dot");
+        assert!(
+            !is_valid("app.super-stt.3voxtral"),
+            "segment starts with a digit"
+        );
+        assert!(
+            !is_valid("app.super-stt.voxtral-"),
+            "segment ends with a hyphen"
+        );
+        assert!(!is_valid("App.Super-STT.Voxtral"), "uppercase");
+        assert!(!is_valid("app.super_stt.voxtral"), "underscore");
+        assert!(!is_valid("app/super-stt/voxtral"), "path separator");
+        assert!(!is_valid(".."), "parent dir");
+    }
+
+    #[test]
+    fn rejects_an_over_length_id() {
+        let long = format!("app.super-stt.{}", "a".repeat(250));
+        assert!(!is_valid(&long));
+    }
+
+    /// The format rules already imply this, but the path-joining guarantee
+    /// must not rest on them alone.
+    #[test]
+    fn every_valid_id_is_a_safe_path_component() {
+        for id in ["app.super-stt.voxtral", "com.example.whisper", "io.a.b.c.d"] {
+            assert!(crate::is_safe_component(id), "{id}");
+        }
+    }
+}

--- a/super-stt-registry-types/src/entry.rs
+++ b/super-stt-registry-types/src/entry.rs
@@ -12,6 +12,12 @@ use crate::forge::Forge;
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Entry {
+    /// Reverse-DNS identifier for the backend, e.g. `com.example.voxtral`.
+    /// Must equal the `[backend].id` of the release manifest this entry points
+    /// at. Required for entries added after the field was introduced; the
+    /// entries that predate it are listed in `registry_toml::GRANDFATHERED`.
+    #[serde(default)]
+    pub id: Option<String>,
     /// Repository hosting the backend, as `<host>/<owner>/<repo>` (e.g.
     /// `github.com/<owner>/<repo>`). The indexer queries this repo's releases
     /// to discover versions.

--- a/super-stt-registry-types/src/index.rs
+++ b/super-stt-registry-types/src/index.rs
@@ -33,6 +33,12 @@ pub struct Index {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexBackend {
     pub id: String,
+    /// The backend's reverse-DNS identifier from its release manifest. Names
+    /// the install directory. `None` for an entry that predates the field;
+    /// `id` remains the registry key and is unchanged, so a client that does
+    /// not read this field installs exactly where it always did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_id: Option<String>,
     pub source: String,
     pub version: String,
     pub tag: String,
@@ -173,6 +179,7 @@ impl IndexBackend {
         } = model_support(&m.models);
         Self {
             id,
+            backend_id: m.backend.id,
             source: m.backend.source,
             version,
             tag,
@@ -449,6 +456,7 @@ mod tests {
             min_client: MIN_CLIENT.into(),
             backends: vec![IndexBackend {
                 id: "openai".into(),
+                backend_id: None,
                 source: "github.com/x/y".into(),
                 version: "1.0.0".into(),
                 tag: "v1.0.0".into(),
@@ -530,6 +538,76 @@ mod tests {
         assert_eq!(b.options.len(), 1, "option must not be dropped");
         assert_eq!(b.options[0].label, "base_url", "label falls back to name");
         assert_eq!(b.options[0].r#type, "string", "type defaults to string");
+    }
+
+    /// `backend_id` carries the manifest's reverse-DNS `[backend].id`,
+    /// distinct from the caller-supplied registry `id`. An older daemon that
+    /// does not read this field still installs into the directory named by
+    /// `id`, so the two must never be conflated.
+    #[test]
+    fn from_manifest_propagates_the_manifest_id_into_backend_id() {
+        let m = crate::manifest::Manifest::parse(
+            r#"
+            [backend]
+            id = "app.super-stt.voxtral"
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
+            description = "Test backend."
+
+            [assets]
+            wasm = "y.wasm"
+            "#,
+        )
+        .unwrap();
+
+        let b = IndexBackend::from_manifest(
+            id_from_source("github.com/x/y"),
+            m,
+            "1.0.0".into(),
+            "v1.0.0".into(),
+            IndexAssets::default(),
+            None,
+        );
+
+        assert_eq!(b.id, "y", "id stays the registry key, unaffected");
+        assert_eq!(b.backend_id.as_deref(), Some("app.super-stt.voxtral"));
+    }
+
+    /// A manifest that predates `[backend].id` yields a `None` `backend_id`,
+    /// not an empty string or a fallback to `source`.
+    #[test]
+    fn from_manifest_leaves_backend_id_none_when_the_manifest_has_none() {
+        let m = crate::manifest::Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
+            description = "Test backend."
+
+            [assets]
+            wasm = "y.wasm"
+            "#,
+        )
+        .unwrap();
+
+        let b = IndexBackend::from_manifest(
+            id_from_source("github.com/x/y"),
+            m,
+            "1.0.0".into(),
+            "v1.0.0".into(),
+            IndexAssets::default(),
+            None,
+        );
+
+        assert!(b.backend_id.is_none());
     }
 
     /// Every install path — registry, custom repo, local dir — synthesizes its

--- a/super-stt-registry-types/src/lib.rs
+++ b/super-stt-registry-types/src/lib.rs
@@ -4,6 +4,7 @@
 //! See `docs/protocol/backend/config.md`.
 
 pub mod arch;
+pub mod backend_id;
 pub mod entry;
 pub mod forge;
 pub mod fs;

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -56,6 +56,12 @@ pub struct Manifest {
 #[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct BackendMeta {
+    /// Globally unique reverse-DNS identifier, e.g. `app.super-stt.voxtral`.
+    /// Names the directory this backend installs into. Optional on disk so a
+    /// backend installed before the field existed keeps loading; required for
+    /// registry listing, which the indexer enforces.
+    #[serde(default)]
+    pub id: Option<String>,
     /// Canonical repository id, e.g. `github.com/<owner>/<repo>`. Becomes the
     /// `source` of every model this backend provides and must be unique
     /// across installed backends. For a monorepo, namespace it under the repo
@@ -570,6 +576,9 @@ pub enum ManifestError {
     /// The `entrypoint` field is not a safe relative path.
     #[error("backend.toml entrypoint {0:?} is not a safe relative path")]
     UnsafeEntrypoint(String),
+    /// `[backend].id` is present but not a well-formed reverse-DNS id.
+    #[error("`[backend].id` is not a valid reverse-DNS id: {0}")]
+    InvalidId(String),
     /// A `[[models.files]]` `destination` is not a safe relative path.
     #[error("backend.toml file destination {0:?} is not a safe relative path")]
     UnsafeDestination(String),
@@ -640,6 +649,14 @@ impl Manifest {
         let mut m: Self = toml::from_str(text)?;
         if !crate::is_safe_relative_path(&m.backend.entrypoint) {
             return Err(ManifestError::UnsafeEntrypoint(m.backend.entrypoint));
+        }
+        // Validated in the canonical parser so the daemon (which joins it onto
+        // the backends dir) and the indexer (which pins it against
+        // registry.toml) inherit one definition.
+        if let Some(id) = &m.backend.id
+            && !crate::backend_id::is_valid(id)
+        {
+            return Err(ManifestError::InvalidId(id.clone()));
         }
         // Each file's `destination` is joined onto the backend dir before the
         // daemon writes the download; reject any value that would escape it.
@@ -722,6 +739,39 @@ impl Manifest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A minimal manifest with no `[backend].id`, for tests that only care
+    /// about behavior around the field.
+    const VALID: &str = r#"
+        [backend]
+        source = "github.com/x/y"
+        name = "Y"
+        version = "1.0.0"
+        kind = "wasm"
+        entrypoint = "y.wasm"
+        contract = "v1"
+        description = "Test backend."
+        "#;
+
+    #[test]
+    fn parses_a_manifest_declaring_a_backend_id() {
+        let t = VALID.replace("[backend]", "[backend]\n    id = \"app.super-stt.voxtral\"");
+        let m = Manifest::parse(&t).expect("a manifest with a valid id parses");
+        assert_eq!(m.backend.id.as_deref(), Some("app.super-stt.voxtral"));
+    }
+
+    #[test]
+    fn a_manifest_without_an_id_still_parses() {
+        let m = Manifest::parse(VALID).expect("id is optional on disk");
+        assert!(m.backend.id.is_none());
+    }
+
+    #[test]
+    fn rejects_a_malformed_backend_id() {
+        let t = VALID.replace("[backend]", "[backend]\n    id = \"voxtral\"");
+        let err = Manifest::parse(&t).unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidId(_)));
+    }
 
     #[test]
     fn parses_wasm_manifest_with_secrets_and_options() {

--- a/super-stt-shared/src/registry/events.rs
+++ b/super-stt-shared/src/registry/events.rs
@@ -62,6 +62,12 @@ pub enum InstallError {
     /// validation, over the size cap, or an identity/entrypoint inconsistent
     /// with the index entry.
     ManifestInvalid,
+    /// The directory this backend installs into already holds a *different*
+    /// backend — one whose `backend.toml` declares another `[backend].source`.
+    /// Completing the install would replace that backend and delete the model
+    /// files under it, so it is refused and both directories are left as they
+    /// were.
+    InstallDirConflict,
 }
 
 impl std::fmt::Display for InstallError {
@@ -75,6 +81,7 @@ impl std::fmt::Display for InstallError {
             Self::TarballUnsafe => "the archive contained unsafe paths",
             Self::InstallIoError => "a filesystem error occurred during install",
             Self::ManifestInvalid => "the backend manifest was missing or invalid",
+            Self::InstallDirConflict => "the install directory already holds a different backend",
         })
     }
 }

--- a/super-stt-shared/src/registry/mod.rs
+++ b/super-stt-shared/src/registry/mod.rs
@@ -19,6 +19,10 @@ pub struct RegistryListResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryBackend {
     pub id: String,
+    /// The backend's reverse-DNS identifier, or `None` when the registry entry
+    /// predates it. Names the install directory.
+    #[serde(default)]
+    pub backend_id: Option<String>,
     pub source: String,
     pub version: String,
     pub name: String,
@@ -144,14 +148,12 @@ pub use super_stt_registry_types::{is_safe_component, is_safe_relative_path};
 mod tests {
     use super::RegistryBackend;
 
-    /// A daemon that predates `update_available` still deserializes here. The
-    /// field moved the update decision from the client to the daemon; a client
-    /// that hard-required it would fail to list anything at all against a
-    /// daemon that has not rolled over, which is worse than not knowing about
-    /// an update.
-    #[test]
-    fn a_registry_entry_without_update_available_still_parses() {
-        let json = serde_json::json!({
+    /// The minimal `/registry/backends` entry every test below starts from,
+    /// extending it with `serde_json::Value` indexing for the field each test
+    /// cares about. One fixture rather than three keeps them from drifting
+    /// apart on the fields that are merely required to parse at all.
+    fn minimal_backend_json() -> serde_json::Value {
+        serde_json::json!({
             "id": "openai",
             "source": "github.com/super-stt/openai",
             "version": "0.1.1",
@@ -166,9 +168,19 @@ mod tests {
             "secrets": [],
             "options": [],
             "compatibility": { "compatible": true },
-            "installed_version": "0.1.0",
-        });
-        let b: RegistryBackend = serde_json::from_value(json).expect("older payload must parse");
+        })
+    }
+
+    /// A daemon that predates `update_available` still deserializes here. The
+    /// field moved the update decision from the client to the daemon; a client
+    /// that hard-required it would fail to list anything at all against a
+    /// daemon that has not rolled over, which is worse than not knowing about
+    /// an update.
+    #[test]
+    fn a_registry_entry_without_update_available_still_parses() {
+        let mut v = minimal_backend_json();
+        v["installed_version"] = serde_json::json!("0.1.0");
+        let b: RegistryBackend = serde_json::from_value(v).expect("older payload must parse");
         assert!(
             !b.update_available,
             "an absent flag reads as no update, never as one"
@@ -180,26 +192,25 @@ mod tests {
     /// ways or it is not compatibility.
     #[test]
     fn a_registry_entry_with_an_unknown_field_still_parses() {
-        let json = serde_json::json!({
-            "id": "openai",
-            "source": "github.com/super-stt/openai",
-            "version": "0.1.1",
-            "name": "OpenAI",
-            "license": "Apache-2.0",
-            "kind": "wasm",
-            "contract": "v1",
-            "online": true,
-            "supports_gpu": false,
-            "supports_cpu": false,
-            "models": [],
-            "secrets": [],
-            "options": [],
-            "compatibility": { "compatible": true },
-            "update_available": true,
-            "a_field_from_a_later_daemon": 42,
-        });
-        let b: RegistryBackend = serde_json::from_value(json).expect("newer payload must parse");
+        let mut v = minimal_backend_json();
+        v["update_available"] = serde_json::json!(true);
+        v["a_field_from_a_later_daemon"] = serde_json::json!(42);
+        let b: RegistryBackend = serde_json::from_value(v).expect("newer payload must parse");
         assert!(b.update_available);
+    }
+
+    /// A daemon that predates `backend_id` still deserializes here, and a
+    /// response carrying one round-trips.
+    #[test]
+    fn backend_id_is_optional_on_the_wire() {
+        let without: RegistryBackend =
+            serde_json::from_value(minimal_backend_json()).expect("parses without backend_id");
+        assert!(without.backend_id.is_none());
+
+        let mut v = minimal_backend_json();
+        v["backend_id"] = serde_json::json!("app.super-stt.voxtral");
+        let with: RegistryBackend = serde_json::from_value(v).expect("parses with backend_id");
+        assert_eq!(with.backend_id.as_deref(), Some("app.super-stt.voxtral"));
     }
 
     fn selected(accel: &[&str]) -> super::SelectedAsset {


### PR DESCRIPTION
Fixes an installed backend never being offered an update, an update destroying its downloaded model weights, and two directories being able to serve the same backend.

## The problem

Three defects, one root cause: the daemon disagreed with itself about what names an installed backend.

`GET /registry/backends` and `POST /registry/backends/update` resolved the installed version by path-joining `backends_dir/<index id>`. Discovery, uninstall, and model switching all key off `[backend].source` instead. A backend installed from a custom repo or a local path lands in a directory named after its **repo**, so the id-keyed join missed and `update_available` was silently `false`. Every entry in `registry/registry.toml` has this mismatch — the index id is `voxtral`, the installed directory is `super-stt-voxtral`.

Separately, `swap_into_place` renamed the install directory aside and deleted it. Model weights live *inside* that directory, so updating a backend discarded them and re-downloaded from Hugging Face — 8.8 GB for Voxtral alone on the development machine.

And nothing prevented `<backends>/voxtral` and `<backends>/super-stt-voxtral` coexisting, stranding an orphaned `models/` subtree that nothing would ever load or clean up.

## What changed

**Update matching keys on `source`.** It is the only identifier both sides always carry: the index always has one, and every `backend.toml` must declare one. A directory name does not qualify — it is derived differently depending on which route installed it. This fixes the reported symptom on its own, with no `id`, no directory rename, and no backend re-release.

**A new reverse-DNS `[backend].id` names install directories.** Required for new `registry.toml` entries, unique across the registry, and pinned by the indexer against the release manifest the same way `source` is pinned against the repo. It travels to the daemon as a new `index.json` field, `backend_id` — a *new* field rather than a repurposed `id`, because an older daemon names directories from `id` while its `transcription.active_backend` still points at the old one.

`id` is deliberately **not** the wire identity. Model identity stays `(name, source)` per [contract.md](docs/protocol/backend/contract.md); widening `id` to replace it would drag in nine endpoint specs, the app, and the applet, and is left to a separate change.

**Model weights survive an update.** A file carries over when both manifests declare the same `destination` with the same `url`; a destination declared twice with conflicting URLs is excluded, because guessing which URL a file came from is not worth a stale weight. Survivors move into the staging directory *before* the swap, so the directory that lands is already complete and the operation stays atomic — and since staging lives under the backends directory, these are same-filesystem renames rather than a multi-gigabyte copy. `sha256` deliberately gates nothing here: `download::usable_existing` already re-verifies every carried file at provision time.

**Duplicates are reconciled, not just deduplicated.** The winner is the highest `version`, then the id-named directory, then lexicographic. Version outranks the id-name on purpose — a backend updated in place before migration existed sits at the repo-named directory on the *newer* version, and preferring the id-name would delete the newer install and silently downgrade the user. The loser's still-valid weights are merged into the winner before it is removed, and a directory whose manifest does not parse is never a candidate.

**An install refuses to replace a different backend.** `backend_id` is unpinned on the custom-repo and local-dir routes and on grandfathered registry entries, and `swap_into_place` never checked what it was replacing — so a repo declaring `id = "app.super-stt.voxtral"` would install into Voxtral's directory and delete it. Installs now refuse with a typed `install_dir_conflict` when the target directory serves a different `source`, and the indexer gained `ensure_unique_backend_ids` mirroring the existing `ensure_unique_sources`. Related: `backend_id` arriving over the wire is validated with `backend_id::is_valid` rather than only `is_safe_component`, since `is_safe_component(".staging")` is `true` and would have pointed an install at the shared staging root.

## Backward compatibility

**No backend re-release is required, and nothing is delisted.** The six current `registry.toml` entries declare no `id` and stay grandfathered — the indexer skips the id pin when an entry declares none, and each stops being exempt the moment it adds one. A backend whose `backend.toml` predates the field keeps loading and keeps receiving updates, and installs under its existing directory name.

`index.json` gains a field rather than changing one. Neither `IndexBackend` nor `RegistryBackend` sets `deny_unknown_fields`, so an older daemon ignores `backend_id` and installs exactly where it always did; `schema_version` stays `1` and `min_client` is unchanged. Wire compatibility is pinned in both directions by tests.

A backend already installed at a non-conforming directory name migrates only when an id-bearing release is installed: the new install lands at `<backends>/<id>`, its weights are carried across first, the old directory is retired, and `transcription.active_backend` follows — via a narrow `rename_active_backend` that preserves `preferred_model`, not `update_active_backend`, which clears it.

## Deferred

Slimming the local-import file set is **not** in this PR. Importing a subprocess backend by path still copies the whole source tree — the observed Voxtral import carried `target/`, `src/`, `tests/`, and 5.3 GB of build artifacts into the install directory. It is independent of everything here and reuses the carry-over predicate once it lands.

## Verification

`just ci` — 1105 tests, 0 failures, including the 21 integration targets that a `--lib` build skips. `discover`, `manifest::validate`, and `dedup_sources` all changed signature, so that full run is what proves no `tests/` caller broke.

Each destructive path has a test that fails without its guard: an install refusing to replace a different backend (both install routes), `.staging` rejected as a `backend_id` at both the boundary and the use site, a reconcile repointing `active_backend` while preserving the model choice, and a loser's weights verified byte-for-byte in the winner before deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
