### PR TITLE
Ignore local coverage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 
+# Coverage output. CI renders these into a throwaway runner and uploads them;
+# running the same recipes locally writes them to the repo root.
+lcov.info
+coverage-html/
+
 docs/design/
 docs/superpowers/
 .superpowers/


### PR DESCRIPTION
Follow-up to #392, which moved the coverage job onto `just` recipes.

Those recipes write `lcov.info` and `coverage-html/` into the repo root. CI renders them into a throwaway runner and uploads them as artifacts, so nothing there notices — but a developer running `just coverage-report-lcov` / `just coverage-report-html` locally is left with two untracked artifacts, one of them a 2.3 MB file and the other a directory of generated HTML.

Verified by running the coverage job's exact sequence locally:

```
just build-mock-wasm-backend         exit 0
just build-mock-wasm-realtime-backend exit 0
just coverage-collect                exit 0   1167 tests, 0 failures
just coverage-report-lcov            exit 0   TOTAL … 58.24% lines
just coverage-report-html            exit 0   coverage-html/index.html
just coverage-badge                  exit 0   {"schemaVersion":1,"label":"coverage","message":"58.2%","color":"orange"}
```

`git status` after that run reports only this `.gitignore` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HmFf3PQNwVDWw4wUtRs2Y