### PR TITLE
Count down before the typing test so it can target any window

### DIFF
--- a/docs/protocol/endpoints/v1/write_method/test.md
+++ b/docs/protocol/endpoints/v1/write_method/test.md
@@ -9,8 +9,12 @@ The string typed is `Super STT input test 123`.
 
 The text goes to whatever window holds keyboard focus on the daemon
 host at the moment of the call — the daemon cannot target a specific
-window. A client offering this as a button should focus a text field
-of its own first, so the user has somewhere to see the result.
+window, and takes no delay parameter. A client offering this as a
+button has two useful shapes: focus a text field of its own first, so
+the user has somewhere to see the result; or count down before
+calling, so the user can switch to the window they actually dictate
+into. The second is the stronger check, since an app that accepts
+simulated keys in one client may still drop them in another.
 Calling it from a remote / sandboxed client types into the *daemon
 host's* focused window, not the caller's.
 

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -132,21 +132,41 @@ impl AppModel {
                 cosmic::widget::text_input::focus(
                     crate::ui::views::input_simulation::test_field_id(),
                 )
-                .chain(Task::perform(test_write_method(), |result| match result {
-                    // `None` is a daemon that typed but named no backend this
-                    // build knows: the test still passed, so report it and
-                    // leave the backend readout empty rather than guessing.
-                    Ok(resolved) => cosmic::Action::App(Message::WriteMethod(
-                        WriteMethodMessage::Tested(resolved),
-                    )),
-                    Err(e) => cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Error(
-                        format!("test failed: {e}"),
-                    ))),
-                }))
+                .chain(write_method_test_task())
+            }
+
+            // The delayed test deliberately does *not* focus the field: the
+            // user is switching to another window, and the apps that silently
+            // drop simulated keys are exactly the ones this page cannot host.
+            WriteMethodMessage::TestDelayed => {
+                self.write_method_test_text.clear();
+                self.clear_action_error(crate::state::ErrorScope::InputSimulation);
+                self.write_method_test_countdown = Some(TEST_COUNTDOWN_SECS);
+                countdown_tick_task()
+            }
+
+            WriteMethodMessage::TestTick => {
+                match advance_countdown(self.write_method_test_countdown) {
+                    Tick::Idle => Task::none(),
+                    Tick::Continue(next) => {
+                        self.write_method_test_countdown = Some(next);
+                        countdown_tick_task()
+                    }
+                    Tick::Fire => {
+                        self.write_method_test_countdown = None;
+                        write_method_test_task()
+                    }
+                }
+            }
+
+            WriteMethodMessage::TestCancel => {
+                self.write_method_test_countdown = None;
+                Task::none()
             }
 
             WriteMethodMessage::Tested(resolved) => {
                 self.resolved_write_method = resolved;
+                self.write_method_test_countdown = None;
                 Task::none()
             }
 
