### PR TITLE
Try the Wayland protocol first and add a typing test

### DIFF
--- a/docs/protocol/endpoints/v1/write_method.md
+++ b/docs/protocol/endpoints/v1/write_method.md
@@ -5,14 +5,20 @@ Read and set the keyboard simulation method used when a
 true` and needs to type the final transcription into the focused
 window.
 
-| Method                | Notes                                                                                |
-|-----------------------|--------------------------------------------------------------------------------------|
-| `auto`                | Pick the best available method for the current session (the default).               |
-| `xdg_desktop_portal`  | Use the portal's `RemoteDesktop` interface; requires a portal available on the bus.  |
-| `ydotool`             | Use the `ydotool` daemon if present; works without a portal on most Wayland sessions. |
-| `wayland_protocol`    | Use a direct Wayland protocol path (compositor-dependent).                            |
+| Method               | Notes                                                                                                                    |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `auto`               | Try `wayland_protocol`, then `xdg_desktop_portal`, then `ydotool`, and use the first the session supports (the default). |
+| `xdg_desktop_portal` | Use the portal's `RemoteDesktop` interface; requires a portal exporting it on the session bus.                            |
+| `ydotool`            | Use the `ydotool` daemon if present; works without a portal on most Wayland sessions.                                    |
+| `wayland_protocol`   | Use a direct Wayland protocol path; requires a compositor exposing `zwp_virtual_keyboard_manager_v1`.                     |
 
-The new method takes effect on the next `/transcribe` request.
+A specific method is used as given: when it is unavailable the request that
+needs it fails rather than falling back. Only `auto` walks the chain.
+
+The new method takes effect on the next `/transcribe` request. To
+check that the configured method can actually type — and, for `auto`,
+to learn which backend it resolves to — use
+[`POST /write_method/test`](./write_method/test.md).
 
 ## Auth
 

--- a/docs/protocol/endpoints/v1/write_method/test.md
+++ b/docs/protocol/endpoints/v1/write_method/test.md
@@ -1,0 +1,76 @@
+# `POST /write_method/test`
+
+Type a short fixed string using the configured write method, so a
+settings UI can show the user whether keyboard simulation actually
+reaches their focused window. The method itself is read / set via
+[`/write_method`](../write_method.md).
+
+The string typed is `Super STT input test 123`.
+
+The text goes to whatever window holds keyboard focus on the daemon
+host at the moment of the call — the daemon cannot target a specific
+window. A client offering this as a button should focus a text field
+of its own first, so the user has somewhere to see the result.
+Calling it from a remote / sandboxed client types into the *daemon
+host's* focused window, not the caller's.
+
+A `success` response means the backend accepted the keystrokes, not
+that they appeared on screen. Some Wayland input paths report success
+even when the compositor routes the events nowhere — for instance
+when no text input is active in the focused client. Seeing the text
+is the actual test; the response only rules out the failures the
+daemon can detect.
+
+## Auth
+
+- **Required scope:** `settings`.
+- `Authorization: Bearer <session_token>` is required.
+- Tokens without the `settings` scope get `403 scope_denied`.
+
+## `POST /write_method/test`
+
+**Request:**
+
+```http
+POST /write_method/test HTTP/1.1
+Host: stt.local
+Authorization: Bearer stt_…64hex…
+```
+
+No request body.
+
+**Response (200):**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status":                "success",
+  "message":               "Typed test text via Wayland protocol",
+  "write_method":          "auto",
+  "resolved_write_method": "wayland_protocol"
+}
+```
+
+| Field                   | Type   | Notes                                                                                                   |
+|-------------------------|--------|---------------------------------------------------------------------------------------------------------|
+| `write_method`          | string | The configured method, exactly as [`GET /write_method`](../write_method.md) reports it.                 |
+| `resolved_write_method` | string | The backend that typed: `xdg_desktop_portal`, `ydotool`, or `wayland_protocol` — never `auto`.          |
+
+`resolved_write_method` is the useful half when `write_method` is
+`auto`: it names the rung the auto chain settled on, which is
+otherwise not observable from the protocol.
+
+The call returns once the keystrokes have been delivered to the
+backend, so a long string blocks for as long as typing takes.
+
+**Errors:**
+
+| HTTP | `message`                  | Meaning                                                                       |
+|------|----------------------------|---------------------------------------------------------------------------------|
+| 401  | `invalid_session`          | Token unknown / expired / `exe_changed`                                        |
+| 403  | `scope_denied`             | Token lacks the `settings` scope                                              |
+| 409  | `recording_in_progress`    | A daemon-mic recording is active and already owns the keyboard                 |
+| 500  | `write_method_unavailable` | No backend could be built — for `auto`, every method in the chain was unusable |
+| 500  | `typing_failed`            | A backend was built but the keystrokes could not be delivered                  |

