### PR TITLE
Link the unstable wasi:cli/exit exit-with-code import

### DIFF
--- a/super-stt-daemon/src/stt_models/wasm/mod.rs
+++ b/super-stt-daemon/src/stt_models/wasm/mod.rs
@@ -92,7 +92,14 @@ impl WasmBackend {
         // and no granted sockets — so the component cannot touch the disk or
         // open raw connections; its only egress is the allowlisted
         // `wasi:http/outgoing-handler`.
-        wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
+        // `cli-exit-with-code` is still an `@unstable` WASI 0.2 feature, so
+        // `LinkOptions::default()` leaves it out of the linker — but Rust's
+        // wasm32-wasip2 std imports it, so every component built with a
+        // toolchain that emits that import fails to instantiate unless the
+        // host opts in. Enable it so backends stay loadable across toolchains.
+        let mut link_options = wasmtime_wasi::p2::bindings::LinkOptions::default();
+        link_options.cli_exit_with_code(true);
+        wasmtime_wasi::p2::add_to_linker_with_options_async(&mut linker, &link_options)?;
         wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker)?;
         // A websocket-capable backend additionally imports
         // `super-stt:realtime/ws` and exports `ws-server`; link the host `ws`


### PR DESCRIPTION
## What

The nightly leg of CI fails to load any WASM backend component:

```
component imports instance `wasi:cli/exit@0.2.12`, but a matching implementation was not found
  0: instance export `exit-with-code` has the wrong type
  1: function implementation is missing
```

Rust's `wasm32-wasip2` std now imports `exit-with-code` from `wasi:cli/exit` alongside the plain `exit`. That function is `@unstable(feature = cli-exit-with-code)` in the WASI 0.2 WIT, and `add_to_linker_async` links with `LinkOptions::default()`, which omits unstable features — so the linker's `wasi:cli/exit` instance no longer satisfies the import type and `instantiate_pre` fails.

This is a host gap, not a test-fixture quirk: a stable-built daemon fails the same way against a component built with a toolchain that emits the import, so it would break real backends as soon as the std change reaches stable.

## Fix

Link WASI with `cli_exit_with_code(true)`. No sandbox change — wasmtime-wasi's `exit_with_code` returns an `I32Exit` trap into the guest store exactly like `exit`; the host process is untouched.

## Verification

- `wasm_mock` + `wasm_mock_realtime` against **nightly-built** fixtures: failed before, pass after
- `cargo test --workspace --all-features --lib`: 754 passed, 0 failed
- clippy pedantic clean, `just fmt` applied, `--no-default-features --features wasm-backends` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnpUdYGN1vf3iguKZ1xnNQ