### PR TITLE
Give the post-processor a device of its own

### DIFF
--- a/docs/protocol/endpoints/v1/pipeline.md
+++ b/docs/protocol/endpoints/v1/pipeline.md
@@ -78,6 +78,8 @@ become insertable, renumbering is the thing to design — a client holding
 | `name`   | string? | That backend's display name; `null` when the stage is empty.            |
 | `model`  | string? | Wire name of the selected model; `null` when none is selected.          |
 | `loaded` | bool    | Whether the model is loaded and running right now.                       |
+| `device` | string? | Where the work runs: the accelerator the loaded model is actually on — `cpu`, `cuda`, `rocm`, `metal`, `vulkan`, or `remote` for a cloud model. `null` until a model has loaded. |
+| `preferred_device` | string? | *Processor stages only.* The stage's own `cpu`/`gpu` ask, set with [`POST /pipeline/{stage}/model`](#post-pipelinestagemodel); `device` is what it resolved to. `null` when the stage has none and follows stage 1's, whose preference lives at [`/active_device`](./active_device.md). |
 | `enabled`| bool    | *Processor stages only.* Whether it should run. Distinct from `loaded`: a stage can be enabled while its model failed to load, and transcripts then pass through unchanged. |
 
 ## `GET /pipeline`
@@ -107,16 +109,19 @@ Content-Type: application/json
       "source": "github.com/super-stt/whisper",
       "name":   "Whisper (local)",
       "model":  "whisper-large-v3",
-      "loaded": true
+      "loaded": true,
+      "device": "cuda"
     },
     {
-      "stage":   2,
-      "role":    "post_processor",
-      "source":  "github.com/jorge-menjivar/super-stt-textclean",
-      "name":    "Text Cleanup",
-      "model":   "textclean",
-      "loaded":  true,
-      "enabled": true
+      "stage":            2,
+      "role":             "post_processor",
+      "source":           "github.com/jorge-menjivar/super-stt-textclean",
+      "name":             "Text Cleanup",
+      "model":            "textclean",
+      "loaded":           true,
+      "device":           "cpu",
+      "preferred_device": "cpu",
+      "enabled":          true
     }
   ]
 }
@@ -133,13 +138,15 @@ Content-Type: application/json
 {
   "status": "success",
   "stage": {
-    "stage":   2,
-    "role":    "post_processor",
-    "source":  "github.com/jorge-menjivar/super-stt-textclean",
-    "name":    "Text Cleanup",
-    "model":   "textclean",
-    "loaded":  true,
-    "enabled": true
+    "stage":            2,
+    "role":             "post_processor",
+    "source":           "github.com/jorge-menjivar/super-stt-textclean",
+    "name":             "Text Cleanup",
+    "model":            "textclean",
+    "loaded":           true,
+    "device":           "cpu",
+    "preferred_device": "cpu",
+    "enabled":          true
   }
 }
 ```
@@ -200,13 +207,18 @@ Host: stt.local
 Authorization: Bearer stt_…64hex…
 Content-Type: application/json
 
-{ "model": "textclean" }
+{ "model": "textclean", "device": "gpu" }
 ```
 
 | Field    | Type   | Required | Notes                                                                    |
 |----------|--------|----------|--------------------------------------------------------------------------|
 | `model`  | string | yes      | A model its backend declares with this stage's `role`                    |
 | `source` | string | no       | Repo id of the serving backend. Omitted resolves to the backend selected for this stage. |
+| `device` | string | no       | *Processor stages only.* The stage's own `cpu`/`gpu` preference, normalized as [`/active_device`](./active_device.md) normalizes (`cuda`/`metal` → `gpu`). Omitted keeps the stored one; a stage that has never been given one follows stage 1's. Stage 1 refuses the field (`400 invalid_value`): its device is the daemon-wide preference at `/active_device`, with a reload of its own. |
+
+A processor stage runs beside the transcription model, so it gets hardware
+chosen for it: a small cleanup model can sit on the CPU while a large
+transcription model has the GPU, or the reverse.
 
 Stage 1 answers `202 Accepted` and switches asynchronously (see
 [`/pipeline/1/model`](./pipeline.md)); stage 2 answers `200` once the load has
@@ -219,7 +231,8 @@ passing text through rather than costing the user their words.
 | HTTP | `error_code`             | Meaning                                                              |
 |------|--------------------------|----------------------------------------------------------------------|
 | 404  | `unknown_stage`          | No such position in the pipeline                                     |
