### PR TITLE
Carry backend descriptions through, and fix the Models page around them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,10 @@ jobs:
       # Collect coverage once; the report steps below render lcov/html/json from
       # this profile data without re-running the suite.
       - name: Collect coverage
-        run: cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --no-report
+        run: just coverage-collect
 
       - name: LCOV report + summary
-        run: |
-          cargo llvm-cov report --lcov --output-path lcov.info --ignore-filename-regex 'tests/'
-          cargo llvm-cov report --summary-only --ignore-filename-regex 'tests/'
+        run: just coverage-report-lcov
 
       - uses: actions/upload-artifact@v7
         with:
@@ -231,27 +229,13 @@ jobs:
       # tree would need lcov's genhtml or grcov; we intentionally keep to the
       # llvm-cov toolchain and accept the flat index.)
       - name: Render HTML coverage report
-        run: |
-          cargo llvm-cov report --html --ignore-filename-regex 'tests/'
-          rm -rf coverage-html && cp -r target/llvm-cov/html coverage-html
+        run: just coverage-report-html
 
       # Drop a shields.io "endpoint" JSON inside the report so the README badge
       # reads the latest line-% straight from Pages — no Gist or PAT. jq ships on
       # the runner.
       - name: Write coverage badge JSON
-        run: |
-          set -euo pipefail
-          pct=$(cargo llvm-cov report --json --summary-only --ignore-filename-regex 'tests/' \
-            | jq -r '.data[0].totals.lines.percent')
-          if   awk "BEGIN{exit !($pct>=90)}"; then color=brightgreen
-          elif awk "BEGIN{exit !($pct>=75)}"; then color=green
-          elif awk "BEGIN{exit !($pct>=60)}"; then color=yellow
-          elif awk "BEGIN{exit !($pct>=40)}"; then color=orange
-          else color=red
-          fi
-          printf '{"schemaVersion":1,"label":"coverage","message":"%.1f%%","color":"%s"}\n' \
-            "$pct" "$color" > coverage-html/coverage.json
-          cat coverage-html/coverage.json
+        run: just coverage-badge
 
       # Browsable HTML artifact for the run, alongside the gh-pages publish below.
       - uses: actions/upload-artifact@v7

--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -159,14 +159,27 @@ label       = "Request timeout"
 description = "Per-request timeout in seconds."
 type        = "integer"
 default     = 30