--- a/docs/protocol/scopes/settings.md
+++ b/docs/protocol/scopes/settings.md
@@ -51,6 +51,7 @@ scope and asked for `daemon_status_changed` or `download_progress`.
 | [`/recording_stop_mode`](../endpoints/v1/recording_stop_mode.md) | POST, GET | Default stop behavior for `/transcribe` (silence_only / silence_and_manual / manual_only)                  |
 | [`/preview_typing`](../endpoints/v1/preview_typing.md)      | POST, GET  | Toggle live typing of preview text while recording                                                    |
 | [`/write_method`](../endpoints/v1/write_method.md)          | POST, GET  | Keyboard simulation method (auto / xdg_desktop_portal / ydotool / wayland_protocol)                   |
+| [`/write_method/test`](../endpoints/v1/write_method/test.md) | POST      | Type a test string with the configured method; reports the backend it resolved to                     |
 | [`/notification_method`](../endpoints/v1/notification_method.md) | POST, GET  | How recording failures are surfaced (auto / dbus / typed / off)                                       |
 | [`/allow_online_models`](../endpoints/v1/allow_online_models.md) | POST, GET | Privacy gate for online providers (OpenAI / Mistral / Deepgram)                                       |
 | [`/custom_models_dir`](../endpoints/v1/custom_models_dir.md) | POST, GET | Where to scan for user-supplied models                                                                |

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -3,6 +3,7 @@
 use crate::core::app::AppModel;
 use crate::daemon::client::{
     set_notification_method, set_preview_typing, set_recording_stop_mode, set_write_method,
+    test_write_method,
 };
 use crate::ui::messages::{
     Message, NotificationMethodMessage, PreviewTypingMessage, RecordingStopModeMessage,
@@ -108,14 +109,49 @@ impl AppModel {
                         WriteMethodMessage::Loaded(method),
                     )),
                     Err(e) => cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Error(
-                        e.to_string(),
+                        format!("couldn't save: {e}"),
                     ))),
                 })
             }
 
             WriteMethodMessage::Loaded(method) => {
                 self.write_method = method;
+                // The stored resolution belonged to the previous method.
+                self.resolved_write_method = None;
                 self.clear_action_error(crate::state::ErrorScope::InputSimulation);
+                Task::none()
+            }
+
+            // Focus the test field *before* asking the daemon to type: it types
+            // into whatever window holds focus, and pressing the button leaves
+            // focus on the button. `chain` orders the two, where `batch` would
+            // race the focus against the round-trip.
+            WriteMethodMessage::Test => {
+                self.write_method_test_text.clear();
+                self.clear_action_error(crate::state::ErrorScope::InputSimulation);
+                cosmic::widget::text_input::focus(
+                    crate::ui::views::input_simulation::test_field_id(),
+                )
+                .chain(Task::perform(test_write_method(), |result| match result {
+                    // `None` is a daemon that typed but named no backend this
+                    // build knows: the test still passed, so report it and
+                    // leave the backend readout empty rather than guessing.
+                    Ok(resolved) => cosmic::Action::App(Message::WriteMethod(
+                        WriteMethodMessage::Tested(resolved),
+                    )),
+                    Err(e) => cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Error(
+                        format!("test failed: {e}"),
+                    ))),
+                }))
+            }
+
+            WriteMethodMessage::Tested(resolved) => {
+                self.resolved_write_method = resolved;
+                Task::none()
+            }
+
+            WriteMethodMessage::TestInput(text) => {
+                self.write_method_test_text = text;
                 Task::none()
             }
 
