### PR TITLE
Stop pinning versions on the installer's internal deps

### DIFF
--- a/super-stt-install/Cargo.toml
+++ b/super-stt-install/Cargo.toml
@@ -17,8 +17,8 @@
     reqwest.workspace = true
     serde.workspace = true
     serde_json.workspace = true
-    super-stt-forge = { version = "0.2.2-beta.2", path = "../super-stt-forge" }
-    super-stt-registry-types = { version = "0.2.2-beta.2", path = "../super-stt-registry-types" }
+    super-stt-forge = { path = "../super-stt-forge" }
+    super-stt-registry-types = { path = "../super-stt-registry-types" }
     tar = "0.4.46"
     thiserror.workspace = true
     tokio.workspace = true


### PR DESCRIPTION
`super-stt-install` is the only crate in the workspace that restates a version
for a sibling:

```toml
super-stt-forge = { version = "0.2.2-beta.2", path = "../super-stt-forge" }
super-stt-registry-types = { version = "0.2.2-beta.2", path = "../super-stt-registry-types" }
```

The other eleven internal dependencies — including `super-stt-app`'s on these
same two crates — are bare path deps that inherit whatever the root
`Cargo.toml` ships. This makes the installer match them.

## Why the pin can't help

A version on a `{ version, path }` dependency is only consulted when the crate
is published to a registry; consumers of a published crate get the version, not
the path. `super-stt-install` is never published — it ships as a release binary
(`release.yml` builds `--bin super-stt-install` and uploads
`super-stt-install-<target>`).

## Why it can hurt

Both crates take `version.workspace = true`, so the requirement is really
"the workspace version must stay >= 0.2.2-beta.2". At `0.2.3` that is invisible,
which is why it has sat here unnoticed. Renumber the workspace below it and the
build stops resolving, with the siblings sitting right there in-tree:

```
error: failed to select a version for the requirement `super-stt-forge = "^0.2.2-beta.2"`
candidate versions found which didn't match: 0.1.0
```

That is not hypothetical — it is exactly what happened downstream in super-tts,
which inherited these two lines from this repo and hit the failure the moment
its workspace version was reset. Fixed there too.

## Verification

- `cargo metadata --locked` passes and **`Cargo.lock` is unchanged** — nothing
  resolves differently today; only the trap is removed.
- `cargo check -p super-stt-install --all-targets` compiles clean, with
  `super-stt-forge` and `super-stt-install` both at `v0.2.3` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ECyrXcwEmyiNyRk4hTN79