+
+[[options]]
+name        = "strip_filler_words"
+label       = "Remove filler sounds"
+description = "Drop um, uh and similar from the transcript."
+type        = "bool"
+default     = true
 ```
+
+A `bool` option is rendered as a switch, so it has no Save button: flipping it
+writes immediately, and flipping it back to `default` clears the stored
+override rather than writing a value identical to it. Declare a `default` for
+every `bool` — without one the switch starts off, and turning it off again has
+nothing to revert to.
 
 | Field         | Type           | Required | Notes                                                  |
 |---------------|----------------|----------|--------------------------------------------------------|
 | `name`        | string         | yes      | snake_case identifier the backend reads the value by. `[a-z][a-z0-9_]*`, unique within the table. |
 | `label`       | string         | no       | Human-readable label shown in the settings UI. Falls back to `name` when absent. |
 | `description` | string         | yes      | Help text shown beside the input in the settings UI.   |
-| `type`        | string         | no       | `string`, `integer`, or `bool`. Drives the input the UI renders. Default `string`. |
+| `type`        | string         | no       | `string`, `integer`, or `bool`. Drives the input the UI renders: `bool` gets a switch that writes on the flip, everything else a text field the user saves. Default `string`. |
 | `default`     | matches `type` | no       | Value used when the user sets none. Forbidden on `base_url` — see below. |
 | `required`    | bool           | no       | Whether a value must be set before the backend can load. Default `false`. |
 

--- a/docs/protocol/endpoints/v1/backends.md
+++ b/docs/protocol/endpoints/v1/backends.md
@@ -60,6 +60,7 @@ Authorization: Bearer stt_…64hex…
     {
       "source": "github.com/super-stt/openai",
       "name":   "OpenAI",
+      "description": "Cloud speech-to-text via the OpenAI API.",
       "version": "0.1.1",               // installed version, re-read from disk per request
       "kind":   "wasm",                 // "wasm" | "subprocess"
       "allowed_hosts": ["api.openai.com"],  // hosts the manifest declares; [] for subprocess/local
@@ -105,6 +106,7 @@ Authorization: Bearer stt_…64hex…
 | `backends`        | array of objects | One per installed backend.                                            |
 | `…[].source`      | string           | Backend repo id; the `source` of every model it serves.              |
 | `…[].name`        | string           | Human-readable backend name.                                         |
+| `…[].description` | string           | The installed manifest's `[backend].description`; `""` when it declares none. A registry entry carries one too, but only for backends the registry lists — for a sideloaded or imported-from-dir backend this is the only description there is. |
 | `…[].version`     | string           | The installed backend's `[backend].version`, read from the `backend.toml` on disk **on every request** — what is on the machine now, not what the daemon saw when it last scanned. This is what is installed, not what is published: it is the only version available for a backend the registry does not list — one imported from a directory or installed from an arbitrary repo — and it is authoritative for the rest, since the registry reports what a release offers rather than what this machine has. The same read backs [`installed_version`](./registry/backends.md) on the registry listing, so the version reported here and the one an update is judged against cannot disagree. Falls back to the version recorded at the last scan if the manifest cannot be read; empty only for a backend installed before the field existed. |
 | `…[].kind`        | string           | `wasm` or `subprocess`.                                              |
 | `…[].allowed_hosts` | array of strings | Hosts the backend **declared** in its `backend.toml` (`[network].allowed_hosts`). Empty for `subprocess` backends (which run with no network) and for backends that declare none. Surfaced in the settings UI's "Online model" badge so the user sees where a cloud backend's audio would go. It is the manifest's declaration alone: a user-set [`base_url`](../../backend/config.md#base_url-and-egress) authorizes a further endpoint, which clients read from that option's `value` rather than from this list. |

--- a/justfile
+++ b/justfile
@@ -187,6 +187,44 @@ coverage-lcov:
 coverage-html *args:
     cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --html {{ args }}
 
+# --- CI coverage: collect once, render many ---
+# The recipes above each run the instrumented suite. CI wants several reports
+# from one run, so it collects profile data with --no-report and renders from
+# it. Same flags, split in two — a report rendered with a different
+# --ignore-filename-regex than the collection would silently count other files.
+
+# Run the instrumented suite and keep the profile data without rendering.
+coverage-collect:
+    cargo llvm-cov --workspace --remap-path-prefix --ignore-filename-regex 'tests/' --no-report
+
+# Write lcov.info from collected data and print the summary.
+coverage-report-lcov:
+    cargo llvm-cov report --lcov --output-path lcov.info --ignore-filename-regex 'tests/'
+    cargo llvm-cov report --summary-only --ignore-filename-regex 'tests/'
+
+# Render the HTML report from collected data into ./coverage-html.
+coverage-report-html:
+    cargo llvm-cov report --html --ignore-filename-regex 'tests/'
+    rm -rf coverage-html && cp -r target/llvm-cov/html coverage-html
+
+# Drop a shields.io "endpoint" JSON inside the rendered report so the README
+# badge reads the latest line-% straight from Pages — no Gist or PAT. Run after
+# coverage-report-html, which creates the directory it writes into.
+coverage-badge:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pct=$(cargo llvm-cov report --json --summary-only --ignore-filename-regex 'tests/' \
+      | jq -r '.data[0].totals.lines.percent')
+    if   awk "BEGIN{exit !($pct>=90)}"; then color=brightgreen
+    elif awk "BEGIN{exit !($pct>=75)}"; then color=green
+    elif awk "BEGIN{exit !($pct>=60)}"; then color=yellow
+    elif awk "BEGIN{exit !($pct>=40)}"; then color=orange
+    else color=red
+    fi
+    printf '{"schemaVersion":1,"label":"coverage","message":"%.1f%%","color":"%s"}\n' \
+      "$pct" "$color" > coverage-html/coverage.json
+    cat coverage-html/coverage.json
+
 # Full local CI gate: format, lint, feature-combo compile, tests, install.sh
 # tests, doctests, schemas
 ci: fmt-check check check-features test test-install doctest schema-check

--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::AppModel;
+use crate::daemon::backends::BackendOption;
 use crate::daemon::client::{
     clear_backend_option, clear_backend_secret, list_backend_secrets, set_backend_option,
     set_backend_secret,
@@ -39,6 +40,7 @@ impl AppModel {
             | BackendMessage::BackendSecretRemoved { .. }
             | BackendMessage::BackendOptionInputChanged { .. }
             | BackendMessage::BackendOptionSaved { .. }
+            | BackendMessage::BackendOptionToggled { .. }
             | BackendMessage::BackendOptionReset { .. } => self.handle_backend_config(message),
         }
     }
@@ -200,6 +202,47 @@ impl AppModel {
                 } else {
                     Task::perform(
                         set_backend_option(source, name, value),
+                        |result| match result {
+                            Ok(()) => cosmic::Action::App(Message::Backend(
+                                BackendMessage::BackendsReload,
+                            )),
+                            Err(e) => cosmic::Action::App(configure_backend_error(&e)),
+                        },
+                    )
+                }
+            }
+
+            // A switch writes on the press: there is no field to type into and
+            // no Save to reach for, so the flip is the save.
+            //
+            // Flipping back to the manifest default clears the override rather
+            // than storing a value identical to it, which keeps the daemon
+            // config a record of real deviations and lets the backend's own
+            // default move later without a stale copy pinning it.
+            BackendMessage::BackendOptionToggled {
+                source,
+                name,
+                value,
+            } => {
+                self.action_error = None;
+                let is_default = self
+                    .backends
+                    .iter()
+                    .find(|b| b.source == source)
+                    .and_then(|b| b.options.iter().find(|o| o.name == name))
+                    .and_then(BackendOption::bool_default)
+                    == Some(value);
+                if is_default {
+                    Task::perform(clear_backend_option(source, name), |result| match result {
+                        Ok(()) => {
+                            cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload))
+                        }
+                        Err(e) => cosmic::Action::App(configure_backend_error(&e)),
+                    })
+                } else {
+                    let value = if value { "true" } else { "false" };
+                    Task::perform(
+                        set_backend_option(source, name, value.to_string()),
                         |result| match result {
                             Ok(()) => cosmic::Action::App(Message::Backend(
                                 BackendMessage::BackendsReload,

--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -9,7 +9,8 @@ use crate::daemon::client::{
 use crate::state::ErrorScope;
 use crate::ui::messages::{BackendMessage, Message};
 use cosmic::prelude::*;
-use super_stt_shared::daemon::http_client::HttpError;
+use std::future::Future;
+use super_stt_shared::daemon::http_client::{HttpError, HttpResult};
 
 /// Build a Configure-sheet-scoped banner message for a failed secret/option save.
 fn configure_backend_error(e: &HttpError) -> Message {
@@ -17,6 +18,18 @@ fn configure_backend_error(e: &HttpError) -> Message {
         scope: ErrorScope::ConfigureBackend,
         message: e.to_string(),
     }
+}
+
+/// Run an option write and settle the sheet either way: reload the catalog so
+/// the row re-renders from what the daemon actually stored, or surface the
+/// failure in the sheet's banner. Set, clear and toggle all end here.
+fn option_write(
+    write: impl Future<Output = HttpResult<()>> + Send + 'static,
+) -> Task<cosmic::Action<Message>> {
+    Task::perform(write, |result| match result {
+        Ok(()) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload)),
+        Err(e) => cosmic::Action::App(configure_backend_error(&e)),
+    })
 }
 
 impl AppModel {
@@ -114,6 +127,18 @@ impl AppModel {
         }
     }
 
+    /// The `default` a `bool` option declares, read as a bool.
+    ///
+    /// A switch flipped back to it is reverting, not choosing, so the write
+    /// clears the override instead of storing a copy of the default.
+    fn option_bool_default(&self, source: &str, name: &str) -> Option<bool> {
+        self.backends
+            .iter()
+            .find(|b| b.source == source)
+            .and_then(|b| b.options.iter().find(|o| o.name == name))
+            .and_then(BackendOption::bool_default)
+    }
+
     /// Handle per-backend secret and option configuration messages.
     fn handle_backend_config(&mut self, message: BackendMessage) -> Task<cosmic::Action<Message>> {
         match message {
@@ -193,22 +218,9 @@ impl AppModel {
                     .cloned()
                     .unwrap_or_default();
                 if value.is_empty() {
-                    Task::perform(clear_backend_option(source, name), |result| match result {
-                        Ok(()) => {
-                            cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload))
-                        }
-                        Err(e) => cosmic::Action::App(configure_backend_error(&e)),
-                    })
+                    option_write(clear_backend_option(source, name))
                 } else {
-                    Task::perform(
-                        set_backend_option(source, name, value),
-                        |result| match result {
-                            Ok(()) => cosmic::Action::App(Message::Backend(
-                                BackendMessage::BackendsReload,
-                            )),
-                            Err(e) => cosmic::Action::App(configure_backend_error(&e)),
-                        },
-                    )
+                    option_write(set_backend_option(source, name, value))
                 }
             }
 
@@ -225,31 +237,10 @@ impl AppModel {
                 value,
             } => {
                 self.action_error = None;
-                let is_default = self
-                    .backends
-                    .iter()
-                    .find(|b| b.source == source)
-                    .and_then(|b| b.options.iter().find(|o| o.name == name))
-                    .and_then(BackendOption::bool_default)
-                    == Some(value);
-                if is_default {
-                    Task::perform(clear_backend_option(source, name), |result| match result {
-                        Ok(()) => {
-                            cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload))
-                        }
-                        Err(e) => cosmic::Action::App(configure_backend_error(&e)),
-                    })
+                if self.option_bool_default(&source, &name) == Some(value) {
+                    option_write(clear_backend_option(source, name))
                 } else {
-                    let value = if value { "true" } else { "false" };
-                    Task::perform(
-                        set_backend_option(source, name, value.to_string()),
-                        |result| match result {
-                            Ok(()) => cosmic::Action::App(Message::Backend(
-                                BackendMessage::BackendsReload,
-                            )),
-                            Err(e) => cosmic::Action::App(configure_backend_error(&e)),
-                        },
-                    )
+                    option_write(set_backend_option(source, name, value.to_string()))
                 }
             }
 
@@ -257,10 +248,7 @@ impl AppModel {
             // option reverts to its daemon default.
             BackendMessage::BackendOptionReset { source, name } => {
                 self.action_error = None;
-                Task::perform(clear_backend_option(source, name), |result| match result {
-                    Ok(()) => cosmic::Action::App(Message::Backend(BackendMessage::BackendsReload)),
-                    Err(e) => cosmic::Action::App(configure_backend_error(&e)),
-                })
+                option_write(clear_backend_option(source, name))
             }
 
             _ => Task::none(),

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -437,6 +437,7 @@ mod tests {
     fn backend(source: &str, model: &str, devices: &[&str]) -> BackendInfo {
         BackendInfo {
             source: source.to_string(),
+            description: String::new(),
             name: "Test".to_string(),
             version: "1.0.0".to_string(),
             kind: "wasm".to_string(),

--- a/super-stt-app/src/state/models.rs
+++ b/super-stt-app/src/state/models.rs
@@ -67,7 +67,7 @@ pub enum ContextPage {
     /// (global vs per-model) is carried by `AppModel::language_picker_target`.
     LanguagePicker,
     /// Right-side sheet for choosing which installed backend to activate (the
-    /// Models page's "Select a backend" / "Switch backend" flow). Scoped to the
+    /// Models page's "Select transcription backend" flow). Scoped to the
     /// Models page; picking a backend activates it and closes the sheet.
     SelectBackend,
     /// Right-side sheet for choosing which installed backend provides the

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -380,6 +380,13 @@ pub enum BackendMessage {
         source: String,
         name: String,
     },
+    /// A `type = "bool"` option's switch was flipped. A switch has no Save
+    /// button to press, so this both records the new value and writes it.
+    BackendOptionToggled {
+        source: String,
+        name: String,
+        value: bool,
+    },
     BackendOptionReset {
         source: String,
         name: String,

--- a/super-stt-app/src/ui/views/models/active.rs
+++ b/super-stt-app/src/ui/views/models/active.rs
@@ -7,11 +7,8 @@ use super_stt_shared::models::protocol::DownloadProgress;
 
 use crate::core::app::{AppModel, ModelOperationState};
 use crate::daemon::backends::BackendInfo;
-use crate::state::ContextPage;
 use crate::ui::icons;
-use crate::ui::messages::{
-    DownloadMessage, LanguageMessage, Message, ModelsPageMessage, ShellMessage,
-};
+use crate::ui::messages::{DownloadMessage, LanguageMessage, Message, ModelsPageMessage};
 
 use super::chips::{
     CloudEgress, backend_has_user_url, backend_is_online, backend_supports_cpu,
@@ -160,15 +157,13 @@ pub(super) fn active_backend_card<'a>(
     let model_loaded = !app.current_source.is_empty() && app.current_source == backend.source;
     let missing = unmet_requirements(&app.backend_secret_configured, backend);
 
-    // Header: glyph + name/description, then the repo button, a "Switch
-    // backend" trigger (reopens the Select-a-backend sheet), Configure, and
+    // Header: glyph + name/description, then the repo button, Configure, and
     // Deselect. The repo button + description replace the old source caption.
+    // Changing backend is ✕ then pick again: one way in, one way out, and no
+    // button that silently swaps what a loaded card is about.
     let description = super::surface::backend_description(app, &source);
     let actions = row![
         super::surface::repo_button(&source),
-        button::standard("Switch backend").on_press(Message::Shell(
-            ShellMessage::ToggleContextPage(ContextPage::SelectBackend),
-        )),
         button::standard("Configure").on_press(Message::ModelsPage(
             ModelsPageMessage::OpenBackendConfig(source.clone()),
         )),

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -690,6 +690,7 @@ mod capability_tests {
     fn backend_with_devices(per_model: &[&[&str]]) -> BackendInfo {
         BackendInfo {
             source: "github.com/super-stt/test".to_string(),
+            description: String::new(),
             name: "Test".to_string(),
             version: "1.0.0".to_string(),
             kind: "subprocess".to_string(),

--- a/super-stt-app/src/ui/views/models/configure.rs
+++ b/super-stt-app/src/ui/views/models/configure.rs
@@ -43,6 +43,13 @@ pub fn configure_sheet<'a>(backend: &'a BackendInfo, app: &'a AppModel) -> Eleme
             section = section.add(secret_row(&backend.source, secret, configured, input));
         }
         for option in &backend.options {
+            // A boolean has exactly two values and no way to be typed wrong,
+            // so it gets a switch that writes on the press. Everything else is
+            // free text and keeps its field + Save.
+            if option.is_bool() {
+                section = section.add(bool_option_row(&backend.source, option));
+                continue;
+            }
             let key = (backend.source.clone(), option.name.clone());
             let input = app
                 .backend_option_inputs
@@ -153,6 +160,36 @@ pub(super) fn secret_row<'a>(
             .into(),
     ])
     .into()
+}
+
+/// One `type = "bool"` option as a settings row with a switch: label,
+/// description, and the toggle opposite them.
+///
+/// No Save and no Reset — the flip is the save, and flipping back to the
+/// backend's default is what clearing an override means for two values. The
+/// switch shows the current state, so the "(default: …)" suffix the text rows
+/// carry would only restate it.
+pub(super) fn bool_option_row<'a>(
+    source: &'a str,
+    option: &'a BackendOption,
+) -> Element<'a, Message> {
+    let display = option.label.clone().unwrap_or_else(|| option.name.clone());
+    let source = source.to_string();
+    let name = option.name.clone();
+
+    let toggle = widget::toggler(option.bool_value()).on_toggle(move |value| {
+        Message::Backend(BackendMessage::BackendOptionToggled {
+            source: source.clone(),
+            name: name.clone(),
+            value,
+        })
+    });
+
+    let mut item = settings::item::builder(display);
+    if !option.description.is_empty() {
+        item = item.description(option.description.clone());
+    }
+    item.control(toggle).into()
 }
 
 /// One option-entry row for a backend (e.g. `base_url`): the label/description

--- a/super-stt-app/src/ui/views/models/installed.rs
+++ b/super-stt-app/src/ui/views/models/installed.rs
@@ -117,9 +117,9 @@ pub(super) fn installed_card<'a>(
     let online = backend_is_online(backend);
     let source = backend.source.clone();
 
-    // Registry entry (by source) supplies the description shown under the name
-    // and the latest version that drives the optional Update item. Compared as
-    // semver so a stale/older index never prompts a downgrade.
+    // Registry entry (by source) supplies the latest version that drives the
+    // optional Update item. Compared as semver so a stale/older index never
+    // prompts a downgrade.
     let registry_map = app.registry.by_source();
     let registry_entry = registry_map.get(source.as_str());
     // An update this card started is the same install pipeline Browse drives,
@@ -128,9 +128,9 @@ pub(super) fn installed_card<'a>(
     // that reads to the user.
     let in_flight = app.registry.installs.get(source.as_str());
     let update_version = update_offer(registry_entry.copied(), in_flight.is_some());
-    let description = registry_entry
-        .and_then(|e| e.description.clone())
-        .filter(|d| !d.is_empty());
+    // Registry first, installed manifest second — the same resolution the
+    // Models page uses, so a sideloaded backend still describes itself here.
+    let description = super::surface::backend_description(app, &source);
 
     // Overflow ("⋯") menu: the optional Update, then Uninstall. Configure left
     // the menu to become a visible button beside it.

--- a/super-stt-app/src/ui/views/models/mod.rs
+++ b/super-stt-app/src/ui/views/models/mod.rs
@@ -228,14 +228,26 @@ pub fn page(app: &AppModel) -> Element<'_, Message> {
         None => page_container(select_sheet::no_backend_empty_state()),
     };
 
-    widget::column::with_capacity(6)
-        .push(page_container(title_row))
+    // Two sections in a fixed-height column compete for it: the column hands
+    // each child its share, and the loser is drawn clipped — a card cut off
+    // mid-description, missing the model picker below it. Scrolling gives both
+    // their natural height instead, so a short window scrolls rather than
+    // truncates. Only the body scrolls; the page title stays put.
+    let body = widget::column::with_capacity(4)
         .push(page_container(section_heading("Transcription")))
         .push(transcription)
         // The post-processor is selected independently of the transcription
         // backend, so its section is shown whether or not one is selected.
         .push(page_container(section_heading("Post-processing")))
-        .push(page_container(post_processing::section(app)))
+        .push(page_container(post_processing::section(app)));
+
+    widget::column::with_capacity(2)
+        .push(page_container(title_row))
+        .push(
+            widget::scrollable(body)
+                .width(Length::Fill)
+                .height(Length::Fill),
+        )
         .height(Length::Fill)
         .spacing(0)
         .into()

--- a/super-stt-app/src/ui/views/models/post_processing.rs
+++ b/super-stt-app/src/ui/views/models/post_processing.rs
@@ -116,16 +116,14 @@ pub(crate) fn section(app: &AppModel) -> Element<'_, Message> {
 }
 
 /// The card header for a selected backend: glyph tile, the backend's name /
-/// version / description, then the repo button, "Switch backend", Configure and
-/// Deselect — the same action set the transcription card carries.
+/// version / description, then the repo button, Configure and Deselect — the
+/// same action set the transcription card carries. Changing backend is ✕ then
+/// pick again.
 fn header<'a>(backend: &'a BackendInfo, app: &'a AppModel) -> Element<'a, Message> {
     let spacing = cosmic::theme::spacing();
     let source = backend.source.clone();
     let actions = row![
         repo_button(&source),
-        button::standard("Switch backend").on_press(Message::Shell(
-            ShellMessage::ToggleContextPage(ContextPage::SelectPostProcessor),
-        )),
         button::standard("Configure").on_press(Message::ModelsPage(
             ModelsPageMessage::OpenBackendConfig(source.clone()),
         )),

--- a/super-stt-app/src/ui/views/models/post_processing.rs
+++ b/super-stt-app/src/ui/views/models/post_processing.rs
@@ -409,6 +409,7 @@ mod tests {
     fn backend(source: &str, name: &str, models: Vec<BackendModel>) -> BackendInfo {
         BackendInfo {
             source: source.into(),
+            description: String::new(),
             name: name.into(),
             version: "1.0.0".into(),
             kind: "wasm".into(),

--- a/super-stt-app/src/ui/views/models/roles.rs
+++ b/super-stt-app/src/ui/views/models/roles.rs
@@ -67,6 +67,7 @@ mod tests {
     fn backend(source: &str, name: &str, models: Vec<BackendModel>) -> BackendInfo {
         BackendInfo {
             source: source.into(),
+            description: String::new(),
             name: name.into(),
             version: "1.0.0".into(),
             kind: "wasm".into(),

--- a/super-stt-app/src/ui/views/models/status.rs
+++ b/super-stt-app/src/ui/views/models/status.rs
@@ -51,6 +51,7 @@ mod unmet_requirements_tests {
     fn backend(secrets: Vec<BackendSecret>, options: Vec<BackendOption>) -> BackendInfo {
         BackendInfo {
             source: "github.com/super-stt/openai".to_string(),
+            description: String::new(),
             name: "OpenAI".to_string(),
             version: "1.0.0".to_string(),
             kind: "wasm".to_string(),
@@ -282,6 +283,7 @@ mod model_status_tests {
     fn backend_with_required_secret() -> BackendInfo {
         BackendInfo {
             source: "github.com/super-stt/openai".to_string(),
+            description: String::new(),
             name: "OpenAI".to_string(),
             version: "1.0.0".to_string(),
             kind: "wasm".to_string(),

--- a/super-stt-app/src/ui/views/models/surface.rs
+++ b/super-stt-app/src/ui/views/models/surface.rs
@@ -274,10 +274,8 @@ pub(super) fn card_title_block<'a>(
     col.into()
 }
 
-/// A backend's one-line description, looked up on its registry entry by
-/// `source`. The installed `/backends` payload carries no description, so the
-/// registry index is the source; `None` when it isn't loaded or has no
-/// (non-empty) description for this backend.
+/// A backend's one-line description, resolved by `source`; `None` when neither
+/// source has a non-empty one.
 pub(super) fn backend_description(app: &AppModel, source: &str) -> Option<String> {
     // The registry's copy wins: it tracks the published release, which may be
     // newer than the manifest sitting on disk. The installed manifest is the

--- a/super-stt-app/src/ui/views/models/surface.rs
+++ b/super-stt-app/src/ui/views/models/surface.rs
@@ -279,10 +279,20 @@ pub(super) fn card_title_block<'a>(
 /// registry index is the source; `None` when it isn't loaded or has no
 /// (non-empty) description for this backend.
 pub(super) fn backend_description(app: &AppModel, source: &str) -> Option<String> {
+    // The registry's copy wins: it tracks the published release, which may be
+    // newer than the manifest sitting on disk. The installed manifest is the
+    // fallback, and the only source for a backend the registry does not list —
+    // sideloaded, or imported from a directory.
     app.registry
         .by_source()
         .get(source)
         .and_then(|e| e.description.clone())
+        .or_else(|| {
+            app.backends
+                .iter()
+                .find(|b| b.source == source)
+                .map(|b| b.description.clone())
+        })
         .filter(|d| !d.is_empty())
 }
 

--- a/super-stt-daemon/src/daemon/backend_config_handlers.rs
+++ b/super-stt-daemon/src/daemon/backend_config_handlers.rs
@@ -78,6 +78,7 @@ impl SuperSTTDaemon {
                 BackendInfo {
                     source: b.source.clone(),
                     name: b.name.clone(),
+                    description: b.description.clone(),
                     // Re-read rather than reported from the scan: a client
                     // showing this beside an update badge would otherwise name
                     // the version the daemon started with while the badge was

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -886,6 +886,7 @@ fn fixture_backend_devices(
     use std::time::Duration;
 
     DiscoveredBackend {
+        description: String::new(),
         dir: std::path::PathBuf::from("/tmp").join(dir_name),
         source: source.to_string(),
         id: None,

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -243,6 +243,7 @@ mod tests {
 
     fn discovered(dir: &str, source: &str, version: &str) -> DiscoveredBackend {
         DiscoveredBackend {
+            description: String::new(),
             dir: PathBuf::from("/backends").join(dir),
             source: source.to_string(),
             id: None,

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -645,6 +645,7 @@ mod tests {
         // A backend declaring no `base_url` option contributes nothing, even
         // with the override still in config.
         let no_base = DiscoveredBackend {
+            description: String::new(),
             options: vec![],
             ..backend
         };
@@ -666,6 +667,7 @@ mod tests {
         // No secrets: the assertions run through the real header path, which
         // would otherwise reach the keyring for the fixture's required key.
         let backend = DiscoveredBackend {
+            description: String::new(),
             secrets: Vec::new(),
             ..openai_backend(source, Vec::new(), None)
         };
@@ -721,6 +723,7 @@ mod tests {
         // No secrets: this drives the real header path, which would otherwise
         // reach the keyring for the fixture's required key.
         let backend = DiscoveredBackend {
+            description: String::new(),
             secrets: Vec::new(),
             ..openai_backend(source, Vec::new(), None)
         };
@@ -789,6 +792,7 @@ mod tests {
         assert!(err.to_string().contains("API base URL"), "{err}");
 
         let undeclared = DiscoveredBackend {
+            description: String::new(),
             options: Vec::new(),
             ..backend
         };
@@ -813,6 +817,7 @@ mod tests {
         // No secrets: this drives the real `backend_headers`, which would
         // otherwise reach the keyring for the fixture's required key.
         let backend = DiscoveredBackend {
+            description: String::new(),
             secrets: Vec::new(),
             ..openai_backend(source, Vec::new(), None)
         };

--- a/super-stt-daemon/src/daemon/startup_tests.rs
+++ b/super-stt-daemon/src/daemon/startup_tests.rs
@@ -22,6 +22,7 @@ const WHISPER_SOURCE: &str = "github.com/jorge-menjivar/super-stt-whisper";
 /// `source` and stores its install-dir name.
 fn discovered(dir: &str, source: &str) -> DiscoveredBackend {
     DiscoveredBackend {
+        description: String::new(),
         dir: PathBuf::from("/var/lib/super-stt/backends").join(dir),
         source: source.to_string(),
         id: None,

--- a/super-stt-daemon/src/daemon/test_fixtures.rs
+++ b/super-stt-daemon/src/daemon/test_fixtures.rs
@@ -25,6 +25,7 @@ pub(crate) fn openai_backend(
     base_url_default: Option<&str>,
 ) -> DiscoveredBackend {
     DiscoveredBackend {
+        description: String::new(),
         dir: std::path::PathBuf::from("/tmp/openai"),
         source: source.to_string(),
         id: None,

--- a/super-stt-daemon/src/stt_models/backends/mod.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod.rs
@@ -32,6 +32,10 @@ pub struct DiscoveredBackend {
     pub id: Option<String>,
     /// Human-facing backend name (`[backend].name`).
     pub name: String,
+    /// `[backend].description` from the manifest, empty when omitted. Carried
+    /// so `GET /backends` can report it: the registry index has one only for
+    /// backends it lists, leaving a sideloaded backend with none anywhere.
+    pub description: String,
     /// The backend's own version (`[backend].version`) as of the last scan.
     ///
     /// Carried from the manifest so the catalog can report what is installed
@@ -234,6 +238,7 @@ fn load_backend(dir: &Path) -> anyhow::Result<DiscoveredBackend> {
         source,
         id: m.backend.id.clone(),
         name: m.backend.name,
+        description: m.backend.description,
         version: m.backend.version,
         kind: m.backend.kind.to_string(),
         entrypoint: m.backend.entrypoint,

--- a/super-stt-daemon/src/stt_models/backends/mod_tests.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod_tests.rs
@@ -296,6 +296,7 @@ fn dir_name_returns_final_component() {
 
     fn fake_backend(dir: PathBuf) -> DiscoveredBackend {
         DiscoveredBackend {
+            description: String::new(),
             dir,
             source: "github.com/super-stt/openai".to_string(),
             id: None,
@@ -514,6 +515,7 @@ fn dedup_sources_falls_back_to_lexicographic_order() {
     use crate::stt_models::ModelDefinition;
     fn fake(dir: &str, source: &str) -> DiscoveredBackend {
         DiscoveredBackend {
+            description: String::new(),
             dir: PathBuf::from(dir),
             source: source.to_string(),
             id: None,
@@ -554,6 +556,7 @@ fn an_empty_source_resolves_nothing() {
 
     fn serving(dir: &str, source: &str, model: &str) -> DiscoveredBackend {
         DiscoveredBackend {
+            description: String::new(),
             dir: PathBuf::from(dir),
             source: source.to_string(),
             id: None,
@@ -693,6 +696,7 @@ fn the_catalog_reports_the_installed_accel() {
 fn at(dir: &str, source: &str, version: &str, id: Option<&str>) -> DiscoveredBackend {
     use crate::stt_models::ModelDefinition;
     DiscoveredBackend {
+        description: String::new(),
         dir: PathBuf::from("/backends").join(dir),
         source: source.to_string(),
         name: dir.to_string(),

--- a/super-stt-shared/src/models/backends.rs
+++ b/super-stt-shared/src/models/backends.rs
@@ -24,6 +24,15 @@ pub struct BackendInfo {
     pub source: String,
     /// Human-readable backend name, e.g. `OpenAI`.
     pub name: String,
+    /// The installed `backend.toml`'s `[backend].description`, empty when the
+    /// manifest omits it.
+    ///
+    /// A registry entry carries one too, but only for backends the registry
+    /// lists: a sideloaded or imported-from-dir backend has no entry, and its
+    /// description would otherwise be invisible everywhere in the UI. `default`
+    /// so a payload written before the field existed still deserializes.
+    #[serde(default)]
+    pub description: String,
     /// The installed backend's `[backend].version`, read from the `backend.toml`
     /// on disk — what is installed, not what is published.
     ///

--- a/super-stt-shared/src/models/backends.rs
+++ b/super-stt-shared/src/models/backends.rs
@@ -177,9 +177,55 @@ pub struct BackendOption {
     pub value: Option<String>,
 }
 
+impl BackendOption {
+    /// Whether the backend declared this option a boolean, so a client can
+    /// offer a switch rather than a free-text field.
+    ///
+    /// An option that declares no type is a string (the manifest default), so
+    /// only an explicit `bool` qualifies.
+    #[must_use]
+    pub fn is_bool(&self) -> bool {
+        self.r#type
+            .as_deref()
+            .is_some_and(|t| t.eq_ignore_ascii_case("bool"))
+    }
+
+    /// This option's effective value read as a boolean.
+    ///
+    /// `value` already carries the override-or-default the daemon resolved;
+    /// `default` is the fallback for a payload that omits it. Anything that
+    /// isn't a recognized true spelling is false, so a malformed stored value
+    /// reads as off rather than failing the row.
+    #[must_use]
+    pub fn bool_value(&self) -> bool {
+        let raw = self.value.as_deref().or(self.default.as_deref());
+        raw.is_some_and(parse_bool)
+    }
+
+    /// The declared default read as a boolean; `None` when none was declared.
+    ///
+    /// Lets a client tell "the user chose this" from "this is just the
+    /// default" — a toggle back to the default clears the override instead of
+    /// storing a value identical to it.
+    #[must_use]
+    pub fn bool_default(&self) -> Option<bool> {
+        self.default.as_deref().map(parse_bool)
+    }
+}
+
+/// The true spellings a manifest or a stored override may use. TOML writes
+/// `true`, but a config edited by hand (or a backend documenting `on`) should
+/// not silently read as off.
+fn parse_bool(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "true" | "1" | "yes" | "on"
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{BackendInfo, BackendModel};
+    use super::{BackendInfo, BackendModel, BackendOption};
 
     /// `GET /backends` must keep carrying `provider` on every model. Clients
     /// through v0.2.0 declare it a required `String`, so a payload without it
@@ -294,6 +340,70 @@ mod tests {
         assert_eq!(
             b.version, "",
             "a missing version reads as unknown, not an error"
+        );
+    }
+
+    fn option(r#type: Option<&str>, default: Option<&str>, value: Option<&str>) -> BackendOption {
+        BackendOption {
+            name: "flag".into(),
+            label: None,
+            description: String::new(),
+            r#type: r#type.map(Into::into),
+            default: default.map(Into::into),
+            required: false,
+            value: value.map(Into::into),
+        }
+    }
+
+    /// Only an explicit `bool` gets a switch: an untyped option is a string by
+    /// manifest default, and rendering it as a toggle would silently rewrite
+    /// whatever the user had stored in it.
+    #[test]
+    fn only_an_explicitly_bool_option_is_a_bool() {
+        assert!(option(Some("bool"), None, None).is_bool());
+        assert!(option(Some("BOOL"), None, None).is_bool());
+        assert!(!option(Some("string"), None, None).is_bool());
+        assert!(!option(None, None, None).is_bool());
+    }
+
+    /// The stored value wins over the default, and a payload carrying neither
+    /// reads as off rather than panicking the row.
+    #[test]
+    fn a_bool_option_reads_its_value_then_its_default() {
+        assert!(option(Some("bool"), Some("false"), Some("true")).bool_value());
+        assert!(!option(Some("bool"), Some("true"), Some("false")).bool_value());
+        assert!(option(Some("bool"), Some("true"), None).bool_value());
+        assert!(!option(Some("bool"), None, None).bool_value());
+    }
+
+    /// A hand-edited config may spell truth several ways; anything else is off.
+    #[test]
+    fn the_spoken_spellings_of_true_all_read_as_on() {
+        for raw in ["true", "TRUE", " 1 ", "yes", "on"] {
+            assert!(
+                option(Some("bool"), None, Some(raw)).bool_value(),
+                "{raw:?} should read as on"
+            );
+        }
+        for raw in ["false", "0", "no", "off", "", "maybe"] {
+            assert!(
+                !option(Some("bool"), None, Some(raw)).bool_value(),
+                "{raw:?} should read as off"
+            );
+        }
+    }
+
+    /// An option declaring no default has none to compare against, so a client
+    /// cannot decide a toggle is "back to default" and must store the value.
+    #[test]
+    fn an_option_without_a_default_reports_no_bool_default() {
+        assert_eq!(
+            option(Some("bool"), Some("true"), None).bool_default(),
+            Some(true)
+        );
+        assert_eq!(
+            option(Some("bool"), None, Some("true")).bool_default(),
+            None
         );
     }
 }


### PR DESCRIPTION
Follow-up to #391. Everything here was found while setting up a real post-processor backend (Tidy) against the pipeline that PR landed — each fix is something that only shows up once a second stage exists and a backend outside the registry is installed.

## 1. `GET /backends` never carried `[backend].description`

The settings app resolved a backend's description **only** from the registry index, so a backend the registry does not list — sideloaded, or imported from a directory — showed no description anywhere in the UI, however carefully its manifest wrote one.

- `DiscoveredBackend` carries the manifest's description through discovery.
- `GET /backends` reports it as `…[].description` (`""` when the manifest declares none, `#[serde(default)]` so older payloads still deserialize).
- The app falls back to it when the registry has no entry. The registry's copy still **wins** where both exist: it tracks the published release, which may be newer than the manifest on disk.