@@ -123,7 +159,7 @@ impl AppModel {
                 log::warn!("Write method error: {err}");
                 self.set_action_error(
                     crate::state::ErrorScope::InputSimulation,
-                    format!("Couldn't save write method: {err}"),
+                    format!("Write method: {err}"),
                 );
                 Task::none()
             }

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -132,6 +132,8 @@ impl AppModel {
             recording_stop_mode:
                 super_stt_shared::models::recording_stop_mode::RecordingStopMode::default(),
             write_method: super_stt_shared::models::write_method::WriteMethod::default(),
+            write_method_test_text: String::new(),
+            resolved_write_method: None,
             notification_method:
                 super_stt_shared::models::notification_method::NotificationMethod::default(),
             volume: 100,

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -131,6 +131,12 @@ pub struct AppModel {
 
     // Write method
     pub write_method: super_stt_shared::models::write_method::WriteMethod,
+    /// Text in the Input Simulation test field — where `POST /write_method/test`
+    /// lands, since the daemon types into whatever window has focus.
+    pub write_method_test_text: String,
+    /// Backend the last test actually typed through. `None` until a test runs;
+    /// with `write_method == Auto` this is the only readout of the real backend.
+    pub resolved_write_method: Option<super_stt_shared::models::write_method::WriteMethod>,
 
     // Notification method
     pub notification_method: super_stt_shared::models::notification_method::NotificationMethod,

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -174,6 +174,8 @@ impl AppModel {
             ),
             Page::InputSimulation => views::input_simulation::page(
                 self.write_method,
+                &self.write_method_test_text,
+                self.resolved_write_method,
                 self.action_error_for(crate::state::ErrorScope::InputSimulation),
             ),
             Page::Models => views::models::page(self),

--- a/super-stt-app/src/daemon/client/mod.rs
+++ b/super-stt-app/src/daemon/client/mod.rs
@@ -35,6 +35,6 @@ pub use v1::settings::recording_stop_mode::{get_recording_stop_mode, set_recordi
 pub use v1::settings::update_beta_optin::set_update_beta_optin;
 pub use v1::settings::update_check_enabled::{get_update_check_enabled, set_update_check_enabled};
 pub use v1::settings::volume::{get_volume, set_volume};
-pub use v1::settings::write_method::{get_write_method, set_write_method};
+pub use v1::settings::write_method::{get_write_method, set_write_method, test_write_method};
 
 pub use v1::update::{check_update_now, get_update_status};

--- a/super-stt-app/src/daemon/client/v1/settings/write_method.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/write_method.rs
@@ -1,8 +1,78 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //! `/write_method` — text-output strategy (auto, xdotool, clipboard, …).
 
+use super_stt_shared::models::write_method::WriteMethod;
+
 settings_getter!(
     get_write_method -> String, "/write_method", "get_write_method",
     |resp| resp.write_method.unwrap_or_else(|| "auto".to_string())
 );
 settings_setter!(set_write_method, method: String, "/write_method", "method", "set_write_method");
+
+/// Type a fixed test string with the configured method
+/// (HTTP `POST /write_method/test`), returning the backend that actually
+/// typed. With `auto` configured that resolved name is the only way to see
+/// which rung of the chain is in use.
+///
+/// `None` means the typing succeeded but the daemon did not name a backend
+/// this build understands — the caller must show nothing rather than guess,
+/// since the obvious guess (`Auto`) is the one value it can never be.
+pub async fn test_write_method()
+-> super_stt_shared::daemon::http_client::HttpResult<Option<WriteMethod>> {
+    crate::daemon::client::internal::session::with_settings_token(|socket, token| async move {
+        let resp = crate::daemon::client::internal::response::require_success(
+            super_stt_shared::daemon::http_client::transport::settings_post(
+                socket,
+                &token,
+                "/write_method/test",
+                &serde_json::json!({}),
+            )
+            .await?,
+            "test_write_method",
+        )?;
+        Ok(parse_resolved(resp.resolved_write_method.as_deref()))
+    })
+    .await
+}
+
+/// Parse the `resolved_write_method` field. Anything the daemon omits, leaves
+/// empty, or names in a token this build doesn't know becomes `None`; so does
+/// `auto`, which the contract forbids there and which would otherwise render
+/// as a backend in its own right.
+fn parse_resolved(raw: Option<&str>) -> Option<WriteMethod> {
+    match raw?.parse().ok()? {
+        WriteMethod::Auto => None,
+        resolved => Some(resolved),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_resolved;
+    use super_stt_shared::models::write_method::WriteMethod;
+
+    #[test]
+    fn parses_the_three_concrete_backends() {
+        assert_eq!(
+            parse_resolved(Some("wayland_protocol")),
+            Some(WriteMethod::WaylandProtocol)
+        );
+        assert_eq!(
+            parse_resolved(Some("xdg_desktop_portal")),
+            Some(WriteMethod::XdgDesktopPortal)
+        );
+        assert_eq!(parse_resolved(Some("ydotool")), Some(WriteMethod::Ydotool));
+    }
+
+    /// The UI shows this as "Active backend", so a value it cannot vouch for
+    /// must produce no row at all. Reporting `Auto` there would claim the
+    /// chain resolved to itself — the exact silent-default lie this readout
+    /// exists to replace.
+    #[test]
+    fn unknown_absent_or_auto_resolve_to_nothing() {
+        assert_eq!(parse_resolved(None), None);
+        assert_eq!(parse_resolved(Some("")), None);
+        assert_eq!(parse_resolved(Some("clipboard_paste")), None);
+        assert_eq!(parse_resolved(Some("auto")), None);
+    }
+}

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -267,6 +267,16 @@ pub enum RecordingStopModeMessage {
 pub enum WriteMethodMessage {
     Changed(WriteMethod),
     Loaded(WriteMethod),
+    /// Ask the daemon to type the test string. The Input Simulation test field
+    /// is focused first so the keystrokes have somewhere to land.
+    Test,
+    /// The daemon typed the test string; carries the backend it resolved to,
+    /// which is the only way to see which rung `Auto` picked. `None` when the
+    /// daemon named no backend this build understands — the typing still
+    /// happened, so that is a pass with an empty readout, not a failure.
+    Tested(Option<WriteMethod>),
+    /// Contents of the test field — whatever the daemon (or the user) typed.
+    TestInput(String),
     Error(String),
 }
 

--- a/super-stt-app/src/ui/views/input_simulation.rs
+++ b/super-stt-app/src/ui/views/input_simulation.rs
@@ -1,13 +1,28 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use cosmic::Element;
-use cosmic::widget::{self, settings};
+use cosmic::iced::widget::row;
+use cosmic::iced::{Alignment, Length};
+use cosmic::widget::{self, Id, button, settings, text};
 use super_stt_shared::models::write_method::WriteMethod;
 
 use super::common::{error_banner, page_layout};
 use crate::ui::messages::{Message, WriteMethodMessage};
 
-/// Input simulation page: write method selection
-pub fn page(write_method: WriteMethod, action_error: Option<&str>) -> Element<'_, Message> {
+/// Id of the test field, so the Test button can focus it before the daemon
+/// types: `POST /write_method/test` types into whatever window holds keyboard
+/// focus, and it needs to be this field rather than the button.
+#[must_use]
+pub fn test_field_id() -> Id {
+    Id::new("write_method_test_field")
+}
+
+/// Input simulation page: write method selection + a live typing test
+pub fn page<'a>(
+    write_method: WriteMethod,
+    test_text: &'a str,
+    resolved: Option<WriteMethod>,
+    action_error: Option<&'a str>,
+) -> Element<'a, Message> {
     let methods = [
         WriteMethod::Auto,
         WriteMethod::XdgDesktopPortal,
@@ -24,22 +39,56 @@ pub fn page(write_method: WriteMethod, action_error: Option<&str>) -> Element<'_
     if let Some(message) = action_error {
         blocks.push(error_banner(message));
     }
-    blocks.push(
-        settings::section()
-            .title("Input Simulation")
-            .add(
-                settings::item::builder("Write Method")
-                    .description("Controls how transcribed text is typed into applications")
-                    .control(widget::dropdown(
-                        method_names,
-                        selected_index,
-                        move |index| {
-                            Message::WriteMethod(WriteMethodMessage::Changed(methods[index]))
-                        },
-                    )),
-            )
-            .into(),
+
+    let mut method_section = settings::section().title("Input Simulation").add(
+        settings::item::builder("Write Method")
+            .description("Controls how transcribed text is typed into applications")
+            .control(widget::dropdown(
+                method_names,
+                selected_index,
+                move |index| Message::WriteMethod(WriteMethodMessage::Changed(methods[index])),
+            )),
     );
 
+    // "Auto" names a chain, not a backend, so the configured value alone never
+    // says what is really typing. A test is the only thing that resolves it.
+    if let Some(resolved) = resolved {
+        method_section = method_section.add(
+            settings::item::builder("Active backend")
+                .description("What the last test actually typed through")
+                .control(text::body(resolved.pretty_name())),
+        );
+    }
+    blocks.push(method_section.into());
+
+    blocks.push(test_section(test_text));
+
     page_layout("Input Simulation", settings::view_column(blocks))
+}
+
+/// Test section: a focused field plus the button that makes the daemon type
+/// into it.
+fn test_section(test_text: &str) -> Element<'_, Message> {
+    let test_row = row![
+        widget::text_input("Typed text lands here…", test_text)
+            .id(test_field_id())
+            .on_input(|text| Message::WriteMethod(WriteMethodMessage::TestInput(text)))
+            .width(Length::Fill),
+        button::suggested("Type test text")
+            .on_press(Message::WriteMethod(WriteMethodMessage::Test)),
+    ]
+    .align_y(Alignment::Center)
+    .spacing(10);
+
+    settings::section()
+        .title("Test")
+        .add(
+            settings::item::builder("Typing test")
+                .description(
+                    "Types a short string into the field using the same writing method \
+                    that will be used by the daemon.",
+                )
+                .flex_control(test_row),
+        )
+        .into()
 }

--- a/super-stt-daemon/src/daemon/core.rs
+++ b/super-stt-daemon/src/daemon/core.rs
@@ -53,6 +53,7 @@ impl SuperSTTDaemon {
             Command::GetRecordingStopMode => self.handle_get_recording_stop_mode().await,
             Command::SetWriteMethod { method } => self.handle_set_write_method(method).await,
             Command::GetWriteMethod => self.handle_get_write_method().await,
+            Command::TestWriteMethod => self.handle_test_write_method().await,
             Command::SetNotificationMethod { method } => {
                 self.handle_set_notification_method(method).await
             }

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -1622,3 +1622,54 @@ async fn record_with_no_model_types_nothing_without_write_mode() {
         "nothing may be typed outside write mode"
     );
 }
+
+/// The write-method test types the string the protocol doc promises, reports
+/// the backend that typed it, and hands the simulator back to the cache. A
+/// regression that skipped the cache return would rebuild the portal session —
+/// three D-Bus round-trips and possibly an authorization prompt — per test.
+#[tokio::test]
+async fn write_method_test_types_the_documented_string_and_recaches() {
+    let daemon = test_daemon().await;
+    let (sim, buf) = crate::output::keyboard::Simulator::capture();
+    *daemon.simulator.write().await = Some(sim);
+
+    let resp = daemon
+        .handle_command(make_request("test_write_method"))
+        .await;
+
+    assert_eq!(resp.status, "success");
+    assert_eq!(*buf.lock().unwrap(), "Super STT input test 123");
+    // The configured method (`auto` by default) and the backend that actually
+    // typed are reported separately — the whole point of the endpoint.
+    assert_eq!(resp.write_method.as_deref(), Some("auto"));
+    assert!(
+        resp.resolved_write_method.is_some(),
+        "a client with `auto` configured has no other way to see the real backend"
+    );
+    assert!(
+        daemon.simulator.read().await.is_some(),
+        "a cacheable simulator must go back to the cache"
+    );
+}
+
+/// A recording already owns the keyboard, so the test must refuse rather than
+/// interleave its string into the user's dictation.
+#[tokio::test]
+async fn write_method_test_refuses_while_recording() {
+    let daemon = test_daemon().await;
+    let (sim, buf) = crate::output::keyboard::Simulator::capture();
+    *daemon.simulator.write().await = Some(sim);
+    *daemon.busy.write().await = true;
+
+    let resp = daemon
+        .handle_command(make_request("test_write_method"))
+        .await;
+
+    assert_eq!(resp.status, "error");
+    assert_eq!(resp.error_code, Some(ErrorCode::RecordingInProgress));
+    assert_eq!(
+        *buf.lock().unwrap(),
+        "",
+        "nothing may be typed while a recording holds the keyboard"
+    );
+}

--- a/super-stt-daemon/src/daemon/http/v1/settings/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/mod.rs
@@ -128,6 +128,7 @@ pub(crate) fn routes() -> Router<AppState> {
             "/write_method",
             get(write_method::get_write_method).post(write_method::set_write_method),
         )
+        .route("/write_method/test", post(write_method::test_write_method))
         .route(
             "/notification_method",
             get(notification_method::get_notification_method)

--- a/super-stt-daemon/src/daemon/http/v1/settings/write_method.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/write_method.rs
@@ -6,3 +6,4 @@ settings_setter!(
     "method"
 );
 settings_dispatch!(get_write_method, "get_write_method");
+settings_dispatch!(test_write_method, "test_write_method");

--- a/super-stt-daemon/src/daemon/settings_handlers.rs
+++ b/super-stt-daemon/src/daemon/settings_handlers.rs
@@ -2,6 +2,7 @@
 
 use crate::config::DaemonConfig;
 use crate::daemon::types::SuperSTTDaemon;
+use crate::output::keyboard::Simulator;
 use log::{info, warn};
 use super_stt_shared::models::notification_method::NotificationMethod;
 use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
@@ -10,6 +11,12 @@ use super_stt_shared::models::update_beta_optin::UpdateBetaOptIn;
 use super_stt_shared::models::write_method::WriteMethod;
 
 impl SuperSTTDaemon {
+    /// What `POST /write_method/test` types. Fixed and documented in
+    /// `docs/protocol/endpoints/v1/write_method/test.md`, so a client can tell
+    /// the user what to expect; kept ASCII so a pass means the common case
+    /// works rather than exercising high-keysym paths a backend may not map.
+    const WRITE_METHOD_TEST_TEXT: &str = "Super STT input test 123";
+
     /// Mutate the config under the write lock, then persist it. Centralizes the
     /// lock → mutate → persist sequence so a settings handler can't hand-roll it
     /// and forget the persist (see Tier 1 #3). Returns the persist outcome so the
@@ -110,6 +117,60 @@ impl SuperSTTDaemon {
             format!("Write method set to {method}"),
             persist,
         )
+    }
+
+    /// Handle test write method command: type a fixed string with the
+    /// configured method so the user can see whether it reaches their focused
+    /// window. Contract: `docs/protocol/endpoints/v1/write_method/test.md`.
+    pub async fn handle_test_write_method(&self) -> DaemonResponse {
+        if *self.busy.read().await {
+            return DaemonResponse::error_with_code(
+                ErrorCode::RecordingInProgress,
+                "recording_in_progress",
+            );
+        }
+
+        let method = self.config.read().await.transcription.write_method;
+
+        // Borrow the cached simulator rather than building a second one: a
+        // fresh portal session costs three D-Bus round-trips and may re-prompt
+        // for authorization, and the test would leave that session behind.
+        let cached = self.simulator.write().await.take();
+        let mut simulator = match cached {
+            Some(s) => s,
+            None => match Simulator::new(method).await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("Write-method test could not build a simulator: {e}");
+                    return DaemonResponse::error_with_code(
+                        ErrorCode::Internal,
+                        "write_method_unavailable",
+                    );
+                }
+            },
+        };
+
+        let resolved = simulator.resolved_method();
+        let result = simulator.type_text(Self::WRITE_METHOD_TEST_TEXT).await;
+
+        // Same cache discipline as a recording (see `Simulator::is_cacheable`).
+        if simulator.is_cacheable() {
+            *self.simulator.write().await = Some(simulator);
+        }
+
+        match result {
+            Ok(()) => {
+                info!("Write-method test typed via {resolved}");
+                DaemonResponse::success()
+                    .with_message(format!("Typed test text via {}", resolved.pretty_name()))
+                    .with_write_method(method.to_string())
+                    .with_resolved_write_method(resolved.to_string())
+            }
+            Err(e) => {
+                warn!("Write-method test failed to type via {resolved}: {e}");
+                DaemonResponse::error_with_code(ErrorCode::Internal, "typing_failed")
+            }
+        }
     }
 
     /// Handle get write method command

--- a/super-stt-daemon/src/output/keyboard/mod.rs
+++ b/super-stt-daemon/src/output/keyboard/mod.rs
@@ -39,8 +39,8 @@ impl Simulator {
     /// Create a simulator for the requested write method.
     ///
     /// # Errors
-    /// Returns an error only when a *specific* method is requested and fails.
-    /// `Auto` always falls back to Wayland protocol.
+    /// Returns an error when a *specific* method is requested and fails, or —
+    /// for `Auto` — when every backend in the chain is unavailable.
     pub async fn new(method: WriteMethod) -> Result<Self> {
         let sim = match method {
             WriteMethod::Auto => Self::auto().await?,
@@ -57,17 +57,44 @@ impl Simulator {
         Ok(sim)
     }
 
-    /// Auto-detect: XDG Portal → ydotool → Wayland protocol.
+    /// Auto-detect: Wayland protocol → XDG Portal → ydotool.
+    ///
+    /// The Wayland protocol leads because it needs nothing installed beyond a
+    /// compositor exposing `zwp_virtual_keyboard_manager_v1`, types the user's
+    /// actual layout, and costs no D-Bus round-trips or authorization prompt.
+    /// The portal follows for sessions that withhold the virtual-keyboard
+    /// global, and ydotool last since it needs a running `ydotoold` and types a
+    /// hardcoded US-QWERTY map.
+    ///
+    /// # Errors
+    /// Only when every backend is unavailable. The message carries each rung's
+    /// reason: a failed recording is the daemon's sole chance to explain why
+    /// nothing can type.
     async fn auto() -> Result<Self> {
         debug!("Auto-detecting write method...");
+        let mut unavailable = Vec::new();
+
+        match EnigoBackend::new() {
+            Ok(backend) => return Ok(Self::WaylandProtocol(Box::new(backend))),
+            Err(e) => {
+                debug!("Wayland protocol unavailable: {e}");
+                unavailable.push(format!("Wayland protocol ({e})"));
+            }
+        }
 
         let portal_available = XdgPortalBackend::is_available().await;
         debug!("XDG Desktop Portal available: {portal_available}");
         if portal_available {
             match XdgPortalBackend::new().await {
                 Ok(backend) => return Ok(Self::XdgPortal(backend)),
-                Err(e) => warn!("XDG Portal available but session failed: {e}"),
+                Err(e) => {
+                    warn!("XDG Portal available but session failed: {e}");
+                    unavailable.push(format!("XDG Desktop Portal ({e})"));
+                }
             }
+        } else {
+            unavailable
+                .push("XDG Desktop Portal (RemoteDesktop interface not on the session bus)".into());
         }
 
         let ydotool_available = YdotoolBackend::is_available();
@@ -75,9 +102,12 @@ impl Simulator {
         if ydotool_available {
             return Ok(Self::Ydotool(YdotoolBackend::new()));
         }
+        unavailable.push("ydotool (not installed or ydotoold not running)".into());
 
-        debug!("Falling back to Wayland protocol");
-        Ok(Self::WaylandProtocol(Box::new(EnigoBackend::new()?)))
+        anyhow::bail!(
+            "no write method available — tried {}",
+            unavailable.join(", ")
+        )
     }
 
     /// Whether this backend may be held across recordings.
@@ -91,6 +121,23 @@ impl Simulator {
     #[must_use]
     pub fn is_cacheable(&self) -> bool {
         !matches!(self, Self::WaylandProtocol(_))
+    }
+
+    /// The concrete method this simulator drives.
+    ///
+    /// Never `Auto` in a shipped build: `auto()` resolves the chain at
+    /// construction, and this is the only way a client can learn which rung it
+    /// landed on (`POST /write_method/test`). The test-only capture backend
+    /// types through no real method and so reports the unresolved `Auto`.
+    #[must_use]
+    pub fn resolved_method(&self) -> WriteMethod {
+        match self {
+            Self::XdgPortal(_) => WriteMethod::XdgDesktopPortal,
+            Self::Ydotool(_) => WriteMethod::Ydotool,
+            Self::WaylandProtocol(_) => WriteMethod::WaylandProtocol,
+            #[cfg(test)]
+            Self::Capture(_) => WriteMethod::Auto,
+        }
     }
 
     /// Human-readable name for logging.

--- a/super-stt-shared/src/models/protocol/command.rs
+++ b/super-stt-shared/src/models/protocol/command.rs
@@ -59,6 +59,10 @@ pub enum Command {
         method: WriteMethod,
     },
     GetWriteMethod,
+    /// Type a fixed string with the configured write method so a settings UI
+    /// can show whether keyboard simulation reaches the focused window.
+    /// Contract: `docs/protocol/endpoints/v1/write_method/test.md`.
+    TestWriteMethod,
     /// The raw wire string, unparsed. `handle_set_notification_method` parses
     /// it (mirrors `SetAudioTheme`) so an unrecognized value can be rejected
     /// with a classified `error_code` (400), not just a bare error string.

--- a/super-stt-shared/src/models/protocol/dispatch.rs
+++ b/super-stt-shared/src/models/protocol/dispatch.rs
@@ -38,6 +38,7 @@ impl TryFrom<DaemonRequest> for Command {
             "get_recording_stop_mode" => Ok(Command::GetRecordingStopMode),
             "set_write_method" => cmd_set_write_method(&request),
             "get_write_method" => Ok(Command::GetWriteMethod),
+            "test_write_method" => Ok(Command::TestWriteMethod),
             "set_notification_method" => cmd_set_notification_method(&request),
             "get_notification_method" => Ok(Command::GetNotificationMethod),
             "set_update_check_enabled" => cmd_set_update_check_enabled(&request),

--- a/super-stt-shared/src/models/protocol/response.rs
+++ b/super-stt-shared/src/models/protocol/response.rs
@@ -121,6 +121,13 @@ pub struct DaemonResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_method: Option<String>,
 
+    /// The concrete backend a `POST /write_method/test` actually typed
+    /// through — never `auto`. Differs from `write_method` whenever the
+    /// configured value is `auto`, which is the only way a client can learn
+    /// which rung of the auto chain is in use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_write_method: Option<String>,
+
     // Notification method
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_method: Option<String>,
@@ -411,6 +418,12 @@ impl DaemonResponse {
     }
 
     #[must_use]
+    pub fn with_resolved_write_method(mut self, method: String) -> Self {
+        self.resolved_write_method = Some(method);
+        self
+    }
+
+    #[must_use]
     pub fn with_notification_method(mut self, method: String) -> Self {
         self.notification_method = Some(method);
         self
@@ -503,4 +516,31 @@ pub struct RocmHostInfo {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VulkanHostInfo {
     pub api_version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DaemonResponse;
+
+    /// `resolved_write_method` stays off the wire until a write-method test
+    /// actually resolves a backend. Every other response would otherwise gain
+    /// the field, and clients that treat its presence as "a test ran" — which
+    /// is the only reason it exists — would misread every settings reply.
+    #[test]
+    fn resolved_write_method_is_omitted_until_set() {
+        let json = serde_json::to_string(&DaemonResponse::success()).expect("serialize");
+        assert!(
+            !json.contains("resolved_write_method"),
+            "absent field must not be serialized: {json}"
+        );
+
+        let json = serde_json::to_string(
+            &DaemonResponse::success().with_resolved_write_method("wayland_protocol".to_string()),
+        )
+        .expect("serialize");
+        assert!(
+            json.contains(r#""resolved_write_method":"wayland_protocol""#),
+            "resolved backend must reach the wire verbatim: {json}"
+        );
+    }
 }

--- a/super-stt-shared/src/models/write_method.rs
+++ b/super-stt-shared/src/models/write_method.rs
@@ -4,7 +4,7 @@ use super::wire_enum::wire_enum_strings;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WriteMethod {
-    /// Auto-detect: try XDG Portal, then ydotool, then wayland-protocol.
+    /// Auto-detect: try wayland-protocol, then XDG Portal, then ydotool.
     #[default]
     Auto,
     /// XDG Desktop Portal `RemoteDesktop` keyboard input.


### PR DESCRIPTION
Reorders the `auto` write-method chain and adds a way to verify typing from the settings app.

## Auto order

`auto` now tries **Wayland protocol → XDG Portal → ydotool**. The Wayland rung leads because it needs nothing installed beyond a compositor exposing `zwp_virtual_keyboard_manager_v1`, types the user's actual layout, and costs no D-Bus round-trips or authorization prompt.

Two consequences of moving it to the front:

- The Wayland rung used to be terminal (`EnigoBackend::new()?`), so its failure aborted. It now falls through like the others.
- With no terminal rung, `auto()` can fail. It bails with every rung's reason rather than a bare enigo error — previously a machine with no usable method produced an error naming only the backend that happened to be last.

A *specific* method still never falls back; that was already the behavior and is now stated in the docs.

## `POST /write_method/test`

Types `Super STT input test 123` with the configured method, so a settings UI can show whether keyboard simulation reaches the focused window. Mirrors the existing `/audio_theme/test`.

The response reports `write_method` (configured) **and** `resolved_write_method` (the backend that actually typed). With `auto` configured, nothing in the protocol previously revealed which rung was live — the configured value says `auto` whether the session is driving enigo, the portal, or ydotool.

The handler refuses with `409 recording_in_progress` when a recording already owns the keyboard, and borrows the cached simulator rather than building a second portal session.

## App

The Input Simulation page gains a Test section: a text field plus a *Type test text* button. The button clears the field, focuses it, then calls the daemon — `chain`, not `batch`, because the daemon types into whatever holds focus and clicking a button leaves focus on the button. An "Active backend" row appears under the dropdown once a test has run.

A resolved name the app can't parse (or `auto`, which the contract forbids there) shows no row at all rather than falling back to a displayed default.

The page copy states the limit plainly: text appearing in the field proves the daemon reaches *this* window, and an app can still drop simulated keys.

## Tests

- Daemon: the test types the documented string, reports configured and resolved methods separately, and returns the simulator to the cache; and refuses while a recording holds the keyboard.
- App: `resolved_write_method` parsing — the three concrete backends map through, while absent/empty/unknown/`auto` produce no readout.
- Shared: `resolved_write_method` stays off the wire until set.

The `auto()` chain itself is not directly testable — each rung needs a live compositor, portal, or ydotoold.

## Verification

`just fmt`, the clippy gate, `cargo check --workspace --all-targets`, and the lib + bin suites pass. Verified live on COSMIC: the test resolves to Wayland protocol and the text lands in the field.
