### PR TITLE
Restart cosmic-panel when uninstall removes the applet

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -20,6 +20,9 @@
 #   - systemd user unit (/usr/lib/systemd/user + ~/.config/systemd/user)
 #   - COSMIC keyboard shortcut (only if it's the lone entry)
 #
+# The COSMIC panel is restarted when an installed applet was removed, so the
+# tray drops it without a relogin.
+#
 # Root-owned files are removed via sudo; it is only invoked when such
 # files are actually present.
 #
@@ -96,6 +99,21 @@ do
     [ -e "$probe" ] && SYSTEM_INSTALL_PRESENT=true
 done
 
+# Whether a COSMIC applet was installed, captured here for the same reason:
+# it decides whether the panel needs restarting once the files are gone
+# (step 6), and by then there is nothing left to probe. Both the system and
+# the legacy per-user layouts count, and the desktop entries are probed as
+# well as the binary so an install missing one of the two still registers.
+APPLET_INSTALLED=false
+for probe in \
+    "$SYSTEM_BIN_DIR/super-stt-cosmic-applet" \
+    "$LEGACY_BIN_DIR/super-stt-cosmic-applet" \
+    "$SYSTEM_DESKTOP_DIR/super-stt-cosmic-applet-full.desktop" \
+    "$DESKTOP_DIR/super-stt-cosmic-applet-full.desktop"
+do
+    [ -e "$probe" ] && APPLET_INSTALLED=true
+done
+
 print_info "Uninstalling Super STT..."
 
 # 1. Disable the unit so it doesn't auto-start after the next reboot,
@@ -169,6 +187,17 @@ if command -v update-desktop-database &> /dev/null; then
         $SUDO update-desktop-database "$SYSTEM_DESKTOP_DIR" 2>/dev/null || true
     fi
 fi
+# The panel keeps a loaded applet in the tray until it restarts, so a removed
+# applet lingers there until the next relogin. Restart it when the applet was
+# actually installed (captured before removal, above) and a panel is actually
+# running; cosmic-session respawns it. Unanchored `-f`, matching the
+# installer's own post-install panel restart, because the panel runs from an
+# absolute path rather than a bare name like the launchers below.
+if [ "$APPLET_INSTALLED" = true ] && pgrep -f cosmic-panel > /dev/null 2>&1; then
+    print_info "Restarting cosmic-panel to drop the removed applet..."
+    pkill -f cosmic-panel 2>/dev/null || true
+fi
+
 # Nudge COSMIC's launcher caches so the removed entries disappear without
 # a relogin; both processes respawn on demand and rescan.
 pkill -f '^cosmic-app-library$' 2>/dev/null || true


### PR DESCRIPTION
`uninstall.sh` nudges the launcher caches (`cosmic-app-library`, `cosmic-launcher`, `pop-launcher`) but never touched `cosmic-panel`, so a removed applet stayed in the tray until the next relogin — the panel keeps it loaded until it restarts.

The installer already does the symmetric thing on the way in (`post_install::Step::RestartPanel`, guarded on `components.applet && applet_was_installed && panel_running`); this makes the way out match.

## What changes

- `APPLET_INSTALLED` is captured next to `SYSTEM_INSTALL_PRESENT`, **before** anything is removed — by the time the panel restart runs in step 6 there is nothing left to probe. It covers the system and legacy per-user layouts, and probes the desktop entry as well as the binary so an install missing one of the two still registers.
- Step 6 restarts the panel before nudging the launchers (the installer's own order), guarded on both the applet having been installed and a panel actually running. `cosmic-session` respawns it.
- The header's summary of side effects mentions the restart.

The `-f` match is unanchored, unlike the launcher `pkill`s just below it, because the panel runs from an absolute path rather than a bare name — same pattern the installer uses, so the two stay consistent.

## Verification

Three cases exercised in a container, driving the real `uninstall.sh` against a fake panel process:

| case | result |
|---|---|
| applet installed + panel running | panel restarted, reported |
| no applet installed + panel running | panel left alone, nothing reported |
| applet installed + no panel running | clean no-op, still exits 0 |

Full install e2e green on both channels (14 passed / 0 failed / 2 environmental xfails) — that path hits the third case, since CI runners have no COSMIC panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ccVVsDsR9ocFNkjiHgz98