### PR TITLE
Make the contract gate reach the user

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -70,39 +70,6 @@ description = "Local Whisper speech-to-text."
 | `license`    | string | for publication | SPDX identifier of a current OSI-approved or FSF Free/Libre license (e.g. `Apache-2.0`, `MIT`, `GPL-3.0-only`), or the literal `other` for a license outside that set. Required for registry publication; optional for locally installed backends. |
 | `description`| string | yes             | One-line, human-readable summary shown in the registry/Browse listing. |
 
-### Contract generations
-
-`contract` is the one thing a manifest says about what it needs from Super
-STT. Each generation is a set of manifest fields and backend routes, and each
-is **additive** over the one before: a `v2` backend serves everything a `v1`
-backend serves, plus what `v2` introduced. Declare the lowest generation whose
-fields you use — a backend that only transcribes is `v1` however new it is.
-
-| Generation | Adds                                                                         | First supported by |
-|------------|------------------------------------------------------------------------------|--------------------|
-| `v1`       | The base contract: transcription over `POST /v1/transcribe`.                 | Super STT 0.1.0    |
-| `v2`       | [`[[models]].role`](#model-roles) and [`POST /v1/process`](./contract.md#post-v1process) — transcript post-processors. | Super STT 0.2.4    |
-
-You never write a Super STT version. The generation implies one, and the
-registry carries it: the indexer stamps each entry with the release that
-introduced its generation, so a Super STT that predates it lists the backend
-as *Not compatible* with the version to update to, rather than installing
-something it cannot drive. A Super STT older than the field itself cannot
-parse the manifest at all — which refuses the install just the same, only
-without the explanation.
-
-The rule is enforced twice from one table. The parser refuses a manifest that
-declares a field newer than its generation:
-
-```
-`[[models]].role` requires `contract = "v2"`, but this manifest declares `contract = "v1"`
-```
-
-and the published `backend.schema.json` disallows the same field under the
-same generation, so an editor bound to the schema flags it before anything is
-released. Spelling a newer field with its default value still counts as
-declaring it.
-
 `license` is checked against the SPDX license list embedded in the registry
 indexer — no network access — and must be a single, current (non-deprecated)
 SPDX identifier that the list marks OSI-approved or FSF Free/Libre, or the
@@ -125,6 +92,52 @@ controls, so two unrelated authors may both publish a backend named
 
 `id` names the install directory. It is not part of model identity, which is
 the `(name, source)` pair described in [contract.md](./contract.md).
+
+### Contract generations
+
+`contract` is the one thing a manifest says about what it needs from Super
+STT. A generation names a set of manifest fields and backend routes, and each
+generation **extends** the one before rather than replacing it: `v2` is
+everything `v1` defines, plus what `v2` adds. Declare the lowest generation
+whose fields you use — a backend that only transcribes is `v1` however new it
+is.
+
+| Generation | Adds                                                                         | First supported by |
+|------------|------------------------------------------------------------------------------|--------------------|
+| `v1`       | The base contract: transcription over `POST /v1/transcribe`.                 | Super STT 0.2.0    |
+| `v2`       | [`[[models]].role`](#model-roles) and [`POST /v1/process`](./contract.md#post-v1process) — transcript post-processors. | Super STT 0.2.4    |
+
+Extending the contract does not oblige a backend to serve all of it. Which
+routes a backend must implement is decided by the models it declares, not by
+its generation: a `v2` backend serving only `post_processor` models implements
+`POST /v1/process` and never `POST /v1/transcribe`. The generation says what
+the daemon may *expect to find*; the models say what it will actually call.
+
+You never write a Super STT version. The generation implies one, and the
+registry carries it: the indexer stamps each entry with the release that
+introduced its generation. A Super STT that predates the generation cannot
+parse it, so it shows the backend in **Browse** as needing a newer Super STT,
+naming the version — and does so whether or not "Show incompatible" is on,
+since that toggle is for hardware this machine cannot satisfy, not for
+something the user can fix by updating.
+
+The rule is enforced twice from one table. The parser refuses a manifest that
+declares a field newer than its generation:
+
+```
+`[[models]].role` requires `contract = "v2"`, but this manifest declares `contract = "v1"`
+— raise the contract to use the field, or remove the field to stay on `v1`
+```
+
+and the published `backend.schema.json` disallows the same field under the
+same generation, so an editor bound to the schema flags it before anything is
+released. Spelling a newer field with its default value still counts as
+declaring it — which is why the message names removing the field too: writing
+a default by hand should not cost every older client.
+
+Only field *names* are versioned this way. A generation that widens an
+existing field's value set instead — a new model `role`, a new device — cannot
+be expressed in that table, and is caught by that field's own parser.
 
 ## `[network]`
 

--- a/docs/protocol/backend/contract.md
+++ b/docs/protocol/backend/contract.md
@@ -81,8 +81,13 @@ a top-level `status` field of `"success"` or `"error"`.
 
 The manifest's [`contract`](./config.md#contract-generations) names a
 *generation* of this agreement — which fields a `backend.toml` may declare
-and which routes a backend must serve. Generations are additive: `v2` is
+and which routes exist to be served. Each generation extends the last: `v2` is
 `v1` plus `[[models]].role` and `POST /v1/process`.
+
+A generation does not oblige a backend to serve all of it. What a backend must
+implement follows from the models it declares — a `v2` backend serving only
+`post_processor` models implements `POST /v1/process` and never
+`POST /v1/transcribe`.
 
 The `/v1` in the route paths is not that number. It is a path segment inside
 the agreement, and an additive generation leaves it alone: a `v2` backend

--- a/docs/protocol/endpoints/v1/registry/backends.md
+++ b/docs/protocol/endpoints/v1/registry/backends.md
@@ -108,8 +108,13 @@ Per-entry fields beyond what `index.json` carries:
   A backend whose [`contract`](../../../backend/config.md#contract-generations)
   generation this daemon does not know is reported here too — before any
   asset question — as `needs Super STT <min_client> or newer (backend contract
-  <contract>); this is <daemon version>`, so the fix is stated rather than
-  discovered on install.
+  <contract>); this is <daemon version>`. `POST .../install` and
+  `POST .../update` return the same sentence as their `422 incompatible`
+  `message`, so the fix is stated wherever the block is met.
+- `compatibility.needs_client_update` — `true` when the block is the contract
+  generation rather than this host's hardware. Such an entry is listed even
+  without `include_incompatible`: the toggle is for hardware a machine will
+  never satisfy, and the remedy here is an update the user can act on.
 - `installed_version` — present if the backend is already installed on this
   host, regardless of its registry status. Read from the installed
   `backend.toml` on every request, so it reflects what is on disk now rather

--- a/registry/README.md
+++ b/registry/README.md
@@ -22,8 +22,14 @@ End users do not interact with this directory.
    generation whose fields your manifest uses — `v1` for a backend that only
    transcribes, `v2` for one that declares a `post_processor` model. That is
    the only compatibility statement you make: the indexer stamps each entry
-   with the Super STT release its generation needs, and older clients list
-   the backend as not compatible rather than installing it.
+   with the Super STT release its generation needs, and a client that predates
+   it says so instead of installing something it cannot drive.
+
+   A client older than the generation *check itself* (0.2.3 and earlier) does
+   not have the stamp to read: it lists the entry as installable and refuses
+   later, when it parses the manifest it downloaded. The refusal is correct
+   either way — nothing is installed that cannot run — but only a client from
+   0.2.4 on can explain it up front.
 2. Open a PR adding a new entry to `registry.toml` in **alphabetical order**:
 
    ```toml

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -947,6 +947,7 @@ mod update_offer_tests {
                 compatible: true,
                 selected_asset: None,
                 reason: None,
+                needs_client_update: false,
             },
             installed_version: installed.map(String::from),
             update_available,

--- a/super-stt-app/src/ui/views/models/download.rs
+++ b/super-stt-app/src/ui/views/models/download.rs
@@ -40,7 +40,14 @@ pub(super) fn download_split(app: &AppModel) -> (Element<'_, Message>, Element<'
         if installed_sources.contains(entry.source.as_str()) {
             continue;
         }
-        if !filters.include_incompatible && !entry.compatibility.compatible {
+        // "Show incompatible" is about hardware this machine will never
+        // satisfy. A backend that needs a newer Super STT is a different thing
+        // — the user can act on it — so it is listed either way, with the
+        // version to update to in its footer.
+        if !filters.include_incompatible
+            && !entry.compatibility.compatible
+            && !entry.compatibility.needs_client_update
+        {
             continue;
         }
         if let Some(o) = filters.online
@@ -275,6 +282,8 @@ pub(super) fn download_card<'a>(
                 entry.source.clone(),
             )))
             .into()
+    } else if entry.compatibility.needs_client_update {
+        button::standard("Update Super STT").into()
     } else {
         button::standard("Not compatible").into()
     };
