### PR TITLE
Stream realtime transcripts as they arrive

### DIFF
--- a/docs/protocol/backend/wasm.md
+++ b/docs/protocol/backend/wasm.md
@@ -172,13 +172,16 @@ Language bindings:
 | Python | `componentize-py -d wit/realtime.wit -w realtime-backend` |
 | Go (TinyGo) | `wit-bindgen-go generate` |
 
-### Known limitation: `subscribe` not implemented
+### Readiness: `subscribe`
 
 The `subscribe` method on both `ws-stream` and `consumer-stream` returns a
-`wasi:io/poll` pollable, but the host-side implementation is not yet
-complete. A guest must poll `recv` sequentially rather than multiplexing
-via `wasi:io/poll`. Do not rely on `subscribe` to detect readability without
-also calling `recv`.
+`wasi:io/poll` pollable. Passing both to `wasi:io/poll`'s `poll` is how a
+guest waits on its consumer and its upstream at once — full duplex, so a
+transcript reaches the consumer while audio is still going up.
+
+Readiness is backed by a one-frame lookahead and is **non-destructive**: the
+frame that made a pollable ready is still returned by the next `recv` on that
+resource. A guest must still call `recv` to take it.
 
 ## Implementation checklist
 
@@ -199,4 +202,5 @@ also calling `recv`.
 - For a realtime backend: declare `[capabilities] websocket = true` and
   `realtime = true` on each realtime model; implement the `realtime-backend`
   world (import `super-stt:realtime/ws`, export `super-stt:realtime/ws-server`);
-  poll `recv` sequentially rather than relying on `subscribe`.
+  and multiplex the consumer and the upstream with `subscribe` +
+  `wasi:io/poll` rather than reading them in sequence.

--- a/super-stt-app/src/core/app/handlers/daemon/mod.rs
+++ b/super-stt-app/src/core/app/handlers/daemon/mod.rs
@@ -102,6 +102,7 @@ impl AppModel {
             self.device_state = DeviceState::Ready;
             self.model_operation_state = ModelOperationState::Ready;
             self.transcription_text.clear();
+            self.preview_text.clear();
         }
 
         // The /events subscription is self-healing