The Library's Installed card had its *own* registry-only lookup and needed the same fallback. Browse deliberately stays registry-only — a backend you have not installed has no local manifest to fall back to.

## 2. The Models page squeezed its own cards

`page()` stacked both sections in a fixed-height column with no scrollable. iced lays a column's children out against a shrinking height limit, so Transcription took its share first and Post-processing was laid out into what was left: the description lost its last line, and the chips, divider and model picker below it were given no height at all. The card rendered as a header over blank space **with no way to load a model**.

Scrolling the body below the title gives each section its natural height.

This only appeared now because the page had a single section until Transcription and Post-processing were split apart.

## 3. Dropped "Switch backend"

Both cards carried a Switch backend button beside the ✕, so a card offered two ways to stop using its backend and the picker sheet had two entry points. Changing backend is now ✕ then pick again — the same path a first selection takes.

## 4. `type = "bool"` options render as a switch

Every one of Tidy's six options was a text field you typed `true` or `false` into and pressed Save. The manifest has declared the type since the beginning; nothing read it.

The flip is the save, so there is no Save and no Reset: flipping back to the declared default **clears** the stored override rather than writing a value identical to it. Only an explicit `bool` qualifies — an untyped option is a string by manifest default, and toggling one would rewrite whatever the user had stored in it. Reading is lenient (`true`/`1`/`yes`/`on`, case- and whitespace-insensitive) so a hand-edited config never silently reads as off; writing is always `true`/`false`.

## Verified

`just check` clean, `cargo fmt` clean, `cargo test` green, plus four new tests on `BackendOption::{is_bool, bool_value, bool_default}`.

Against a live daemon holding the Tidy backend imported from a directory:

```
name:        Tidy
source:      github.com/jorge-menjivar/super-stt-tidy
models:      [('rules-v1', 'post_processor')]
description: Tidies up dictated text before it is typed. Removes filler sounds,
             collapses stutters, repairs punctuation and spacing, and fixes
             sentence casing. Runs locally in microseconds with no network
             access, and never rewrites your words.
```

and the switch's exact round-trip:

```
1. fresh:                    default='true'  value='true'
2. off  → POST value=false:  default='true'  value='false'   (config: remove_fillers = "false")
3. on   → DELETE override:   default='true'  value='true'
```

The layout fix in §2 is the one thing verified by reading iced's column layout and the build rather than visually — reproducing it needs a short window, which is how it was reported.

Docs: `backends.md` documents the new field and shows it in the example payload; `config.md` documents what `type = "bool"` now renders and notes that a `bool` option should declare a `default`, or its switch starts off with nothing to revert to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HmFf3PQNwVDWw4wUtRs2Y