@@ -157,6 +177,7 @@ impl AppModel {
 
             WriteMethodMessage::Error(err) => {
                 log::warn!("Write method error: {err}");
+                self.write_method_test_countdown = None;
                 self.set_action_error(
                     crate::state::ErrorScope::InputSimulation,
                     format!("Write method: {err}"),
@@ -204,5 +225,112 @@ impl AppModel {
                 Task::none()
             }
         }
+    }
+}
+
+/// Seconds a delayed write-method test waits before typing — long enough to
+/// alt-tab into the target window, short enough that the user doesn't wonder
+/// whether the button worked.
+const TEST_COUNTDOWN_SECS: u8 = 3;
+
+/// Ask the daemon to type the test string, mapping the outcome onto the
+/// write-method messages. Shared by the immediate and delayed tests, which
+/// differ only in what happens *before* this runs.
+fn write_method_test_task() -> Task<cosmic::Action<Message>> {
+    Task::perform(test_write_method(), |result| match result {
+        // `None` is a daemon that typed but named no backend this build
+        // knows: the test still passed, so report it and leave the backend
+        // readout empty rather than guessing.
+        Ok(resolved) => {
+            cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Tested(resolved)))
+        }
+        Err(e) => cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::Error(format!(
+            "test failed: {e}"
+        )))),
+    })
+}
+
+/// What a countdown tick should do.
+#[derive(Debug, PartialEq, Eq)]
+enum Tick {
+    /// No countdown is running — the tick belongs to one already cancelled.
+    Idle,
+    /// Keep counting, with this many seconds left.
+    Continue(u8),
+    /// Time is up: type now.
+    Fire,
+}
+
+/// Advance a countdown by one second.
+///
+/// `None` in means `Idle` out, and that is the whole point: cancelling clears
+/// the countdown but cannot unschedule the tick already in flight, so without
+/// this the stale tick would restart the countdown the user just stopped —
+/// and then type into their window.
+fn advance_countdown(remaining: Option<u8>) -> Tick {
+    match remaining {
+        None => Tick::Idle,
+        // `saturating_sub` also covers a `Some(0)` that no code path should
+        // produce: firing is the safe reading of "no time left".
+        Some(secs) => match secs.saturating_sub(1) {
+            0 => Tick::Fire,
+            next => Tick::Continue(next),
+        },
+    }
+}
+
+/// One second of countdown. Re-armed per tick rather than run as a
+/// subscription so the timer exists only while a countdown does.
+fn countdown_tick_task() -> Task<cosmic::Action<Message>> {
+    Task::perform(
+        async {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        },
+        |()| cosmic::Action::App(Message::WriteMethod(WriteMethodMessage::TestTick)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TEST_COUNTDOWN_SECS, Tick, advance_countdown};
+
+    /// The full run from button press to typing: one tick per second, firing
+    /// on the last. Getting this wrong types either a second early or never.
+    #[test]
+    fn counts_down_once_per_second_then_fires() {
+        let mut remaining = Some(TEST_COUNTDOWN_SECS);
+        let mut ticks = 0;
+        loop {
+            match advance_countdown(remaining) {
+                Tick::Continue(next) => {
+                    remaining = Some(next);
+                    ticks += 1;
+                }
+                Tick::Fire => {
+                    ticks += 1;
+                    break;
+                }
+                Tick::Idle => panic!("a running countdown must not report idle"),
+            }
+        }
+        assert_eq!(
+            ticks, TEST_COUNTDOWN_SECS,
+            "one tick per displayed second, no more"
+        );
+    }
+
+    /// A cancel clears the countdown but cannot unschedule the tick already in
+    /// flight. That tick must do nothing — otherwise the cancelled test still
+    /// types into whatever window the user moved to.
+    #[test]
+    fn a_tick_after_cancel_does_nothing() {
+        assert_eq!(advance_countdown(None), Tick::Idle);
+    }
+
+    /// Defensive: no path sets zero, but "no time left" can only mean fire.
+    #[test]
+    fn zero_fires_rather_than_underflowing() {
+        assert_eq!(advance_countdown(Some(0)), Tick::Fire);
+        assert_eq!(advance_countdown(Some(1)), Tick::Fire);
     }
 }

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -134,6 +134,7 @@ impl AppModel {
             write_method: super_stt_shared::models::write_method::WriteMethod::default(),
             write_method_test_text: String::new(),
             resolved_write_method: None,
+            write_method_test_countdown: None,
             notification_method:
                 super_stt_shared::models::notification_method::NotificationMethod::default(),
             volume: 100,

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -137,6 +137,9 @@ pub struct AppModel {
     /// Backend the last test actually typed through. `None` until a test runs;
     /// with `write_method == Auto` this is the only readout of the real backend.
     pub resolved_write_method: Option<super_stt_shared::models::write_method::WriteMethod>,
+    /// Seconds left before a delayed write-method test types. `None` when no
+    /// countdown is running, which is also how a cancel is recorded.
+    pub write_method_test_countdown: Option<u8>,
 
     // Notification method
     pub notification_method: super_stt_shared::models::notification_method::NotificationMethod,

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -176,6 +176,7 @@ impl AppModel {
                 self.write_method,
                 &self.write_method_test_text,
                 self.resolved_write_method,
+                self.write_method_test_countdown,
                 self.action_error_for(crate::state::ErrorScope::InputSimulation),
             ),
             Page::Models => views::models::page(self),

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -270,6 +270,13 @@ pub enum WriteMethodMessage {
     /// Ask the daemon to type the test string. The Input Simulation test field
     /// is focused first so the keystrokes have somewhere to land.
     Test,
+    /// Start the countdown before an unfocused test, giving the user time to
+    /// switch to the window they actually dictate into.
+    TestDelayed,
+    /// One second of that countdown elapsed.
+    TestTick,
+    /// Abandon a running countdown before it types.
+    TestCancel,
     /// The daemon typed the test string; carries the backend it resolved to,
     /// which is the only way to see which rung `Auto` picked. `None` when the
     /// daemon named no backend this build understands — the typing still

--- a/super-stt-app/src/ui/views/input_simulation.rs
+++ b/super-stt-app/src/ui/views/input_simulation.rs
@@ -21,6 +21,7 @@ pub fn page<'a>(
     write_method: WriteMethod,
     test_text: &'a str,
     resolved: Option<WriteMethod>,
+    countdown: Option<u8>,
     action_error: Option<&'a str>,
 ) -> Element<'a, Message> {
     let methods = [
@@ -61,14 +62,14 @@ pub fn page<'a>(
     }
     blocks.push(method_section.into());
 
-    blocks.push(test_section(test_text));
+    blocks.push(test_section(test_text, countdown));
 
     page_layout("Input Simulation", settings::view_column(blocks))
 }
 
-/// Test section: a focused field plus the button that makes the daemon type
-/// into it.
-fn test_section(test_text: &str) -> Element<'_, Message> {
+/// Test section: the in-app typing test, plus the delayed one that targets
+/// whatever window the user switches to.
+fn test_section(test_text: &str, countdown: Option<u8>) -> Element<'_, Message> {
     let test_row = row![
         widget::text_input("Typed text lands here…", test_text)
             .id(test_field_id())
@@ -80,6 +81,18 @@ fn test_section(test_text: &str) -> Element<'_, Message> {
     .align_y(Alignment::Center)
     .spacing(10);
 
+    // Mid-countdown the only useful action is calling it off: starting a second
+    // test would race the first into whichever window won the focus.
+    let delayed_control: Element<'_, Message> = if let Some(secs) = countdown {
+        button::destructive(format!("Cancel — typing in {secs}…"))
+            .on_press(Message::WriteMethod(WriteMethodMessage::TestCancel))
+            .into()
+    } else {
+        button::standard("Start countdown")
+            .on_press(Message::WriteMethod(WriteMethodMessage::TestDelayed))
+            .into()
+    };
+
     settings::section()
         .title("Test")
         .add(
@@ -89,6 +102,14 @@ fn test_section(test_text: &str) -> Element<'_, Message> {
                     that will be used by the daemon.",
                 )
                 .flex_control(test_row),
+        )
+        .add(
+            settings::item::builder("Test another window")
+                .description(
+                    "Counts down before typing, so you can switch to the app you \
+                    actually dictate into.",
+                )
+                .control(delayed_control),
         )
         .into()
 }