-| 400  | `invalid_value`          | `model` missing or empty. To stop a stage, use `DELETE`.             |
+| 400  | `invalid_value`          | `model` missing or empty (to stop a stage, use `DELETE`), or `device` sent to a stage that does not take one |
+| 400  | `invalid_device`         | `device` is not `cpu` or `gpu`                                       |
 | 400  | `invalid_model`          | No installed backend serves `(model, source)`, or its role does not match this stage |
 | 400  | `invalid_backend`        | `source` omitted and no backend is selected for this stage           |
 | 400  | `online_models_disabled` | The model is online and online models are disabled                   |

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -71,6 +71,7 @@ impl AppModel {
             // shape of endpoint, so nothing loads until a model is enabled.
             PostProcessorMessage::SelectBackend(source) => {
                 self.staged_post_processor = None;
+                self.staged_post_processor_device = None;
                 // The choice came from the picker sheet; dismiss it now that it
                 // has been made, exactly as `SelectBackend` does.
                 self.core.window.show_context = false;
@@ -82,6 +83,7 @@ impl AppModel {
 
             PostProcessorMessage::Deselect => {
                 self.staged_post_processor = None;
+                self.staged_post_processor_device = None;
                 Task::perform(clear_post_processor_backend(), Self::reload_post_processor)
             }
 
@@ -97,9 +99,22 @@ impl AppModel {
                         .into_iter()
                         .nth(index)
                 {
+                    // Default the device with the model, as staging a
+                    // transcription model does, so Load has one to send.
+                    self.staged_post_processor_device =
+                        crate::ui::views::models::post_processor_default_device(
+                            backend,
+                            &model,
+                            self.post_processor.preferred_device.as_deref(),
+                        );
                     self.staged_post_processor = Some((model, backend.source.clone()));
                     self.clear_action_error(crate::state::ErrorScope::PostProcessing);
                 }
+                Task::none()
+            }
+
+            PostProcessorMessage::StagedDevice(device) => {
+                self.staged_post_processor_device = Some(device);
                 Task::none()
             }
 
@@ -119,8 +134,20 @@ impl AppModel {
                     return Task::none();
                 };
                 let (model, source) = selection;
+                // The device the dropdown shows: the staged pick, else the
+                // default the view computes for the model — so what is sent
+                // is what the user saw. `None` for a model with no device to
+                // choose, which the daemon reads as "keep what is stored".
+                let device = self.staged_post_processor_device.clone().or_else(|| {
+                    let backend = self.backends.iter().find(|b| b.source == source)?;
+                    crate::ui::views::models::post_processor_default_device(
+                        backend,
+                        &model,
+                        self.post_processor.preferred_device.as_deref(),
+                    )
+                });
                 Task::perform(
-                    set_post_processor(model, Some(source)),
+                    set_post_processor(model, Some(source), device),
                     Self::reload_post_processor,
                 )
             }
@@ -144,6 +171,7 @@ impl AppModel {
                 // showing the daemon's selection after a refused save.
                 if self.staged_post_processor == state.selection() {
                     self.staged_post_processor = None;
+                    self.staged_post_processor_device = None;
                 }
                 self.post_processor = state;
                 self.clear_action_error(crate::state::ErrorScope::PostProcessing);

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -133,6 +133,7 @@ impl AppModel {
             // completes; the default is the daemon's default too (off).
             post_processor: crate::daemon::client::PostProcessorState::default(),
             staged_post_processor: None,
+            staged_post_processor_device: None,
             recording_stop_mode:
                 super_stt_shared::models::recording_stop_mode::RecordingStopMode::default(),
             write_method: super_stt_shared::models::write_method::WriteMethod::default(),

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -137,6 +137,11 @@ pub struct AppModel {
     /// is local until the Enable button commits it. `None` means "use whatever
     /// the daemon already has selected".
     pub staged_post_processor: Option<(String, String)>,
+    /// The device the staged post-processor should load on, `cpu` or `gpu`.
+    /// Mirrors `models_page.staged_device`: defaulted when a model is staged,
+    /// changed from the dropdown, sent with Load. `None` when the staged
+    /// model offers no device to choose (an online model).
+    pub staged_post_processor_device: Option<String>,
 
     // Recording stop mode
     pub recording_stop_mode: super_stt_shared::models::recording_stop_mode::RecordingStopMode,

--- a/super-stt-app/src/daemon/client/v1/settings/post_processor.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/post_processor.rs
@@ -40,6 +40,15 @@ pub struct PostProcessorState {
     pub source: Option<String>,
     #[serde(default)]
     pub loaded: bool,
+    /// The accelerator the loaded model actually runs on (`cpu`, `cuda`, …);
+    /// `None` until one has loaded.
+    #[serde(default)]
+    pub device: Option<String>,
+    /// The stage's own `cpu`/`gpu` preference; `None` when it has none and
+    /// follows the transcription stage's. Absent from a daemon that predates
+    /// per-stage devices, which reads the same way.
+    #[serde(default)]
+    pub preferred_device: Option<String>,
 }
 
 impl PostProcessorState {
@@ -81,15 +90,23 @@ pub async fn clear_post_processor() -> HttpResult<()> {
     .await
 }
 
-/// Run final transcripts through `model` (HTTP `POST /post_processor`).
+/// Run final transcripts through `model` (HTTP `POST /pipeline/2/model`).
 ///
 /// `source` is optional: omitted, the daemon resolves the model against the
 /// selected post-processor backend, exactly as `POST /active_model` resolves
-/// against the active one.
-pub async fn set_post_processor(model: String, source: Option<String>) -> HttpResult<()> {
+/// against the active one. `device` is the stage's own `cpu`/`gpu`; omitted,
+/// the daemon keeps the one it has stored.
+pub async fn set_post_processor(
+    model: String,
+    source: Option<String>,
+    device: Option<String>,
+) -> HttpResult<()> {
     let mut body = serde_json::json!({ "model": model });
     if let Some(source) = source {
         body["source"] = serde_json::Value::String(source);
+    }
+    if let Some(device) = device {
+        body["device"] = serde_json::Value::String(device);
     }
     with_settings_token(move |socket, token| {
         let body = body.clone();
@@ -124,4 +141,40 @@ pub async fn clear_post_processor_backend() -> HttpResult<()> {
         require_unit(resp, "clear_stage_backend")
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PostProcessorState;
+
+    /// A daemon that predates per-stage devices sends neither field; the
+    /// state reads as "no preference, nothing resolved" rather than failing
+    /// the settings load.
+    #[test]
+    fn a_stage_without_device_fields_still_parses() {
+        let state: PostProcessorState = serde_json::from_value(serde_json::json!({
+            "stage": 2, "role": "post_processor",
+            "source": "github.com/x/y", "model": "cleanup", "loaded": true, "enabled": true
+        }))
+        .expect("older payload must parse");
+        assert_eq!(state.device, None);
+        assert_eq!(state.preferred_device, None);
+        assert_eq!(
+            state.selection(),
+            Some(("cleanup".to_string(), "github.com/x/y".to_string()))
+        );
+    }
+
+    /// The ask and the answer are separate fields and both come through.
+    #[test]
+    fn the_stages_device_fields_carry_through() {
+        let state: PostProcessorState = serde_json::from_value(serde_json::json!({
+            "model": "cleanup", "source": "github.com/x/y",
+            "loaded": true, "enabled": true,
+            "device": "cuda", "preferred_device": "gpu"
+        }))
+        .expect("parses");
+        assert_eq!(state.device.as_deref(), Some("cuda"));
+        assert_eq!(state.preferred_device.as_deref(), Some("gpu"));
+    }
 }

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -281,6 +281,9 @@ pub enum PostProcessorMessage {
     /// The index is into the selected backend's post-processor models, in the
     /// order `crate::ui::views::models::post_processor_models` returns them.
     Staged(usize),
+    /// User picked the device the staged model should load on — staged
+    /// locally, sent with Enable. Mirrors [`ModelsPageMessage::StageActiveDevice`].
+    StagedDevice(String),
     /// Commit the staged (or already-selected) model and turn processing on.
     Enable,
     /// Turn processing off. The selection is kept, so re-enabling needs no

--- a/super-stt-app/src/ui/views/models/mod.rs
+++ b/super-stt-app/src/ui/views/models/mod.rs
@@ -34,7 +34,7 @@ use crate::ui::messages::Message;
 /// The post-processor models one backend serves, in the same order the
 /// Post-processing dropdown renders them — the settings handler resolves a
 /// picked index through this, so both sides must agree.
-pub(crate) use post_processing::post_processor_models;
+pub(crate) use post_processing::{post_processor_default_device, post_processor_models};
 
 pub use post_processing::post_processor_sheet;
 

--- a/super-stt-app/src/ui/views/models/post_processing.rs
+++ b/super-stt-app/src/ui/views/models/post_processing.rs
@@ -29,7 +29,7 @@ use crate::ui::messages::{Message, ModelsPageMessage, PostProcessorMessage, Shel
 use super::active::backend_glyph_tile;
 use super::chips::{
     CloudEgress, backend_has_user_url, backend_is_online, backend_supports_cpu,
-    backend_supports_gpu, capability_chips, count_chip,
+    backend_supports_gpu, capability_chips, count_chip, offered_devices,
 };
 use super::surface::{
     backend_description, card_divider, card_surface, card_title_block, muted_text_color,
@@ -52,6 +52,26 @@ pub(crate) fn post_processor_backends(backends: &[BackendInfo]) -> Vec<&BackendI
 /// called by both.
 pub(crate) fn post_processor_models(backend: &BackendInfo) -> Vec<String> {
     super::roles::models_for(backend, true)
+}
+
+/// The device a freshly staged post-processor should load on, or `None` when
+/// the model offers no device to choose (an online model, or one this install
+/// cannot run anywhere).
+///
+/// The stage's stored preference wins when the model can honor it; otherwise
+/// the first device the model offers, which is what staging a transcription
+/// model defaults to. One function for the view and the handler, so the
+/// dropdown shows exactly what Load sends.
+pub(crate) fn post_processor_default_device(
+    backend: &BackendInfo,
+    model: &str,
+    preferred: Option<&str>,
+) -> Option<String> {
+    let offered = offered_devices(backend, model);
+    preferred
+        .filter(|p| offered.iter().any(|d| d == p))
+        .map(str::to_string)
+        .or_else(|| offered.first().cloned())
 }
 
 /// The backend the card is about: the one the daemon has selected.
@@ -200,7 +220,16 @@ fn control_row<'a>(app: &'a AppModel, backend: &'a BackendInfo) -> Element<'a, M
             .model
             .clone()
             .unwrap_or_else(|| "post-processor".to_string());
-        let label = text::body(format!("Active: {model}"))
+        // Where it runs, the way the transcription card says "· cpu": the
+        // daemon reports the accelerator the load landed on, once it has.
+        let device_suffix = app
+            .post_processor
+            .device
+            .as_deref()
+            .filter(|d| !d.is_empty() && *d != "none")
+            .map(|d| format!(" · {d}"))
+            .unwrap_or_default();
+        let label = text::body(format!("Active: {model}{device_suffix}"))
             .class(cosmic::theme::Text::Accent)
             .width(Length::Fill);
         return row![
@@ -223,22 +252,58 @@ fn control_row<'a>(app: &'a AppModel, backend: &'a BackendInfo) -> Element<'a, M
         .filter(|(_, source)| source == &backend.source)
         .map(|(model, _)| model.clone())
         .or_else(|| app.post_processor.model.clone());
-    let selected = shown.and_then(|m| models.iter().position(|n| n == &m));
+    let selected = shown
+        .as_ref()
+        .and_then(|m| models.iter().position(|n| n == m));
+    // Model select takes twice the width of the device select, as on the
+    // transcription card.
     let dropdown = widget::dropdown(models, selected, |index| {
         Message::PostProcessor(PostProcessorMessage::Staged(index))
     })
     .placeholder("Select model")
-    .width(Length::Fill);
+    .width(Length::FillPortion(2));
 
-    row![
-        dropdown,
-        button::suggested("Load model")
-            .leading_icon(icons::phosphor_handle(icons::PLAY))
-            .on_press_maybe(selected.map(|_| Message::PostProcessor(PostProcessorMessage::Enable))),
-    ]
-    .spacing(spacing.space_s)
-    .align_y(Alignment::Center)
-    .into()
+    let mut picker_row = row![dropdown]
+        .spacing(spacing.space_s)
+        .align_y(Alignment::Center)
+        .width(Length::Fill);
+
+    // Device dropdown — only when the shown model offers a device to choose.
+    // The staged pick wins; otherwise the default Load would send, so the
+    // dropdown never shows one thing while Load does another.
+    if let Some(model) = shown.as_deref() {
+        let devices = offered_devices(backend, model);
+        if !devices.is_empty() {
+            let current = app.staged_post_processor_device.clone().or_else(|| {
+                post_processor_default_device(
+                    backend,
+                    model,
+                    app.post_processor.preferred_device.as_deref(),
+                )
+            });
+            let device_index = current.and_then(|d| devices.iter().position(|x| x == &d));
+            let devices_pick = devices.clone();
+            picker_row = picker_row.push(
+                widget::dropdown(devices, device_index, move |index| {
+                    Message::PostProcessor(PostProcessorMessage::StagedDevice(
+                        devices_pick[index].clone(),
+                    ))
+                })
+                .placeholder("Device")
+                .width(Length::FillPortion(1)),
+            );
+        }
+    }
+
+    picker_row
+        .push(
+            button::suggested("Load model")
+                .leading_icon(icons::phosphor_handle(icons::PLAY))
+                .on_press_maybe(
+                    selected.map(|_| Message::PostProcessor(PostProcessorMessage::Enable)),
+                ),
+        )
+        .into()
 }
 
 /// Shown when post-processors are installed but none is chosen: a prompt and
@@ -487,5 +552,95 @@ mod tests {
             ],
         );
         assert_eq!(post_processor_models(&b), vec!["zeta", "alpha"]);
+    }
+}
+
+#[cfg(test)]
+mod device_tests {
+    use super::*;
+    use crate::daemon::backends::BackendModel;
+
+    fn model_on(name: &str, devices: &[&str]) -> BackendModel {
+        BackendModel {
+            name: name.into(),
+            provider: String::new(),
+            supported_devices: devices.iter().map(|d| (*d).to_string()).collect(),
+            estimated_vram_bytes: 0,
+            multilingual: false,
+            supported_languages: Vec::new(),
+            primary_language: "en".into(),
+            realtime: false,
+            role: "post_processor".into(),
+        }
+    }
+
+    fn backend_with(models: Vec<BackendModel>, installed_accel: &[&str]) -> BackendInfo {
+        BackendInfo {
+            source: "github.com/x/clean".into(),
+            description: String::new(),
+            name: "Clean".into(),
+            version: "1.0.0".into(),
+            kind: "subprocess".into(),
+            allowed_hosts: Vec::new(),
+            installed_accel: installed_accel.iter().map(|a| (*a).to_string()).collect(),
+            models,
+            secrets: Vec::new(),
+            options: Vec::new(),
+        }
+    }
+
+    /// The stage's stored preference is honored when the model can run there.
+    #[test]
+    fn the_stored_preference_wins_when_the_model_offers_it() {
+        let b = backend_with(vec![model_on("s1", &["cpu", "gpu"])], &["cuda"]);
+        assert_eq!(
+            post_processor_default_device(&b, "s1", Some("gpu")).as_deref(),
+            Some("gpu")
+        );
+        assert_eq!(
+            post_processor_default_device(&b, "s1", Some("cpu")).as_deref(),
+            Some("cpu")
+        );
+    }
+
+    /// With no preference, or one the model cannot honor, the first offered
+    /// device is the default — the same rule staging a transcription model
+    /// follows.
+    #[test]
+    fn otherwise_the_first_offered_device_is_the_default() {
+        let b = backend_with(vec![model_on("s1", &["cpu", "gpu"])], &["cuda"]);
+        assert_eq!(
+            post_processor_default_device(&b, "s1", None).as_deref(),
+            Some("cpu")
+        );
+        // A CPU-only model cannot honor a `gpu` preference.
+        let cpu_only = backend_with(vec![model_on("rules", &["cpu"])], &[]);
+        assert_eq!(
+            post_processor_default_device(&cpu_only, "rules", Some("gpu")).as_deref(),
+            Some("cpu")
+        );
+    }
+
+    /// A GPU the install cannot use is not offered: a CPU-only build of a
+    /// backend whose model declares `gpu` still defaults to the CPU.
+    #[test]
+    fn a_cpu_only_install_never_defaults_to_the_gpu() {
+        let b = backend_with(vec![model_on("s1", &["cpu", "gpu"])], &["cpu"]);
+        assert_eq!(
+            post_processor_default_device(&b, "s1", Some("gpu")).as_deref(),
+            Some("cpu")
+        );
+    }
+
+    /// An online model offers nothing to choose, so there is no default and
+    /// Load sends no device.
+    #[test]
+    fn an_online_model_has_no_device_to_default() {
+        let b = backend_with(vec![model_on("cloud", &["none"])], &[]);
+        assert_eq!(
+            post_processor_default_device(&b, "cloud", Some("gpu")),
+            None
+        );
+        assert_eq!(post_processor_default_device(&b, "missing", None), None);
     }
 }

--- a/super-stt-daemon/src/config.rs
+++ b/super-stt-daemon/src/config.rs
@@ -120,6 +120,13 @@ pub struct PostProcessorConfig {
     /// model selection uses.
     #[serde(default)]
     pub source: String,
+    /// The stage's own device preference, `cpu` or `gpu`. The post-processor
+    /// runs beside the transcription model, so it gets hardware chosen for it
+    /// rather than stage 1's. Empty — every config written before the field
+    /// existed — means "follow the transcription preference", which is what
+    /// those loads always did.
+    #[serde(default)]
+    pub device: String,
 }
 
 impl PostProcessorConfig {
@@ -439,10 +446,13 @@ impl DaemonConfig {
 
     /// Select the post-processor model and whether it runs. Stored as the same
     /// `(name, source)` pair every model selection uses.
-    pub fn enable_post_processor(&mut self, model: String, source: String) {
+    pub fn enable_post_processor(&mut self, model: String, source: String, device: Option<String>) {
         self.post_processor.enabled = true;
         self.post_processor.model = model;
         self.post_processor.source = source;
+        if let Some(device) = device {
+            self.post_processor.device = device;
+        }
     }
 
     /// Stop running the post-processor, keeping the selection so re-enabling

--- a/super-stt-daemon/src/daemon/core.rs
+++ b/super-stt-daemon/src/daemon/core.rs
@@ -47,9 +47,11 @@ impl SuperSTTDaemon {
             Command::ListAudioThemes => self.handle_list_audio_themes(),
             Command::SetPreviewTyping { enabled } => self.handle_set_preview_typing(enabled).await,
             Command::GetPreviewTyping => self.handle_get_preview_typing(),
-            Command::SetPostProcessor { model, source } => {
-                self.handle_set_post_processor(model, source).await
-            }
+            Command::SetPostProcessor {
+                model,
+                source,
+                device,
+            } => self.handle_set_post_processor(model, source, device).await,
             Command::GetPostProcessor => self.handle_get_post_processor().await,
             Command::ClearPostProcessor => self.handle_clear_post_processor().await,
             Command::SetPostProcessorBackend { source } => {

--- a/super-stt-daemon/src/daemon/http/v1/settings/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/pipeline.rs
@@ -38,6 +38,10 @@ struct Stage {
     cancel_model: Option<&'static str>,
     /// Re-instantiate in place to pick up changed secrets/options.
     reload_model: Option<&'static str>,
+    /// Whether `set_model` takes the stage's `device` with it. Stage 1's device
+    /// is a daemon-wide preference with its own endpoint (`/active_device`)
+    /// and a reload of its own; a later stage's is a property of that stage.
+    takes_device: bool,
 }
 
 impl Stage {
@@ -51,6 +55,7 @@ impl Stage {
                 clear_model: "unload_active_model",
                 cancel_model: Some("cancel_download"),
                 reload_model: Some("reload_active_model"),
+                takes_device: false,
             }),
             2 => Some(Self {
                 set_backend: "set_post_processor_backend",
@@ -62,6 +67,7 @@ impl Stage {
                 // `POST .../model` does the same job.
                 cancel_model: None,
                 reload_model: None,
+                takes_device: true,
             }),
             _ => None,
         }
@@ -153,6 +159,10 @@ pub(crate) struct SetModelBody {
     /// Omitted resolves to the backend selected for this stage.
     #[serde(default)]
     pub(crate) source: Option<String>,
+    /// The stage's `cpu`/`gpu` preference. Omitted keeps the stored one.
+    /// Stages whose device lives elsewhere refuse it (see [`Stage::takes_device`]).
+    #[serde(default)]
+    pub(crate) device: Option<String>,
 }
 
 /// `POST /pipeline/{stage}/model` — run a model in this stage.
@@ -167,6 +177,21 @@ pub(crate) async fn set_stage_model(
     let mut data = serde_json::json!({ "model": body.model });
     if let Some(source) = body.source {
         data["source"] = serde_json::Value::String(source);
+    }
+    if let Some(device) = body.device {
+        // Refused rather than ignored: a client that sent a device for stage
+        // 1 expects the model to land on it, and silently loading it
+        // elsewhere is the worse surprise.
+        if !cmds.takes_device {
+            return json_error_msg(
+                StatusCode::BAD_REQUEST,
+                "invalid_value",
+                &format!(
+                    "Stage {stage} does not take a device here; set it with POST /active_device."
+                ),
+            );
+        }
+        data["device"] = serde_json::Value::String(device);
     }
     let resp = dispatch(&s.daemon, build_request(cmds.set_model, Some(data))).await;
     json_response(&resp).into_response()

--- a/super-stt-daemon/src/daemon/model_management/post_processor.rs
+++ b/super-stt-daemon/src/daemon/model_management/post_processor.rs
@@ -53,7 +53,16 @@ impl SuperSTTDaemon {
             );
         }
 
-        let device_pref = self.preferred_device.read().await.clone();
+        // The stage's own preference when it has one; otherwise stage 1's,
+        // which is what every load did before the field existed.
+        let device_pref = {
+            let own = self.config.read().await.post_processor.device.clone();
+            if own.is_empty() {
+                self.preferred_device.read().await.clone()
+            } else {
+                own
+            }
+        };
         let (instance, definition) = self
             .instantiate_backend(&name, &source, &device_pref)
             .await?;
@@ -88,5 +97,18 @@ impl SuperSTTDaemon {
     /// Whether a post-processor is currently loaded.
     pub(in crate::daemon) async fn post_processor_loaded(&self) -> bool {
         self.post_processor.read().await.is_some()
+    }
+
+    /// The accelerator the loaded post-processor actually runs on, as the
+    /// short wire name (`cpu`, `cuda`, `rocm`, `metal`, `vulkan`, `remote`);
+    /// `None` when nothing is loaded. The preference asks for `gpu`; this is
+    /// what that resolved to, the way `/active_device` reports
+    /// `resolved_accel` for stage 1.
+    pub(in crate::daemon) async fn post_processor_device(&self) -> Option<String> {
+        self.post_processor
+            .read()
+            .await
+            .as_ref()
+            .map(|loaded| crate::daemon::types::normalize_device(&loaded.instance.device()))
     }
 }

--- a/super-stt-daemon/src/daemon/pipeline_handlers.rs
+++ b/super-stt-daemon/src/daemon/pipeline_handlers.rs
@@ -94,11 +94,19 @@ impl SuperSTTDaemon {
     }
 
     /// Stage 2: the post-processor that rewrites each final transcript.
-    async fn post_processor_stage(&self) -> serde_json::Value {
-        let (enabled, model, source) = {
+    ///
+    /// Also what `POST`/`DELETE /pipeline/2[/model]` answer with, so the
+    /// shape cannot drift between a read and a write.
+    pub(in crate::daemon) async fn post_processor_stage(&self) -> serde_json::Value {
+        let (enabled, model, source, preferred_device) = {
             let config = self.config.read().await;
             let pp = &config.post_processor;
-            (pp.enabled, pp.model.clone(), pp.source.clone())
+            (
+                pp.enabled,
+                pp.model.clone(),
+                pp.source.clone(),
+                pp.device.clone(),
+            )
         };
         let source = (!source.is_empty()).then_some(source);
         let name = self.backend_name(source.as_deref()).await;
@@ -110,6 +118,12 @@ impl SuperSTTDaemon {
             "name": name,
             "model": (!model.is_empty()).then_some(model),
             "loaded": self.post_processor_loaded().await,
+            // Where the work runs, as stage 1 reports it: the accelerator the
+            // loaded instance is actually on, null until one has loaded.
+            "device": self.post_processor_device().await,
+            // The stage's own `cpu`/`gpu` ask, which `device` is the answer
+            // to. Null when it has none and follows stage 1's.
+            "preferred_device": (!preferred_device.is_empty()).then_some(preferred_device),
             // Processor stages carry the user's on/off choice separately from
             // whether the model actually came up: a selection can be enabled
             // while its load failed, and transcripts then pass through.

--- a/super-stt-daemon/src/daemon/post_processor_handlers.rs
+++ b/super-stt-daemon/src/daemon/post_processor_handlers.rs
@@ -36,13 +36,35 @@ impl SuperSTTDaemon {
     /// `POST /active_model`.
     ///
     /// An empty `source` resolves to the selected post-processor backend, so a
-    /// client that has already chosen one names only the model.
-    pub async fn handle_set_post_processor(&self, model: String, source: String) -> DaemonResponse {
+    /// client that has already chosen one names only the model. `device` is
+    /// the stage's own `cpu`/`gpu` preference; `None` keeps the stored one.
+    pub async fn handle_set_post_processor(
+        &self,
+        model: String,
+        source: String,
+        device: Option<String>,
+    ) -> DaemonResponse {
         // Loading and unloading a backend instance during a recording is the
         // same hazard as switching the transcription model mid-recording.
         if let Some(resp) = self.guard_model_mutation("change the post-processor").await {
             return resp;
         }
+
+        // Validate and normalize (`cuda`/`metal` → `gpu`) before anything is
+        // persisted, with the same code and wording `/active_device` uses for
+        // the same mistake.
+        let device = match device {
+            None => None,
+            Some(raw) => match crate::daemon::device_management::parse_device_preference(&raw) {
+                Some(normalized) => Some(normalized),
+                None => {
+                    return DaemonResponse::error_with_code(
+                        ErrorCode::InvalidDevice,
+                        &format!("Invalid device '{raw}'. Must be 'cpu' or 'gpu'"),
+                    );
+                }
+            },
+        };
 
         // Resolve the backend the same way `set_model` does: an omitted source
         // means "the one already selected", and having none selected is the
@@ -92,7 +114,9 @@ impl SuperSTTDaemon {
         }
 
         let persist = self
-            .set_config_field(|c| c.enable_post_processor(model.clone(), source.clone()))
+            .set_config_field(|c| {
+                c.enable_post_processor(model.clone(), source.clone(), device.clone());
+            })
             .await;
 
         // A load failure is reported in the message but does not fail the call:
@@ -203,21 +227,10 @@ impl SuperSTTDaemon {
         )
     }
 
-    /// The `{ enabled, model, source, loaded }` body both the getter and the
-    /// setters answer with, so the shape cannot drift between them.
+    /// The stage object every setter answers with — the same one
+    /// `GET /pipeline/2` reads, so a write's echo and the next read cannot
+    /// disagree.
     async fn post_processor_payload(&self) -> serde_json::Value {
-        let (enabled, model, source) = {
-            let config = self.config.read().await;
-            let pp = &config.post_processor;
-            (pp.enabled, pp.model.clone(), pp.source.clone())
-        };
-        serde_json::json!({
-            "enabled": enabled,
-            // Null rather than "" for an empty selection: the field is an
-            // identity, and an empty string is not one.
-            "model": (!model.is_empty()).then_some(model),
-            "source": (!source.is_empty()).then_some(source),
-            "loaded": self.post_processor_loaded().await,
-        })
+        self.post_processor_stage().await
     }
 }

--- a/super-stt-daemon/tests/http_smoke_pipeline.rs
+++ b/super-stt-daemon/tests/http_smoke_pipeline.rs
@@ -292,6 +292,105 @@ async fn post_processor_defaults_to_disabled_and_unselected() {
     assert_eq!(pp["model"], serde_json::Value::Null);
     assert_eq!(pp["source"], serde_json::Value::Null);
     assert_eq!(pp["loaded"], false);
+    // No preference of its own yet (it would follow stage 1), and nothing has
+    // loaded to run anywhere.
+    assert_eq!(pp["preferred_device"], serde_json::Value::Null);
+    assert_eq!(pp["device"], serde_json::Value::Null);
+}
+
+/// The stage has a device of its own. It rides along with the model, is
+/// normalized the way `/active_device` normalizes (`cuda` → `gpu`), survives
+/// as configuration, and a later `POST` without one keeps it.
+#[tokio::test]
+async fn the_stages_device_is_its_own_and_is_kept() {
+    let (_guard, sock, token) = start_daemon(&["settings"]).await;
+
+    let (status, body) = post_req(
+        &sock,
+        PP_STAGE_MODEL,
+        &token,
+        serde_json::json!({ "model": "cleanup-1", "source": FIXTURE_SOURCE, "device": "cuda" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["post_processor"]["preferred_device"], "gpu",
+        "cuda normalizes to gpu"
+    );
+
+    let (_, body) = get(&sock, PP_STAGE, &token).await;
+    assert_eq!(body["stage"]["preferred_device"], "gpu");
+    // The fixture's placeholder entrypoint cannot load, so nothing is running
+    // anywhere yet: the ask is recorded, the answer is still null.
+    assert_eq!(body["stage"]["device"], serde_json::Value::Null);
+
+    // Re-running the model without naming a device keeps the one stored.
+    let (status, body) = post_req(
+        &sock,
+        PP_STAGE_MODEL,
+        &token,
+        serde_json::json!({ "model": "cleanup-1" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["post_processor"]["preferred_device"], "gpu");
+
+    // And naming one replaces it.
+    let (status, body) = post_req(
+        &sock,
+        PP_STAGE_MODEL,
+        &token,
+        serde_json::json!({ "model": "cleanup-1", "device": "cpu" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["post_processor"]["preferred_device"], "cpu");
+}
+
+/// A device that is not `cpu`/`gpu` is refused with the code `/active_device`
+/// uses, before anything is persisted — the selection must not half-apply.
+#[tokio::test]
+async fn an_unknown_device_is_refused_before_anything_is_saved() {
+    let (_guard, sock, token) = start_daemon(&["settings"]).await;
+
+    let (status, body) = post_req(
+        &sock,
+        PP_STAGE_MODEL,
+        &token,
+        serde_json::json!({ "model": "cleanup-1", "source": FIXTURE_SOURCE, "device": "tpu" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    assert_eq!(body["error_code"], "invalid_device");
+
+    let (_, body) = get(&sock, PP_STAGE, &token).await;
+    assert_eq!(body["stage"]["enabled"], false, "nothing was saved");
+    assert_eq!(body["stage"]["model"], serde_json::Value::Null);
+}
+
+/// Stage 1's device is the daemon-wide preference behind `/active_device`,
+/// with a reload of its own; sending one here is refused rather than ignored,
+/// since the caller expects the model to land on it.
+#[tokio::test]
+async fn stage_one_does_not_take_a_device_with_its_model() {
+    let (_guard, sock, token) = start_daemon(&["settings"]).await;
+
+    let (status, body) = post_req(
+        &sock,
+        "/pipeline/1/model",
+        &token,
+        serde_json::json!({ "model": "whisper-1", "source": FIXTURE_SOURCE, "device": "gpu" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    assert_eq!(body["error_code"], "invalid_value");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("/active_device"),
+        "the refusal names where the device does go: {body}"
+    );
 }
 
 /// Enable → read back → disable. `POST` names the model to run; `DELETE` stops

--- a/super-stt-shared/src/models/protocol/command.rs
+++ b/super-stt-shared/src/models/protocol/command.rs
@@ -55,9 +55,14 @@ pub enum Command {
     /// the selected post-processor backend, the way `SetModel` resolves against
     /// the active backend. The model must be one its backend declares with
     /// `role = "post_processor"`.
+    ///
+    /// `device` is the stage's own `cpu`/`gpu` preference: the post-processor
+    /// runs beside the transcription model, on hardware chosen for it, not
+    /// inherited from stage 1. `None` keeps whatever the stage already has.
     SetPostProcessor {
         model: String,
         source: String,
+        device: Option<String>,
     },
     GetPostProcessor,
     /// Stop running the post-processor, keeping the selection.

--- a/super-stt-shared/src/models/protocol/dispatch.rs
+++ b/super-stt-shared/src/models/protocol/dispatch.rs
@@ -200,6 +200,7 @@ fn cmd_set_device(request: &DaemonRequest) -> Result<Command, String> {
 ///
 /// `source` is optional and resolves to the selected post-processor backend
 /// when omitted, exactly as `set_model` resolves against the active backend.
+/// `device` is optional too; omitted, the stage keeps its stored preference.
 /// There is no `enabled` field — this command *is* "enable with this model",
 /// and `clear_post_processor` is its off switch.
 fn cmd_set_post_processor(request: &DaemonRequest) -> Result<Command, String> {
@@ -234,7 +235,27 @@ fn cmd_set_post_processor(request: &DaemonRequest) -> Result<Command, String> {
         return Err(e.to_string());
     }
 
-    Ok(Command::SetPostProcessor { model, source })
+    // Present-but-not-a-string is a malformed request, not an omitted field:
+    // silently reading `"device": 7` as "keep the current one" would hide the
+    // caller's bug.
+    let device = match data.get("device") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(d)) => {
+            if let Err(e) =
+                validation::validate_string(d, "device", validation::limits::MAX_NAME_LENGTH)
+            {
+                return Err(e.to_string());
+            }
+            Some(d.clone())
+        }
+        Some(_) => return Err("device must be a string for set_post_processor command".into()),
+    };
+
+    Ok(Command::SetPostProcessor {
+        model,
+        source,
+        device,
+    })
 }
 
 /// Parse `set_post_processor_backend`: which backend provides the

--- a/super-stt-shared/src/models/protocol/tests.rs
+++ b/super-stt-shared/src/models/protocol/tests.rs
@@ -555,12 +555,49 @@ fn set_post_processor_parses_the_model_and_source() {
         })),
     );
     match Command::try_from(req).expect("parses") {
-        Command::SetPostProcessor { model, source } => {
+        Command::SetPostProcessor {
+            model,
+            source,
+            device,
+        } => {
             assert_eq!(model, "cleanup-small");
             assert_eq!(source, "github.com/super-stt/cleanup");
+            assert_eq!(device, None, "no device named means keep the stored one");
         }
         other => panic!("wrong command: {other:?}"),
     }
+}
+
+/// The stage's device rides along with the model: the post-processor runs on
+/// hardware picked for it, not on whatever stage 1 happens to use. The parser
+/// only carries the string; the daemon decides what `cpu`/`gpu`/`cuda` mean.
+#[test]
+fn set_post_processor_carries_the_stages_device() {
+    let req = make_request(
+        "set_post_processor",
+        Some(serde_json::json!({ "model": "cleanup-small", "device": "gpu" })),
+    );
+    match Command::try_from(req).expect("parses") {
+        Command::SetPostProcessor { device, .. } => assert_eq!(device.as_deref(), Some("gpu")),
+        other => panic!("wrong command: {other:?}"),
+    }
+
+    // An explicit null is the same as absent.
+    let req = make_request(
+        "set_post_processor",
+        Some(serde_json::json!({ "model": "cleanup-small", "device": null })),
+    );
+    match Command::try_from(req).expect("parses") {
+        Command::SetPostProcessor { device, .. } => assert_eq!(device, None),
+        other => panic!("wrong command: {other:?}"),
+    }
+
+    // A device that is not a string is a malformed request, not "keep it".
+    let req = make_request(
+        "set_post_processor",
+        Some(serde_json::json!({ "model": "cleanup-small", "device": 7 })),
+    );
+    assert!(Command::try_from(req).is_err());
 }
 
 /// An omitted `source` resolves to the selected post-processor backend at
@@ -573,7 +610,7 @@ fn set_post_processor_takes_a_bare_model_name() {
         Some(serde_json::json!({ "model": "cleanup-small" })),
     );
     match Command::try_from(req).expect("parses") {
-        Command::SetPostProcessor { model, source } => {
+        Command::SetPostProcessor { model, source, .. } => {
             assert_eq!(model, "cleanup-small");
             assert_eq!(source, "");
         }


### PR DESCRIPTION
## What

Stage 2 loaded on whatever `/active_device` said — the *transcription* model's preference. With Whisper on the CPU, S1-mini could only follow it there, and the Post-processing card offered no way to say otherwise.

## Daemon

- `POST /pipeline/2/model` takes an optional **`device`** (`cpu`/`gpu`; `cuda`/`metal` normalize like `/active_device`), stored in `[post_processor] device` and kept by a later POST that omits it.
- A stage that has never been given one still follows stage 1's — what every load did before — so an existing config changes nothing.
- Stage 1 refuses the field (`400 invalid_value`, naming `/active_device`): its device is the daemon-wide preference with a reload of its own. Refused rather than ignored, since a caller who sent it expects the model to land there.
- The stage object gains **`preferred_device`** (the ask) beside **`device`** (where the loaded model actually runs — stage 1 already reported this, undocumented; now both are in the table). The POST/DELETE answers return that same stage object instead of a second hand-built copy.

## App

The Post-processing card gets the device dropdown the transcription card has. The default is the stored preference when the model can honor it, else the model's first offered device — one function (`post_processor_default_device`) serves the view and the handler, so Load sends exactly what the dropdown shows. The Active line reads `Active: s1-mini-q4_k_m · cuda`.

## Tests

- protocol: `device` parses, `null` = absent, non-string refused
- smoke (`http_smoke_pipeline`): stored + normalized + kept across a POST without it; unknown device refused before anything is saved; stage 1 refuses it
- app: default-device rule (preference honored / first offered / CPU-only install / online model), and stage payloads with and without the new fields

`just check`, `just fmt-check`, daemon lib (514), shared (139), pipeline/events/settings/backends smoke all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HmFf3PQNwVDWw4wUtRs2Y
