### PR TITLE
Inject option and secret headers on subprocess requests

### DIFF
--- a/super-stt-daemon/src/bin/mock_backend.rs
+++ b/super-stt-daemon/src/bin/mock_backend.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::extract::{DefaultBodyLimit, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -98,8 +98,14 @@ async fn transcribe(State(s): State<Arc<AppState>>, _body: String) -> (StatusCod
 
 /// `POST /v1/process` — echoes the submitted text back prefixed, behind the
 /// same `loaded` gate as `transcribe`, so a test can assert both that the route
-/// is reached and that the text round-tripped.
-async fn process(State(s): State<Arc<AppState>>, body: String) -> (StatusCode, Json<Value>) {
+/// is reached and that the text round-tripped. Any `x-stt-option-*` headers
+/// on the request are echoed too, sorted, as ` [name=value …]`, so a test can
+/// assert the daemon injected them.
+async fn process(
+    State(s): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: String,
+) -> (StatusCode, Json<Value>) {
     if !s.loaded.load(Ordering::SeqCst) {
         return (
             StatusCode::CONFLICT,
@@ -116,8 +122,21 @@ async fn process(State(s): State<Arc<AppState>>, body: String) -> (StatusCode, J
             Json(json!({ "status": "error", "message": "invalid_text" })),
         );
     }
+    let mut options: Vec<String> = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let name = k.as_str().strip_prefix("x-stt-option-")?;
+            Some(format!("{name}={}", v.to_str().unwrap_or("?")))
+        })
+        .collect();
+    options.sort();
+    let echoed = if options.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", options.join(" "))
+    };
     (
         StatusCode::OK,
-        Json(json!({ "status": "success", "text": format!("processed: {text}") })),
+        Json(json!({ "status": "success", "text": format!("processed: {text}{echoed}") })),
     )
 }

--- a/super-stt-daemon/src/daemon/model_management/instantiate.rs
+++ b/super-stt-daemon/src/daemon/model_management/instantiate.rs
@@ -106,6 +106,13 @@ impl SuperSTTDaemon {
         name: &str,
         device_pref: &str,
     ) -> Result<Box<dyn Transcribe>> {
+        // The same secret/option headers the WASM transport is handed: a
+        // subprocess backend reads its `[[options]]` off the request too.
+        // Resolved before the download tracker exists, so a missing required
+        // secret fails the load without leaving a progress card behind.
+        let overrides = self.backend_option_overrides(backend).await?;
+        let headers = self.backend_headers(backend, &overrides).await?;
+
         // Count the files we'll provision so the tracker's denominator is
         // accurate from the first broadcast. Each `[[models.files]]` entry is
         // one file. Empty-files models (cloud-only) skip the tracker entirely —
@@ -151,6 +158,7 @@ impl SuperSTTDaemon {
             name,
             device_pref,
             tracker.as_ref(),
+            headers,
         )
         .await;
 
@@ -182,14 +190,15 @@ impl SuperSTTDaemon {
         )
     }
 
-    /// Form `x-stt-secret-*` / `x-stt-option-*` headers for a WASM backend.
+    /// Form the `x-stt-secret-*` / `x-stt-option-*` headers a backend is
+    /// handed on every `/v1` request, whichever transport carries it.
     ///
     /// Secrets come solely from the generic per-backend keyring store
     /// (`backend:<source>:<name>`) written by the settings app — there is no
     /// legacy `<provider>-api-key` fallback, so the key must be set for this
     /// specific backend. Options use the config override if set, else the
     /// manifest default. A required secret that resolves to nothing is an error.
-    #[cfg(feature = "wasm-backends")]
+    #[cfg(any(feature = "wasm-backends", feature = "subprocess-backends"))]
     async fn backend_headers(
         &self,
         backend: &DiscoveredBackend,
@@ -262,11 +271,12 @@ impl SuperSTTDaemon {
     ///
     /// # Errors
     /// Returns an error when a declared, non-empty `base_url` yields no host.
-    #[cfg(feature = "wasm-backends")]
+    #[cfg(any(feature = "wasm-backends", feature = "subprocess-backends"))]
     async fn backend_option_overrides(
         &self,
         backend: &DiscoveredBackend,
     ) -> Result<std::collections::HashMap<String, String>> {
+        #[allow(unused_mut)] // mutated only by the canonicalization below
         let mut overrides: std::collections::HashMap<String, String> = self
             .config
             .read()
@@ -276,35 +286,13 @@ impl SuperSTTDaemon {
             .get(&backend.source)
             .cloned()
             .unwrap_or_default();
-        let name = backends::base_url::OPTION_NAME;
-        let Some(opt) = backend.options.iter().find(|o| o.name == name) else {
-            return Ok(overrides);
-        };
-        let Some(raw) = overrides.get(name).cloned() else {
-            return Ok(overrides);
-        };
-        if raw.trim().is_empty() {
-            overrides.remove(name);
-        } else if let Some(canonical) = backends::base_url::normalize(&raw) {
-            // The scheme the daemon chose for a value that named none decides
-            // whether the request is encrypted, so an operator asking later why
-            // a gateway was reached in the clear needs it on the record.
-            if !raw.contains("://") {
-                log::info!(
-                    "Backend {}: base_url `{}` names no scheme; reading it as `{canonical}`",
-                    backend.source,
-                    raw.trim()
-                );
-            }
-            overrides.insert(name.to_string(), canonical);
-        } else {
-            // Shaped like the missing-secret error above: name the setting the
-            // user can act on, never the internals.
-            bail!(
-                "{} is not a valid URL.",
-                opt.label.as_deref().unwrap_or(&opt.name)
-            );
-        }
+        // `base_url` is an endpoint to dial, and only the WASM transport can
+        // dial anything — a subprocess backend has no network. Reading it
+        // shares the WASM host's URL code, so a build without that transport
+        // passes the value through as set, which costs nothing for the only
+        // backends such a build can run.
+        #[cfg(feature = "wasm-backends")]
+        canonicalize_base_url(backend, &mut overrides)?;
         Ok(overrides)
     }
 
@@ -573,6 +561,49 @@ mod resolve_accel_tests {
     }
 }
 
+/// Canonicalize a declared `base_url` override in place (see
+/// [`normalize`](backends::base_url::normalize)); drop one that is only
+/// whitespace; fail on one no host can be read from.
+///
+/// # Errors
+/// Returns an error when a declared, non-empty `base_url` yields no host.
+#[cfg(feature = "wasm-backends")]
+fn canonicalize_base_url(
+    backend: &DiscoveredBackend,
+    overrides: &mut std::collections::HashMap<String, String>,
+) -> Result<()> {
+    let name = backends::base_url::OPTION_NAME;
+    let Some(opt) = backend.options.iter().find(|o| o.name == name) else {
+        return Ok(());
+    };
+    let Some(raw) = overrides.get(name).cloned() else {
+        return Ok(());
+    };
+    if raw.trim().is_empty() {
+        overrides.remove(name);
+    } else if let Some(canonical) = backends::base_url::normalize(&raw) {
+        // The scheme the daemon chose for a value that named none decides
+        // whether the request is encrypted, so an operator asking later why
+        // a gateway was reached in the clear needs it on the record.
+        if !raw.contains("://") {
+            log::info!(
+                "Backend {}: base_url `{}` names no scheme; reading it as `{canonical}`",
+                backend.source,
+                raw.trim()
+            );
+        }
+        overrides.insert(name.to_string(), canonical);
+    } else {
+        // Shaped like the missing-secret error above: name the setting the
+        // user can act on, never the internals.
+        bail!(
+            "{} is not a valid URL.",
+            opt.label.as_deref().unwrap_or(&opt.name)
+        );
+    }
+    Ok(())
+}
+
 /// The effective value of a backend option — the user's override if set, else
 /// the manifest default — as injected into the backend's headers by
 /// [`SuperSTTDaemon::backend_headers`].
@@ -582,7 +613,7 @@ mod resolve_accel_tests {
 /// must not widen the sandbox. The settings-facing read path
 /// (`http/v1/backends/options.rs::effective`) resolves the same two sources
 /// separately, for display.
-#[cfg(feature = "wasm-backends")]
+#[cfg(any(feature = "wasm-backends", feature = "subprocess-backends"))]
 fn resolved_backend_option(
     overrides: &std::collections::HashMap<String, String>,
     opt: &backends::manifest::Opt,

--- a/super-stt-daemon/src/stt_models/subprocess/mod.rs
+++ b/super-stt-daemon/src/stt_models/subprocess/mod.rs
@@ -39,6 +39,10 @@ pub struct SubprocessBackend {
     info: ModelInfoData,
     /// Device label reported by the backend's `/v1/status` (e.g. `"cuda"`).
     device: String,
+    /// The `x-stt-secret-*` / `x-stt-option-*` pairs injected on every `/v1`
+    /// request, per the contract's request-header section. Formed once at
+    /// spawn from the user's settings, like the WASM transport's.
+    context_headers: Vec<(String, String)>,
 }
 
 impl SubprocessBackend {
@@ -48,7 +52,8 @@ impl SubprocessBackend {
     /// files are downloaded into `<backend_dir>/<dest>`. `device_pref` is the
     /// resolved accelerator (`"cpu"`, `"cuda"`, `"rocm"`, `"metal"`,
     /// `"vulkan"`), or empty when none resolved, which leaves the backend to
-    /// select for itself.
+    /// select for itself. `context_headers` are the already-formed
+    /// `x-stt-secret-*` / `x-stt-option-*` pairs to inject on every request.
     ///
     /// # Errors
     /// Returns an error if provisioning, spawning, or loading fails.
@@ -57,6 +62,7 @@ impl SubprocessBackend {
         model_name: &str,
         device_pref: &str,
         tracker: Option<&Arc<crate::download_progress::DownloadProgressTracker>>,
+        context_headers: Vec<(String, String)>,
     ) -> Result<Self> {
         let manifest = Manifest::load(backend_dir)?;
 
@@ -162,6 +168,7 @@ impl SubprocessBackend {
             model_id: model_name.to_string(),
             info,
             device: "unknown".to_string(),
+            context_headers,
         };
 
         backend.wait_for_ping(Duration::from_secs(30)).await?;
@@ -228,7 +235,8 @@ impl SubprocessBackend {
         }
     }
 
-    /// One HTTP request over the backend's Unix socket.
+    /// One HTTP request over the backend's Unix socket, carrying `headers`
+    /// plus the secret/option context every `/v1` request gets.
     async fn request(
         &self,
         method: &str,
@@ -249,7 +257,7 @@ impl SubprocessBackend {
             .method(method)
             .uri(path)
             .header("host", "backend.local");
-        for (k, v) in headers {
+        for (k, v) in headers.iter().chain(&self.context_headers) {
             builder = builder.header(k.as_str(), v.as_str());
         }
         let req = builder.body(Full::new(Bytes::from(body)))?;

--- a/super-stt-daemon/tests/subprocess_mock.rs
+++ b/super-stt-daemon/tests/subprocess_mock.rs
@@ -89,7 +89,7 @@ async fn subprocess_orchestration_against_mock() {
     let (dir, _cleanup) = seed_backend_dir("orchestration");
 
     // Spawn + load via the real daemon orchestration.
-    let mut backend = SubprocessBackend::spawn(&dir, "mock", "cpu", None)
+    let mut backend = SubprocessBackend::spawn(&dir, "mock", "cpu", None, Vec::new())
         .await
         .expect("spawn + load mock backend");
 
@@ -121,10 +121,10 @@ async fn two_backends_from_one_directory_run_concurrently() {
 
     let (dir, _cleanup) = seed_backend_dir("concurrent");
 
-    let mut transcriber = SubprocessBackend::spawn(&dir, "mock", "cpu", None)
+    let mut transcriber = SubprocessBackend::spawn(&dir, "mock", "cpu", None, Vec::new())
         .await
         .expect("spawn + load the transcription model");
-    let mut processor = SubprocessBackend::spawn(&dir, "mock-cleanup", "cpu", None)
+    let mut processor = SubprocessBackend::spawn(&dir, "mock-cleanup", "cpu", None, Vec::new())
         .await
         .expect("spawn + load the post-processor alongside it");
 
@@ -154,4 +154,37 @@ async fn two_backends_from_one_directory_run_concurrently() {
     assert_eq!(text, "mock transcription");
 
     transcriber.shutdown().await.expect("clean shutdown");
+}
+
+/// The contract says every `/v1` request carries the user's `[[options]]` as
+/// `x-stt-option-*` headers, whichever transport. A subprocess backend that
+/// steers on an option — a register, a style prompt — reads them off the
+/// request, so the daemon has to put them there; the mock echoes what it got.
+#[tokio::test]
+async fn option_headers_reach_the_subprocess() {
+    if std::env::var("SUPER_STT_TEST_SUBPROCESS").is_err() {
+        return; // needs a systemd --user session
+    }
+    install_crypto_provider();
+
+    let (dir, _cleanup) = seed_backend_dir("headers");
+
+    let headers = vec![
+        ("x-stt-option-styling".to_string(), "formal".to_string()),
+        ("x-stt-option-context".to_string(), "email".to_string()),
+    ];
+    let mut processor = SubprocessBackend::spawn(&dir, "mock-cleanup", "cpu", None, headers)
+        .await
+        .expect("spawn + load the post-processor");
+
+    let processed = processor
+        .process_text("um so hello", Some("en"))
+        .await
+        .expect("the post-processor serves /v1/process");
+    assert_eq!(
+        processed, "processed: um so hello [context=email styling=formal]",
+        "the option headers must arrive on the request"
+    );
+
+    processor.shutdown().await.expect("clean shutdown");
 }


### PR DESCRIPTION
## What

Subprocess backends never received `x-stt-option-*` / `x-stt-secret-*` headers. The contract ([request headers](docs/protocol/backend/contract.md#request-headers)) and [subprocess.md](docs/protocol/backend/subprocess.md#startup) both say the daemon injects them on every `/v1` request, but only the WASM transport did — `SubprocessBackend` sent `content-type` and `x-stt-model` and nothing else. A subprocess backend that steers on an option (the S1-mini post-processor's `styling` / `structure` / `context`) silently ran at its defaults.

## How

- `SubprocessBackend::spawn` takes the already-formed headers and `request()` chains them onto every call — load, status, transcribe, process — the same coverage as the WASM `invoke`.
- `instantiate_subprocess` resolves them with the same `backend_option_overrides` + `backend_headers` the WASM path uses. Resolved **before** the download tracker is registered, so a missing required secret fails the load without leaving a progress card behind.
- Those helpers were `#[cfg(feature = "wasm-backends")]`; now `any(wasm-backends, subprocess-backends)`. The `base_url` canonicalization inside `backend_option_overrides` reads through the WASM host's IP helpers, so it moves to a wasm-gated `canonicalize_base_url()`; a subprocess-only build passes the value through verbatim, which costs nothing since a subprocess has no network to dial.

## Test

The mock backend's `/v1/process` echoes any `x-stt-option-*` it receives; new `subprocess_mock::option_headers_reach_the_subprocess` spawns it with two options and asserts `processed: um so hello [context=email styling=formal]`. Systemd-gated like the rest of that file; passes locally.

Also: `just check`, `just check-features` (all three combos), 514 daemon lib tests.

No doc changes — they already described this; the code now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HmFf3PQNwVDWw4wUtRs2Y