@@ -301,14 +310,18 @@ pub(super) fn download_card<'a>(
         .align_y(Alignment::Center)
         .into()
     } else if !entry.compatibility.compatible {
-        let reason = entry
-            .compatibility
-            .reason
-            .as_deref()
-            .unwrap_or("incompatible hardware or OS");
+        let (lead, fallback) = if entry.compatibility.needs_client_update {
+            (
+                "Needs a newer Super STT",
+                "this backend needs a newer Super STT",
+            )
+        } else {
+            ("Not compatible", "incompatible hardware or OS")
+        };
+        let reason = entry.compatibility.reason.as_deref().unwrap_or(fallback);
         row![
             icons::phosphor_destructive(icons::WARNING, 14.0),
-            text::caption(format!("Not compatible: {reason}")),
+            text::caption(format!("{lead}: {reason}")),
         ]
         .spacing(spacing.space_xxs)
         .align_y(Alignment::Center)

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -233,9 +233,13 @@ fn select_install_compat(
     let host = host_detect::detect();
     let sel = compat::select(&host, entry);
     let Some(asset) = compat::to_selected_asset(entry, &sel) else {
-        return Err(Box::new(super::registry_error(
+        // `select` already worked out why; dropping it here is what made this
+        // a bare `incompatible` the caller had to guess at — and the reason is
+        // the whole value of the check when the remedy is "update Super STT".
+        return Err(Box::new(super::registry_error_msg(
             StatusCode::UNPROCESSABLE_ENTITY,
             "incompatible",
+            sel.reason().unwrap_or("no compatible asset for this host"),
         )));
     };
     Ok((sel, asset))

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -75,17 +75,27 @@ pub(super) fn installed_version_for_source(
     )
 }
 
-/// Whether the index offers something newer than what is installed.
+/// Whether the index offers something newer than what is installed *and this
+/// daemon could install it*.
 ///
 /// The daemon answers this rather than each client re-deriving it: it is the
 /// side that reads the installed manifest and owns the index. A backend that is
 /// not installed here has no update to offer — it has an *install* — so `None`
 /// is `false` rather than "everything is an update".
 ///
+/// `compatible` is part of the answer, not a separate concern. A newer release
+/// this host cannot run is not an update the user can take: offering it puts an
+/// Update button on a card whose only outcome is `422 incompatible`. The
+/// commonest way for that to happen now is a release that moved to a contract
+/// generation this daemon predates — precisely the case where the user needs to
+/// update Super STT, not the backend.
+///
 /// The comparison itself is the shared semver one, which already refuses a
 /// downgrade and refuses to guess at a version it cannot parse.
-fn update_available(installed: Option<&str>, index_version: &str) -> bool {
-    installed.is_some_and(|i| super_stt_registry_types::version::update_available(i, index_version))
+fn update_available(installed: Option<&str>, index_version: &str, compatible: bool) -> bool {
+    compatible
+        && installed
+            .is_some_and(|i| super_stt_registry_types::version::update_available(i, index_version))
 }
 
 /// Map a registry entry + compatibility result to the wire `RegistryBackend` shape.
@@ -140,8 +150,12 @@ fn map_entry(
                 default: o.default.clone(),
             })
             .collect(),
+        update_available: update_available(
+            installed_version.as_deref(),
+            &entry.version,
+            compat_field.compatible,
+        ),
         compatibility: compat_field,
-        update_available: update_available(installed_version.as_deref(), &entry.version),
         installed_version,
         index_stale: entry
             .index_stale
@@ -176,23 +190,22 @@ pub(crate) async fn list_registry_backends(
         }
 
         let sel = compat::select(&host, entry);
-        let compatible = !matches!(sel, compat::Selection::Incompatible { .. });
+        let compatible = sel.reason().is_none();
+        let needs_client_update = sel.needs_client_update();
 
-        if !compatible && !q.include_incompatible {
+        // A client-update block is always listed: `include_incompatible` is
+        // about hardware this host will never satisfy, and swallowing "your
+        // Super STT is too old" behind the same toggle hides the one notice
+        // that would tell the user what to do.
+        if !compatible && !needs_client_update && !q.include_incompatible {
             continue;
         }
 
-        let selected_asset = compat::to_selected_asset(entry, &sel);
-        let reason = if let compat::Selection::Incompatible { ref reason } = sel {
-            Some(reason.clone())
-        } else {
-            None
-        };
-
         let compat_field = Compatibility {
             compatible,
-            selected_asset,
-            reason,
+            selected_asset: compat::to_selected_asset(entry, &sel),
+            reason: sel.reason().map(ToOwned::to_owned),
+            needs_client_update,
         };
 
         result.push(map_entry(
@@ -226,17 +239,27 @@ mod tests {
     /// unreadable version never becomes one on the way to the wire.
     #[test]
     fn only_an_installed_older_version_has_an_update() {
-        assert!(update_available(Some("0.1.0"), "0.1.1"));
-        assert!(update_available(Some("v1.0.0"), "1.0.1"));
+        assert!(update_available(Some("0.1.0"), "0.1.1", true));
+        assert!(update_available(Some("v1.0.0"), "1.0.1", true));
 
         // Not installed: the client is offered an install, not an update.
-        assert!(!update_available(None, "0.1.1"));
+        assert!(!update_available(None, "0.1.1", true));
         // Already current, and a stale index that would prompt a downgrade.
-        assert!(!update_available(Some("0.1.1"), "0.1.1"));
-        assert!(!update_available(Some("0.2.0"), "0.1.1"));
+        assert!(!update_available(Some("0.1.1"), "0.1.1", true));
+        assert!(!update_available(Some("0.2.0"), "0.1.1", true));
         // Neither side is guessed at when it cannot be parsed.
-        assert!(!update_available(Some("1.0.0"), "nightly"));
-        assert!(!update_available(Some(""), "1.0.0"));
+        assert!(!update_available(Some("1.0.0"), "nightly", true));
+        assert!(!update_available(Some(""), "1.0.0", true));
+    }
+
+    /// A newer release this daemon cannot install is not an update on offer.
+    /// The Update button it would otherwise draw leads only to
+    /// `422 incompatible` — and when the cause is a contract generation this
+    /// build predates, updating the *backend* was never the fix.
+    #[test]
+    fn an_incompatible_release_is_not_offered_as_an_update() {
+        assert!(update_available(Some("0.1.0"), "0.2.0", true));
+        assert!(!update_available(Some("0.1.0"), "0.2.0", false));
     }
 
     use crate::stt_models::backends::DiscoveredBackend;
@@ -276,7 +299,7 @@ mod tests {
             ),
             Some("0.1.0".to_string())
         );
-        assert!(update_available(Some("0.1.0"), "0.1.1"));
+        assert!(update_available(Some("0.1.0"), "0.1.1", true));
     }
 
     #[test]

--- a/super-stt-daemon/src/daemon/http/v1/registry/update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/update.rs
@@ -107,9 +107,12 @@ fn select_update_compat(
     let sel = compat::select(&host, entry);
 
     if compat::to_selected_asset(entry, &sel).is_none() {
-        return Err(Box::new(super::registry_error(
+        // Same as the install path: say why, rather than making the client
+        // re-derive it from a listing it may not have refreshed.
+        return Err(Box::new(super::registry_error_msg(
             StatusCode::UNPROCESSABLE_ENTITY,
             "incompatible",
+            sel.reason().unwrap_or("no compatible asset for this host"),
         )));
     }
 

--- a/super-stt-daemon/src/registry/compat.rs
+++ b/super-stt-daemon/src/registry/compat.rs
@@ -4,6 +4,7 @@
 //! the runtime device preference is intentionally decoupled and never affects
 //! which asset is downloaded.
 
+use semver::Version;
 use super_stt_registry_types::manifest::Contract;
 use super_stt_shared::registry::SelectedAsset;
 
@@ -13,8 +14,39 @@ use crate::registry::index_schema::{IndexBackend, IndexSubprocessAsset};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Selection {
     Wasm,
-    Subprocess { index: usize },
-    Incompatible { reason: String },
+    Subprocess {
+        index: usize,
+    },
+    Incompatible {
+        reason: String,
+    },
+    /// This build does not know the entry's contract generation. Distinct
+    /// from [`Incompatible`](Self::Incompatible) because the remedy is
+    /// different in kind: a host that lacks the right GPU will never run this
+    /// asset, but a Super STT that is merely too old is one update away — so
+    /// clients surface this even where they hide hardware mismatches.
+    NeedsClientUpdate {
+        reason: String,
+    },
+}
+
+impl Selection {
+    /// The human-readable reason this entry cannot be installed, or `None`
+    /// when it can.
+    #[must_use]
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Wasm | Self::Subprocess { .. } => None,
+            Self::Incompatible { reason } | Self::NeedsClientUpdate { reason } => Some(reason),
+        }
+    }
+
+    /// Whether the block is "your Super STT is too old" rather than "this
+    /// machine cannot run it".
+    #[must_use]
+    pub fn needs_client_update(&self) -> bool {
+        matches!(self, Self::NeedsClientUpdate { .. })
+    }
 }
 
 /// Below this major version an AMD architecture's *stepping* is a whole
@@ -51,6 +83,11 @@ fn gfx_is_exact(
     asset.major == host.major && asset.minor == host.minor && asset.step == host.step
 }
 
+/// Longest registry-supplied contract string echoed into a reason. A
+/// generation is `v` plus digits; anything longer is not one, and the reason
+/// is user-facing text assembled from a document this daemon did not write.
+const MAX_ECHOED_CONTRACT: usize = 16;
+
 /// Why an entry's contract generation cannot be driven by this daemon, or
 /// `None` when it can.
 ///
@@ -60,20 +97,33 @@ fn gfx_is_exact(
 /// test. The index also stamps the release that introduced the generation, so
 /// the reason can say what to update to even for a generation this build has
 /// never heard of.
+///
+/// Both echoed values come from `index.json`, which is fetched — and
+/// `SUPER_STT_REGISTRY_URL` can point somewhere else, which is why
+/// `retain_safe_backends` already sanitizes the fields that become paths.
+/// These two only become text, so they are bounded rather than rejected: the
+/// contract is truncated, and `min_client` is quoted only when it parses as
+/// semver *and* actually exceeds this build. A floor at or below the running
+/// version would otherwise produce advice the user has already followed.
 fn contract_block(entry: &IndexBackend) -> Option<String> {
     if entry.contract.parse::<Contract>().is_ok() {
         return None;
     }
     let daemon = crate::registry::index_schema::CLIENT_VERSION;
-    Some(match entry.min_client.as_deref() {
-        Some(min) => format!(
-            "needs Super STT {min} or newer (backend contract {}); this is {daemon}",
-            entry.contract
-        ),
-        None => format!(
-            "needs a newer Super STT (backend contract {}); this is {daemon}",
-            entry.contract
-        ),
+    let contract: String = entry.contract.chars().take(MAX_ECHOED_CONTRACT).collect();
+    let floor = entry.min_client.as_deref().filter(|min| {
+        match (Version::parse(min), Version::parse(daemon)) {
+            (Ok(min), Ok(running)) => min > running,
+            _ => false,
+        }
+    });
+    Some(match floor {
+        Some(min) => {
+            format!(
+                "needs Super STT {min} or newer (backend contract {contract}); this is {daemon}"
+            )
+        }
+        None => format!("needs a newer Super STT (backend contract {contract}); this is {daemon}"),
     })
 }
 
@@ -83,7 +133,7 @@ pub fn select(host: &Host, entry: &IndexBackend) -> Selection {
     // compatible asset, whatever the host looks like. Listing, install and
     // update all route through here, so one check covers all three.
     if let Some(reason) = contract_block(entry) {
-        return Selection::Incompatible { reason };
+        return Selection::NeedsClientUpdate { reason };
     }
     if entry.kind == "wasm" {
         return if entry.assets.wasm.is_some() {
@@ -311,7 +361,7 @@ pub fn to_selected_asset(entry: &IndexBackend, sel: &Selection) -> Option<Select
                 cudnn: a.cudnn,
             })
         }
-        Selection::Incompatible { .. } => None,
+        Selection::Incompatible { .. } | Selection::NeedsClientUpdate { .. } => None,
     }
 }
 
@@ -940,9 +990,15 @@ mod tests {
         });
         e.contract = "v99".into();
         e.min_client = Some("9.9.9".into());
-        let Selection::Incompatible { reason } = select(&host_cpu(), &e) else {
-            panic!("an unknown contract must be incompatible");
-        };
+        let sel = select(&host_cpu(), &e);
+        assert!(
+            sel.needs_client_update(),
+            "the remedy is a Super STT update"
+        );
+        let reason = sel
+            .reason()
+            .expect("a blocked entry states why")
+            .to_string();
         assert!(reason.contains("9.9.9"), "{reason}");
         assert!(reason.contains("v99"), "{reason}");
         assert!(
@@ -953,9 +1009,10 @@ mod tests {
         // An index published before the stamp still refuses, just without the
         // number.
         e.min_client = None;
-        let Selection::Incompatible { reason } = select(&host_cpu(), &e) else {
-            panic!("still incompatible without a stamp");
-        };
+        let reason = select(&host_cpu(), &e)
+            .reason()
+            .expect("still blocked without a stamp")
+            .to_string();
         assert!(reason.contains("newer Super STT"), "{reason}");
     }
 }

--- a/super-stt-daemon/src/registry/install.rs
+++ b/super-stt-daemon/src/registry/install.rs
@@ -100,7 +100,7 @@ where
     let kind_subdir = match selection {
         Selection::Wasm => false,
         Selection::Subprocess { .. } => true,
-        Selection::Incompatible { reason: _ } => {
+        Selection::Incompatible { .. } | Selection::NeedsClientUpdate { .. } => {
             return Err((P::Resolving, InstallError::Incompatible));
         }
     };
@@ -251,7 +251,9 @@ where
                 Ok(())
             }
         }
-        Selection::Incompatible { reason: _ } => Err((P::Resolving, InstallError::Incompatible)),
+        Selection::Incompatible { .. } | Selection::NeedsClientUpdate { .. } => {
+            Err((P::Resolving, InstallError::Incompatible))
+        }
     }
 }
 

--- a/super-stt-daemon/src/stt_models/backends/mod.rs
+++ b/super-stt-daemon/src/stt_models/backends/mod.rs
@@ -74,7 +74,7 @@ pub struct DiscoveredBackend {
 /// is judged against cannot disagree.
 #[must_use]
 pub fn installed_version(dir: &Path) -> Option<String> {
-    manifest::Manifest::load(dir)
+    manifest::Manifest::load_installed(dir)
         .ok()
         .map(|m| m.backend.version)
 }
@@ -191,7 +191,12 @@ fn is_id_named(b: &DiscoveredBackend) -> bool {
 /// manifest; this function enforces the cross-field device rules via
 /// [`validate_supported_devices`].
 fn load_backend(dir: &Path) -> anyhow::Result<DiscoveredBackend> {
-    let mut m = Manifest::load(dir)?;
+    // `load_installed`, not `load`: this backend is already on disk, and the
+    // contract-field rule exists to stop a *new* manifest getting in. Holding
+    // an installed one to it would drop a backend that installed cleanly under
+    // an earlier build out of the catalog, models and all, over a file the
+    // user never wrote.
+    let mut m = Manifest::load_installed(dir)?;
     manifest::validate_runtime(&m)?;
     // A `base_url` value authorizes egress the sandbox would otherwise refuse,
     // so only the user may supply one. A manifest that declares a default is

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -131,16 +131,15 @@ impl fmt::Display for Kind {
 /// itself against every daemon released before it.
 ///
 /// Variant order is generation order; the derived `Ord` relies on it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
 pub enum Contract {
     /// The v1 contract (`docs/protocol/backend/contract.md`): transcription
     /// only.
-    #[serde(rename = "v1")]
     V1,
     /// v1 plus `[[models]].role` and `POST /v1/process` — a backend may serve
     /// transcript post-processors.
-    #[serde(rename = "v2")]
     V2,
 }
 
@@ -159,10 +158,23 @@ impl Contract {
     /// daemon that does not know the generation can still tell the user what
     /// to update to. A backend author never writes a Super STT version: they
     /// declare the contract, and this table is what it means.
+    ///
+    /// Reported, never compared: the daemon decides compatibility by whether
+    /// it can parse the generation at all, so a prerelease of the version
+    /// named here (`0.2.4-beta.1`, which semver orders *below* `0.2.4`) is not
+    /// wrongly locked out. It is a string for the user, not a gate.
+    ///
+    /// A new row is a forecast until its release ships, and nothing can check
+    /// it: the version that introduces a generation is by definition not yet
+    /// tagged when the row is written. Renumbering that release means
+    /// renumbering here.
     #[must_use]
     pub const fn min_client(self) -> &'static str {
         match self {
-            Self::V1 => "0.1.0",
+            // Not 0.1.0: `[backend].contract` — and the backend manifest
+            // itself — first shipped in 0.2.0 (#212). A 0.1.x daemon has no
+            // notion of an installable backend to gate.
+            Self::V1 => "0.2.0",
             Self::V2 => "0.2.4",
         }
     }
@@ -181,11 +193,31 @@ impl std::str::FromStr for Contract {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "v1" => Ok(Self::V1),
-            "v2" => Ok(Self::V2),
-            _ => Err(format!("Unknown contract: {s}")),
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|c| c.to_string() == s)
+            .ok_or_else(|| {
+                let known: Vec<String> = Self::ALL.iter().map(ToString::to_string).collect();
+                format!(
+                    "unknown contract `{s}`; this build knows {}",
+                    known.join(", ")
+                )
+            })
+    }
+}
+
+/// Routed through `FromStr` so one table — `ALL` plus `Display` — is the only
+/// place a generation is spelled, and so the error names what this build does
+/// know. That message is what a user sees when a daemon meets a backend from a
+/// newer generation, so it is worth more than serde's "unknown variant".
+impl<'de> Deserialize<'de> for Contract {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let text = String::deserialize(d)?;
+        text.parse().map_err(serde::de::Error::custom)
     }
 }
 
@@ -212,14 +244,46 @@ impl ContractField {
     /// `[[models]].role`.
     #[must_use]
     pub fn path(&self) -> String {
+        if self.is_array_table() {
+            format!("[[{}]].{}", self.table, self.key)
+        } else {
+            format!("[{}].{}", self.table, self.key)
+        }
+    }
+
+    /// Whether the field's table is an array of tables (`[[models]]`) rather
+    /// than a plain one (`[backend]`).
+    ///
+    /// The single answer for every consumer: the manifest spelling above, the
+    /// raw-document audit, and the schema rule (which must attach to `items`
+    /// for an array). Adding a row for a table not listed here fails the
+    /// schema's own test rather than silently generating a rule that matches
+    /// nothing.
+    #[must_use]
+    pub fn is_array_table(&self) -> bool {
+        matches!(self.table, "models" | "secrets" | "options")
+    }
+
+    /// The name of this table's type in the generated JSON schema, or `None`
+    /// for a table the schema builder has no mapping for.
+    #[must_use]
+    pub fn schema_definition(&self) -> Option<&'static str> {
         match self.table {
-            "models" | "secrets" | "options" => format!("[[{}]].{}", self.table, self.key),
-            table => format!("[{table}].{}", self.key),
+            "backend" => Some("BackendMeta"),
+            "models" => Some("ModelEntry"),
+            "secrets" => Some("Secret"),
+            "options" => Some("Opt"),
+            _ => None,
         }
     }
 }
 
 /// Every field introduced after v1, with the generation that introduced it.
+///
+/// Field **names** only. A generation that widens an existing field's value
+/// set instead — a new `ModelRole`, a new `Device` — cannot be expressed here,
+/// and a manifest using such a value under an older `contract` is caught by
+/// that field's own `FromStr` rather than by this table.
 pub const CONTRACT_FIELDS: &[ContractField] = &[ContractField {
     since: Contract::V2,
     table: "models",
@@ -744,9 +808,15 @@ pub enum ManifestError {
     #[error("`[backend].id` is not a valid reverse-DNS id: {0}")]
     InvalidId(String),
     /// A field was declared that the manifest's `contract` does not include.
+    ///
+    /// Both fixes are named because they are not equivalent: raising the
+    /// contract is right for a manifest that means to use the field, but it
+    /// also raises the release floor for every client. An author who wrote the
+    /// field's default value by hand wants the other one.
     #[error(
         "`{field}` requires `contract = \"{since}\"`, but this manifest declares \
-         `contract = \"{declared}\"`"
+         `contract = \"{declared}\"` — raise the contract to use the field, or \
+         remove the field to stay on `{declared}`"
     )]
     FieldRequiresContract {
         /// The field, spelled as in the manifest (e.g. `[[models]].role`).
@@ -828,10 +898,12 @@ fn first_field_beyond_contract(
         .iter()
         .filter(|field| field.since > declared)
         .find(|field| match raw.get(field.table) {
-            Some(toml::Value::Array(entries)) => entries
+            Some(toml::Value::Array(entries)) if field.is_array_table() => entries
                 .iter()
                 .any(|entry| entry.as_table().is_some_and(|t| t.contains_key(field.key))),
-            Some(toml::Value::Table(table)) => table.contains_key(field.key),
+            Some(toml::Value::Table(table)) if !field.is_array_table() => {
+                table.contains_key(field.key)
+            }
             _ => false,
         })
 }
@@ -844,8 +916,36 @@ impl Manifest {
     /// lives in the single canonical parser so every consumer inherits it.
     ///
     /// # Errors
-    /// Returns a [`ManifestError`] on TOML errors or an unsafe entrypoint.
+    /// Returns a [`ManifestError`] on TOML errors, an unsafe entrypoint or
+    /// file destination, a malformed `[backend].id`, a malformed
+    /// `[[assets.subprocess]]` entry, or a field the declared
+    /// [`contract`](Contract) does not include
+    /// ([`FieldRequiresContract`](ManifestError::FieldRequiresContract)).
     pub fn parse(text: &str) -> Result<Self, ManifestError> {
+        Self::parse_inner(text, ContractFields::Enforced)
+    }
+
+    /// Parse a manifest that is **already installed** on this machine.
+    ///
+    /// Identical to [`parse`](Self::parse) except that the contract-field rule
+    /// does not apply. That rule's job is to stop a manifest getting in, and
+    /// this one is already in: enforcing it at discovery would make a backend
+    /// that installed cleanly under an earlier build disappear from the
+    /// catalog — taking its downloaded models out of reach — over a manifest
+    /// the user cannot edit and did not write.
+    ///
+    /// Only discovery of the installed backends directory uses this. Every
+    /// path that admits a *new* manifest — registry install, custom repo,
+    /// import-from-directory, and the indexer — goes through
+    /// [`parse`](Self::parse).
+    ///
+    /// # Errors
+    /// As [`parse`](Self::parse), less `FieldRequiresContract`.
+    pub fn parse_installed(text: &str) -> Result<Self, ManifestError> {
+        Self::parse_inner(text, ContractFields::Ignored)
+    }
+
+    fn parse_inner(text: &str, fields: ContractFields) -> Result<Self, ManifestError> {
         let mut m: Self = toml::from_str(text)?;
         // Every field defaults when absent, so the typed struct cannot tell
         // "declared `role`" from "left it out". The raw document can, and the
@@ -853,14 +953,20 @@ impl Manifest {
         // field at all, not even with its default value, because the v1
         // schema does not have it. Parsed from the text a second time rather
         // than converted from one `Table`, so the typed parse above keeps its
-        // line/column spans in error messages.
-        let raw: toml::Table = toml::from_str(text)?;
-        if let Some(field) = first_field_beyond_contract(&raw, m.backend.contract) {
-            return Err(ManifestError::FieldRequiresContract {
-                field: field.path(),
-                since: field.since,
-                declared: m.backend.contract,
-            });
+        // line/column spans in error messages — and only when some field could
+        // actually be in breach, which for a manifest declaring the latest
+        // generation is never.
+        if fields == ContractFields::Enforced
+            && CONTRACT_FIELDS.iter().any(|f| f.since > m.backend.contract)
+        {
+            let raw: toml::Table = toml::from_str(text)?;
+            if let Some(field) = first_field_beyond_contract(&raw, m.backend.contract) {
+                return Err(ManifestError::FieldRequiresContract {
+                    field: field.path(),
+                    since: field.since,
+                    declared: m.backend.contract,
+                });
+            }
         }
         if !crate::is_safe_relative_path(&m.backend.entrypoint) {
             return Err(ManifestError::UnsafeEntrypoint(m.backend.entrypoint));
@@ -939,16 +1045,41 @@ impl Manifest {
     /// Returns a [`ManifestError`] if the file is missing, unreadable, or
     /// fails [`Manifest::parse`].
     pub fn load(dir: &Path) -> Result<Self, ManifestError> {
+        Self::load_with(dir, Self::parse)
+    }
+
+    /// [`load`](Self::load) for a backend already installed here — see
+    /// [`parse_installed`](Self::parse_installed) for why the contract-field
+    /// rule is not applied.
+    ///
+    /// # Errors
+    /// As [`load`](Self::load), less `FieldRequiresContract`.
+    pub fn load_installed(dir: &Path) -> Result<Self, ManifestError> {
+        Self::load_with(dir, Self::parse_installed)
+    }
+
+    fn load_with(
+        dir: &Path,
+        parse: fn(&str) -> Result<Self, ManifestError>,
+    ) -> Result<Self, ManifestError> {
         let path = dir.join("backend.toml");
         let text = std::fs::read_to_string(&path).map_err(|err| ManifestError::Io {
             path: path.display().to_string(),
             err,
         })?;
-        Self::parse(&text).map_err(|err| ManifestError::Parse {
+        parse(&text).map_err(|err| ManifestError::Parse {
             path: path.display().to_string(),
             err: Box::new(err),
         })
     }
+}
+
+/// Whether [`Manifest::parse_inner`] holds a manifest to the contract-field
+/// rule. Installed manifests are exempt; everything admitting a new one is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContractFields {
+    Enforced,
+    Ignored,
 }
 
 #[cfg(test)]
@@ -1154,12 +1285,6 @@ mod tests {
         }
     }
 
-    /// A `[[models]]` table may carry keys this crate does not read, and
-    /// `provider` is the one published backends actually ship. The parser must
-    /// keep ignoring it: a manifest is fetched from a backend's release at
-    /// index time, so rejecting an unread key would drop every already-released
-    /// backend out of the index rather than fail some local build.
-    ///
     /// A manifest declaring `contract` and one `[[models]]` entry carrying
     /// `extra`, for the contract-field tests.
     fn manifest_with(contract: &str, extra: &str) -> String {
@@ -1194,7 +1319,8 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "`[[models]].role` requires `contract = \"v2\"`, but this manifest declares \
-             `contract = \"v1\"`"
+             `contract = \"v1\"` — raise the contract to use the field, or remove the \
+             field to stay on `v1`"
         );
         match err {
             ManifestError::FieldRequiresContract {
@@ -1208,6 +1334,38 @@ mod tests {
             }
             other => panic!("expected FieldRequiresContract, got {other}"),
         }
+    }
+
+    /// A manifest already installed here is exempt. Enforcing the rule at
+    /// discovery would delete a working backend from the catalog — models and
+    /// all — because a build that installed it did not yet have the rule. The
+    /// rule stops a manifest getting in; this one is in.
+    #[test]
+    fn an_installed_manifest_is_not_held_to_the_contract_field_rule() {
+        let text = manifest_with("v1", r#"role = "post_processor""#);
+        assert!(
+            Manifest::parse(&text).is_err(),
+            "the strict parser still refuses it"
+        );
+        let m = Manifest::parse_installed(&text).expect("an installed manifest still loads");
+        assert!(
+            m.models[0].role.is_post_processor(),
+            "and keeps the role it was installed with"
+        );
+    }
+
+    /// The exemption is only the contract-field rule. Everything else a
+    /// manifest can get wrong is still refused, however it got onto disk.
+    #[test]
+    fn an_installed_manifest_is_still_held_to_every_other_rule() {
+        let unsafe_entrypoint = manifest_with("v1", "").replace(
+            r#"entrypoint = "y.wasm""#,
+            r#"entrypoint = "../escape.wasm""#,
+        );
+        assert!(matches!(
+            Manifest::parse_installed(&unsafe_entrypoint),
+            Err(ManifestError::UnsafeEntrypoint(_))
+        ));
     }
 
     /// The rule is about what was written, not what it means: spelling the
@@ -1289,14 +1447,20 @@ mod tests {
                 "v1 is the base; it introduces nothing"
             );
             assert!(
-                matches!(field.table, "backend" | "models" | "secrets" | "options"),
-                "{}: unknown table",
+                field.schema_definition().is_some(),
+                "{}: no schema definition mapped for its table",
                 field.path()
             );
         }
         assert_eq!(CONTRACT_FIELDS[0].path(), "[[models]].role");
     }
 
+    /// A `[[models]]` table may carry keys this crate does not read, and
+    /// `provider` is the one published backends actually ship. The parser must
+    /// keep ignoring it: a manifest is fetched from a backend's release at
+    /// index time, so rejecting an unread key would drop every already-released
+    /// backend out of the index rather than fail some local build.
+    ///
     /// Concretely, this is the test that fails if `deny_unknown_fields` is ever
     /// added to `ModelEntry`.
     #[test]

--- a/super-stt-registry-types/src/schema.rs
+++ b/super-stt-registry-types/src/schema.rs
@@ -287,7 +287,7 @@ fn contract_rules() -> Vec<Value> {
                 // Indexing a `Value` with `[]` creates the object on the way
                 // down, so the shape is written once, at the leaf.
                 let table = &mut then[field.table];
-                if matches!(field.table, "models" | "secrets" | "options") {
+                if field.is_array_table() {
                     table["items"]["properties"][field.key] = json!(false);
                 } else {
                     table["properties"][field.key] = json!(false);

--- a/super-stt-registry-types/tests/schema_validation.rs
+++ b/super-stt-registry-types/tests/schema_validation.rs
@@ -362,6 +362,28 @@ fn conditional_property_names_exist() {
     }
 }
 
+/// Every table a `CONTRACT_FIELDS` row may name resolves to a definition the
+/// schema actually has, so a future row cannot generate a rule that matches
+/// nothing. Checked over the mapping rather than over today's rows, which name
+/// only `models`.
+#[test]
+fn every_mappable_contract_table_has_a_schema_definition() {
+    use super_stt_registry_types::manifest::{Contract, ContractField};
+    let schema = super_stt_registry_types::schema::backend_schema();
+    let defs = schema["definitions"].as_object().expect("definitions");
+    for table in ["backend", "models", "secrets", "options"] {
+        let field = ContractField {
+            since: Contract::LATEST,
+            table,
+            key: "unused",
+        };
+        let def = field
+            .schema_definition()
+            .unwrap_or_else(|| panic!("`{table}` has no schema definition mapped"));
+        assert!(defs.contains_key(def), "`{table}` maps to missing `{def}`");
+    }
+}
+
 /// A model entry that declares `role`, the field v2 introduced.
 fn post_processor_model() -> Value {
     json!({
@@ -438,11 +460,21 @@ fn contract_rule_field_names_exist() {
     let schema = super_stt_registry_types::schema::backend_schema();
     let defs = schema["definitions"].as_object().expect("definitions");
     for field in CONTRACT_FIELDS {
-        let def = match field.table {
-            "models" => "ModelEntry",
-            "backend" => "BackendMeta",
-            other => panic!("no definition mapping for table `{other}`"),
+        // A row naming a table the schema builder cannot map would generate a
+        // rule matching nothing — silently un-gating the field. That is a
+        // failure to report, not a reason to abort the run.
+        let Some(def) = field.schema_definition() else {
+            panic!(
+                "{}: no schema definition mapped for table `{}`",
+                field.path(),
+                field.table
+            );
         };
+        assert!(
+            defs.contains_key(def),
+            "{}: schema has no `{def}` definition",
+            field.path()
+        );
         assert!(
             defs[def]["properties"]
                 .as_object()

--- a/super-stt-shared/src/registry/mod.rs
+++ b/super-stt-shared/src/registry/mod.rs
@@ -80,6 +80,16 @@ pub struct Compatibility {
     pub selected_asset: Option<SelectedAsset>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Whether the block is "this Super STT is too old" rather than "this
+    /// machine cannot run it".
+    ///
+    /// The two are hidden differently. A host that lacks the right GPU will
+    /// never run the asset, so Browse tucks it behind "Show incompatible"; a
+    /// Super STT one version behind is a thing the user can fix in a minute,
+    /// and hiding it hides the only notice they would get. `false` on an older
+    /// daemon that does not send the field, which lists as it always did.
+    #[serde(default)]
+    pub needs_client_update: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Review follow-up to #395, which you merged while I was working through the findings. The gate itself was correct; it was largely invisible, and it had one outright regression.

## Fixes, in the order they bite

**Installed backends no longer vanish.** The contract-field rule refuses a manifest that spells a field newer than its contract — right for a manifest coming *in*, wrong for one already on disk, which a build without the rule may have installed. Discovery would have dropped such a backend from the catalog, its downloaded models with it, over a file the user never wrote and cannot fix. `Manifest::parse_installed` / `load_installed` exempt exactly that case; every path admitting a new manifest still uses `parse`. This was live: `~/.local/share/super-stt/backends/app.super-stt.tidy` is `contract = "v1"` carrying `role`.

**The block reaches Browse.** `include_incompatible` defaults to `false` and the app drops incompatible entries client-side, so the reason was invisible in the one place a user would meet it — which defeated the headline behavior of #395. A contract block is not hardware: the remedy is an update the user can act on. `Selection::NeedsClientUpdate` is now distinct from `Incompatible`, rides the wire as `compatibility.needs_client_update`, is listed whatever the toggle says, and reads "Needs a newer Super STT" with the version instead of a flat "Not compatible".

**Install and update say why.** Both discarded the reason `select` had already computed and answered a bare `422 incompatible`.

**No Update button that cannot be pressed.** `update_available` is now ANDed with compatibility; it previously offered an update whose only outcome was 422.

**The reason is no longer assembled from unvalidated registry text.** `contract` is truncated and `min_client` is quoted only when it parses as semver *and* exceeds this build — a poisoned index could otherwise advise "needs Super STT 0.1.0 or newer; this is 0.2.3". `retain_safe_backends` already sanitizes the fields that become paths; these two became user-facing text.

## Corrections

- `V1.min_client()` is **0.2.0**, not 0.1.0 — `[backend].contract` first shipped in 0.2.0 (#212). The wrong value is already published, so this is a fix to a live claim.
- Generations **extend without obliging**: a v2 backend serving only post-processors implements `/v1/process` and never `/v1/transcribe`. The docs claimed a v2 backend serves everything v1 does — contradicted by this PR's own fixture.
- `FieldRequiresContract` names both fixes. Raising the contract also raises the release floor for every client; an author who hand-wrote a field's default wants the other one.
- `Contract` is spelled once (`ALL` + `Display`), with `FromStr` naming the generations this build knows.
- Array-vs-plain tables and schema definition names come from `ContractField` instead of three hand-copied matches; the schema test now fails rather than aborting on an unmapped table.
- The second TOML parse is skipped when no field could be in breach — it ran on every installed backend on every `GET /backends`.
- The `### Contract generations` heading no longer re-parents the `license` paragraph and `#### id format` beneath it.
- `registry/README.md` no longer claims 0.2.3-and-earlier clients explain the block. They refuse it — correctly — but cannot say why, and that limit is now stated.

## Verified

Live, against an index the real indexer built:

```
super-stt-tidy   contract=v2   compatible=True  needs_update=False
future           contract=v99  compatible=False needs_update=True
                 reason='needs Super STT 9.9.9 or newer (backend contract v99); this is 0.2.3'
liar             contract=v42  compatible=False needs_update=True
                 reason='needs a newer Super STT (backend contract v42); this is 0.2.3'   ← min_client "0.1.0" not echoed

default listing (no include_incompatible) → all three listed
install v99   → 422 + "needs Super STT 9.9.9 or newer (backend contract v99); this is 0.2.3"
install Tidy  → 202, installed with role=post_processor
import v1+role → 422 + "…raise the contract to use the field, or remove the field to stay on `v1`"
```

And a daemon pointed at the real installed Tidy (`contract = "v1"` carrying `role`) discovers it rather than dropping it.

`just ci` clean at 1235 tests, including new coverage for the installed-manifest exemption (and that it exempts *only* the contract-field rule), the compatibility-aware update offer, and the schema table mapping.

## Not fixed

- **Index-level `min_client` stays `0.1.0`.** Raising it would warn every ≤0.2.3 daemon about every backend, v1 ones included, since it is an index-wide soft floor. Those daemons still refuse a v2 manifest — they just download the asset first and report it generically. Fixing that properly needs a per-entry floor those clients can read, which they cannot.
- **The indexer carry-forward** republishes a prior entry verbatim for up to 30 days when the current parser refuses its pinned manifest. Latent, and pre-existing.
- **Enum-value additions** (a new `ModelRole`, a new `Device`) cannot be expressed in `CONTRACT_FIELDS`, which versions field names. Now documented rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HmFf3PQNwVDWw4wUtRs2Y