--- a/super-stt-app/src/core/app/handlers/recording.rs
+++ b/super-stt-app/src/core/app/handlers/recording.rs
@@ -62,6 +62,7 @@ impl AppModel {
 
                 self.recording_status = RecordingStatus::Recording;
                 self.transcription_text.clear();
+                self.preview_text.clear();
 
                 let stream = record_command_stream();
                 cosmic::task::stream(stream.map(|event| match event {
@@ -85,7 +86,9 @@ impl AppModel {
             }),
 
             RecordingMessage::PreviewTextReceived(text) => {
-                self.transcription_text = text;
+                // Previews land on their own line; the final result below is
+                // left alone until it actually arrives.
+                self.preview_text = text;
                 Task::none()
             }
 
@@ -95,6 +98,8 @@ impl AppModel {
                     text.chars().take(50).collect::<String>()
                 );
                 self.transcription_text = text;
+                // The live line has been superseded by the final transcript.
+                self.preview_text.clear();
                 self.recording_status = RecordingStatus::Idle;
                 self.audio_level = 0.0;
                 Task::none()

--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -101,6 +101,7 @@ impl AppModel {
             ),
             recording_status: RecordingStatus::Idle,
             transcription_text: String::new(),
+            preview_text: String::new(),
             audio_level: 0.0,
             is_speech_detected: false,
             audio_themes: Vec::new(),

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -74,6 +74,11 @@ pub struct AppModel {
     pub recording_status: RecordingStatus,
     /// Latest transcription text
     pub transcription_text: String,
+    /// Latest incremental preview, shown on its own line above the final text.
+    /// Previews and finals used to share `transcription_text`, so a preview was
+    /// indistinguishable from a result; keeping them apart is what makes a
+    /// realtime model's incremental output visible as such.
+    pub preview_text: String,
     /// Current audio level (0.0 to 1.0)
     pub audio_level: f32,
     /// Whether speech is currently detected

--- a/super-stt-app/src/core/app/view.rs
+++ b/super-stt-app/src/core/app/view.rs
@@ -184,6 +184,7 @@ impl AppModel {
                 self.notification_method,
                 &self.recording_status,
                 &self.transcription_text,
+                &self.preview_text,
                 self.audio_level,
                 self.is_speech_detected,
                 self.action_error_for(crate::state::ErrorScope::Recording),

--- a/super-stt-app/src/ui/views/recording.rs
+++ b/super-stt-app/src/ui/views/recording.rs
@@ -83,10 +83,28 @@ fn notifications_section(notification_method: NotificationMethod) -> Element<'st
         .into()
 }
 
-/// Test recording section: record button, audio level, transcription output
+/// How much of the live preview to keep on screen. Sized to fill the row
+/// without wrapping at the default window width.
+const LIVE_LINE_CHARS: usize = 90;
+
+/// The last `max_chars` characters of `text`, prefixed with an ellipsis when
+/// something was dropped. Counts chars, not bytes — a multibyte transcript must
+/// not be sliced mid-character.
+fn live_tail(text: &str, max_chars: usize) -> String {
+    let total = text.chars().count();
+    if total <= max_chars {
+        return text.to_string();
+    }
+    let tail: String = text.chars().skip(total - max_chars).collect();
+    format!("\u{2026}{tail}")
+}
+
+/// Test recording section: record button, audio level, live preview line,
+/// transcription output
 fn test_section<'a>(
     recording_status: &'a RecordingStatus,
     transcription_text: &'a str,
+    preview_text: &'a str,
     audio_level: f32,
     is_speech_detected: bool,
 ) -> Element<'a, Message> {
@@ -116,6 +134,24 @@ fn test_section<'a>(
     .align_y(Alignment::Center)
     .spacing(10);
 
+    // One line that keeps changing: the newest incremental text, held to a
+    // single row so the section doesn't reflow on every update. Previews grow
+    // word by word, so the tail is the part worth showing.
+    let live_widget = {
+        let content = if preview_text.is_empty() {
+            "\u{2014}".to_string()
+        } else {
+            live_tail(preview_text, LIVE_LINE_CHARS)
+        };
+        widget::container(
+            text::body(content)
+                .wrapping(cosmic::iced::widget::text::Wrapping::None)
+                .width(Length::Fill),
+        )
+        .width(Length::Fill)
+        .clip(true)
+    };
+
     let transcription_widget = {
         let content = if transcription_text.is_empty() {
             "Transcriptions will appear here after test recordings...".to_string()
@@ -136,6 +172,7 @@ fn test_section<'a>(
         .title("Test")
         .add(settings::item("Status", text::body(recording_text)))
         .add(settings::flex_item("Audio Level", audio_widget))
+        .add(settings::flex_item("Live", live_widget))
         .add(settings::flex_item("", transcription_widget))
         .into()
 }
@@ -149,6 +186,7 @@ pub fn page<'a>(
     notification_method: NotificationMethod,
     recording_status: &'a RecordingStatus,
     transcription_text: &'a str,
+    preview_text: &'a str,
     audio_level: f32,
     is_speech_detected: bool,
     action_error: Option<&'a str>,
@@ -165,6 +203,7 @@ pub fn page<'a>(
     blocks.push(test_section(
         recording_status,
         transcription_text,
+        preview_text,
         audio_level,
         is_speech_detected,
     ));

--- a/super-stt-daemon/src/daemon/http/server.rs
+++ b/super-stt-daemon/src/daemon/http/server.rs
@@ -218,8 +218,17 @@ pub async fn start_http_server(
                 tokio::spawn(async move {
                     let io = hyper_util::rt::TokioIo::new(stream);
                     let svc = hyper_util::service::TowerToHyperService::new(app_for_conn);
+                    // `.with_upgrades()` is what makes an HTTP/1.1 protocol
+                    // upgrade actually happen. Without it hyper writes the
+                    // `101 Switching Protocols` response and then drops the
+                    // connection instead of handing the IO to
+                    // `hyper::upgrade::on`, so `GET /v1/transcribe/realtime`
+                    // completed its handshake and died before the first
+                    // WebSocket frame — the guest's opening `recv` saw a closed
+                    // consumer stream and returned without a word.
                     if let Err(e) = hyper::server::conn::http1::Builder::new()
                         .serve_connection(io, svc)
+                        .with_upgrades()
                         .await
                     {
                         log::debug!("http connection finished: {e}");

--- a/super-stt-daemon/src/daemon/recording/mod.rs
+++ b/super-stt-daemon/src/daemon/recording/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod preview;
+#[cfg(feature = "wasm-backends")]
+mod realtime;
 mod transcribe;
 
 use crate::daemon::types::SuperSTTDaemon;
@@ -164,9 +166,22 @@ impl SuperSTTDaemon {
         // Capture is starting — announce it now that the recorder exists.
         self.emit_recording_started(write_mode).await;
 
-        // Phase 2: stream preview transcriptions while capturing.
-        self.run_preview_loop(&session, typer, write_mode, request_language)
+        // Phase 2: stream incremental transcripts while capturing.
+        //
+        // A realtime model streams through one live session for the whole take,
+        // which also produces the final transcript — so Phase 4 is skipped when
+        // it succeeds. Every other model has no incremental output, so previews
+        // are simulated by re-transcribing a sliding window.
+        #[cfg(feature = "wasm-backends")]
+        let streamed = self
+            .run_realtime_stream_loop(&session, typer, write_mode, request_language)
             .await;
+        #[cfg(not(feature = "wasm-backends"))]
+        let streamed: Option<String> = None;
+        if streamed.is_none() {
+            self.run_preview_loop(&session, typer, write_mode, request_language)
+                .await;
+        }
 
         // Cloned out before `collect_and_clear_preview` consumes the session.
         let speech_state = Arc::clone(&session.speech_state);
@@ -217,8 +232,19 @@ impl SuperSTTDaemon {
             return Ok(Ok(String::new()));
         }
 
-        // Phase 4: final transcription.
+        // Phase 4: final transcription. A realtime session already produced it
+        // while capturing; the event pair is still emitted so the events
+        // contract sees a `transcribing_started` for every
+        // `transcribing_stopped` `finalize_recording_session` sends.
         self.emit_transcribing_started();
+        if let Some(text) = streamed {
+            if write_mode {
+                info!("Writing transcription via {}", typer.write_method_name());
+                typer.process_final_text(&text).await;
+            }
+            self.finalize_recording_session(&text, true, None).await;
+            return Ok(Ok(text));
+        }
         let transcription_result = match self
             .transcribe_final(&full_audio_data, request_language)
             .await

--- a/super-stt-daemon/src/daemon/recording/preview.rs
+++ b/super-stt-daemon/src/daemon/recording/preview.rs
@@ -280,57 +280,77 @@ impl SuperSTTDaemon {
         if let Ok(text) = self
             .transcribe_audio_chunk(&resampled_audio, request_language)
             .await
-            && !text.trim().is_empty()
         {
-            let processed = crate::output::preview::preprocess_text(&text, true);
-
-            info!(
-                "Preview: '{}'",
-                processed.chars().take(30).collect::<String>()
-            );
-
-            // Live preview to widgets holding `global_transcriptions`.
-            self.events.publish_partial_stt(processed.clone(), 1.0);
-
-            // Stream to the waiting client (the id is only used to gate slot
-            // claim/clear in the HTTP handler).
-            if let Some((_, ref tx)) = *self.preview_text.read().await {
-                let _ = tx.send(processed);
-            }
-
-            // Type on screen if in write mode. The typing is now async, and the
-            // `actually_typed` guard is a `!Send` `std::Mutex` guard that cannot
-            // be held across an `.await`. Take the mirror string out in a scope
-            // that drops the guard before typing, then write it back — safe
-            // because `update_preview` and `clear_preview` both run under
-            // `&mut Typer` and never overlap (audit Tier 3 #35). Skip on a
-            // poisoned lock, as before.
-            // Type on screen only when write-mode AND preview-typing are both
-            // active. The loop may be running purely to stream preview frames to
-            // a client (`stream_realtime`) with preview-typing off, in which case
-            // it must not type.
-            let type_on_screen = write_mode
-                && self
-                    .preview_typing_enabled
-                    .load(std::sync::atomic::Ordering::Relaxed);
-            let taken = if type_on_screen {
-                session
-                    .actually_typed
-                    .lock()
-                    .ok()
-                    .map(|mut g| std::mem::take(&mut *g))
-            } else {
-                None
-            };
-            if let Some(mut actually_typed) = taken {
-                typer.update_preview(&text, &mut actually_typed).await;
-                if let Ok(mut g) = session.actually_typed.lock() {
-                    *g = actually_typed;
-                }
-            }
+            self.emit_preview(&text, session, typer, write_mode).await;
         }
 
         false // Normal completion — do not skip the timeout check
+    }
+
+    /// Publish one preview transcript everywhere a preview goes: `/events`
+    /// subscribers holding `global_transcriptions`, the waiting `/transcribe`
+    /// SSE client, and — when write-mode and preview-typing are both on — the
+    /// focused window.
+    ///
+    /// Shared by both producers of incremental text: the sliding-window loop
+    /// that simulates streaming for batch models, and the live session a
+    /// realtime model streams through. Empty text is not a preview.
+    pub(super) async fn emit_preview(
+        &self,
+        text: &str,
+        session: &RecordingSession,
+        typer: &mut Typer,
+        write_mode: bool,
+    ) {
+        if text.trim().is_empty() {
+            return;
+        }
+        let processed = crate::output::preview::preprocess_text(text, true);
+
+        info!(
+            "Preview: '{}'",
+            processed.chars().take(30).collect::<String>()
+        );
+
+        // Live preview to widgets holding `global_transcriptions`.
+        self.events.publish_partial_stt(processed.clone(), 1.0);
+
+        // Stream to the waiting client (the id is only used to gate slot
+        // claim/clear in the HTTP handler).
+        if let Some((_, ref tx)) = *self.preview_text.read().await {
+            let _ = tx.send(processed);
+        }
+
+        // Type on screen if in write mode. The typing is now async, and the
+        // `actually_typed` guard is a `!Send` `std::Mutex` guard that cannot
+        // be held across an `.await`. Take the mirror string out in a scope
+        // that drops the guard before typing, then write it back — safe
+        // because `update_preview` and `clear_preview` both run under
+        // `&mut Typer` and never overlap (audit Tier 3 #35). Skip on a
+        // poisoned lock, as before.
+        // Type on screen only when write-mode AND preview-typing are both
+        // active. The loop may be running purely to stream preview frames to
+        // a client (`stream_realtime`) with preview-typing off, in which case
+        // it must not type.
+        let type_on_screen = write_mode
+            && self
+                .preview_typing_enabled
+                .load(std::sync::atomic::Ordering::Relaxed);
+        let taken = if type_on_screen {
+            session
+                .actually_typed
+                .lock()
+                .ok()
+                .map(|mut g| std::mem::take(&mut *g))
+        } else {
+            None
+        };
+        if let Some(mut actually_typed) = taken {
+            typer.update_preview(text, &mut actually_typed).await;
+            if let Ok(mut g) = session.actually_typed.lock() {
+                *g = actually_typed;
+            }
+        }
     }
 
     /// Erase preview text typed during Phase 2. Split out of

--- a/super-stt-daemon/src/daemon/recording/realtime.rs
+++ b/super-stt-daemon/src/daemon/recording/realtime.rs
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Phase 2 for a realtime model: one live session for the whole take.
+//!
+//! A batch model has no incremental output, so [`run_preview_loop`] simulates
+//! streaming by re-transcribing a sliding window every `processing_interval`. A
+//! realtime model *does* emit incremental transcripts, so simulating them is
+//! both wasteful and worse: each window re-opened a fresh upstream session
+//! (`transcribe_via_realtime` buffers the whole recording, then opens a socket)
+//! and every `preview` frame the backend produced was thrown away.
+//!
+//! This module holds one session open for the take instead, feeding captured
+//! audio in as it arrives and forwarding the backend's own `preview` frames to
+//! [`SuperSTTDaemon::emit_preview`] — the same place the sliding-window loop
+//! publishes, so `/events`, the `/transcribe` SSE stream, and preview typing all
+//! work unchanged. The session's `done` frame is the final transcript, so the
+//! separate Phase 4 decode is skipped entirely.
+//!
+//! **What this does not fix.** The daemon's `ws-stream::subscribe` still traps,
+//! so a guest cannot wait on the consumer and its upstream at once and runs
+//! half-duplex: it forwards all audio first, then drains transcripts. Previews
+//! therefore still arrive in a burst after the take ends. This makes the path
+//! honest and cheap — one session per recording carrying the backend's real
+//! output — not yet responsive.
+#![cfg(feature = "wasm-backends")]
+
+use std::time::Duration;
+
+use log::{debug, info, warn};
+use serde_json::Value;
+
+use super::RecordingSession;
+use crate::daemon::types::SuperSTTDaemon;
+use crate::output::typer::Typer;
+use crate::stt_models::wasm::ws_host::{
+    CONSUMER_INCOMING_CAPACITY, ConsumerStreamTransport, WsFrame,
+};
+
+/// How often to hand newly captured audio to the session. Matches the preview
+/// loop's completion poll, so the end of capture is still noticed within ~100ms.
+const STREAM_POLL: Duration = Duration::from_millis(100);
+
+/// Sample rate declared in the `start` frame. The consumer contract is PCM16
+/// mono at the declared rate; 16 kHz is what the rest of the daemon resamples
+/// to, and a backend needing something else converts on its own side.
+const TARGET_RATE: u32 = 16000;
+
+/// Same runaway guard the sliding-window loop applies.
+const MAX_TAKE: Duration = Duration::from_mins(1);
+
+impl SuperSTTDaemon {
+    /// Stream the take through the active model's realtime session.
+    ///
+    /// Returns the final transcript, or `None` when this take is not one a
+    /// realtime session can serve — the active model is not realtime, or the
+    /// session failed. `None` means the caller falls back to its normal Phase 4
+    /// decode, so a failure here costs efficiency, never the transcription.
+    pub(super) async fn run_realtime_stream_loop(
+        &self,
+        session: &RecordingSession,
+        typer: &mut Typer,
+        write_mode: bool,
+        request_language: Option<&str>,
+    ) -> Option<String> {
+        // Held for the session's lifetime, exactly as the consumer WebSocket
+        // path holds it: the model must not be swapped mid-stream.
+        let guard = self.model.read().await;
+        let loaded = guard.as_ref()?;
+        if !loaded.definition.realtime {
+            return None;
+        }
+
+        // incoming: us -> guest (bounded, so capture applies backpressure
+        // instead of growing memory); outgoing: guest -> us (unbounded — the
+        // guest produces bounded output and must never stall).
+        let (incoming_tx, incoming_rx) =
+            tokio::sync::mpsc::channel::<WsFrame>(CONSUMER_INCOMING_CAPACITY);
+        let (outgoing_tx, mut outgoing_rx) = tokio::sync::mpsc::unbounded_channel::<WsFrame>();
+        let transport = ConsumerStreamTransport {
+            incoming: incoming_rx,
+            outgoing: outgoing_tx,
+        };
+
+        // The guest's session and our pump run concurrently on this task: the
+        // pump feeds audio and drains frames, the session drives the backend.
+        let session_fut = loaded.instance.realtime_session(transport);
+        let pump = self.pump_take(
+            session,
+            typer,
+            write_mode,
+            request_language,
+            &incoming_tx,
+            &mut outgoing_rx,
+        );
+        let (session_result, transcript) = tokio::join!(session_fut, pump);
+
+        if let Err(e) = session_result {
+            warn!("realtime streaming session ended with error: {e:#}");
+            return None;
+        }
+        transcript
+    }
+
+    /// Feed captured audio into the session and forward what comes back.
+    /// Returns the transcript carried by the session's `done` frame.
+    async fn pump_take(
+        &self,
+        session: &RecordingSession,
+        typer: &mut Typer,
+        write_mode: bool,
+        request_language: Option<&str>,
+        incoming_tx: &tokio::sync::mpsc::Sender<WsFrame>,
+        outgoing_rx: &mut tokio::sync::mpsc::UnboundedReceiver<WsFrame>,
+    ) -> Option<String> {
+        let mut start = serde_json::json!({ "type": "start", "sample_rate": TARGET_RATE });
+        // `auto` is the reserved "detect it" value, which the contract spells as
+        // an absent field.
+        if let Some(language) = request_language.filter(|l| *l != "auto") {
+            start["language"] = Value::String(language.to_string());
+        }
+        if incoming_tx
+            .send(WsFrame::Text(start.to_string()))
+            .await
+            .is_err()
+        {
+            warn!("realtime session ended before the start frame was accepted");
+            return None;
+        }
+
+        let mut transcript = None;
+        let mut sent_samples = 0usize;
+        loop {
+            // Anything the guest has already emitted, without blocking the feed.
+            while let Ok(frame) = outgoing_rx.try_recv() {
+                self.handle_stream_frame(&frame, session, typer, write_mode, &mut transcript)
+                    .await;
+            }
+
+            if session.recorder_handle.is_finished() {
+                break;
+            }
+            tokio::time::sleep(STREAM_POLL).await;
+
+            // Same runaway guard as the sliding-window loop: signal the
+            // recorder's stop channel so capture ends and the audio so far is
+            // returned, rather than streaming forever.
+            if session.start_time.elapsed() > MAX_TAKE {
+                warn!("Recording timeout reached, signalling recorder to stop");
+                if let Some(tx) = self.manual_stop_tx.read().await.as_ref() {
+                    let _ = tx.send(());
+                }
+                break;
+            }
+
+            if !self
+                .feed_new_audio(session, &mut sent_samples, incoming_tx)
+                .await
+            {
+                break; // the session is gone; stop feeding it
+            }
+        }
+
+        // Whatever landed between the last poll and the recorder stopping.
+        self.feed_new_audio(session, &mut sent_samples, incoming_tx)
+            .await;
+        let _ = incoming_tx
+            .send(WsFrame::Text(r#"{"type":"stop"}"#.to_string()))
+            .await;
+
+        // Drain to completion: the guest drops its sender when the session ends,
+        // which is what closes this loop.
+        while let Some(frame) = outgoing_rx.recv().await {
+            self.handle_stream_frame(&frame, session, typer, write_mode, &mut transcript)
+                .await;
+        }
+        transcript
+    }
+
+    /// Hand the session every sample captured since the last call. Returns
+    /// `false` once the session is no longer accepting audio.
+    async fn feed_new_audio(
+        &self,
+        session: &RecordingSession,
+        sent_samples: &mut usize,
+        incoming_tx: &tokio::sync::mpsc::Sender<WsFrame>,
+    ) -> bool {
+        // The take's buffer is cleared at the start and drained at the end, and
+        // nothing evicts from the front, so a running index into it is stable.
+        let new_samples: Vec<f32> = {
+            let buffer = session.preview_buffer.lock();
+            let total = buffer.len();
+            if total <= *sent_samples {
+                return true;
+            }
+            let taken = buffer.range(*sent_samples..).copied().collect();
+            *sent_samples = total;
+            taken
+        };
+
+        let device_rate = session.device_sample_rate;
+        let samples = if device_rate == TARGET_RATE {
+            new_samples
+        } else {
+            // Resampling is CPU work; a poll's worth of audio is ~100ms rather
+            // than the sliding window's 5s, but keep it off the async worker for
+            // the same reason (audit 2 Tier 3 #2).
+            match tokio::task::spawn_blocking(move || {
+                super_stt_shared::utils::audio::resample(
+                    &new_samples,
+                    device_rate,
+                    TARGET_RATE,
+                    super_stt_shared::audio_utils::ResampleQuality::Fast,
+                )
+            })
+            .await
+            {
+                Ok(Ok(resampled)) => resampled,
+                Ok(Err(e)) => {
+                    warn!("Failed to resample streaming audio: {e}");
+                    return true;
+                }
+                Err(e) => {
+                    warn!("Streaming resample task panicked: {e}");
+                    return true;
+                }
+            }
+        };
+        if samples.is_empty() {
+            return true;
+        }
+
+        debug!(
+            "Streaming {} samples to the realtime session",
+            samples.len()
+        );
+        incoming_tx
+            .send(WsFrame::Binary(to_pcm16(&samples)))
+            .await
+            .is_ok()
+    }
+
+    /// Route one frame from the guest: previews go where every preview goes,
+    /// `done` is the transcript, `error` is logged and ends with no transcript
+    /// so the caller falls back.
+    async fn handle_stream_frame(
+        &self,
+        frame: &WsFrame,
+        session: &RecordingSession,
+        typer: &mut Typer,
+        write_mode: bool,
+        transcript: &mut Option<String>,
+    ) {
+        match classify_frame(frame) {
+            Some(StreamEvent::Preview(text)) => {
+                self.emit_preview(&text, session, typer, write_mode).await;
+            }
+            Some(StreamEvent::Done(text)) => {
+                info!(
+                    "Realtime session finished: '{}'",
+                    text.chars().take(30).collect::<String>()
+                );
+                *transcript = Some(text);
+            }
+            Some(StreamEvent::Error(message)) => {
+                warn!("Realtime session reported an error: {message}");
+            }
+            None => debug!("Ignoring unrecognized frame from the realtime session"),
+        }
+    }
+}
+
+/// What one consumer-protocol frame means. Split from the effects so the
+/// parsing — the part with edge cases — is unit-testable without a daemon, a
+/// recorder, or a microphone.
+#[derive(Debug, PartialEq, Eq)]
+enum StreamEvent {
+    Preview(String),
+    Done(String),
+    Error(String),
+}
+
+/// Classify a frame from the guest, or `None` for anything the protocol does
+/// not define in this direction (binary, non-JSON, unknown or missing `type`).
+fn classify_frame(frame: &WsFrame) -> Option<StreamEvent> {
+    // The consumer protocol is JSON text guest -> daemon; binary only goes the
+    // other way.
+    let WsFrame::Text(text) = frame else {
+        return None;
+    };
+    let event: Value = serde_json::from_str(text).ok()?;
+    let field = |name: &str| event.get(name).and_then(Value::as_str).map(str::to_string);
+    match event.get("type").and_then(Value::as_str)? {
+        // A preview with no text says nothing; there is no preview to publish.
+        "preview" => field("text").map(StreamEvent::Preview),
+        // A `done` without a transcription is still the end of the take: an
+        // empty transcript, not a missing one.
+        "done" => Some(StreamEvent::Done(
+            field("transcription").unwrap_or_default(),
+        )),
+        "error" => Some(StreamEvent::Error(
+            field("message").unwrap_or_else(|| "unknown error".to_string()),
+        )),
+        _ => None,
+    }
+}
+
+/// f32 samples as PCM16 little-endian mono — the consumer contract's audio
+/// frame.
+#[allow(clippy::cast_possible_truncation)] // intentional f32 -> i16 PCM clamp
+fn to_pcm16(samples: &[f32]) -> Vec<u8> {
+    let mut pcm = Vec::with_capacity(samples.len() * 2);
+    for &sample in samples {
+        let value = (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+        pcm.extend_from_slice(&value.to_le_bytes());
+    }
+    pcm
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StreamEvent, WsFrame, classify_frame, to_pcm16};
+
+    fn text(frame: &str) -> WsFrame {
+        WsFrame::Text(frame.to_string())
+    }
+
+    /// The three frames the consumer protocol defines guest -> daemon.
+    #[test]
+    fn classify_frame_reads_the_protocol_frames() {
+        assert_eq!(
+            classify_frame(&text(r#"{"type":"preview","text":"hello wor"}"#)),
+            Some(StreamEvent::Preview("hello wor".to_string()))
+        );
+        assert_eq!(
+            classify_frame(&text(r#"{"type":"done","transcription":"hello world"}"#)),
+            Some(StreamEvent::Done("hello world".to_string()))
+        );
+        assert_eq!(
+            classify_frame(&text(r#"{"type":"error","message":"upstream refused"}"#)),
+            Some(StreamEvent::Error("upstream refused".to_string()))
+        );
+    }
+
+    /// An escaped transcript must come back as the characters it denotes, not
+    /// the source text — the reason this parses JSON rather than scanning it.
+    #[test]
+    fn classify_frame_decodes_escapes() {
+        assert_eq!(
+            classify_frame(&text(
+                r#"{"type":"done","transcription":"line\none \"quoted\""}"#
+            )),
+            Some(StreamEvent::Done("line\none \"quoted\"".to_string()))
+        );
+        // Non-ASCII survives too; a transcript is arbitrary UTF-8.
+        assert_eq!(
+            classify_frame(&text(r#"{"type":"preview","text":"café — naïve"}"#)),
+            Some(StreamEvent::Preview("café — naïve".to_string()))
+        );
+    }
+
+    /// A `done` carrying nothing still ends the take with an empty transcript;
+    /// a `preview` carrying nothing has no preview to publish.
+    #[test]
+    fn classify_frame_handles_missing_payloads() {
+        assert_eq!(
+            classify_frame(&text(r#"{"type":"done"}"#)),
+            Some(StreamEvent::Done(String::new()))
+        );
+        assert_eq!(
+            classify_frame(&text(r#"{"type":"error"}"#)),
+            Some(StreamEvent::Error("unknown error".to_string()))
+        );
+        assert_eq!(classify_frame(&text(r#"{"type":"preview"}"#)), None);
+    }
+
+    /// Anything the protocol does not define is ignored rather than guessed at:
+    /// a frame the daemon misreads as `done` would truncate a recording.
+    #[test]
+    fn classify_frame_ignores_everything_else() {
+        assert_eq!(classify_frame(&text(r#"{"type":"session.created"}"#)), None);
+        assert_eq!(classify_frame(&text(r#"{"no_type":"x"}"#)), None);
+        assert_eq!(classify_frame(&text("not json at all")), None);
+        assert_eq!(classify_frame(&text("")), None);
+        // Binary only ever goes daemon -> guest.
+        assert_eq!(classify_frame(&WsFrame::Binary(vec![0, 1, 2])), None);
+    }
+
+    /// s16le mono, clamped — the audio frame the consumer contract specifies.
+    #[test]
+    fn to_pcm16_encodes_little_endian_and_clamps() {
+        let pcm = to_pcm16(&[0.0, 1.0, -1.0, 2.0, -2.0]);
+        assert_eq!(pcm.len(), 10, "2 bytes per sample");
+        let sample = |i: usize| i16::from_le_bytes([pcm[i * 2], pcm[i * 2 + 1]]);
+        assert_eq!(sample(0), 0);
+        assert_eq!(sample(1), i16::MAX);
+        assert_eq!(sample(2), -i16::MAX);
+        // Out of range clamps rather than wrapping — a wrap would invert the
+        // waveform and produce audible garbage upstream.
+        assert_eq!(sample(3), i16::MAX);
+        assert_eq!(sample(4), -i16::MAX);
+    }
+
+    #[test]
+    fn to_pcm16_of_nothing_is_nothing() {
+        assert!(to_pcm16(&[]).is_empty());
+    }
+}

--- a/super-stt-daemon/src/stt_models/wasm/ws_host.rs
+++ b/super-stt-daemon/src/stt_models/wasm/ws_host.rs
@@ -58,12 +58,76 @@ pub use self::super_stt::realtime::ws::{CloseFrame, WsError, WsFrame};
 /// [`WsError::Closed`].
 pub struct WsStreamResource {
     stream: Option<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+    /// One-frame lookahead. `wasi:io/poll` asks "is this readable?" without
+    /// taking anything, but a `WebSocketStream` only answers by consuming, so
+    /// [`Pollable::ready`] reads one frame and parks it here for the `recv`
+    /// that follows. Readiness therefore stays non-destructive from the guest's
+    /// side: every frame `ready` observes is still delivered by `recv`.
+    pending: Option<std::result::Result<WsFrame, WsError>>,
 }
 
 impl WsStreamResource {
     fn new(stream: WebSocketStream<MaybeTlsStream<TcpStream>>) -> Self {
         Self {
             stream: Some(stream),
+            pending: None,
+        }
+    }
+
+    /// The next frame the protocol exposes, skipping tungstenite's ping/pong.
+    ///
+    /// Cancel-safe, which `poll` requires: it races several `ready` futures and
+    /// drops the losers. Dropping this future at its only await point cannot
+    /// lose a frame — `StreamExt::next` leaves partially-read bytes in
+    /// tungstenite's own buffer, and a frame that *has* been decoded is stored
+    /// by the caller with no await in between.
+    async fn next_frame(&mut self) -> std::result::Result<WsFrame, WsError> {
+        let Some(stream) = self.stream.as_mut() else {
+            return Err(WsError::Closed);
+        };
+        loop {
+            match stream.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    return Ok(WsFrame::Text(text.as_str().to_string()));
+                }
+                Some(Ok(Message::Binary(data))) => return Ok(WsFrame::Binary(data.into())),
+                Some(Ok(Message::Close(frame))) => {
+                    // Emit the close once, then mark the stream closed so the
+                    // next recv returns `WsError::Closed`.
+                    self.stream = None;
+                    let close = frame.map_or(
+                        CloseFrame {
+                            code: 1005,
+                            reason: String::new(),
+                        },
+                        |f| CloseFrame {
+                            code: f.code.into(),
+                            reason: f.reason.as_str().to_string(),
+                        },
+                    );
+                    return Ok(WsFrame::Close(close));
+                }
+                // Ping/pong are handled by tungstenite's auto-pong; skip them
+                // and read the next data frame.
+                Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => {}
+                Some(Err(e)) => {
+                    self.stream = None;
+                    return Err(WsError::RecvFailed(format!("recv failed: {e}")));
+                }
+                None => {
+                    self.stream = None;
+                    return Err(WsError::Closed);
+                }
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl wasmtime_wasi::p2::Pollable for WsStreamResource {
+    async fn ready(&mut self) {
+        if self.pending.is_none() {
+            self.pending = Some(self.next_frame().await);
         }
     }
 }
@@ -92,13 +156,50 @@ pub struct ConsumerStreamTransport {
 /// with [`WsError::Closed`].
 pub struct ConsumerStreamResource {
     transport: Option<ConsumerStreamTransport>,
+    /// One-frame lookahead, for the same reason as
+    /// [`WsStreamResource::pending`]: readiness must not consume.
+    pending: Option<std::result::Result<WsFrame, WsError>>,
+}
+
+impl ConsumerStreamResource {
+    /// The next frame from the consumer, or [`WsError::Closed`] once the axum
+    /// side has hung up.
+    ///
+    /// Cancel-safe: `tokio::sync::mpsc::Receiver::recv` is documented not to
+    /// lose a message when its future is dropped, which is what lets `poll`
+    /// race this against the upstream's readiness.
+    async fn next_frame(&mut self) -> std::result::Result<WsFrame, WsError> {
+        let Some(transport) = self.transport.as_mut() else {
+            return Err(WsError::Closed);
+        };
+        if let Some(frame) = transport.incoming.recv().await {
+            Ok(frame)
+        } else {
+            // The consumer (axum) hung up: mark the session closed so the next
+            // recv also returns `WsError::Closed`.
+            self.transport = None;
+            Err(WsError::Closed)
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl wasmtime_wasi::p2::Pollable for ConsumerStreamResource {
+    async fn ready(&mut self) {
+        if self.pending.is_none() {
+            self.pending = Some(self.next_frame().await);
+        }
+    }
 }
 
 impl ConsumerStreamResource {
     /// Wrap a live transport for handoff to the guest.
     #[must_use]
     pub fn new(t: ConsumerStreamTransport) -> Self {
-        Self { transport: Some(t) }
+        Self {
+            transport: Some(t),
+            pending: None,
+        }
     }
 }
 
@@ -236,57 +337,23 @@ impl self::super_stt::realtime::ws::HostWsStream for Host {
         self_: Resource<WsStreamResource>,
     ) -> Result<Result<WsFrame, WsError>> {
         let res = self.table.get_mut(&self_)?;
-        let Some(stream) = res.stream.as_mut() else {
-            return Ok(Err(WsError::Closed));
-        };
-        loop {
-            match stream.next().await {
-                Some(Ok(Message::Text(text))) => {
-                    return Ok(Ok(WsFrame::Text(text.as_str().to_string())));
-                }
-                Some(Ok(Message::Binary(data))) => {
-                    return Ok(Ok(WsFrame::Binary(data.into())));
-                }
-                Some(Ok(Message::Close(frame))) => {
-                    // Emit the close once, then mark the stream closed so the
-                    // next recv returns `WsError::Closed`.
-                    res.stream = None;
-                    let close = frame.map_or(
-                        CloseFrame {
-                            code: 1005,
-                            reason: String::new(),
-                        },
-                        |f| CloseFrame {
-                            code: f.code.into(),
-                            reason: f.reason.as_str().to_string(),
-                        },
-                    );
-                    return Ok(Ok(WsFrame::Close(close)));
-                }
-                // Ping/pong are handled by tungstenite's auto-pong; skip them
-                // and read the next data frame.
-                Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => {}
-                Some(Err(e)) => {
-                    res.stream = None;
-                    return Ok(Err(WsError::RecvFailed(format!("recv failed: {e}"))));
-                }
-                None => {
-                    res.stream = None;
-                    return Ok(Err(WsError::Closed));
-                }
-            }
+        // A frame `subscribe`/`ready` already pulled off the socket is handed
+        // over before touching the stream again.
+        if let Some(frame) = res.pending.take() {
+            return Ok(frame);
         }
+        Ok(res.next_frame().await)
     }
 
     async fn subscribe(
         &mut self,
-        _self_: Resource<WsStreamResource>,
+        self_: Resource<WsStreamResource>,
     ) -> Result<Resource<wasmtime_wasi::p2::bindings::io::poll::Pollable>> {
-        // Wiring a real wasi:io/poll Pollable into the tungstenite stream is
-        // non-trivial (it needs a host-side waker the poll loop can await).
-        // The first realtime backend polls `recv` sequentially instead, so
-        // this stays unimplemented for now.
-        wasmtime::bail!("ws-stream::subscribe is not yet implemented")
+        // Readiness is backed by the one-frame lookahead: the pollable resolves
+        // when a frame has been pulled off the socket, and `recv` then hands
+        // that same frame over. Lets a guest wait on its consumer and its
+        // upstream at once instead of running half-duplex.
+        wasmtime_wasi::p2::subscribe(&mut self.table, self_)
     }
 
     async fn close(&mut self, self_: Resource<WsStreamResource>) -> Result<Result<(), WsError>> {
@@ -341,27 +408,20 @@ impl self::super_stt::realtime::ws::HostConsumerStream for Host {
         self_: Resource<ConsumerStreamResource>,
     ) -> Result<Result<WsFrame, WsError>> {
         let res = self.table.get_mut(&self_)?;
-        let Some(transport) = res.transport.as_mut() else {
-            return Ok(Err(WsError::Closed));
-        };
-        if let Some(frame) = transport.incoming.recv().await {
-            Ok(Ok(frame))
-        } else {
-            // The consumer (axum) hung up: mark the session closed so the next
-            // recv also returns `WsError::Closed`.
-            res.transport = None;
-            Ok(Err(WsError::Closed))
+        // A frame `subscribe`/`ready` already took off the channel is handed
+        // over before awaiting another.
+        if let Some(frame) = res.pending.take() {
+            return Ok(frame);
         }
+        Ok(res.next_frame().await)
     }
 
     async fn subscribe(
         &mut self,
-        _self_: Resource<ConsumerStreamResource>,
+        self_: Resource<ConsumerStreamResource>,
     ) -> Result<Resource<wasmtime_wasi::p2::bindings::io::poll::Pollable>> {
-        // Same documented limitation as `ws-stream::subscribe`: a real
-        // wasi:io/poll Pollable needs a host-side waker; the first realtime
-        // backend polls `recv` sequentially instead.
-        wasmtime::bail!("consumer-stream::subscribe is not yet implemented")
+        // Backed by the same one-frame lookahead as `ws-stream::subscribe`.
+        wasmtime_wasi::p2::subscribe(&mut self.table, self_)
     }
 
     async fn close(

--- a/super-stt-daemon/tests/fixtures/mock-wasm-realtime-backend/src/lib.rs
+++ b/super-stt-daemon/tests/fixtures/mock-wasm-realtime-backend/src/lib.rs
@@ -50,7 +50,14 @@ impl WsServerGuest for Component {
     /// `start`), emit a `preview` then a `done` frame, and close. Never opens an
     /// upstream WebSocket, so no egress occurs.
     fn handle(_headers: Vec<(String, Vec<u8>)>, consumer: ConsumerStream) -> Result<(), WsError> {
-        // Block for the consumer's start frame (the daemon's host recv awaits it).
+        // Wait for readiness through `wasi:io/poll` before reading, which is
+        // how a real full-duplex guest waits on its consumer and its upstream at
+        // once. Exercises the host's `subscribe` + `Pollable`: while those were
+        // stubbed this trapped, taking the session down with it.
+        let readable = consumer.subscribe();
+        let ready = wasi::io::poll::poll(&[&readable]);
+        assert_eq!(ready.as_slice(), &[0], "the consumer must be the ready one");
+        // Readiness must not consume: the frame `poll` saw is still here.
         match consumer.recv() {
             Ok(WsFrame::Text(_) | WsFrame::Binary(_)) => {}
             Ok(WsFrame::Close(_)) | Err(_) => return Ok(()),

--- a/super-stt-daemon/tests/http_smoke_realtime.rs
+++ b/super-stt-daemon/tests/http_smoke_realtime.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Realtime WebSocket transport, end to end over the daemon's real HTTP
+//! listener: `GET /v1/transcribe/realtime`.
+//!
+//! Every other realtime test drives `WasmBackend::realtime_session` directly
+//! (`wasm_mock_realtime.rs`), which skips the HTTP layer entirely. That left the
+//! protocol upgrade itself untested — and unimplemented: hyper writes the `101
+//! Switching Protocols` response but only performs the upgrade when the
+//! connection is built with `.with_upgrades()`. Without it the handshake
+//! "succeeded" and the socket was dropped before the first frame, so the guest's
+//! opening `recv` saw a closed consumer stream and returned without a word. The
+//! round-trip test below fails exactly that way if the call is ever lost again.
+//!
+//! Uses `SUPER_STT_AUTO_APPROVE=1` (no GUI) + `SUPER_STT_KEYRING_MOCK=1`
+//! (in-memory keyring), so it runs in the default `cargo test` flow.
+#![cfg(feature = "wasm-backends")]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use futures::{SinkExt, StreamExt};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::client::conn::http1::handshake;
+use hyper::{Method, Request, StatusCode};
+use super_stt_shared::daemon::http_client;
+use tokio::net::UnixStream;
+use tokio::time::sleep;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
+const FIXTURE_SOURCE: &str = "github.com/super-stt/mock-realtime";
+const REALTIME_MODEL: &str = "mock-realtime-1";
+/// Pinned in the fixture component (`MOCK_REALTIME_TRANSCRIPTION`).
+const MOCK_TRANSCRIPT: &str = "mock realtime transcription";
+
+/// The prebuilt mock realtime component, or `None` when it isn't built. CI runs
+/// `just build-mock-wasm-realtime-backend` first; a bare `cargo test` skips.
+fn mock_component() -> Option<PathBuf> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+        "tests/fixtures/mock-wasm-realtime-backend/target/wasm32-wasip2/release/mock_wasm_realtime_backend.wasm",
+    );
+    p.exists().then_some(p)
+}
+
+struct DaemonGuard {
+    child: Child,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        for p in &self.cleanup_paths {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+fn next_test_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+    UNIQ.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Seed a websocket-capable backend serving one `realtime` model, backed by the
+/// prebuilt mock component. `supported_devices = ["cpu"]` keeps it clear of the
+/// separate online-models gate; realtime is not a property of the device.
+fn seed_realtime_backend(data_home: &Path, component: &Path) {
+    let backend_dir = data_home
+        .join("super-stt")
+        .join("backends")
+        .join("mock-realtime");
+    std::fs::create_dir_all(&backend_dir).expect("create fixture backend dir");
+
+    let toml = format!(
+        r#"[backend]
+source = "{FIXTURE_SOURCE}"
+name = "Mock Realtime"
+version = "1.0.0"
+kind = "wasm"
+entrypoint = "mock.wasm"
+contract = "v1"
+description = "Realtime transport fixture."
+license = "GPL-3.0-only"
+
+[capabilities]
+websocket = true
+
+[[models]]
+name = "{REALTIME_MODEL}"
+primary_language = "en"
+supported_languages = ["en"]
+supported_devices = ["cpu"]
+realtime = true
+"#
+    );
+    std::fs::write(backend_dir.join("backend.toml"), toml).expect("write fixture backend.toml");
+    std::fs::copy(component, backend_dir.join("mock.wasm")).expect("stage mock component");
+}
+
+/// Boot a daemon against a temp socket + XDG dirs. `component` seeds the
+/// realtime fixture when given; without it the daemon has no realtime model.
+async fn start_daemon(scopes: &[&str], component: Option<&Path>) -> (DaemonGuard, PathBuf, String) {
+    let unique = format!("stt-realtime-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    let data_home = tmp.join(format!("{unique}-data"));
+    std::fs::create_dir_all(&config_home).expect("create test config dir");
+    std::fs::create_dir_all(&data_home).expect("create test data dir");
+    if let Some(component) = component {
+        seed_realtime_backend(&data_home, component);
+    }
+
+    let child = Command::new(DAEMON_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn super-stt-daemon");
+
+    // Hand the child to the guard before the readiness loop: the timeout panic
+    // below must still kill and reap the daemon, not leak it.
+    let guard = DaemonGuard {
+        child,
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+    };
+
+    let deadline = Instant::now() + Duration::from_mins(2);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists()
+            && http_client::auth_request(http_socket.clone(), "realtime-smoke-probe", &["status"])
+                .await
+                .is_ok()
+        {
+            let auth = http_client::auth_request(http_socket.clone(), "realtime-smoke", scopes)
+                .await
+                .expect("auth_request for test scopes");
+            return (guard, http_socket, auth.session_token);
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    panic!("daemon HTTP listener not ready within 120s");
+}
+
+/// Issue one HTTP request and return `(status, raw body)`.
+async fn send(
+    socket_path: &PathBuf,
+    method: Method,
+    path: &str,
+    token: &str,
+    body: Option<serde_json::Value>,
+) -> (StatusCode, Vec<u8>) {
+    let stream = UnixStream::connect(socket_path).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Full<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let payload = body
+        .map(|b| serde_json::to_vec(&b).expect("serialize body"))
+        .unwrap_or_default();
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(format!("http://stt.local{path}"))
+        .header("host", "stt.local")
+        .header("authorization", format!("Bearer {token}"));
+    if !payload.is_empty() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let request = builder
+        .body(Full::new(Bytes::from(payload)))
+        .expect("build request");
+    let response = sender.send_request(request).await.expect("send request");
+    let status = response.status();
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    (status, bytes.to_vec())
+}
+
+/// Select the realtime model into stage 1 and wait for it to be loaded.
+async fn select_realtime_model(socket_path: &PathBuf, token: &str) {
+    let (status, body) = send(
+        socket_path,
+        Method::POST,
+        "/v1/pipeline/1/model",
+        token,
+        Some(serde_json::json!({ "model": REALTIME_MODEL, "source": FIXTURE_SOURCE })),
+    )
+    .await;
+    assert!(
+        status.is_success(),
+        "selecting the realtime model failed: {status} {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        let (status, body) = send(socket_path, Method::GET, "/v1/status", token, None).await;
+        if status.is_success() {
+            let json: serde_json::Value = serde_json::from_slice(&body).expect("status json");
+            if json["model_loaded"] == true && json["current_model"] == REALTIME_MODEL {
+                return;
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    panic!("realtime model was not loaded within 30s");
+}
+
+/// Open the consumer realtime WebSocket over the daemon's Unix socket.
+async fn open_realtime_ws(
+    socket_path: &PathBuf,
+    token: &str,
+) -> tokio_tungstenite::WebSocketStream<UnixStream> {
+    let mut request = "ws://stt.local/v1/transcribe/realtime"
+        .into_client_request()
+        .expect("build ws request");
+    request.headers_mut().insert(
+        "authorization",
+        format!("Bearer {token}").parse().expect("header value"),
+    );
+    let stream = UnixStream::connect(socket_path).await.expect("connect");
+    let (ws, _response) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("websocket upgrade");
+    ws
+}
+
+/// The whole consumer contract over the real listener: upgrade, `start`, PCM,
+/// `stop`, and the `preview` + `done` frames coming back.
+///
+/// This is the regression guard for the protocol upgrade. Without
+/// `.with_upgrades()` on the hyper connection the handshake still returns `101`
+/// and this test fails at the first `next()` — the daemon drops the socket
+/// before a single frame moves.
+#[tokio::test]
+async fn realtime_websocket_session_round_trip() {
+    let Some(component) = mock_component() else {
+        eprintln!(
+            "skipping: mock realtime component not built (run `just build-mock-wasm-realtime-backend`)"
+        );
+        return;
+    };
+    let (_guard, sock, token) =
+        start_daemon(&["settings", "status", "transcribe"], Some(&component)).await;
+    select_realtime_model(&sock, &token).await;
+
+    let mut ws = open_realtime_ws(&sock, &token).await;
+    ws.send(Message::Text(
+        r#"{"type":"start","sample_rate":16000}"#.into(),
+    ))
+    .await
+    .expect("send start");
+    // 100 ms of silence, s16le mono — the mock ignores audio, but a real
+    // consumer always sends some and the relay must carry it.
+    ws.send(Message::Binary(vec![0u8; 3200].into()))
+        .await
+        .expect("send audio");
+    ws.send(Message::Text(r#"{"type":"stop"}"#.into()))
+        .await
+        .expect("send stop");
+
+    let mut preview = None;
+    let mut done = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while preview.is_none() || done.is_none() {
+        let next = tokio::time::timeout_at(deadline, ws.next()).await;
+        let Ok(frame) = next else {
+            panic!("timed out waiting for frames (preview={preview:?}, done={done:?})");
+        };
+        match frame {
+            Some(Ok(Message::Text(text))) => {
+                let event: serde_json::Value =
+                    serde_json::from_str(&text).expect("frame must be JSON");
+                match event["type"].as_str() {
+                    Some("preview") => preview = Some(event["text"].as_str().unwrap().to_string()),
+                    Some("done") => {
+                        done = Some(event["transcription"].as_str().unwrap().to_string());
+                    }
+                    Some("error") => panic!("backend reported an error: {text}"),
+                    _ => {}
+                }
+            }
+            Some(Ok(_)) => {}
+            // A close (or a dropped socket) before both frames is the failure
+            // the missing upgrade produced.
+            Some(Err(e)) => panic!("websocket errored early: {e} (preview={preview:?})"),
+            None => panic!("socket closed before done (preview={preview:?})"),
+        }
+    }
+
+    assert_eq!(preview.unwrap(), MOCK_TRANSCRIPT);
+    assert_eq!(done.unwrap(), MOCK_TRANSCRIPT);
+}
+
+/// The route sits behind the `transcribe` scope, and the check runs before any
+/// upgrade: a `status`-only token is refused outright. Hermetic — no component
+/// needed, so this half of the contract is covered even without the wasm build.
+#[tokio::test]
+async fn realtime_websocket_requires_the_transcribe_scope() {
+    let (_guard, sock, token) = start_daemon(&["status"], None).await;
+
+    let (status, _) = send(&sock, Method::GET, "/v1/transcribe/realtime", &token, None).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a token without `transcribe` must not reach the upgrade"
+    );
+}


### PR DESCRIPTION
Realtime transcription was broken at three layers, each hiding the next. Verified end to end against the real OpenAI API.

## 1. The realtime endpoint never worked

`GET /v1/transcribe/realtime` completed its handshake and immediately died. hyper performs an HTTP/1.1 protocol upgrade only when the connection is built with `.with_upgrades()` — which appeared nowhere in the daemon. It wrote `101 Switching Protocols` and then dropped the socket, so the guest's opening `recv` saw an already-closed consumer stream and returned silently. No error frame, no log line.

This affected **every** realtime backend, not just OpenAI. Nothing caught it because all realtime tests drove `realtime_session` directly and bypassed HTTP.

## 2. Realtime previews were simulated, not streamed

The preview loop re-transcribes a 5-second sliding window every `processing_interval`, because a batch model has no incremental output. A realtime model *does* — but `transcribe_via_realtime` buffered the entire take, opened a socket per window, and kept only the final `done`.

A ten-second recording opened **six** upstream sessions and threw away every `preview` frame they produced.

Phase 2 now holds one session open for the take, feeds captured audio in as it arrives, and forwards the backend's own previews through the same `emit_preview` the sliding-window loop uses — so `/events`, the `/transcribe` SSE stream, and preview typing all work unchanged. The transport was never the problem; it just had nothing true to carry.

## 3. `subscribe` trapped, forcing half duplex

Both WS resources now carry a one-frame lookahead. `wasi:io/poll` asks whether a stream is readable *without* taking anything, but a `WebSocketStream` only answers by consuming — so `ready` reads one frame and parks it for the `recv` that follows. Readiness stays non-destructive from the guest's side.

Measured against the real OpenAI API, same audio:

```
BEFORE                                  AFTER
[ 4475.1] -> stop                       [ 3805.6] <- preview 'And'
[ 4476.5] <- preview 'And'              [ 3887.1] <- preview 'And I'
[ 4476.6] <- preview 'And I'            [ 3897.3] <- preview 'And I will'
   … 12 previews in 0.2 ms …            [ 4024.1] <- preview '… assure'
[ 5080.6] <- DONE                       [ 4400.1] <- preview '… you that'
                                        [ 4471.0] -> stop
```

Six previews arrive **before** `stop`, spread across the take with natural gaps, instead of landing in a burst after it.

## App

Previews get their own line above the final transcript instead of overwriting it, so incremental output is visible as incremental.

## Tests

- **`http_smoke_realtime.rs`** — drives a real WebSocket over the daemon's own listener against a fixture realtime backend. Verified to fail with the original `BrokenPipe` when `.with_upgrades()` is removed, so it is a real regression guard rather than one that passes either way. A second, hermetic test covers the `transcribe` scope gate.
- **The mock realtime fixture now calls `subscribe` + `poll`** before reading, so the host readiness path is exercised in CI — that call trapped before this change.
- **Unit tests** for the streaming loop's frame parsing (escape decoding, missing payloads, unknown frames) and PCM16 clamping.

Coverage boundary worth naming: the pump loop itself — buffer indexing, backpressure, the session/pump join — needs a real microphone and is **not** covered. `http_smoke_realtime.rs` exercises the same guest/host plumbing over the WebSocket path, which is the closest available proxy.

## Companion PR

The matching backend change is jorge-menjivar/super-stt-openai#6, which needs this one to land first — against a daemon without `subscribe` it would trap. This PR is independent and safe on its own: a guest that reads its sockets in sequence still works, just without the interleaving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSTjnhp28CwVcEqnWxzN9C
