### PR TITLE
Give every pipeline stage its own model operation

### DIFF
--- a/super-stt-app/src/core/app/handlers/daemon/events.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/events.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::core::app::{AppModel, DeviceState, ModelOperationState};
-use crate::state::device_offers::PP_STAGE;
+use crate::core::app::{AppModel, DeviceState};
+use crate::state::device_offers::{PP_STAGE, STT_STAGE};
 use crate::ui::messages::{DaemonMessage, DeviceMessage, DownloadMessage, Message, UpdateMessage};
 use cosmic::prelude::*;
 use log::{debug, info, warn};
@@ -238,15 +238,13 @@ impl AppModel {
         // Handle model readiness - clear switching state
         if model_loaded {
             info!("Received ready event: model loading completed");
+            // Stage 2's `ready` is intercepted before this, so this one is
+            // stage 1's.
             info!(
-                "Model state before ready event: {:?}",
-                self.model_operation_state
+                "Stage 1 model state before ready event: {:?}",
+                self.model_operations.get(STT_STAGE)
             );
-            self.model_operation_state = ModelOperationState::Ready;
-            info!(
-                "Model state after ready event: {:?}",
-                self.model_operation_state
-            );
+            self.model_operations.set_ready(STT_STAGE);
         }
     }
 
@@ -283,8 +281,8 @@ impl AppModel {
         self.current_model_epoch = self.current_model_epoch.wrapping_add(1);
         self.current_model.clone_from(&model);
         self.current_source.clone_from(&source);
-        self.model_operation_state = ModelOperationState::Ready;
-        info!("Model state updated to Ready after model_switched event");
+        self.model_operations.set_ready(STT_STAGE);
+        info!("Stage 1 model state updated to Ready after model_switched event");
         // Mirror CurrentModelLoaded/ModelChanged: fetch the per-model language
         // block so the active-backend card's language button shows the model's
         // resolved language instead of the neutral "Language" label. A client that
@@ -323,9 +321,16 @@ impl AppModel {
                 cosmic::Action::App(Message::Download(DownloadMessage::DownloadCompleted(model)))
             }));
         } else if progress.status == "cancelled" {
-            return Some(Task::perform(async move { progress.model_name }, |model| {
-                cosmic::Action::App(Message::Download(DownloadMessage::DownloadCancelled(model)))
-            }));
+            let (model, stage) = (progress.model_name, progress.stage);
+            return Some(Task::perform(
+                async move { (model, stage) },
+                |(model, stage)| {
+                    cosmic::Action::App(Message::Download(DownloadMessage::DownloadCancelled {
+                        model,
+                        stage,
+                    }))
+                },
+            ));
         }
         None
     }

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -5,7 +5,7 @@ mod events;
 use crate::core::app::events::classify_daemon_error;
 use crate::core::app::handlers::tasks::{build_load_settings_tasks, ping_task};
 use crate::core::app::subscription::SETTINGS_APP_ID;
-use crate::core::app::{AppModel, DeviceState, ModelOperationState};
+use crate::core::app::{AppModel, DeviceState};
 use crate::daemon::client::test_daemon_connection;
 use crate::state::{AudioTheme, DaemonStatus};
 use crate::ui::messages::{DaemonMessage, Message, ModelMessage};
@@ -100,7 +100,9 @@ impl AppModel {
         // Only clear potentially stuck switching states on actual reconnect, not periodic pings
         if was_disconnected {
             self.device_state = DeviceState::Ready;
-            self.model_operation_state = ModelOperationState::Ready;
+            // Every stage: an operation the app was tracking belongs to a
+            // session that is gone.
+            self.model_operations.reset();
             self.transcription_text.clear();
         }
 

--- a/super-stt-app/src/core/app/handlers/device.rs
+++ b/super-stt-app/src/core/app/handlers/device.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::core::app::{AppModel, DeviceState, ModelOperationState};
+use crate::state::device_offers::STT_STAGE;
 use crate::ui::messages::{DeviceMessage, Message};
 use cosmic::prelude::*;
 use log::info;
@@ -32,9 +33,14 @@ impl AppModel {
                 // failure on that page's card banner rather than hijacking the
                 // Recording page's transcription box (Tier 3 #11).
                 self.device_state = DeviceState::Ready;
-                self.model_operation_state = ModelOperationState::Error {
-                    message: format!("Device error: {err}"),
-                };
+                // Device switching is the transcription card's control, so its
+                // failure belongs on that card.
+                self.model_operations.set(
+                    STT_STAGE,
+                    ModelOperationState::Error {
+                        message: format!("Device error: {err}"),
+                    },
+                );
                 Task::none()
             }
         }

--- a/super-stt-app/src/core/app/handlers/download.rs
+++ b/super-stt-app/src/core/app/handlers/download.rs
@@ -2,6 +2,7 @@
 
 use crate::core::app::{AppModel, ModelOperationState};
 use crate::daemon::client::{cancel_download, get_download_status};
+use crate::state::device_offers::STT_STAGE;
 use crate::ui::messages::{DownloadMessage, Message};
 use cosmic::prelude::*;
 use log::info;
@@ -15,12 +16,12 @@ impl AppModel {
     ) -> Task<cosmic::Action<Message>> {
         match message {
             DownloadMessage::DownloadProgressUpdate(_)
-            | DownloadMessage::CancelDownload
+            | DownloadMessage::CancelDownload(_)
             | DownloadMessage::CheckDownloadStatus
-            | DownloadMessage::NoDownloadInProgress => self.handle_download_progress(message),
+            | DownloadMessage::NoDownloadInProgress(_) => self.handle_download_progress(message),
 
             DownloadMessage::DownloadCompleted(_)
-            | DownloadMessage::DownloadCancelled(_)
+            | DownloadMessage::DownloadCancelled { .. }
             | DownloadMessage::DownloadError { .. } => self.handle_download_completion(message),
         }
     }
@@ -38,52 +39,56 @@ impl AppModel {
                 Task::none()
             }
 