### PR DESCRIPTION
Follow-up to #386: adds the delayed mode of the write-method typing test.

The immediate test proves the daemon can reach *this* window. That's the weaker of the two checks — per the enigo investigation, cosmic/GTK clients accepted `commit_string` fine while Zen and Telegram silently dropped it, so a green result in the settings app can coexist with nothing landing where you actually dictate.

"Test another window" counts down from 3 first, so you can switch to the real target before the daemon types.

## Where the delay lives

Entirely in the app. `POST /write_method/test` is unchanged — no delay parameter, no new endpoint. The countdown needs per-second UI ticks regardless, and the protocol stays smaller for it. The doc's client guidance now describes both shapes and says which is the stronger check.

The delayed path deliberately skips the `text_input::focus` step the immediate path uses; focusing the app's own field is exactly what it's trying not to do.

## Countdown mechanics

Re-armed one tick at a time via `Task::perform` + `sleep`, rather than a subscription, so the timer exists only while a countdown does — no idle wakeups on a page nobody is looking at.

Cancelling clears the countdown but cannot unschedule the tick already in flight. That tick has to be inert, or the cancelled test still fires into whatever window the user moved to. The rule is extracted as `advance_countdown` so that case is directly testable rather than implied by the handler's control flow.

## Tests

- The full run from button press to typing: one tick per displayed second, firing on the last.
- A tick arriving after a cancel does nothing.
- `Some(0)` fires rather than underflowing — no path produces it, but "no time left" has only one safe reading.

`just fmt`, the clippy gate, `cargo check --workspace --all-targets`, and the lib + bin suites pass.