-            DownloadMessage::CancelDownload => {
-                // The stage the card showing this progress is for — the same
-                // one the daemon reported it under.
-                Task::perform(
-                    cancel_download(self.model_operation_stage),
-                    |result| match result {
-                        Ok(_) => cosmic::Action::App(Message::Download(
-                            DownloadMessage::DownloadCancelled(String::new()),
-                        )),
-                        Err(e) => {
-                            cosmic::Action::App(Message::Download(DownloadMessage::DownloadError {
-                                model: String::new(),
-                                error: e.to_string(),
-                            }))
-                        }
-                    },
-                )
+            DownloadMessage::CancelDownload(stage) => {
+                // The stage of the card the Cancel button sits on, taken from
+                // the progress it is showing.
+                Task::perform(cancel_download(stage), move |result| match result {
+                    Ok(_) => {
+                        cosmic::Action::App(Message::Download(DownloadMessage::DownloadCancelled {
+                            model: String::new(),
+                            stage,
+                        }))
+                    }
+                    Err(e) => {
+                        cosmic::Action::App(Message::Download(DownloadMessage::DownloadError {
+                            model: String::new(),
+                            error: e.to_string(),
+                            stage,
+                        }))
+                    }
+                })
             }
 
             DownloadMessage::CheckDownloadStatus => {
-                // Only poll while a switch is actually pending. A Ready state
-                // needs no poll, and an Error state (e.g. a switch that just
-                // failed) must keep its banner rather than be cleared here.
-                if matches!(
-                    self.model_operation_state,
-                    ModelOperationState::Loading { .. } | ModelOperationState::Downloading { .. }
-                ) {
-                    Task::perform(get_download_status(), |result| match result {
-                        Ok(Some(progress)) => {
-                            // Download is actually happening
-                            cosmic::Action::App(Message::Download(
-                                DownloadMessage::DownloadProgressUpdate(progress),
-                            ))
-                        }
-                        // No download in progress (loaded from cache, or the
-                        // switch failed): fall through to NoDownloadInProgress.
-                        Ok(None) | Err(_) => cosmic::Action::App(Message::Download(
-                            DownloadMessage::NoDownloadInProgress,
-                        )),
-                    })
-                } else {
-                    Task::none()
-                }
+                // Poll each stage still owed an outcome, and only those. A
+                // Ready stage needs no poll, and an Error state (e.g. a switch
+                // that just failed) must keep its banner rather than be
+                // cleared here. Every stage asks about itself: polling stage 1
+                // for a stage-2 download would find nothing and collapse the
+                // post-processor's progress card.
+                Task::batch(
+                    self.model_operations
+                        .pending_stages()
+                        .into_iter()
+                        .map(|stage| {
+                            Task::perform(get_download_status(stage), move |result| match result {
+                                Ok(Some(progress)) => {
+                                    // Download is actually happening
+                                    cosmic::Action::App(Message::Download(
+                                        DownloadMessage::DownloadProgressUpdate(progress),
+                                    ))
+                                }
+                                // No download in progress (loaded from cache, or
+                                // the switch failed): fall through.
+                                Ok(None) | Err(_) => cosmic::Action::App(Message::Download(
+                                    DownloadMessage::NoDownloadInProgress(stage),
+                                )),
+                            })
+                        }),
+                )
             }
 
-            DownloadMessage::NoDownloadInProgress => {
+            DownloadMessage::NoDownloadInProgress(stage) => {
                 // Only clear a `Downloading` state. A `Loading` state means
                 // the daemon's `set_model` HTTP call is still in flight (the
                 // subprocess might still be spawning, or the WASM component
@@ -97,15 +102,27 @@ impl AppModel {
                 // The Error branch is preserved untouched — that's its own
                 // contract (see `ModelError` handler).
                 if matches!(
-                    self.model_operation_state,
-                    ModelOperationState::Downloading { .. }
+                    self.model_operations.get(stage),
+                    Some(ModelOperationState::Downloading { .. })
                 ) {
-                    self.model_operation_state = ModelOperationState::Ready;
+                    self.model_operations.set_ready(stage);
                 }
                 Task::none()
             }
 
             _ => Task::none(),
+        }
+    }
+
+    /// Drop the locally-tracked model for a stage whose operation just ended
+    /// badly. Only stage 1's identity is mirrored in the app (`current_model`
+    /// and its source); stage 2's lives in the post-processor block, which the
+    /// daemon re-reports, so there is nothing to clear for it here. Clearing
+    /// unconditionally is what used to blank the transcription card when a
+    /// post-processor download failed.
+    fn forget_stage_model(&mut self, stage: u32) {
+        if stage == STT_STAGE {
+            self.clear_loaded_model();
         }
     }
 
@@ -121,27 +138,34 @@ impl AppModel {
                 Task::none()
             }
 
-            DownloadMessage::DownloadCancelled(model_name) => {
-                info!("Model {model_name} download was cancelled");
+            DownloadMessage::DownloadCancelled { model, stage } => {
+                info!("Model {model} download on stage {stage} was cancelled");
                 // The daemon already unloaded the previous model before
-                // the failed instantiate, so it's now idle (with the
-                // active backend still selected). Reflect that locally
+                // the failed instantiate, so that stage is now idle (with the
+                // backend still selected). Reflect that locally
                 // — no further set_model: an empty `previous_*` would
                 // resolve to "no installed backend serves ''" and surface
                 // as a UI error.
-                self.model_operation_state = ModelOperationState::Ready;
-                self.clear_loaded_model();
+                self.model_operations.set_ready(stage);
+                self.forget_stage_model(stage);
                 Task::none()
             }
 
-            DownloadMessage::DownloadError { model, error } => {
-                warn!("Download error for model {model}: {error}");
-                // Surface on the Models card banner instead of hijacking the
+            DownloadMessage::DownloadError {
+                model,
+                error,
+                stage,
+            } => {
+                warn!("Download error for model {model} on stage {stage}: {error}");
+                // Surface on that stage's card banner instead of hijacking the
                 // Recording page's transcription box (Tier 3 #11).
-                self.model_operation_state = ModelOperationState::Error {
-                    message: format!("Download failed: {error}"),
-                };
-                self.clear_loaded_model();
+                self.model_operations.set(
+                    stage,
+                    ModelOperationState::Error {
+                        message: format!("Download failed: {error}"),
+                    },
+                );
+                self.forget_stage_model(stage);
                 Task::none()
             }
 

--- a/super-stt-app/src/core/app/handlers/model.rs
+++ b/super-stt-app/src/core/app/handlers/model.rs
@@ -4,6 +4,7 @@ use crate::core::app::{AppModel, ModelOperationState};
 use crate::daemon::client::{
     get_active_backend, get_current_device, get_current_model, get_gpu_info, list_available_models,
 };
+use crate::state::device_offers::STT_STAGE;
 use crate::ui::messages::{DeviceMessage, Message, ModelMessage, ModelsPageMessage};
 use cosmic::prelude::*;
 use log::info;
@@ -85,7 +86,7 @@ impl AppModel {
                 }
                 self.current_model.clone_from(&model);
                 self.current_source.clone_from(&source);
-                self.model_operation_state = ModelOperationState::Ready;
+                self.model_operations.set_ready(STT_STAGE);
                 // Fetch the per-model language block now that a model is loaded.
                 // Wire point 1: model loaded (CurrentModelLoaded).
                 self.load_model_language(source, model)
@@ -98,7 +99,7 @@ impl AppModel {
                 self.current_model_epoch = self.current_model_epoch.wrapping_add(1);
                 self.current_model.clone_from(&model);
                 self.current_source.clone_from(&source);
-                self.model_operation_state = ModelOperationState::Ready;
+                self.model_operations.set_ready(STT_STAGE);
                 // Fetch the per-model language block now that a model is loaded.
                 // Wire point 1: model loaded (ModelChanged).
                 self.load_model_language(source, model)
@@ -140,8 +141,9 @@ impl AppModel {
         warn!("Model operation failed: {err}");
         let home = std::env::var("HOME").unwrap_or_default();
         let sanitized = sanitize_home(err, &home);
-        self.model_operation_state = ModelOperationState::Error { message: sanitized };
-        // A failed switch leaves the daemon idle (no model) — the backend stays
+        self.model_operations
+            .set(STT_STAGE, ModelOperationState::Error { message: sanitized });
+        // A failed switch leaves stage 1 idle (no model) — the backend stays
         // selected, but no model is loaded.
         self.clear_loaded_model();
     }

--- a/super-stt-app/src/core/app/handlers/models_page/mod.rs
+++ b/super-stt-app/src/core/app/handlers/models_page/mod.rs
@@ -3,7 +3,7 @@
 mod install;
 mod registry;
 
-use crate::core::app::{AppModel, ModelOperationState};
+use crate::core::app::AppModel;
 use crate::daemon::client::{
     clear_active_backend, get_gpu_info, get_model_device, list_model_devices, list_stage_devices,
     set_active_backend, set_model, set_model_device, unload_active_model,
@@ -173,7 +173,7 @@ impl AppModel {
                 self.clear_loaded_model();
                 self.models_page.staged_model = None;
                 self.models_page.staged_device = None;
-                self.model_operation_state = ModelOperationState::Ready;
+                self.model_operations.set_ready(STT_STAGE);
                 Task::perform(unload_active_model(), |result| match result {
                     Ok(_) => cosmic::Action::None,
                     Err(e) => {
@@ -195,8 +195,10 @@ impl AppModel {
             log::warn!("LoadStagedModel ignored — no staged model");
             return Task::none();
         };
-        if !self.is_model_ready() {
-            log::warn!("Model operation already in progress — ignoring Load click");
+        // Stage 1's own operation only: the post-processor provisions
+        // independently, and its download must not swallow this click.
+        if !self.is_model_ready(STT_STAGE) {
+            log::warn!("A stage-1 model operation is already in progress — ignoring Load click");
             return Task::none();
         }
 
@@ -330,7 +332,7 @@ impl AppModel {
                 let prev_active = self.models_page.active_backend.take();
                 self.models_page.active_backend = Some(source.clone());
                 self.clear_loaded_model();
-                self.model_operation_state = ModelOperationState::Ready;
+                self.model_operations.set_ready(STT_STAGE);
                 // Activation comes from the Models page's "Select a backend" sheet;
                 // dismiss it now that a choice was made.
                 self.core.window.show_context = false;
@@ -374,7 +376,7 @@ impl AppModel {
                 // that self-heals on the next refresh.)
                 self.models_page.active_backend = None;
                 self.clear_loaded_model();
-                self.model_operation_state = ModelOperationState::Ready;
+                self.model_operations.set_ready(STT_STAGE);
                 self.models_page.configure_backend = None;
                 // Close the configuration sheet if it was open for this backend.
                 self.core.window.show_context = false;

--- a/super-stt-app/src/core/app/handlers/settings.rs
+++ b/super-stt-app/src/core/app/handlers/settings.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::core::app::{AppModel, ModelOperationState};
+use crate::core::app::AppModel;
 use crate::daemon::client::{
     clear_post_processor, clear_post_processor_backend, get_model_device, list_model_devices,
     list_stage_devices, set_model_device, set_notification_method, set_post_processor,
@@ -249,9 +249,7 @@ impl AppModel {
     /// by the `download_progress` ticks that name its model. The write's own
     /// response is the end of it.
     pub(in crate::core::app) fn finish_post_processor_operation(&mut self) {
-        if self.model_operation_stage == PP_STAGE {
-            self.model_operation_state = ModelOperationState::Ready;
-        }
+        self.model_operations.set_ready(PP_STAGE);
     }
 
     /// Ask the daemon which devices the post-processor backend can run its
@@ -296,6 +294,16 @@ impl AppModel {
             .staged_post_processor
             .as_ref()
             .and_then(|_| self.staged_post_processor_device.clone());
+        // Mark stage 2 busy before the request goes out, as the transcription
+        // card does. This is what the card's own Load button reads, so without
+        // it a second click could fire a second load while the first is still
+        // in flight. Both outcomes below end it: the reload's `Loaded` and the
+        // failure's `Error` each finish the stage-2 operation.
+        self.set_model_loading(
+            model.clone(),
+            "Initiating model switch...".to_string(),
+            PP_STAGE,
+        );
         Task::perform(
             async move {
                 // Set before the load so the load picks it up; for a model

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -8,7 +8,7 @@ use cosmic::prelude::*;
 use cosmic::widget::nav_bar;
 use std::collections::HashMap;
 
-use super::{AppModel, DeviceState, ModelOperationState};
+use super::{AppModel, DeviceState};
 
 /// Builds the navigation bar with all Super STT pages inserted in order.
 fn build_nav() -> nav_bar::Model {
@@ -114,17 +114,14 @@ impl AppModel {
             current_model: String::new(),
             current_source: String::new(),
             current_model_epoch: 0,
-            model_operation_state: ModelOperationState::Loading {
-                target_model: String::new(),
-                status_message: "Loading initial model state...".to_string(),
-            },
-            model_operation_stage: crate::state::device_offers::STT_STAGE,
+            model_operations: crate::state::model_operations::ModelOperations::opening(
+                "Loading initial model state...".to_string(),
+            ),
 
             // Initialize device state
             current_device: String::new(), // Empty until loaded from daemon
             gpu_info: Vec::new(),
             device_state: DeviceState::Ready,
-            last_switch_progress_at: None,
             last_event_timestamp: None,
 
             // Initialize preview typing state (disabled by default as beta feature)

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -20,24 +20,10 @@ use cosmic::widget::{menu, nav_bar};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// Unified model operation state that encompasses downloading, loading, and switching
-#[derive(Debug, Clone)]
-pub enum ModelOperationState {
-    /// Model is ready for use
-    Ready,
-    /// Downloading model files with progress information
-    Downloading {
-        target_model: String,
-        progress: super_stt_shared::models::protocol::DownloadProgress,
-    },
-    /// Loading model into memory (after download completed)
-    Loading {
-        target_model: String,
-        status_message: String,
-    },
-    /// Model operation failed
-    Error { message: String },
-}
+/// The model operation a pipeline stage has in flight. Defined with the
+/// per-stage container that holds it, and re-exported here because every
+/// handler reaches it through the app model.
+pub use crate::state::model_operations::{ModelOperationState, ModelOperations};
 
 /// Device switching state
 #[derive(Debug, Clone, PartialEq)]
@@ -102,14 +88,11 @@ pub struct AppModel {
     /// discarded on arrival if the counter has since advanced — so a slow,
     /// stale reconnect query can never clobber a fresher live event.
     pub current_model_epoch: u64,
-    /// Model operation state (downloading, loading, or ready)
-    pub model_operation_state: ModelOperationState,
-    /// Which pipeline stage [`AppModel::model_operation_state`] belongs to, so
-    /// the progress lands on the card that started it. The daemon's progress
-    /// events carry a model name and nothing else, so the stage is resolved
-    /// from the catalog when the operation starts and kept for the rest of it
-    /// — including a terminal error, which carries no model name at all.
-    pub model_operation_stage: u32,
+    /// What each pipeline stage has in flight: a download, a load, a failure,
+    /// or nothing. Per stage because the stages provision independently, so
+    /// one stage's work must neither render on another's card nor keep its
+    /// Load button disabled.
+    pub model_operations: ModelOperations,
 
     // Device management state
     /// The accelerator the loaded stage-1 model is on (`cpu`/`cuda`/…), from
@@ -121,11 +104,6 @@ pub struct AppModel {
     pub gpu_info: Vec<super_stt_shared::models::protocol::GpuInfo>,
     /// Device switching state
     pub device_state: DeviceState,
-    /// Timestamp of the last model-switch progress signal (switch start or any
-    /// `download_progress` tick). Drives the stall watchdog in the
-    /// `PingTimeout` handler so a switch that stops making progress surfaces an
-    /// error instead of spinning forever. `None` when no switch is in flight.
-    pub last_switch_progress_at: Option<std::time::Instant>,
     /// Last event timestamp for polling daemon events
     pub last_event_timestamp: Option<String>,
 

--- a/super-stt-app/src/core/app/small_state.rs
+++ b/super-stt-app/src/core/app/small_state.rs
@@ -4,6 +4,7 @@ use crate::ui::messages::Message;
 use cosmic::prelude::*;
 
 use super::{AppModel, DeviceState, ModelOperationState};
+use crate::state::device_offers::STT_STAGE;
 
 /// Stall threshold for the model-switch watchdog. If a switch makes no
 /// progress for this long, the UI flips to an error instead of spinning
@@ -14,9 +15,11 @@ use super::{AppModel, DeviceState, ModelOperationState};
 const SWITCH_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(5);
 
 impl AppModel {
-    /// Check if model is ready
-    pub fn is_model_ready(&self) -> bool {
-        matches!(self.model_operation_state, ModelOperationState::Ready)
+    /// Whether `stage` is free to start a model operation. Asked per stage:
+    /// the daemon runs the stages independently, so a post-processor download
+    /// must leave the transcription card's Load button live.
+    pub fn is_model_ready(&self, stage: u32) -> bool {
+        self.model_operations.is_ready(stage)
     }
 
     /// Clear the locally-tracked loaded model — its name and source.
@@ -37,11 +40,14 @@ impl AppModel {
         progress: super_stt_shared::models::protocol::DownloadProgress,
         stage: u32,
     ) {
-        self.model_operation_stage = stage;
-        self.model_operation_state = ModelOperationState::Downloading {
-            target_model,
-            progress,
-        };
+        // A tick is progress, so it restarts that stage's stall clock.
+        self.model_operations.start(
+            stage,
+            ModelOperationState::Downloading {
+                target_model,
+                progress,
+            },
+        );
     }
 
     /// Set model to loading state, for the stage running the model.
@@ -51,13 +57,14 @@ impl AppModel {
         status_message: String,
         stage: u32,
     ) {
-        // Entering a switch starts the stall watchdog clock (see PingTimeout).
-        self.last_switch_progress_at = Some(std::time::Instant::now());
-        self.model_operation_stage = stage;
-        self.model_operation_state = ModelOperationState::Loading {
-            target_model,
-            status_message,
-        };
+        // Entering a switch starts that stage's stall clock (see PingTimeout).
+        self.model_operations.start(
+            stage,
+            ModelOperationState::Loading {
+                target_model,
+                status_message,
+            },
+        );
     }
 
     /// Set device to switching state
@@ -87,7 +94,6 @@ impl AppModel {
         &mut self,
         progress: &super_stt_shared::models::protocol::DownloadProgress,
     ) {
-        self.last_switch_progress_at = Some(std::time::Instant::now());
         let target_model = progress.model_name.clone();
         // The daemon says which stage it is provisioning for, so the progress
         // lands on the card that started it rather than on whichever card
@@ -111,12 +117,15 @@ impl AppModel {
                     .error
                     .clone()
                     .unwrap_or_else(|| "Model switch failed".to_string());
-                self.model_operation_stage = stage;
-                self.model_operation_state = ModelOperationState::Error { message };
-                // A failed switch leaves the daemon idle — clear the selection
+                self.model_operations
+                    .set(stage, ModelOperationState::Error { message });
+                // A failed switch leaves that stage idle — clear the selection
                 // so the UI doesn't show a model that isn't loaded (mirrors the
-                // `ModelError` handler).
-                self.clear_loaded_model();
+                // `ModelError` handler). Only stage 1's identity is kept here,
+                // so a post-processor's failure must not clear it.
+                if stage == STT_STAGE {
+                    self.clear_loaded_model();
+                }
             }
             "completed" | "cancelled" => {
                 // State will be updated by subsequent daemon events
@@ -131,28 +140,20 @@ impl AppModel {
 
     /// Model-switch stall watchdog, called on each `PingTimeout` tick. While a
     /// switch is in flight, a progress event (download tick, `loading_model`,
-    /// or the initial `set_model_loading`) resets the clock; if none arrives
-    /// within [`SWITCH_STALL_TIMEOUT`], flip to an error so the UI doesn't
-    /// spin forever. No-op outside a switch.
+    /// or the initial `set_model_loading`) resets that stage's clock; if none
+    /// arrives within [`SWITCH_STALL_TIMEOUT`], flip that stage to an error so
+    /// the UI doesn't spin forever. Each stage is timed on its own, so a busy
+    /// one cannot keep a stalled one alive. No-op outside a switch.
     pub(in crate::core::app) fn check_switch_stall(&mut self) {
-        if !matches!(
-            self.model_operation_state,
-            ModelOperationState::Loading { .. } | ModelOperationState::Downloading { .. }
-        ) {
-            return;
-        }
-        if let Some(since) = self.last_switch_progress_at
-            && since.elapsed() > SWITCH_STALL_TIMEOUT
-        {
+        let stalled = self.model_operations.fail_stalled(
+            SWITCH_STALL_TIMEOUT,
+            "Model switch stalled — the daemon stopped reporting progress.",
+        );
+        for stage in stalled {
             log::warn!(
-                "Model switch stalled: no progress for {}s",
+                "Model switch on stage {stage} stalled: no progress for {}s",
                 SWITCH_STALL_TIMEOUT.as_secs()
             );
-            self.model_operation_state = ModelOperationState::Error {
-                message: "Model switch stalled — the daemon stopped reporting progress."
-                    .to_string(),
-            };
-            self.last_switch_progress_at = None;
         }
     }
 

--- a/super-stt-app/src/daemon/client/v1/settings/active_model.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/active_model.rs
@@ -63,6 +63,16 @@ async fn fetch_stage(socket: std::path::PathBuf, token: &str) -> HttpResult<Stag
     transport::get_json::<StageStatus>(socket, token, STT_STAGE).await
 }
 
+/// The same read for any stage, addressed by position. Each stage reports only
+/// its own switch, so a caller asking about one stage never sees another's.
+async fn fetch_stage_at(
+    socket: std::path::PathBuf,
+    token: &str,
+    stage: u32,
+) -> HttpResult<StageStatus> {
+    transport::get_json::<StageStatus>(socket, token, &format!("/pipeline/{stage}")).await
+}
+
 /// Get current loaded model from daemon as `(name source)`
 /// (HTTP `GET /pipeline/1`).
 pub async fn get_current_model() -> HttpResult<(String, String)> {
@@ -90,12 +100,14 @@ pub async fn get_current_device() -> HttpResult<Option<String>> {
     .await
 }
 
-/// Get current download status. Composed from the stage's `switch.download`
-/// sub-object.
-pub async fn get_download_status()
--> HttpResult<Option<super_stt_shared::models::protocol::DownloadProgress>> {
-    with_settings_token(|socket, token| async move {
-        let status = fetch_stage(socket, &token).await?;
+/// The download `stage` has in flight, composed from that stage's
+/// `switch.download` sub-object. The polled counterpart of the
+/// `download_progress` event, for the ticks a client may have missed.
+pub async fn get_download_status(
+    stage: u32,
+) -> HttpResult<Option<super_stt_shared::models::protocol::DownloadProgress>> {
+    with_settings_token(move |socket, token| async move {
+        let status = fetch_stage_at(socket, &token, stage).await?;
         let Some(switch) = status.stage.switch else {
             return Ok(None);
         };
@@ -113,9 +125,9 @@ pub async fn get_download_status()
         let progress = super_stt_shared::models::protocol::DownloadProgress {
             model_name: target_field("model"),
             source: target_field("source"),
-            // This block is stage 1's by construction — it is read from
-            // `GET /pipeline/1`, which reports only its own stage's switch.
-            stage: super_stt_shared::models::protocol::TRANSCRIPTION_STAGE,
+            // The stage that was asked: `GET /pipeline/{stage}` reports only
+            // its own switch, so the answer belongs to the stage in the path.
+            stage,
             current_file: download.current_file,
             file_index: download.file_index,
             total_files: download.total_files,

--- a/super-stt-app/src/state/mod.rs
+++ b/super-stt-app/src/state/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod device_offers;
 pub mod language;
+pub mod model_operations;
 pub mod models;
 pub mod models_page;
 pub mod registry;

--- a/super-stt-app/src/state/model_operations.rs
+++ b/super-stt-app/src/state/model_operations.rs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! The model operation each pipeline stage has in flight.
+//!
+//! The stages provision independently. The daemon will load a transcription
+//! model while a post-processor is still downloading, and reports every load,
+//! download and failure under its own `stage`.
+//!
+//! The app used to keep one operation and a number saying whose it was. One
+//! stage's work therefore spoke for both: a post-processor download left the
+//! transcription card's Load button disabled, and a stage-2 failure cleared
+//! the loaded stage-1 model. Each stage gets its own slot here instead, so a
+//! card reads, and writes, only its own.
+//!
+//! A stage this app does not know is ignored rather than rejected. The numbers
+//! arrive off the wire, and a daemon that grows a third stage should leave an
+//! older app rendering the two it understands.
+
+use std::time::{Duration, Instant};
+
+pub use super::device_offers::{PP_STAGE, STT_STAGE};
+
+/// A stage's model operation: downloading files, loading them, or done.
+#[derive(Debug, Clone, Default)]
+pub enum ModelOperationState {
+    /// Nothing in flight for this stage.
+    #[default]
+    Ready,
+    /// Downloading model files, with the daemon's latest progress.
+    Downloading {
+        target_model: String,
+        progress: super_stt_shared::models::protocol::DownloadProgress,
+    },
+    /// Loading the model into memory, after any download finished.
+    Loading {
+        target_model: String,
+        status_message: String,
+    },
+    /// The operation failed, with the daemon's reason.
+    Error { message: String },
+}
+
+impl ModelOperationState {
+    /// Whether the daemon still owes an outcome for this operation. The stall
+    /// watchdog and the progress poll both act only on such a stage: `Ready`
+    /// needs no poll, and `Error` must keep its banner rather than be cleared
+    /// by one.
+    #[must_use]
+    pub const fn is_pending(&self) -> bool {
+        matches!(self, Self::Loading { .. } | Self::Downloading { .. })
+    }
+}
+
+/// One stage's operation, plus the clock the stall watchdog reads.
+#[derive(Debug, Clone, Default)]
+struct StageOperation {
+    state: ModelOperationState,
+    /// When this stage last showed progress — the operation starting, or any
+    /// `download_progress` tick for it. `None` outside an operation. Per stage
+    /// because a busy stage would otherwise keep a stalled one's clock alive.
+    last_progress_at: Option<Instant>,
+}
+
+/// What every pipeline stage has in flight, addressed by the daemon's own
+/// stage numbers.
+#[derive(Debug, Clone, Default)]
+pub struct ModelOperations {
+    transcription: StageOperation,
+    post_processor: StageOperation,
+}
+
+impl ModelOperations {
+    /// The state the app opens in: stage 1 is loading, because the first thing
+    /// the app does is read what the daemon already has. Every other stage is
+    /// idle until the daemon says otherwise.
+    #[must_use]
+    pub fn opening(status_message: String) -> Self {
+        let mut ops = Self::default();
+        ops.start(
+            STT_STAGE,
+            ModelOperationState::Loading {
+                target_model: String::new(),
+                status_message,
+            },
+        );
+        ops
+    }
+
+    fn slot(&self, stage: u32) -> Option<&StageOperation> {
+        match stage {
+            STT_STAGE => Some(&self.transcription),
+            PP_STAGE => Some(&self.post_processor),
+            _ => None,
+        }
+    }
+
+    fn slot_mut(&mut self, stage: u32) -> Option<&mut StageOperation> {
+        match stage {
+            STT_STAGE => Some(&mut self.transcription),
+            PP_STAGE => Some(&mut self.post_processor),
+            _ => None,
+        }
+    }
+
+    /// What `stage` has in flight, or `None` for a stage this app does not
+    /// track — which renders as nothing rather than as somebody else's work.
+    #[must_use]
+    pub fn get(&self, stage: u32) -> Option<&ModelOperationState> {
+        self.slot(stage).map(|s| &s.state)
+    }
+
+    /// Whether `stage` is free to start an operation. An untracked stage has
+    /// nothing in flight, so it reads as ready.
+    #[must_use]
+    pub fn is_ready(&self, stage: u32) -> bool {
+        self.slot(stage)
+            .is_none_or(|s| matches!(s.state, ModelOperationState::Ready))
+    }
+
+    /// The stages still owed an outcome, in pipeline order. What the progress
+    /// poll asks about: each stage is polled for its own download, so a
+    /// stage-1 answer can never clear a stage-2 card.
+    #[must_use]
+    pub fn pending_stages(&self) -> Vec<u32> {
+        [STT_STAGE, PP_STAGE]
+            .into_iter()
+            .filter(|&stage| self.get(stage).is_some_and(ModelOperationState::is_pending))
+            .collect()
+    }
+
+    /// Record `state` for `stage`, leaving the stall clock alone. For the
+    /// terminal writes — an outcome arrived, so there is no longer anything to
+    /// time.
+    pub fn set(&mut self, stage: u32, operation: ModelOperationState) {
+        if let Some(slot) = self.slot_mut(stage) {
+            slot.state = operation;
+        }
+    }
+
+    /// Finish `stage`'s operation, whatever it was.
+    pub fn set_ready(&mut self, stage: u32) {
+        self.set(stage, ModelOperationState::Ready);
+    }
+
+    /// Begin (or advance) an operation on `stage`, restarting its stall clock.
+    /// For the writes that mean the daemon is working: a switch starting, a
+    /// download tick, a load beginning.
+    pub fn start(&mut self, stage: u32, operation: ModelOperationState) {
+        if let Some(slot) = self.slot_mut(stage) {
+            slot.state = operation;
+            slot.last_progress_at = Some(Instant::now());
+        }
+    }
+
+    /// Put every stage back to idle. For a daemon reconnect, where any
+    /// operation the app was tracking belongs to a session that is gone.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Fail every stage whose in-flight operation has shown no progress for
+    /// `timeout`, and name them. A stage that has already failed, or has
+    /// nothing in flight, is left alone.
+    pub fn fail_stalled(&mut self, timeout: Duration, message: &str) -> Vec<u32> {
+        let mut stalled = Vec::new();
+        for stage in [STT_STAGE, PP_STAGE] {
+            let Some(slot) = self.slot_mut(stage) else {
+                continue;
+            };
+            if !slot.state.is_pending() {
+                continue;
+            }
+            if slot
+                .last_progress_at
+                .is_some_and(|at| at.elapsed() > timeout)
+            {
+                slot.state = ModelOperationState::Error {
+                    message: message.to_string(),
+                };
+                slot.last_progress_at = None;
+                stalled.push(stage);
+            }
+        }
+        stalled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loading(model: &str) -> ModelOperationState {
+        ModelOperationState::Loading {
+            target_model: model.to_string(),
+            status_message: "Loading model...".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_stage_starts_idle_and_reads_back_what_it_was_given() {
+        let mut ops = ModelOperations::default();
+        assert!(ops.is_ready(STT_STAGE));
+        assert!(ops.is_ready(PP_STAGE));
+
+        ops.start(PP_STAGE, loading("s1-mini"));
+        assert!(!ops.is_ready(PP_STAGE));
+        assert!(matches!(
+            ops.get(PP_STAGE),
+            Some(ModelOperationState::Loading { target_model, .. }) if target_model == "s1-mini"
+        ));
+    }
+
+    /// The reported bug: a post-processor download left the transcription
+    /// card's Load button disabled, because one state spoke for both stages.
+    #[test]
+    fn one_stages_operation_leaves_the_other_free() {
+        let mut ops = ModelOperations::default();
+        ops.start(PP_STAGE, loading("s1-mini"));
+        assert!(
+            ops.is_ready(STT_STAGE),
+            "stage 2's load must not block stage 1"
+        );
+
+        ops.start(STT_STAGE, loading("whisper-large"));
+        assert!(!ops.is_ready(STT_STAGE));
+        assert!(!ops.is_ready(PP_STAGE), "and stage 2 keeps its own");
+
+        ops.set_ready(PP_STAGE);
+        assert!(ops.is_ready(PP_STAGE));
+        assert!(!ops.is_ready(STT_STAGE), "finishing one leaves the other");
+    }
+
+    #[test]
+    fn only_the_stages_still_working_are_polled() {
+        let mut ops = ModelOperations::default();
+        assert!(ops.pending_stages().is_empty());
+
+        ops.start(PP_STAGE, loading("s1-mini"));
+        assert_eq!(ops.pending_stages(), vec![PP_STAGE]);
+
+        ops.start(STT_STAGE, loading("whisper-large"));
+        assert_eq!(ops.pending_stages(), vec![STT_STAGE, PP_STAGE]);
+
+        // A failure is an outcome: the stage is no longer owed one.
+        ops.set(
+            STT_STAGE,
+            ModelOperationState::Error {
+                message: "no".to_string(),
+            },
+        );
+        assert_eq!(ops.pending_stages(), vec![PP_STAGE]);
+    }
+
+    #[test]
+    fn a_stage_the_app_does_not_know_is_ignored() {
+        let mut ops = ModelOperations::default();
+        ops.start(7, loading("from-the-future"));
+        assert!(ops.get(7).is_none(), "it is rendered by nothing");
+        assert!(ops.is_ready(7), "and blocks nothing");
+        assert!(ops.is_ready(STT_STAGE), "least of all another stage");
+        assert!(ops.pending_stages().is_empty());
+    }
+
+    /// A zero timeout makes every in-flight stage overdue at once, which is
+    /// the mechanism under test — not the duration.
+    #[test]
+    fn a_stalled_stage_fails_alone() {
+        let mut ops = ModelOperations::default();
+        ops.start(PP_STAGE, loading("s1-mini"));
+        ops.set(STT_STAGE, ModelOperationState::Ready);
+
+        let stalled = ops.fail_stalled(Duration::ZERO, "stalled");
+        assert_eq!(stalled, vec![PP_STAGE]);
+        assert!(matches!(
+            ops.get(PP_STAGE),
+            Some(ModelOperationState::Error { message }) if message == "stalled"
+        ));
+        assert!(ops.is_ready(STT_STAGE), "an idle stage is not failed");
+
+        // Already failed: nothing left to time out, so it is not re-reported.
+        assert!(ops.fail_stalled(Duration::ZERO, "stalled").is_empty());
+    }
+
+    #[test]
+    fn a_reconnect_drops_every_stages_operation() {
+        let mut ops = ModelOperations::default();
+        ops.start(STT_STAGE, loading("whisper-large"));
+        ops.start(PP_STAGE, loading("s1-mini"));
+
+        ops.reset();
+        assert!(ops.is_ready(STT_STAGE));
+        assert!(ops.is_ready(PP_STAGE));
+    }
+
+    #[test]
+    fn the_app_opens_reading_the_transcription_stage() {
+        let ops = ModelOperations::opening("Loading initial model state...".to_string());
+        assert!(!ops.is_ready(STT_STAGE));
+        assert_eq!(ops.pending_stages(), vec![STT_STAGE]);
+        assert!(ops.is_ready(PP_STAGE));
+    }
+}

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -265,13 +265,28 @@ pub enum DeviceMessage {
 /// Model-download progress lifecycle.
 #[derive(Debug, Clone)]
 pub enum DownloadMessage {
+    /// A progress snapshot, from a `download_progress` event or a poll. The
+    /// stage it belongs to travels inside it.
     DownloadProgressUpdate(super_stt_shared::models::protocol::DownloadProgress),
-    CancelDownload,
+    /// Abandon the download the named stage has in flight. Every variant below
+    /// that settles a stage's card carries its stage for the same reason: the
+    /// two stages download independently, so an outcome that did not say whose
+    /// it was would settle whichever card happened to be showing.
+    CancelDownload(u32),
     DownloadCompleted(String), // model name
-    DownloadCancelled(String), // model name
-    DownloadError { model: String, error: String },
+    DownloadCancelled {
+        model: String,
+        stage: u32,
+    },
+    DownloadError {
+        model: String,
+        error: String,
+        stage: u32,
+    },
+    /// Ask every stage still owed an outcome for its progress.
     CheckDownloadStatus,
-    NoDownloadInProgress,
+    /// The named stage has no download in flight after all.
+    NoDownloadInProgress(u32),
 }
 
 /// Preview-typing setting.

--- a/super-stt-app/src/ui/views/models/active.rs
+++ b/super-stt-app/src/ui/views/models/active.rs
@@ -414,7 +414,7 @@ pub(super) fn staged_model_picker<'a>(
     let load_button = button::suggested("Load model")
         .leading_icon(icons::phosphor_handle(icons::PLAY))
         .on_press_maybe(
-            (staged_ok && app.is_model_ready())
+            (staged_ok && app.is_model_ready(STT_STAGE))
                 .then_some(Message::ModelsPage(ModelsPageMessage::LoadStagedModel)),
         );
     picker_row = picker_row.push(load_button);
@@ -443,15 +443,11 @@ pub(super) fn staged_model_picker<'a>(
 
 /// The in-flight model operation, on the card that owns it.
 ///
-/// One runs at a time — the daemon serializes model mutations — and the
-/// progress events that drive it carry a model name and nothing else, so
-/// `stage` is what keeps a post-processor's download off the transcription
-/// card and a transcription model's off the post-processing one.
+/// The stages provision independently, so each card reads its own stage: a
+/// post-processor's download belongs off the transcription card, and a
+/// transcription model's off the post-processing one, even while both run.
 pub(super) fn operation_status(app: &AppModel, stage: u32) -> Option<Element<'_, Message>> {
-    if app.model_operation_stage != stage {
-        return None;
-    }
-    match &app.model_operation_state {
+    match app.model_operations.get(stage)? {
         ModelOperationState::Ready => None,
         ModelOperationState::Downloading {
             target_model,
@@ -498,7 +494,11 @@ pub(super) fn card_download_progress<'a>(
         row![
             text::caption(bytes).width(Length::Fill),
             widget::button::destructive("Cancel")
-                .on_press(Message::Download(DownloadMessage::CancelDownload)),
+                // The stage the daemon reported this download under, so the
+                // cancel reaches the stage whose card the button is on.
+                .on_press(Message::Download(DownloadMessage::CancelDownload(
+                    progress.stage,
+                ))),
         ]
         .align_y(Alignment::Center),
     ]

--- a/super-stt-app/src/ui/views/models/post_processing.rs
+++ b/super-stt-app/src/ui/views/models/post_processing.rs
@@ -288,8 +288,13 @@ fn control_row<'a>(app: &'a AppModel, backend: &'a BackendInfo) -> Element<'a, M
         .push(
             button::suggested("Load model")
                 .leading_icon(icons::phosphor_handle(icons::PLAY))
+                // Disabled while stage 2 already has an operation in flight,
+                // the way the transcription card's is. Stage 1's work does not
+                // enter into it: the two stages load independently.
                 .on_press_maybe(
-                    selected.map(|_| Message::PostProcessor(PostProcessorMessage::Enable)),
+                    selected
+                        .filter(|_| app.is_model_ready(PP_STAGE))
+                        .map(|_| Message::PostProcessor(PostProcessorMessage::Enable)),
                 ),
         )
         .into()


### PR DESCRIPTION
## The bug

Loading a transcription model was refused while a post-processor was
downloading.

The daemon has allowed this since the stages started provisioning
independently. Its only guard on either stage's load is the recording one, the
download manager has been keyed by stage since #403, and the two model slots
take different locks. The block was entirely in the settings app.

## Cause

The app kept one model operation and a number saying which stage it belonged
to, so one stage's work spoke for both. The transcription card's Load button
reads "is an operation running", with no stage in the question, and the click
handler asked the same thing again, so a post-processor download closed that
path twice over.

The reverse did not hold. Stage 2's Load button had no readiness gate at all
and stayed live during a stage-1 download.

## The fix

Each stage gets its own slot, in a small container that also holds that
stage's stall clock. `is_model_ready` takes the stage it is asking about, each
card renders and settles only its own operation, and stage 2's Load button
gains the gate it never had, plus the click-time loading mark that makes it
bite.

An unknown stage number is ignored rather than rejected, so a daemon that
grows a third stage leaves an older app rendering the two it understands.

## Three defects in the same state, fixed with it

- **A stage-2 failure cleared the loaded transcription model.** Only stage 1's
  identity is mirrored in the app, so that clear is now stage 1's alone.
- **The progress poll always read `/pipeline/1`.** Firing during a stage-2
  download, it found nothing and collapsed the post-processor's progress card.
  Each pending stage is now polled for itself, and every download outcome
  carries the stage it settles.
- **One stall clock timed both stages**, so a busy stage kept a stalled one
  alive. Each stage is timed on its own.

## Tests

Seven tests on the new container, which is pure and needs no app instance:
stages not blocking each other (the reported bug), per-stage polling and
stalling, an unknown stage being inert, and the reconnect and opening states.
This also starts closing the app-test gap noted in #403, where none of this
state was reachable from a test.

`just check`, `just check-features`, `just fmt-check` and `just config-compat`
pass, and the full workspace suite is green at 1143 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwetg5qfGimsUqJ3jCPB1C