### PR TITLE
Generate the daemon protocol's OpenAPI document from its router

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
       - name: Check generated TOML schemas are current
         run: just schema-check
 
+      # The protocol spec is generated from the daemon's router, so a route
+      # added or changed without regenerating it is drift between what the
+      # daemon serves and what it publishes. Failing here is the whole point:
+      # the fix is `just openapi`, and the diff above says what moved.
+      - name: Check the OpenAPI document is current
+        run: just openapi-check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -150,6 +157,90 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: just fmt-check
+
+  protocol:
+    name: Protocol docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: taiki-e/install-action@v2.87.0
+        with:
+          tool: just
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev libasound2-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      # Build from the router rather than trusting the committed file, so what
+      # is published is what this commit's daemon actually serves. The `test`
+      # job's openapi-check is what keeps the committed copy honest.
+      - name: Generate the OpenAPI document
+        run: just openapi
+
+      - name: Assemble the site
+        run: |
+          set -euo pipefail
+          rm -rf protocol-site && mkdir protocol-site
+          cp docs/protocol/openapi.json protocol-site/openapi.json
+          # Both viewers ship, and both fetch ./openapi.json, so they work here
+          # unchanged. openapi.html is Swagger UI — the default, and what `just
+          # openapi-serve` opens — published as the index as well so the bare
+          # directory URL lands there. Scalar sits beside it at scalar.html and
+          # the two cross-link.
+          cp docs/protocol/openapi.html protocol-site/index.html
+          cp docs/protocol/openapi.html protocol-site/openapi.html
+          cp docs/protocol/scalar.html protocol-site/scalar.html
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: protocol-openapi
+          path: protocol-site
+
+      # --- main only: publish to GitHub Pages ---
+      # Same approach as the coverage publish below: this repo serves Pages from
+      # the `gh-pages` branch (the registry index.json lives there), so only the
+      # `protocol/` subtree is replaced and everything else on the branch is
+      # left alone. Served at
+      # https://jorge-menjivar.github.io/super-stt/protocol/.
+      - name: Publish protocol docs to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          rm -rf publish && mkdir publish && cd publish
+          git init -q -b gh-pages
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          for attempt in 1 2 3 4 5; do
+            if git fetch --depth=1 origin gh-pages 2>/dev/null; then
+              git reset --hard -q FETCH_HEAD
+            fi
+            touch .nojekyll
+            rm -rf protocol
+            cp -r ../protocol-site protocol
+            git add -A
+            if git diff --cached --quiet; then
+              echo "protocol docs unchanged; nothing to publish"
+              exit 0
+            fi
+            git -c user.name=actions -c user.email=actions@github.com \
+                commit -q -m "Update protocol docs ($GITHUB_SHA)"
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "gh-pages push rejected (attempt $attempt); rebasing and retrying"
+            sleep 3
+          done
+          echo "failed to publish protocol docs after 5 attempts" >&2
+          exit 1
 
   coverage:
     name: Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -266,7 +266,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1981,7 +1981,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2229,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3753,7 +3753,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3956,7 +3956,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6112,7 +6112,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6179,7 +6179,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6617,7 +6617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6861,6 +6861,8 @@ dependencies = [
  "toml 1.1.0+spec-1.1.0",
  "ulid",
  "urlencoding",
+ "utoipa",
+ "utoipa-axum",
  "uuid",
  "wasmtime",
  "wasmtime-wasi",
@@ -6949,6 +6951,7 @@ dependencies = [
  "spdx",
  "thiserror 2.0.18",
  "toml 1.1.0+spec-1.1.0",
+ "utoipa",
 ]
 
 [[package]]
@@ -6975,6 +6978,7 @@ dependencies = [
  "super-stt-registry-types",
  "thiserror 2.0.18",
  "tokio",
+ "utoipa",
  "uuid",
 ]
 
@@ -7095,7 +7099,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7558,7 +7562,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7740,6 +7744,43 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "uuid"
@@ -8802,7 +8843,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,16 @@
         tokio-util = "0.7"
         # Filesystem utilities
         toml = "1.0.6"
+        # OpenAPI: the daemon protocol spec is generated from the router and the
+        # wire types, not hand-maintained (see `just openapi`). `axum_extras`
+        # teaches the `#[utoipa::path]` macro to read axum's own extractors, so
+        # path/query parameters come from the handler signature instead of a
+        # second declaration that could disagree with it.
+        utoipa = { version = "5.5.0", features = ["axum_extras", "chrono"] }
+        # Binds utoipa to axum: `OpenApiRouter` collects each route's spec as the
+        # route itself is registered, so a route and its documentation are one
+        # declaration and cannot drift apart.
+        utoipa-axum = "0.2.0"
         uuid = { version = "1.23.0", features = ["v4"] }
         # Build dependencies
         vergen = { version = "8.3.1", features = ["git", "gitcl"] }

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This is a snapshot. The app always shows the current catalog, published live at 
 
 Super STT is built to be built on. The details live in developer-facing docs:
 
-- **Build a client** — get transcriptions, event streams, or recording control into your own app, in any language, over the documented HTTP protocol → **[docs/protocol/](./docs/protocol/)**
+- **Build a client** — get transcriptions, event streams, or recording control into your own app, in any language, over the documented HTTP protocol → **[docs/protocol/](./docs/protocol/)**, with every endpoint in the **[API reference](https://jorge-menjivar.github.io/super-stt/protocol/)**
 - **Add your own model** — package a speech model as a backend the daemon can install and run, then publish it to the catalog → **[docs/protocol/](./docs/protocol/)** and **[registry/README.md](./registry/README.md)**
 - **Contribute** — build from source, workspace layout, and the PR workflow → **[CONTRIBUTING.md](./CONTRIBUTING.md)**
 

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -53,12 +53,30 @@ What the protocol gives you:
 
 Reference:
 
+- **[Browse the API reference](https://jorge-menjivar.github.io/super-stt/protocol/)**
+  — every endpoint, parameter and response shape, rendered from
+  [openapi.json](./openapi.json). Point a client generator at that file to get
+  a typed client in your language.
+
+  Two renderings of the same document, each linking to the other:
+  [Swagger UI](https://jorge-menjivar.github.io/super-stt/protocol/) and
+  [Scalar](https://jorge-menjivar.github.io/super-stt/protocol/scalar.html).
+  Locally, `just openapi-serve` opens the first and `just openapi-serve
+  --scalar` the second. Neither offers "Try it out": the daemon listens on a
+  Unix socket, which a browser cannot dial.
 - [transport.md](./transport.md) — the wire shape: HTTP framing, SSE, error
   envelopes, connection lifecycle, and a minimal non-Rust client recipe.
 - [auth.md](./auth.md) — the consent handshake, tokens, and the full scope
   catalog.
 - [endpoints/](./endpoints/) — every endpoint, request/response by request.
 - [scopes/](./scopes/) — what each scope unlocks.
+
+The OpenAPI document is generated from the daemon's router, not maintained
+alongside it: every route is registered through the same declaration that
+carries its documentation, and CI fails when the committed file and the router
+disagree. Regenerate it with `just openapi`. The prose above is not replaced by
+it — that explains *when* to call an endpoint and how the pieces fit, where the
+spec states the shapes exactly, for tooling.
 
 ## Add your own model
 

--- a/docs/protocol/openapi.html
+++ b/docs/protocol/openapi.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: GPL-3.0-only -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Super STT daemon protocol — Swagger UI</title>
+    <!--
+      The default view of openapi.json, which is generated from the daemon's
+      router (`just openapi`) rather than maintained by hand. scalar.html is the
+      same document rendered with Scalar; `just openapi-serve --scalar` opens
+      that one.
+
+      Serve it, don't open it as a file:// URL — the page fetches openapi.json,
+      which the file: origin blocks. `just openapi-serve` does the right thing.
+
+      Swagger UI 5 is required, not 4: the document is OpenAPI 3.1, which 4.x
+      does not read.
+    -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.14/swagger-ui.css"
+    />
+    <style>
+      body { margin: 0; }
+      /* Swagger UI renders its own topbar only in the standalone preset; this
+         is the one bit of chrome we add, so the two views can be swapped
+         without going back to the terminal. */
+      .viewswitch {
+        background: #1b1b1b;
+        color: #d8d8d8;
+        font: 13px/1 ui-sans-serif, system-ui, -apple-system, sans-serif;
+        padding: 0.75rem 1.25rem;
+      }
+      .viewswitch a { color: #8ec7ff; }
+      #fallback {
+        display: none;
+        margin: 4rem auto;
+        max-width: 34rem;
+        padding: 0 1.5rem;
+        font: 15px/1.6 ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+      #fallback code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.9em;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="viewswitch">
+      Swagger UI · <a href="./scalar.html">switch to the Scalar view</a>
+    </div>
+    <div id="swagger-ui"></div>
+
+    <div id="fallback">
+      <h1>Viewer unavailable</h1>
+      <p>
+        Swagger UI could not be loaded, which usually means this machine is
+        offline. The specification itself is local and unaffected —
+        <a href="./openapi.json">openapi.json</a> is right here.
+      </p>
+      <p>Regenerate it from the daemon's router with <code>just openapi</code>.</p>
+    </div>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.14/swagger-ui-bundle.js"
+      onerror="document.getElementById('fallback').style.display='block'"
+    ></script>
+    <script>
+      window.addEventListener("load", function () {
+        if (typeof SwaggerUIBundle === "undefined") return;
+        window.ui = SwaggerUIBundle({
+          url: "./openapi.json",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          // No "Try it out". The daemon listens on a Unix domain socket, which
+          // a browser cannot dial, so an interactive request form could only
+          // ever produce failures.
+          supportedSubmitMethods: [],
+          tryItOutEnabled: false,
+          docExpansion: "list",
+          defaultModelsExpandDepth: 1,
+          defaultModelExpandDepth: 3,
+          displayRequestDuration: false,
+          filter: true,
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/docs/protocol/openapi.json
+++ b/docs/protocol/openapi.json
@@ -1,0 +1,7372 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Super STT daemon protocol",
+    "description": "HTTP/1.1 + JSON over a Unix domain socket at `$XDG_RUNTIME_DIR/stt/super-stt-http.sock` (override with `SUPER_STT_HTTP_SOCKET`). There is no TCP listener: the socket's filesystem permissions are the first layer of access control, and the daemon reads `SO_PEERCRED` on each connection to identify the calling binary.\n\nEvery endpoint except `POST /v1/auth/request` requires `Authorization: Bearer <token>`. A token is minted only after the user approves your app in a consent popup, and is bound to the approved binary — an app cannot widen its own permissions. See `docs/protocol/auth.md`.\n\nBecause the transport is a Unix socket, the `servers` entry below is nominal; point your client at the socket and use any `Host`. With curl:\n\n```\ncurl --unix-socket \"$XDG_RUNTIME_DIR/stt/super-stt-http.sock\" \\\n     -H \"Authorization: Bearer $STT_TOKEN\" \\\n     http://stt.local/v1/ping\n```",
+    "contact": {
+      "name": "Super STT",
+      "url": "https://github.com/jorge-menjivar/super-stt"
+    },
+    "license": {
+      "name": "GPL-3.0-only",
+      "identifier": "GPL-3.0-only"
+    },
+    "version": "0.2.4-beta.1"
+  },
+  "servers": [
+    {
+      "url": "http://stt.local",
+      "description": "Nominal host; the transport is the Unix socket"
+    }
+  ],
+  "paths": {
+    "/v1/audio_theme": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read the selected audio cue theme",
+        "description": "Answers with the selected theme's token.",
+        "operationId": "get_audio_theme",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudioThemeState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Select the audio cue theme",
+        "description": "Chooses which set of sounds marks the start and end of a recording. List the accepted values with `GET /audio_themes`; set the loudness at `/volume`.",
+        "operationId": "set_audio_theme",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAudioThemeBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudioThemeState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/audio_theme/test": {
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Play the selected theme's cues",
+        "description": "Plays the start and stop cues once, at the configured volume, so a settings UI can preview a theme without starting a recording. Changes nothing.",
+        "operationId": "test_audio_theme",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/audio_themes": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "List the available audio cue themes",
+        "description": "Every theme `POST /audio_theme` accepts. The set is fixed in the daemon build, not user-extensible.",
+        "operationId": "list_audio_themes",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AudioThemeList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/auth/request": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Ask the user for a session token",
+        "description": "The consent handshake, and the only endpoint reachable without a token.\n\nThe daemon reads `SO_PEERCRED` on your connection, resolves `/proc/<pid>/exe`, and shows the user a popup naming that binary and the scopes you asked for. On Allow it mints a 32-byte token bound to that binary and valid for 30 days.\n\nA denial is remembered for the `(binary, scopes)` pair for the rest of the daemon's lifetime and answers `403` immediately without re-prompting — renaming your app does not clear it, since the key is the binary. Restarting the daemon does.\n\nSetting `SUPER_STT_AUTO_APPROVE=1` in the daemon's environment skips the popup entirely; it is for tests and CI, not for production.",
+        "operationId": "auth_request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The user approved. Store the token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthOk"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Body was missing or malformed (`invalid_body`), or `scopes` was empty or named an unknown scope (`invalid_scope`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The user denied or dismissed the popup (`user_denied`, `user_dismissed`), a previous denial for this binary and scope set still stands (`user_denied_cached`), the connecting user is not the daemon's own (`uid_mismatch`), the daemon could not resolve your binary and so refused to identify you (`peer_unverifiable`), or the popup could not be shown (`popup_failed`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/status": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Check the held token without prompting",
+        "description": "Reports what the presented token is good for, and never opens a consent popup — which is what makes it the right probe for a headless or CLI client. Reaching this handler at all means the token validated.\n\nUse it to fail fast on a token about to expire, rather than discovering it mid-operation.",
+        "operationId": "auth_status",
+        "responses": {
+          "200": {
+            "description": "The token is valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthStatusOk"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed — re-run the consent handshake.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": []
+          }
+        ]
+      }
+    },
+    "/v1/backends": {
+      "get": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "List installed backends",
+        "description": "Every backend installed on this machine, each with the models it serves, the options it exposes, and which of its secrets are configured. Secret *values* are never returned — only whether each is set.\n\nThis is the full catalog, roles included. `GET /models` is the narrower read a transcription-model picker wants; browsing what is *available to install* is `GET /registry/backends`.",
+        "operationId": "list_backends",
+        "responses": {
+          "200": {
+            "description": "The installed catalog.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackendCatalog"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/backends/{source}": {
+      "delete": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Uninstall a backend",
+        "description": "Removes an installed backend and its files from disk.\n\nIf the backend was filling a pipeline stage, that stage is emptied first: any loaded model is unloaded and the selection cleared, so the daemon does not end up pointing at files that no longer exist. The response says which stages were affected.\n\nRefused with `409 backend_busy` while a recording or realtime session is in flight — removing files out from under one would strand state it still depends on.",
+        "operationId": "uninstall_backend",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UninstallResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No installed backend claims that `source`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A recording or realtime session is in flight (`backend_busy`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The files could not be removed (`remove_failed`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/backends/{source}/models/{model}/language": {
+      "get": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Read a model's language override",
+        "description": "The language this specific model transcribes in, which overrides the global `/language` setting. Addressed by `(source, model)` rather than \"the active model\", so it can be read whether or not the model is loaded.\n\n`null` means no override: the model follows the global setting.",
+        "operationId": "get_one",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The model's name, as `GET /backends` spells it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "How this model's language resolves.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelLanguageState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such model (`unknown_model`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Set a model's language override",
+        "description": "Pins this model to a language regardless of the global `/language` setting. A tag the model does not serve is refused rather than silently ignored.\n\nOverridden in turn by a `language` field in a single `POST /transcribe` body.",
+        "operationId": "set",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The model's name, as `GET /backends` spells it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguageBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Override set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelLanguageState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The body was empty (`invalid_request`), or this model does not serve that language (`unsupported_language`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such model (`unknown_model`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Clear a model's language override",
+        "description": "Removes the per-model pin, returning this model to the global `/language` setting.",
+        "operationId": "clear",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The model's name, as `GET /backends` spells it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Override cleared.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelLanguageState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such model (`unknown_model`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/backends/{source}/options/list": {
+      "get": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "List a backend's options",
+        "description": "Every option this backend declares, each with its label, type, default, and the value actually in effect. This is what a settings UI renders a form from.\n\nOptions are the backend's own configuration — an endpoint URL, a model parameter — declared in its manifest. Credentials are not options; those are secrets, at `/backends/{source}/secrets/list`.",
+        "operationId": "list",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The backend's options.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackendOptions"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No installed backend has that `source` (`unknown_backend`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/backends/{source}/options/{name}": {
+      "get": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Read one option's effective value",
+        "description": "The value in effect for a single option, alongside the manifest default so a UI can show what clearing it would revert to.",
+        "operationId": "get_one",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The option's name, as the backend's manifest declares it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The option's effective value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptionValue"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such option (`unknown_option`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Override an option",
+        "description": "Stores a value for this option, overriding the manifest default. Answers with the option's new effective value, so a UI can render the result without a second read.\n\nA `base_url` value is canonicalized before storage, so the field reads back the endpoint that will actually be dialed — the scheme in particular, since whether a request is encrypted should not be invisible in the field the user is looking at. A value that yields no host is stored as typed rather than refused; model load rejects it by name. Every other option is stored verbatim, whitespace included, because it may carry meaning the daemon does not interpret.\n\nA loaded model does not pick this up on its own — reload the stage with `POST /pipeline/{stage}/model/reload`.",
+        "operationId": "set",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The option's name, as the backend's manifest declares it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OptionBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Stored; this is the new effective value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptionValue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was empty (`invalid_request`). Use `DELETE` to clear an override.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such option (`unknown_option`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Clear an option override",
+        "description": "Removes the stored value, reverting the option to the manifest default. Answers with the effective value that results, which is the default when one is declared and `null` when none is.",
+        "operationId": "delete_option",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fwhisper"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The option's name, as the backend's manifest declares it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cleared; this is the value now in effect.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptionValue"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such option (`unknown_option`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/backends/{source}/secrets/list": {
+      "get": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "List a backend's secrets",
+        "description": "Every credential this backend declares, with whether each is currently set. **Values are never returned** — not here, not anywhere. They live in the system keyring, and the only operations are write and clear.\n\nThis is a separate scope from `settings` precisely because it is the credential surface: a token granted `settings` cannot reach it.",
+        "operationId": "list",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fopenai"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The declared secrets and whether each is set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `secrets` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "secrets"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/backends/{source}/secrets/{name}": {
+      "get": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Check whether one secret is set",
+        "description": "Reports existence only. There is no endpoint that returns a stored credential.",
+        "operationId": "get_one",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fopenai"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The secret's name, as the backend's manifest declares it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Whether a value is stored.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretConfigured"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `secrets` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "secrets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Store a secret",
+        "description": "Writes the credential to the system keyring. It cannot be read back afterwards; only replaced or cleared.\n\nA loaded model does not pick up a new credential on its own — reload the stage with `POST /pipeline/{stage}/model/reload`.",
+        "operationId": "set",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fopenai"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The secret's name, as the backend's manifest declares it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecretBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Stored.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretConfigured"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was empty (`invalid_request`). Use `DELETE` to clear a secret.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `secrets` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The keyring could not be written (`keyring_unavailable`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "secrets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "backends"
+        ],
+        "summary": "Clear a secret",
+        "description": "Removes the stored credential from the keyring, returning the secret to unset. A backend that requires it will refuse to load until one is stored again.",
+        "operationId": "delete_secret",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "description": "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "github.com%2Facme%2Fopenai"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The secret's name, as the backend's manifest declares it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cleared.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretConfigured"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `secrets` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The keyring could not be written (`keyring_unavailable`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "secrets"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/custom_models_dir": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read the custom models directory",
+        "description": "Answers with the configured path, or `null` when no override is set.",
+        "operationId": "get_custom_models_dir",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomModelsDirState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Point the daemon at a models directory of your own",
+        "description": "Overrides where the daemon looks for model files. Send `null` to clear the override and fall back to the default location. Backends installed from the registry are unaffected — this is for models supplied out of band.",
+        "operationId": "set_custom_models_dir",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomModelsDirBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomModelsDirState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Subscribe to the event stream",
+        "description": "A Server-Sent Events stream of everything the daemon publishes. The response is `text/event-stream` and stays open until the client disconnects, the daemon shuts down, or the calling binary changes on disk (which emits a final `revoked` frame and invalidates the token).\n\nThe first frame is always `subscribed`, carrying a `client_id` and the topic list that was accepted. A `: keepalive` comment is sent periodically so idle connections are not reaped by intermediaries.\n\n**Scopes are per topic, not per endpoint.** Any valid token reaches this route; the subscription is then refused whole if the token lacks the scope for *any* requested topic, so ask only for what you hold.\n\n| Topic | Scope |\n|---|---|\n| `recording_started`, `recording_stopped`, `recording_state`, `transcribing_started`, `transcribing_stopped` | `recording_events` |\n| `frequency_bands` | `audio_visualization` |\n| `partial_stt`, `final_stt` | `global_transcriptions` |\n| `daemon_status_changed`, `download_progress`, `registry_install` | `daemon_status` |\n\nUnder backpressure the daemon drops frames rather than buffering them without bound; visualization frames are what shed in practice.",
+        "operationId": "events",
+        "parameters": [
+          {
+            "name": "topics",
+            "in": "query",
+            "description": "Comma-separated topic names, at least one. Unknown or empty → `400 invalid_topic`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "recording_state,final_stt"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The stream is open. Frames follow as `event:`/`data:` pairs.",
+            "content": {
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "`topics` was missing, empty, or named a topic that does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the scope for one of the requested topics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": []
+          }
+        ]
+      }
+    },
+    "/v1/gpu_info": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Inventory the host's GPUs",
+        "description": "What the daemon can see of this machine's accelerators: one entry per detected GPU with its memory, plus the host-wide driver and runtime versions that decide which backend builds will actually run here.\n\nDetection is a live probe, so this reflects the machine now rather than a cached answer. A host with no GPU answers `200` with an empty list.",
+        "operationId": "get_gpu_info",
+        "responses": {
+          "200": {
+            "description": "The detected GPUs and host toolchain versions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GpuInventory"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/language": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read the default transcription language",
+        "description": "A BCP-47 tag, `auto`, or `null` when nothing is configured.",
+        "operationId": "get_language",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Set the default transcription language",
+        "description": "Sets the language every model transcribes in unless something more specific overrides it: a per-model setting, or a `language` field in a single `POST /transcribe` body.",
+        "operationId": "set_language",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetLanguageBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Clear the default transcription language",
+        "description": "Removes the global setting, returning every model to detecting the language itself. Per-model overrides are untouched.",
+        "operationId": "clear_language",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "List the models the active backend can transcribe with",
+        "description": "Scoped to the backend currently filling stage 1 — only its models are switchable. Post-processor models are excluded, since selecting one as a transcription model would fail every recording; the full catalog with roles is at `GET /backends`.",
+        "operationId": "list_models",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/notification_method": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read how failures are announced",
+        "description": "Answers with the configured method. This governs only failures the user would otherwise never learn about — a transcript that could not be written to the focused window, say — not routine status, which rides on the event stream.",
+        "operationId": "get_notification_method",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationMethodState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Choose how failures are announced",
+        "description": "Selects how the daemon tells the user when something goes wrong — a desktop notification, or nothing at all. This is about failures the user would otherwise never see, such as a transcript that could not be written to the focused window.",
+        "operationId": "set_notification_method",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetNotificationMethodBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationMethodState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/ping": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Liveness probe",
+        "description": "Confirms the listener is reachable and the presented token is valid. Introspects no state.\n\nTo check whether the *token* is still good without risking a consent popup, prefer `GET /auth/status` — that is the dedicated probe.",
+        "operationId": "ping",
+        "responses": {
+          "200": {
+            "description": "The daemon is up. `message` is always `pong`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                },
+                "example": {
+                  "message": "pong",
+                  "status": "success"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Connection refused — the daemon is over its per-client connection cap.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": []
+          }
+        ]
+      }
+    },
+    "/v1/pipeline": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Report every pipeline stage",
+        "description": "The ordered stages a transcript passes through. Stage 1 turns audio into text; every later stage rewrites what the one before it produced.\n\nEach stage reports which backend fills it, which model is selected, whether that model is up, the accelerator it actually runs on, and any load still in flight. Stages are addressed by position precisely so a third can be appended without inventing a third endpoint for it.",
+        "operationId": "get_pipeline",
+        "responses": {
+          "200": {
+            "description": "Every stage, stage 1 first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PipelineReport"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Report one pipeline stage",
+        "description": "The same object `GET /pipeline` carries in its array, for a client that only cares about one position. It is narrowed from that report rather than derived separately, so one stage and the whole list can never disagree.",
+        "operationId": "get_stage",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The stage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StageEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Select the backend filling a stage",
+        "description": "Points a stage at an installed backend. Selecting a backend does not load a model — do that with `POST /pipeline/{stage}/model`.\n\nA backend that serves nothing this stage can run is refused: filling stage 2 with a transcription-only backend would leave the user staring at an empty model picker with no reason given.",
+        "operationId": "set_stage_backend",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetBackendBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Selected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StageMutation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No installed backend has that `source`, or it serves nothing this stage can run (`invalid_backend`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Empty a stage",
+        "description": "Deselects the stage's backend, unloading its model first if one is up. The stage then does nothing: stage 1 empty means no transcription, stage 2 empty means transcripts pass through unrewritten.",
+        "operationId": "clear_stage_backend",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Emptied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StageMutation"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}/device/list": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "List the devices this stage's backend can run on",
+        "description": "The devices the backend filling this stage can run on this host, without naming a model. Use it before a model is chosen; once one is, the per-model list is the narrower and more accurate answer.",
+        "operationId": "list_stage_devices",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The devices on offer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The stage has no backend selected (`invalid_backend`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}/model": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Run a model in a stage",
+        "description": "Loads `model` into the stage, downloading it first if this machine does not have it yet. That download can be long: watch the `download_progress` event topic, or poll `GET /pipeline/{stage}` and read `switch`. Abandon it with `POST /pipeline/{stage}/model/cancel`.\n\nOmitting `source` uses the backend already selected for the stage.",
+        "operationId": "set_stage_model",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetModelBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Accepted. The model may still be downloading — read `switch` to follow it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StageMutation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No such model (`invalid_model`), or no such backend (`invalid_backend`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Stop a stage's model",
+        "description": "Unloads the model, freeing its device memory, and leaves the backend selected so a different model can be loaded without re-selecting it. To empty the stage entirely, use `DELETE /pipeline/{stage}`.",
+        "operationId": "clear_stage_model",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unloaded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StageMutation"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}/model/cancel": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Abandon a stage's in-flight load",
+        "description": "Stops the download or load this stage has in flight. Scoped to the stage: the stages provision independently, so cancelling one is not a licence to abandon another's download.\n\n`409 no_switch_in_progress` when the stage has nothing in flight.",
+        "operationId": "cancel_stage_model",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancelled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Nothing was in flight for this stage (`no_switch_in_progress`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}/model/reload": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Re-instantiate a stage's model in place",
+        "description": "Tears the model down and brings it back up so it picks up changed secrets and options — an API key set through `/backends/{source}/secrets`, say — without the client having to unload and reload by hand.\n\nNothing is re-downloaded; the files on disk are unchanged.",
+        "operationId": "reload_stage_model",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reloaded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}/model/{model}/device": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Read a model's device preference",
+        "description": "The accelerator this model is set to run on, and — when the preference is the generic `gpu` — what it actually resolved to once loaded. The preference is per model, not per stage: two models in the same stage can prefer different devices.",
+        "operationId": "get_model_device",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The model's name, as `GET /models` or `GET /backends` spells it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The preference, and what it resolved to.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelDevice"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "Set a model's device preference",
+        "description": "Chooses the accelerator this model runs on. If it is the model the stage is currently running, it is reloaded onto the new device; otherwise the preference is stored and takes effect at the next load.\n\nList what this host can offer with `GET /pipeline/{stage}/model/{model}/device/list`.",
+        "operationId": "set_model_device",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The model's name, as `GET /models` or `GET /backends` spells it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetDeviceBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Preference set; this is the resulting report.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelDevice"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "This host cannot offer that device (`invalid_device`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/pipeline/{stage}/model/{model}/device/list": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "List the devices a model can run on here",
+        "description": "What this machine can actually offer this model — the intersection of the host's accelerators and the builds the model ships. Fill a device picker from this rather than from `GET /gpu_info`, which reports the hardware without regard to what the model supports.",
+        "operationId": "list_model_devices",
+        "parameters": [
+          {
+            "name": "stage",
+            "in": "path",
+            "description": "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The model's name, as `GET /models` or `GET /backends` spells it.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The devices on offer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such stage (`unknown_stage`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/preview_typing": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read whether live preview typing is on",
+        "description": "Answers with the current state. On means a realtime-capable model's partial transcript is typed into the focused window as it forms; off means nothing is written until the transcript is final. A model without a realtime session ignores the setting either way.",
+        "operationId": "get_preview_typing",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewTypingState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Turn live preview typing on or off",
+        "description": "When on, a realtime-capable model's incremental transcript is typed into the focused window as it forms, and corrected in place as later audio revises it. When off, nothing is written until the transcript is final.",
+        "operationId": "set_preview_typing",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewTypingBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewTypingState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/recording_stop_mode": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read what currently ends a recording",
+        "description": "Answers with the configured mode. It governs daemon-mic captures started through `POST /transcribe`; the pre-captured path has no capture to end, and a `wait: true` caller can always end one by closing the connection.",
+        "operationId": "get_recording_stop_mode",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordingStopModeState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Choose what ends a recording",
+        "description": "Sets whether a recording stops on an explicit signal, on a period of silence, or on either. This governs daemon-mic captures started through `POST /transcribe`; it has no bearing on the pre-captured path, which has no capture to end.",
+        "operationId": "set_recording_stop_mode",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetRecordingStopModeBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordingStopModeState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/registry/backends": {
+      "get": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "Browse the published backend catalog",
+        "description": "Every backend published to the registry, with the models each serves and whether this machine can run it. `compatible` is decided against the host's actual accelerators and this Super STT's version, so the list reflects what is installable here rather than what exists in general.\n\n`needs_client_update` separates the two ways a backend can be blocked: a host that lacks the right GPU will never run it, but a Super STT one version behind is something the user can fix in a minute. Surface those differently.\n\nThis is what is *available*; `GET /backends` is what is installed.",
+        "operationId": "list_registry_backends",
+        "parameters": [
+          {
+            "name": "include_incompatible",
+            "in": "query",
+            "description": "Include entries this machine cannot run. Off by default, so the catalog\nshows what is actually installable here.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Filter by backend kind.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "online",
+            "in": "query",
+            "description": "Filter by whether the backend calls out to a network service.",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Case-insensitive substring match over name and description.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The catalog.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The catalog could not be fetched and nothing is cached (`registry_unavailable`). Retry, or force a fetch with `POST /registry/backends/refresh`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/registry/backends/install": {
+      "post": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "Install a backend",
+        "description": "Installs a backend from the registry, from a git repo, or from a local path — send exactly one of `source`, `repo_url`, or `local_path`.\n\nThe daemon picks the release asset matching this host's architecture and accelerators, and answers `202` as soon as that choice is made: the download itself continues in the background. Follow it on the `registry_install` event topic, keyed by the returned `install_id`. A `warning` means the install proceeded with a caveat worth showing the user.\n\nInstalling neither selects the backend nor loads a model — do that through `/pipeline/{stage}`.",
+        "operationId": "install_registry_backend",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstallRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted; the download runs in the background.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstallAccepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Not exactly one of `source`, `repo_url`, `local_path` (`bad_request`), or no asset matches this host.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No catalog entry for that `source` (`not_found`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "An install for this backend is already in flight, or a recording is running (`backend_busy`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/registry/backends/refresh": {
+      "post": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "Re-fetch the backend catalog",
+        "description": "Pulls the published index again rather than serving what is cached, and reports how many backends it now holds. Use it after a backend is published, or to clear an `index_stale` flag.\n\n`GET /registry/backends` refreshes on its own schedule; this forces it now.",
+        "operationId": "refresh_registry",
+        "responses": {
+          "200": {
+            "description": "Refreshed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The catalog could not be fetched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/registry/backends/update": {
+      "post": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "Update an installed backend",
+        "description": "Upgrades an installed backend to the newest version the catalog offers for this host. Answers with the versions moved between; `noop` is `true` when the installed version was already current, which is a success rather than an error.\n\nLike install, the download runs in the background — follow `install_id` on the `registry_install` topic when one is returned.",
+        "operationId": "update_registry_backend",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Up to date already, or the upgrade was accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No installed backend has that `source` (`not_found`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "An install is already in flight, or a recording is running (`backend_busy`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/status": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Current model and device",
+        "description": "A snapshot of what the daemon is running: which model is loaded, on which accelerator, and whether a recording cycle is in flight.\n\nSubscriber introspection and other operator detail are not exposed here — see `GET /pipeline/1` and `GET /pipeline/{stage}/model/{model}/device`, which need the `settings` scope.",
+        "operationId": "status",
+        "responses": {
+          "200": {
+            "description": "The daemon's current state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DaemonStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `status` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "status"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/transcribe": {
+      "post": {
+        "tags": [
+          "transcribe"
+        ],
+        "summary": "Transcribe supplied audio, or start a microphone recording",
+        "description": "One endpoint with four behaviours, selected by the body:\n\n| Body | Behaviour | Response |\n|---|---|---|\n| `audio_data` present | Transcribe the supplied buffer; the microphone is never opened | `200` JSON with `transcription` |\n| no `audio_data`, `wait: false` (default) | Start recording and detach; stop it with `POST /transcribe/stop` | `202` with `message: \"Recording started\"` |\n| `wait: true` | Record, then stream the result | `200 text/event-stream`, one `done` frame |\n| `wait: true`, `stream_realtime: true` | As above, plus incremental previews | `200 text/event-stream`, `preview` frames then `done` |\n\nOn the streaming paths a daemon-side failure arrives as a single `error` frame, and closing the connection stops the recording. Frames are:\n\n| `event:` | `data:` |\n|---|---|\n| `preview` | `{ \"text\": \"hello wor…\" }` |\n| `done` | `{ \"transcription\": \"hello world\" }` |\n| `error` | `{ \"message\": \"…\" }` |\n\nStarting while a recording is already in flight is `409 recording_in_progress` — this endpoint only ever *starts* one. Read `busy` from `GET /status` and call `POST /transcribe/stop` to end the running capture.",
+        "operationId": "transcribe",
+        "requestBody": {
+          "description": "All fields optional; the combination selects the behaviour.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranscribeBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Pre-captured audio: the finished transcription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transcription"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Microphone recording started and detached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                },
+                "example": {
+                  "message": "Recording started",
+                  "status": "success"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`audio_data` was not an array of numbers, or `stream_realtime` was sent with it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `transcribe` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A recording is already in flight (`recording_in_progress`), or no model is loaded (`model_not_loaded`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "transcribe"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/transcribe/realtime": {
+      "get": {
+        "tags": [
+          "transcribe"
+        ],
+        "summary": "Open a realtime transcription session (WebSocket)",
+        "description": "An HTTP/1.1 upgrade to a WebSocket, bridged to the loaded model's realtime session. Send audio frames, receive transcript frames as they form.\n\nOnly realtime-capable models serve this. The daemon caps concurrent sessions and answers `503` rather than queueing beyond it; a session with no incoming frame for a minute is treated as dead and dropped.\n\nBeing a WebSocket, the frame protocol is not describable in OpenAPI — see `docs/protocol/wit/realtime.wit` for the message shapes.",
+        "operationId": "realtime_ws_handler",
+        "responses": {
+          "101": {
+            "description": "Upgraded; the realtime session is open."
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `transcribe` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "No model is loaded, or the loaded model has no realtime session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Too many concurrent realtime sessions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "transcribe"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/transcribe/stop": {
+      "post": {
+        "tags": [
+          "transcribe"
+        ],
+        "summary": "Stop the in-flight microphone recording",
+        "description": "Ends a recording started by `POST /transcribe`. Idempotent: stopping when nothing is recording succeeds with `No recording in progress`.\n\n`message` says what happened — `Recording stop signal sent`, `Manual stop not enabled in current mode`, or `Transcription in progress, please wait`. The transcript itself does not come back here; it arrives on the `final_stt` event topic, or on the stream if the recording was started with `wait: true`.",
+        "operationId": "transcribe_stop",
+        "responses": {
+          "200": {
+            "description": "Stop signal sent, or nothing was recording.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                },
+                "example": {
+                  "message": "Recording stop signal sent",
+                  "status": "success"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `transcribe` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "transcribe"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/update": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read the last self-update check",
+        "description": "Reports what the most recent check found, without performing one. `checked_at` is `null` until a check has run, and `last_check_error` says why the last attempt failed if it did.\n\nWhich channel is consulted follows `/update_beta_optin`; `beta_optin_effective` reports the setting even before a check has resolved a channel of its own. To force a check now, use `POST /update/check`.",
+        "operationId": "get_update",
+        "responses": {
+          "200": {
+            "description": "The last known update state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfUpdateStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/update/check": {
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Check for a Super STT update now",
+        "description": "Runs the check immediately rather than waiting for the daemon's own schedule, and answers with the result — the same shape `GET /update` reports. Works whether or not the periodic check is enabled.\n\nThis only *looks*. Nothing is downloaded or installed as a result.",
+        "operationId": "post_check",
+        "responses": {
+          "200": {
+            "description": "The check ran; this is what it found. A network failure is reported in `last_check_error`, not as an HTTP error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfUpdateStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/update_beta_optin": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read the update channel opt-in",
+        "description": "Answers with the configured opt-in — whether the update check considers beta builds or stable releases only. This is about Super STT itself, not about the backends under `/registry`, which are versioned separately.",
+        "operationId": "get_update_beta_optin",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBetaOptinState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Choose whether updates include prereleases",
+        "description": "Selects which release channel the update check considers. Opting in offers beta builds as they are published; opting out considers stable releases only.",
+        "operationId": "set_update_beta_optin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUpdateBetaOptinBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBetaOptinState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/update_check_enabled": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read whether periodic update checks are on",
+        "description": "Answers with the current state. Off stops the daemon checking on its own schedule; it does not disable updating, since `POST /update/check` still runs a check on demand.",
+        "operationId": "get_update_check_enabled",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateCheckEnabledState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Turn the periodic update check on or off",
+        "description": "Controls whether the daemon checks for new Super STT releases on its own schedule. Turning it off does not disable updating — `POST /update/check` still works on demand.",
+        "operationId": "set_update_check_enabled",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCheckEnabledBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateCheckEnabledState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/volume": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read the audio cue volume",
+        "description": "The level rides in `message` as a bare number — `\"75\"` — not as a field of its own, so parse it back out.",
+        "operationId": "get_volume",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Set the audio cue volume",
+        "description": "Sets the loudness of the recording cues on a 0–100 scale. `0` silences them without changing which theme is selected; the theme itself is read and written at `/audio_theme`.",
+        "operationId": "set_volume",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetVolumeBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ack"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/write_method": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Read how transcripts are delivered",
+        "description": "Answers with the configured preference. What it actually resolves to in this session can differ — `POST /write_method/test` reports both.",
+        "operationId": "get_write_method",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WriteMethodState"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Choose how transcripts reach the focused window",
+        "description": "Selects the mechanism the daemon uses to deliver a finished transcript — simulated typing, the clipboard, and so on. Which mechanisms work depends on the session: some need a compositor that permits synthetic input. Try one with `POST /write_method/test` before committing a user to it.",
+        "operationId": "set_write_method",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetWriteMethodBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Applied.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WriteMethodState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The value was rejected — out of range, or not one of the accepted tokens.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    },
+    "/v1/write_method/test": {
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Write sample text using the configured method",
+        "description": "Delivers a short sample to the focused window exactly as a real transcript would be, so a user can confirm the method works before relying on it. Focus the window that should receive it first.\n\nThe response reports both the configured preference and what it resolved to, which is how a UI shows that a preferred mechanism silently fell back to another. Refused with `409` while a recording is in flight.",
+        "operationId": "test_write_method",
+        "responses": {
+          "200": {
+            "description": "Done.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WriteMethodTest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Token unknown, expired, or its binary changed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReasonEnvelope"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The token lacks the `settings` scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-client rate limit hit; back off and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_token": [
+              "settings"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Ack": {
+        "type": "object",
+        "description": "The plain acknowledgement: an operation succeeded, with a sentence saying\nwhat happened.\n\nA good number of settings endpoints answer with exactly this, on `GET` as\nwell as `POST` — `GET /volume` reports the level inside `message` rather\nthan as a field of its own. Where that is true the endpoint's own\ndocumentation says so, because a client has to parse the number back out.",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail. Not a stable identifier — do not switch on it.\n\nOptional because a few commands acknowledge without a sentence, and the\nkey is then absent rather than empty. Every endpoint documented as\ncarrying its value in the message always sets it."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `success`.",
+            "example": "success"
+          }
+        }
+      },
+      "ActiveBackend": {
+        "type": "object",
+        "description": "The backend filling stage 1, as that stage's mutations report it.",
+        "required": [
+          "source",
+          "name",
+          "model_loaded"
+        ],
+        "properties": {
+          "model_loaded": {
+            "type": "boolean",
+            "description": "Whether one of its models is currently up."
+          },
+          "name": {
+            "type": "string",
+            "description": "Its display name."
+          },
+          "source": {
+            "type": "string",
+            "description": "The backend's repo id."
+          }
+        }
+      },
+      "AudioTheme": {
+        "type": "string",
+        "enum": [
+          "classic",
+          "gentle",
+          "minimal",
+          "scifi",
+          "musical",
+          "nature",
+          "retro",
+          "silent"
+        ]
+      },
+      "AudioThemeList": {
+        "type": "object",
+        "description": "Every audio cue theme the daemon ships.",
+        "required": [
+          "status",
+          "available_audio_themes"
+        ],
+        "properties": {
+          "available_audio_themes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AudioTheme"
+            }
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "AudioThemeState": {
+        "type": "object",
+        "description": "The selected audio cue theme.",
+        "required": [
+          "status",
+          "audio_theme"
+        ],
+        "properties": {
+          "audio_theme": {
+            "type": "string",
+            "description": "The selected theme's token.",
+            "example": "classic"
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "AuthOk": {
+        "type": "object",
+        "description": "A freshly minted session token.",
+        "required": [
+          "status",
+          "session_token",
+          "scopes",
+          "expires_at"
+        ],
+        "properties": {
+          "expires_at": {
+            "type": "string",
+            "description": "RFC 3339 expiry, 30 days out."
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The scopes actually granted, sorted and deduplicated."
+          },
+          "session_token": {
+            "type": "string",
+            "description": "Send this as `Authorization: Bearer <token>` on every other endpoint.\nBound to the approved binary — it stops working if that binary changes\non disk."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `success`.",
+            "example": "success"
+          }
+        }
+      },
+      "AuthRequestBody": {
+        "type": "object",
+        "required": [
+          "app_name",
+          "scopes"
+        ],
+        "properties": {
+          "app_name": {
+            "type": "string",
+            "description": "The name shown to the user in the consent popup. Self-reported and\ntherefore untrusted: the daemon identifies you by your binary, and a\nprevious denial sticks to that binary whatever name you send next.",
+            "example": "My App"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The scopes to request, at least one. Every entry must be known or the\nwhole request is refused; ask only for what you need, since the user\nsees the list.",
+            "example": [
+              "transcribe",
+              "status"
+            ]
+          },
+          "version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Your app's version. Accepted for forwards compatibility; unused today.",
+            "example": "0.1"
+          }
+        }
+      },
+      "AuthStatusOk": {
+        "type": "object",
+        "description": "What the token currently held is good for.",
+        "required": [
+          "status",
+          "scopes",
+          "expires_at"
+        ],
+        "properties": {
+          "expires_at": {
+            "type": "string",
+            "description": "RFC 3339 expiry, so a headless client can renew before it lapses."
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The scopes the token was minted under."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `success`.",
+            "example": "success"
+          }
+        }
+      },
+      "BackendCatalog": {
+        "type": "object",
+        "description": "Every installed backend, with its models, options and secrets.",
+        "required": [
+          "status",
+          "backends"
+        ],
+        "properties": {
+          "backends": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackendInfo"
+            }
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "BackendInfo": {
+        "type": "object",
+        "description": "A single installed backend and everything the settings UI needs to render\nits section.",
+        "required": [
+          "source",
+          "name",
+          "models",
+          "secrets",
+          "options"
+        ],
+        "properties": {
+          "allowed_hosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Hosts the backend is permitted to reach (`[network].allowed_hosts` from\nits `backend.toml`). Empty for subprocess/local backends. Feeds the\n\"Online model\" badge so the user sees where a cloud backend's audio goes."
+          },
+          "description": {
+            "type": "string",
+            "description": "The installed `backend.toml`'s `[backend].description`, empty when the\nmanifest omits it.\n\nA registry entry carries one too, but only for backends the registry\nlists: a sideloaded or imported-from-dir backend has no entry, and its\ndescription would otherwise be invisible everywhere in the UI. `default`\nso a payload written before the field existed still deserializes."
+          },
+          "installed_accel": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Acceleration backends of the asset variant actually installed on this\nhost, e.g. `[\"cuda\"]` or `[\"cpu\"]`.\n\nEmpty for a backend imported from a local directory, where the binary's\naccel is not knowable, for one installed before the daemon recorded it,\nand for a `wasm` backend — its `installed.json` records `\"wasm\"` for its\nown purposes, but that is a transport, not an accelerator, so it is\nfiltered before it reaches this field. Clients read an empty list as \"no\ninformation\" and fall back to each model's `supported_devices`.\n\nA client offering a device picker intersects: a `cpu` asset offers the\nCPU alone, an accelerated one offers both, since a GPU build still runs\non the CPU."
+          },
+          "kind": {
+            "type": "string",
+            "description": "`\"wasm\"` or `\"subprocess\"` — the backend's transport."
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackendModel"
+            },
+            "description": "Models this backend serves."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable backend name, e.g. `OpenAI`."
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackendOption"
+            },
+            "description": "Non-sensitive options stored in the daemon config."
+          },
+          "secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackendSecret"
+            },
+            "description": "Sensitive values (API keys, etc.) stored in the system keyring."
+          },
+          "source": {
+            "type": "string",
+            "description": "Repo id the backend was installed from, e.g.\n`github.com/super-stt/openai`. Used as the daemon's keyring account\nkey and option key."
+          },
+          "version": {
+            "type": "string",
+            "description": "The installed backend's `[backend].version`, read from the `backend.toml`\non disk — what is installed, not what is published.\n\nFor a backend the registry does not list (imported from a directory, or\ninstalled from an arbitrary repo) this is the only version there is; for\nthe rest it is still the authoritative one, since the registry reports\nwhat a release offers rather than what this machine has. `default` so a\npayload written before the field existed still deserializes."
+          }
+        }
+      },
+      "BackendModel": {
+        "type": "object",
+        "description": "One model served by a backend.",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "estimated_vram_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Conservative GPU memory estimate (weights + KV cache + overhead) in\nbytes; `0` when unknown or not GPU-resident. Drives the \"may not fit\"\nwarning when a CUDA load is staged against the detected GPU memory.",
+            "minimum": 0
+          },
+          "multilingual": {
+            "type": "boolean",
+            "description": "Whether this model supports multiple transcription languages (as\nopposed to a mono-lingual model baked for a single language)."
+          },
+          "name": {
+            "type": "string"
+          },
+          "primary_language": {
+            "type": "string",
+            "description": "The model's built-in default language (BCP-47 tag)."
+          },
+          "realtime": {
+            "type": "boolean",
+            "description": "Whether the model is driven over the realtime WebSocket path rather than\nbatch `POST /v1/transcribe`."
+          },
+          "role": {
+            "type": "string",
+            "description": "What the model is for: `\"transcription\"` (the default) or\n`\"post_processor\"`. A settings UI filters its transcription-model picker\nand its post-processor picker on this.\n\n`default` rather than required, so a catalog from a daemon that predates\nthe field still parses — reading every model as transcribing, which is\nwhat it was."
+          },
+          "supported_devices": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Devices the model can be loaded onto. Non-empty `snake_case` values\nfrom `[\"cpu\", \"cuda\", \"metal\", \"none\"]`. The settings UI surfaces\nthese as the device choice in the active-backend card; `\"none\"`\n(the only-entry sentinel for online models) means no device picker\nis shown."
+          },
+          "supported_languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "BCP-47 tags the model can transcribe, e.g. `[\"en\", \"es\", \"fr\"]`.\nEmpty for mono-lingual models."
+          }
+        }
+      },
+      "BackendOption": {
+        "type": "object",
+        "description": "A non-sensitive option the backend accepts, stored in the daemon config.",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "default": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable label for the UI. Falls back to `name` when absent."
+          },
+          "name": {
+            "type": "string",
+            "description": "`snake_case` identifier (the daemon config key; the backend reads it as\n`x-stt-option-<name>`)."
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The option's input type (`string` / `integer` / `bool`); absent when the\nbackend declared none."
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Current effective value (override or default) reported by the daemon."
+          }
+        }
+      },
+      "BackendOptionValue": {
+        "type": "object",
+        "description": "One option a backend declares, with the value in effect.",
+        "required": [
+          "name",
+          "label",
+          "type",
+          "required"
+        ],
+        "properties": {
+          "default": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The manifest's default, or `null` when it declares none."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for a settings UI; falls back to `name`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The option's identifier, as the backend's manifest declares it."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the backend refuses to load without a value."
+          },
+          "type": {
+            "type": "string",
+            "description": "The declared type — `string`, `number`, and so on."
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What is actually in effect: the user's override if set, otherwise the\ndefault."
+          }
+        }
+      },
+      "BackendOptions": {
+        "type": "object",
+        "description": "Every option a backend declares.",
+        "required": [
+          "status",
+          "options"
+        ],
+        "properties": {
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BackendOptionValue"
+            }
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "BackendSecret": {
+        "type": "object",
+        "description": "A sensitive value the backend requires, stored in the system keyring.",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable label for the UI. Falls back to `name` when absent."
+          },
+          "name": {
+            "type": "string",
+            "description": "`snake_case` identifier (the keyring account suffix; the backend reads\nit as `x-stt-secret-<name>`)."
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Compatibility": {
+        "type": "object",
+        "required": [
+          "compatible"
+        ],
+        "properties": {
+          "compatible": {
+            "type": "boolean"
+          },
+          "needs_client_update": {
+            "type": "boolean",
+            "description": "Whether the block is \"this Super STT is too old\" rather than \"this\nmachine cannot run it\".\n\nThe two are hidden differently. A host that lacks the right GPU will\nnever run the asset, so Browse tucks it behind \"Show incompatible\"; a\nSuper STT one version behind is a thing the user can fix in a minute,\nand hiding it hides the only notice they would get. `false` on an older\ndaemon that does not send the field, which lists as it always did."
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "selected_asset": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SelectedAsset"
+              }
+            ]
+          }
+        }
+      },
+      "CudaHostInfo": {
+        "type": "object",
+        "description": "The installed NVIDIA driver's CUDA version, e.g. `\"13.3\"`.",
+        "required": [
+          "driver_version"
+        ],
+        "properties": {
+          "driver_version": {
+            "type": "string"
+          }
+        }
+      },
+      "CustomModelsDirBody": {
+        "type": "object",
+        "description": "Point the daemon at a models directory of your own",
+        "properties": {
+          "path": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Absolute path to the directory, or `null` to clear the override."
+          }
+        }
+      },
+      "CustomModelsDirState": {
+        "type": "object",
+        "description": "The models directory override.",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "custom_models_dir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The configured directory, or `null` when no override is set. Always\npresent — `null` is the answer, not an absent key."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "DaemonStatus": {
+        "type": "object",
+        "description": "What `GET /status` reports.",
+        "required": [
+          "status",
+          "device",
+          "model_loaded",
+          "busy"
+        ],
+        "properties": {
+          "busy": {
+            "type": "boolean",
+            "description": "`true` while a daemon-mic cycle is active — capture *and* the\ntranscription and typing that follow it. A toggle hotkey reads this and\ncalls `POST /transcribe/stop` when true, `POST /transcribe` when false."
+          },
+          "current_model": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The loaded model's name. Absent when `model_loaded` is `false`.",
+            "example": "whisper-tiny"
+          },
+          "device": {
+            "type": "string",
+            "description": "The accelerator the loaded model actually runs on: `cpu`, `cuda`,\n`rocm`, `metal`, `vulkan`, or `remote` for a model served over the\nnetwork. `unknown` when nothing is loaded.",
+            "example": "cuda"
+          },
+          "model_loaded": {
+            "type": "boolean",
+            "description": "`false` while the initial model is still loading, or after a failed\nswitch."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `success`.",
+            "example": "success"
+          }
+        }
+      },
+      "DeviceList": {
+        "type": "object",
+        "description": "The devices a model or a stage can run on.",
+        "required": [
+          "status",
+          "available_devices"
+        ],
+        "properties": {
+          "available_devices": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Accelerator tokens, e.g. `cpu`, `cuda`, `vulkan`.",
+            "example": [
+              "cpu",
+              "cuda"
+            ]
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "ErrorCode": {
+        "type": "string",
+        "enum": [
+          "recording_in_progress",
+          "download_in_progress",
+          "no_switch_in_progress",
+          "model_not_loaded",
+          "invalid_model",
+          "invalid_backend",
+          "cuda_unavailable",
+          "invalid_device",
+          "invalid_audio_theme",
+          "unsupported_language",
+          "invalid_value",
+          "not_found",
+          "internal",
+          "unknown"
+        ]
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "description": "The error envelope, as [`transport.md`] specifies it.\n\n`error_code` is the stable, machine-readable identifier clients switch on\nand the field that determines the HTTP status; `message` is prose for a\nhuman and may be reworded at any time.\n\n[`transport.md`]: https://github.com/jorge-menjivar/super-stt/blob/main/docs/protocol/transport.md",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "error_code": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ErrorCode",
+                "description": "The stable identifier for this failure. Absent only on an unclassified\nserver-side error."
+              }
+            ]
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `error`.",
+            "example": "error"
+          }
+        }
+      },
+      "GpuHostInfo": {
+        "type": "object",
+        "description": "Host-wide GPU toolchain/driver versions reported on\n[`GET /gpu_info`](../../../docs/protocol/endpoints/v1/gpu_info.md), independent\nof any one GPU. Each field is `null` when that accelerator's runtime isn't\ndetected on this host — see `docs/protocol/endpoints/v1/gpu_info.md` for\nwhat presence and absence do and don't imply for each one.",
+        "properties": {
+          "cuda": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CudaHostInfo"
+              }
+            ]
+          },
+          "rocm": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RocmHostInfo"
+              }
+            ]
+          },
+          "vulkan": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VulkanHostInfo"
+              }
+            ]
+          }
+        }
+      },
+      "GpuInfo": {
+        "type": "object",
+        "description": "One GPU as reported by [`GET /gpu_info`](../../../docs/protocol/endpoints/v1/gpu_info.md).\n`vendor` is a lowercase `snake_case` tag (`nvidia` / `amd` / `intel` /\n`apple` / `unknown`). `total_bytes` is dedicated VRAM for discrete GPUs and\nthe shared system-memory ceiling for integrated/unified GPUs;\n`free_bytes` / `used_bytes` are `null` when the platform doesn't report them.",
+        "required": [
+          "name",
+          "vendor",
+          "total_bytes"
+        ],
+        "properties": {
+          "arch_target": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The architecture a prebuilt asset must target to run on this GPU, in\nthe vendor's own spelling: `\"sm_86\"` on NVIDIA, `\"gfx1030\"` on AMD.\n`null` when the driver reports none (an Apple or Intel GPU, or an AMD\ncard on a kernel without KFD)."
+          },
+          "free_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "name": {
+            "type": "string"
+          },
+          "total_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "used_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "vendor": {
+            "type": "string"
+          }
+        }
+      },
+      "GpuInventory": {
+        "type": "object",
+        "description": "The host's GPUs and its GPU toolchain versions.",
+        "required": [
+          "status",
+          "gpu_info",
+          "host"
+        ],
+        "properties": {
+          "gpu_info": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GpuInfo"
+            },
+            "description": "One entry per detected GPU; empty on a host with none."
+          },
+          "host": {
+            "$ref": "#/components/schemas/GpuHostInfo",
+            "description": "Driver and runtime versions, independent of any one GPU."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "IndexModel": {
+        "type": "object",
+        "description": "The browse-only model subset the catalog and host-compatibility filter need\nbefore download. The authoritative manifest (languages, files, …) ships as\nthe pinned `manifest` asset and is installed verbatim — it is not re-encoded\nhere. Also the leaf type for `/registry/backends` (`RegistryModel`).",
+        "required": [
+          "name",
+          "supported_devices"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "description": "What the model is for: `\"transcription\"` (the default) or\n`\"post_processor\"`. Lets Browse show that a backend provides a\npost-processor before it is installed. `default` so an index published\nbefore the field existed still parses, reading every model as\ntranscribing — which is what it was."
+          },
+          "supported_devices": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "IndexOption": {
+        "type": "object",
+        "required": [
+          "name",
+          "label",
+          "type"
+        ],
+        "properties": {
+          "default": {},
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "IndexSecret": {
+        "type": "object",
+        "required": [
+          "name",
+          "label",
+          "required"
+        ],
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "IndexStale": {
+        "type": "object",
+        "required": [
+          "latest_attempted",
+          "tag",
+          "error",
+          "since"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "latest_attempted": {
+            "type": "string"
+          },
+          "since": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "InstallAccepted": {
+        "type": "object",
+        "required": [
+          "install_id",
+          "source",
+          "version",
+          "selected_asset"
+        ],
+        "properties": {
+          "install_id": {
+            "type": "string"
+          },
+          "selected_asset": {
+            "$ref": "#/components/schemas/SelectedAsset"
+          },
+          "source": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "warning": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "InstallRequest": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "source"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "repo_url"
+            ],
+            "properties": {
+              "repo_url": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "local_path"
+            ],
+            "properties": {
+              "local_path": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "InstallerAsset": {
+        "type": "object",
+        "required": [
+          "name",
+          "url",
+          "size",
+          "sha256"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "sha256": {
+            "type": "string",
+            "description": "Hex SHA-256 of the binary at `url`, from the release's `SHA256SUMS`\nasset. Always present when `installer_asset` is non-null — clients\nMUST verify the downloaded bytes against this before executing it\n(the daemon omits `installer_asset` entirely rather than publish one\nwithout a verifiable digest)."
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "LanguageBody": {
+        "type": "object",
+        "description": "The language this model should transcribe in.",
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "A BCP-47 tag such as `es`, or `auto` to let the model detect it. Empty is\nrefused — clear an override with `DELETE`.",
+            "example": "es"
+          }
+        }
+      },
+      "LanguageState": {
+        "type": "object",
+        "description": "The default transcription language.",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "language": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A BCP-47 tag, `auto`, or `null` when nothing is configured. Always\npresent — `null` is the answer, not an absent key.",
+            "example": "es"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "ModelDevice": {
+        "type": "object",
+        "description": "A model's device preference, what it resolved to, and what this host can\noffer it.",
+        "required": [
+          "status",
+          "available_devices"
+        ],
+        "properties": {
+          "available_devices": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "What this host can actually offer this model — the intersection of the\nmachine's accelerators and the builds the model ships. Empty for a model\nthat runs remotely.",
+            "example": [
+              "cpu",
+              "cuda"
+            ]
+          },
+          "device": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The preference itself: `cpu`, `gpu`, or a specific accelerator. `none`\nfor a model that runs remotely and therefore has no local device."
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "resolved_accel": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What a `gpu` preference resolved to once a model loaded — `cuda`,\n`rocm`, `metal`, `vulkan`. `null` while the preference is `gpu` but\nnothing has loaded yet; equal to the preference when it is `cpu`.\n\nDoubly optional because the wire distinguishes three states and a client\nreads them differently: the key absent means this response does not speak\nto the device at all, an explicit `null` means the preference is `gpu`\nand nothing has resolved it yet, and a value is the accelerator in use.\nCollapsing the first two would report \"unresolved\" where the daemon said\nnothing."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "ModelLanguageBlock": {
+        "type": "object",
+        "description": "How one model's transcription language resolves.\n\nThe per-model endpoints answer with this under `language`, where the global\n`/language` endpoints answer with a bare tag. Same field name, different\nshapes: the per-model answer has to explain *why* a language is in effect,\nsince three settings can decide it.",
+        "required": [
+          "multilingual",
+          "source",
+          "primary",
+          "supported"
+        ],
+        "properties": {
+          "effective": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The tag actually used, after resolution. `null` when the model detects\nthe language itself."
+          },
+          "multilingual": {
+            "type": "boolean",
+            "description": "Whether this model can transcribe more than one language at all. A\nmonolingual model ignores every setting below."
+          },
+          "override": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The per-model override, or `null` when none is set."
+          },
+          "primary": {
+            "type": "string",
+            "description": "The model's own default language."
+          },
+          "source": {
+            "type": "string",
+            "description": "Which setting `effective` came from: the per-model override, the global\nsetting, or the model's own default."
+          },
+          "supported": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Every tag this model accepts."
+          }
+        }
+      },
+      "ModelLanguageState": {
+        "type": "object",
+        "description": "The per-model language resolution.",
+        "required": [
+          "status",
+          "language"
+        ],
+        "properties": {
+          "language": {
+            "$ref": "#/components/schemas/ModelLanguageBlock"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "ModelList": {
+        "type": "object",
+        "description": "The models the backend filling stage 1 can transcribe with.",
+        "required": [
+          "status",
+          "available_models"
+        ],
+        "properties": {
+          "available_models": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "description": "`[name, source]` pairs. Post-processor models are excluded — they are not\nswitchable transcription models, and offering one would fail every\nrecording. The full catalog, roles included, is at `GET /backends`.",
+            "example": [
+              [
+                "whisper-tiny",
+                "github.com/super-stt/whisper"
+              ]
+            ]
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "NotificationMethodState": {
+        "type": "object",
+        "description": "How failures are announced.",
+        "required": [
+          "status",
+          "notification_method"
+        ],
+        "properties": {
+          "notification_method": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "OptionBody": {
+        "type": "object",
+        "description": "The value to store for an option.",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The new value. Empty is refused — clear an override with `DELETE`\ninstead, which is the operation that reverts to the manifest default."
+          }
+        }
+      },
+      "OptionValue": {
+        "type": "object",
+        "description": "One option's effective value.",
+        "required": [
+          "status",
+          "name"
+        ],
+        "properties": {
+          "default": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The manifest default, so a UI can show what clearing would revert to."
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What is in effect now."
+          }
+        }
+      },
+      "PipelineReport": {
+        "type": "object",
+        "description": "The whole pipeline, in order.",
+        "required": [
+          "status",
+          "pipeline"
+        ],
+        "properties": {
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pipeline": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StageReport"
+            },
+            "description": "Stage 1 first. A transcript passes through these in order."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "PostProcessorState": {
+        "type": "object",
+        "description": "Stage 2's state, as that stage's mutations report it.",
+        "required": [
+          "enabled",
+          "loaded"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "The user's on/off choice, which is separate from whether the model came\nup: a stage can be enabled with a failed load, and transcripts then pass\nthrough untouched."
+          },
+          "loaded": {
+            "type": "boolean",
+            "description": "Whether that model is loaded and ready."
+          },
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The selected model, or `null` when none is picked."
+          },
+          "source": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The selected backend, or `null` when the stage is empty."
+          }
+        }
+      },
+      "PreviewTypingBody": {
+        "type": "object",
+        "description": "Turn live preview typing on or off",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the feature is on."
+          }
+        }
+      },
+      "PreviewTypingState": {
+        "type": "object",
+        "description": "Whether live preview typing is on.",
+        "required": [
+          "status",
+          "preview_typing_enabled"
+        ],
+        "properties": {
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "preview_typing_enabled": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "Reason": {
+        "type": "object",
+        "description": "The `data` object of a [`ReasonEnvelope`].",
+        "required": [
+          "reason"
+        ],
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Which case of `message` occurred — e.g. `expired`, `exe_changed`,\n`user_denied`."
+          }
+        }
+      },
+      "ReasonEnvelope": {
+        "type": "object",
+        "description": "The auth-failure envelope: `message` names the failure and `data.reason`\nsays which of its cases occurred.\n\nDistinct from [`ErrorEnvelope`] because the auth surface predates\n`error_code` and clients read `data.reason` there. Both are documented\nrather than reconciled, since changing either is a breaking wire change.",
+        "required": [
+          "status",
+          "message",
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Reason"
+          },
+          "message": {
+            "type": "string",
+            "description": "The failure identifier, e.g. `invalid_session` or `auth_denied`."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `error`.",
+            "example": "error"
+          }
+        }
+      },
+      "RecordingStopModeState": {
+        "type": "object",
+        "description": "What ends a recording.",
+        "required": [
+          "status",
+          "recording_stop_mode"
+        ],
+        "properties": {
+          "recording_stop_mode": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "RefreshResponse": {
+        "type": "object",
+        "required": [
+          "schema_version",
+          "generated_at",
+          "backend_count"
+        ],
+        "properties": {
+          "backend_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "RegistryBackend": {
+        "type": "object",
+        "required": [
+          "id",
+          "source",
+          "version",
+          "name",
+          "license",
+          "kind",
+          "contract",
+          "online",
+          "supports_gpu",
+          "supports_cpu",
+          "models",
+          "secrets",
+          "options",
+          "compatibility"
+        ],
+        "properties": {
+          "allowed_hosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "backend_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The backend's reverse-DNS identifier, or `None` when the registry entry\npredates it. Names the install directory."
+          },
+          "compatibility": {
+            "$ref": "#/components/schemas/Compatibility"
+          },
+          "contract": {
+            "type": "string",
+            "description": "The contract generation the backend declares, as published. Carried\nas a string so a client lists an entry whose generation it does not\nknow; `compatibility` says whether this daemon can drive it."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "index_stale": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/IndexStale"
+              }
+            ]
+          },
+          "installed_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "kind": {
+            "type": "string"
+          },
+          "license": {
+            "type": "string"
+          },
+          "min_client": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The Super STT release that first understood `contract`, as stamped by\nthe indexer. `None` for an index that predates the stamp."
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IndexModel"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "online": {
+            "type": "boolean"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IndexOption"
+            }
+          },
+          "secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IndexSecret"
+            }
+          },
+          "source": {
+            "type": "string"
+          },
+          "supports_cpu": {
+            "type": "boolean"
+          },
+          "supports_gpu": {
+            "type": "boolean"
+          },
+          "update_available": {
+            "type": "boolean",
+            "description": "Whether `version` is newer than `installed_version`, decided by the\ndaemon.\n\nThe comparison is semver, and it belongs here rather than in each client\nfor the same reason `installed_version` does: the daemon is what reads\nthe installed manifest and owns the index, so it is the one place that\ncan answer without a client re-deriving it. A client that wants to\npresent the versions still has both.\n\n`false` when nothing is installed, when the installed version is at or\nahead of the index's, or when either version does not parse."
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "RegistryError": {
+        "type": "object",
+        "description": "The registry surface's error envelope, which carries one extra key.\n\nThese endpoints shipped before `error_code` existed, spelling the failure\nidentity as `error`. That key is still sent, because clients read it; the\nstandard `error_code` was added alongside rather than in place of it, so the\nwhole surface honors the \"`error_code` on every error\" rule without breaking\nanyone. Both name the same failure and always agree.\n\nDocumented as its own shape rather than folded into [`ErrorEnvelope`]:\n`error` appears *only* here, and putting it on the shared envelope would\ntell every other endpoint's reader to expect a key they will never receive.",
+        "required": [
+          "status",
+          "error_code",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "The same identifier under the key this surface has always used. Retained\nfor clients written against it; prefer `error_code`.",
+            "example": "not_found"
+          },
+          "error_code": {
+            "type": "string",
+            "description": "The stable identifier for this failure.",
+            "example": "not_found"
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable detail, when there is any to add."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `error`.",
+            "example": "error"
+          }
+        }
+      },
+      "RegistryListResponse": {
+        "type": "object",
+        "required": [
+          "schema_version",
+          "generated_at",
+          "backends"
+        ],
+        "properties": {
+          "backends": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegistryBackend"
+            }
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "schema_version": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "RocmHostInfo": {
+        "type": "object",
+        "description": "The installed `ROCm` userspace release, e.g. `\"6.2.4\"`. Advisory only — see\n`docs/protocol/endpoints/v1/gpu_info.md`; `arch_target` is what a build must\nactually match.",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "SecretBody": {
+        "type": "object",
+        "description": "The secret to store.",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The credential itself. Written to the system keyring, never returned by\nany endpoint. Empty is refused — clear a secret with `DELETE`."
+          }
+        }
+      },
+      "SecretConfigured": {
+        "type": "object",
+        "description": "Whether one secret is set.",
+        "required": [
+          "status",
+          "configured"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "description": "Whether a value is stored."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Absent on write and clear, which answer about the secret just addressed."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "SecretList": {
+        "type": "object",
+        "description": "Every secret a backend declares.",
+        "required": [
+          "status",
+          "secrets"
+        ],
+        "properties": {
+          "secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SecretState"
+            }
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "SecretState": {
+        "type": "object",
+        "description": "One secret a backend declares, and whether it is set.",
+        "required": [
+          "name",
+          "label",
+          "required",
+          "configured"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "description": "Whether a value is stored. The value itself is never returned."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for a settings UI; falls back to `name`."
+          },
+          "name": {
+            "type": "string",
+            "description": "The secret's identifier, as the backend's manifest declares it."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the backend refuses to load without it."
+          }
+        }
+      },
+      "SelectedAsset": {
+        "type": "object",
+        "required": [
+          "target",
+          "accel"
+        ],
+        "properties": {
+          "accel": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Acceleration backends the selected build carries. A single entry is\nboth read and written as a bare string, a list of two or more as an\narray — a client that declares this field as a plain `String` still\nparses the catalog for every asset that carries one runtime."
+          },
+          "cuda_major": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "cuda_sm": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "cudnn": {
+            "type": "boolean"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
+      },
+      "SelfUpdateStatus": {
+        "type": "object",
+        "required": [
+          "current_version",
+          "update_available",
+          "beta_optin_effective"
+        ],
+        "properties": {
+          "beta_optin_effective": {
+            "type": "boolean"
+          },
+          "checked_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "current_version": {
+            "type": "string"
+          },
+          "installer_asset": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InstallerAsset"
+              }
+            ]
+          },
+          "last_check_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "update_available": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SetAudioThemeBody": {
+        "type": "object",
+        "description": "Select the audio cue theme",
+        "required": [
+          "theme"
+        ],
+        "properties": {
+          "theme": {
+            "type": "string",
+            "description": "A theme token from `GET /audio_themes`, e.g. `classic`. An unknown token is a `400`."
+          }
+        }
+      },
+      "SetBackendBody": {
+        "type": "object",
+        "description": "Which backend should fill the stage.",
+        "required": [
+          "source"
+        ],
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "The backend's repo id, as `GET /backends` reports it.",
+            "example": "github.com/acme/whisper"
+          }
+        }
+      },
+      "SetDeviceBody": {
+        "type": "object",
+        "description": "Which accelerator the model should run on.",
+        "required": [
+          "device"
+        ],
+        "properties": {
+          "device": {
+            "type": "string",
+            "description": "An accelerator token from the stage's or model's device list — `cpu`,\n`cuda`, `vulkan`, or the generic `gpu`.",
+            "example": "cuda"
+          }
+        }
+      },
+      "SetLanguageBody": {
+        "type": "object",
+        "description": "Set the default transcription language",
+        "required": [
+          "language"
+        ],
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "A BCP-47 tag such as `es`, or `auto` to let the model detect the language."
+          }
+        }
+      },
+      "SetModelBody": {
+        "type": "object",
+        "description": "Which model to run in the stage.",
+        "required": [
+          "model"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The model's name.",
+            "example": "whisper-tiny"
+          },
+          "source": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The backend serving it. Omitted resolves to the backend already selected\nfor this stage."
+          }
+        }
+      },
+      "SetNotificationMethodBody": {
+        "type": "object",
+        "description": "Choose how failures are announced",
+        "required": [
+          "method"
+        ],
+        "properties": {
+          "method": {
+            "type": "string",
+            "description": "One of the accepted `snake_case` method tokens. An unknown token is a `400`."
+          }
+        }
+      },
+      "SetRecordingStopModeBody": {
+        "type": "object",
+        "description": "Choose what ends a recording",
+        "required": [
+          "mode"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "One of the accepted `snake_case` mode tokens. An unknown token is a `400`."
+          }
+        }
+      },
+      "SetUpdateBetaOptinBody": {
+        "type": "object",
+        "description": "Choose whether updates include prereleases",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "One of the accepted `snake_case` opt-in tokens. An unknown token is a `400`."
+          }
+        }
+      },
+      "SetVolumeBody": {
+        "type": "object",
+        "description": "Set the audio cue volume",
+        "required": [
+          "volume"
+        ],
+        "properties": {
+          "volume": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Integer in `0..=100`. Anything outside that range is a `400`.",
+            "minimum": 0
+          }
+        }
+      },
+      "SetWriteMethodBody": {
+        "type": "object",
+        "description": "Choose how transcripts reach the focused window",
+        "required": [
+          "method"
+        ],
+        "properties": {
+          "method": {
+            "type": "string",
+            "description": "One of the accepted `snake_case` method tokens. An unknown token is a `400`."
+          }
+        }
+      },
+      "StageEnvelope": {
+        "type": "object",
+        "description": "One stage of the pipeline.",
+        "required": [
+          "status",
+          "stage"
+        ],
+        "properties": {
+          "stage": {
+            "$ref": "#/components/schemas/StageReport"
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "StageMutation": {
+        "type": "object",
+        "description": "The answer to a stage mutation.\n\nThe two stages answer with different keys — stage 1 with `active_backend`,\nstage 2 with `post_processor` — because each grew its own endpoint before\nthe pipeline addressed stages by position. Both are documented rather than\nreconciled: changing either is a breaking wire change. Read the stage back\nwith `GET /pipeline/{stage}` for the one shape both share.",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "active_backend": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ActiveBackend",
+                "description": "Stage 1 only. `null` when the stage was emptied.\n\nDoubly optional for the same reason `resolved_accel` is: absent means\nthis was a stage 2 mutation, which reports `post_processor` instead;\n`null` means stage 1 itself is now empty."
+              }
+            ]
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "post_processor": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PostProcessorState",
+                "description": "Stage 2 only."
+              }
+            ]
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          }
+        }
+      },
+      "StageReport": {
+        "type": "object",
+        "description": "One stage of the pipeline: which backend fills it, what is running there,\nand the load still in flight, if any.\n\nEvery optional field here serializes as an explicit `null` rather than being\nomitted — a stage reports its whole shape whatever state it is in, so a\nclient can read `source` without first checking the key exists. `enabled` is\nthe one exception, and is absent rather than null on a stage that has no\non/off choice of its own.",
+        "required": [
+          "stage",
+          "role",
+          "loaded"
+        ],
+        "properties": {
+          "device": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The accelerator the loaded model actually runs on — not the user's\npreference, which is read per model through\n`/pipeline/{stage}/model/{model}/device`. `null` when nothing is loaded,\nsince nothing runs anywhere."
+          },
+          "enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "The user's on/off choice, for stages that carry one separately from\nwhether the model came up: a stage can be enabled while its load failed,\nand transcripts then pass through untouched. Absent on stage 1, which\nhas no switch of its own."
+          },
+          "loaded": {
+            "type": "boolean",
+            "description": "Whether that model is loaded and ready to run."
+          },
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The model selected in this stage; `null` when none is picked."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "That backend's display name; `null` when the stage is empty."
+          },
+          "role": {
+            "$ref": "#/components/schemas/StageRole"
+          },
+          "source": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The backend filling this stage; `null` when the stage is empty."
+          },
+          "stage": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Position in the pipeline: [`TRANSCRIPTION_STAGE`], [`POST_PROCESSOR_STAGE`].",
+            "minimum": 0
+          },
+          "switch": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/StageSwitch",
+                "description": "The load or download in flight for this stage; `null` when idle.\n\nThe daemon runs one model operation at a time but not always for the\nsame stage, so this is reported per stage rather than globally."
+              }
+            ]
+          }
+        }
+      },
+      "StageRole": {
+        "type": "string",
+        "description": "What a stage does to the transcript passing through it.",
+        "enum": [
+          "transcription",
+          "post_processor"
+        ]
+      },
+      "StageSwitch": {
+        "type": "object",
+        "description": "A model load in flight for one stage.",
+        "required": [
+          "phase",
+          "target",
+          "started_at",
+          "download"
+        ],
+        "properties": {
+          "download": {
+            "$ref": "#/components/schemas/SwitchDownload",
+            "description": "Byte and file progress, for the `downloading` phase."
+          },
+          "phase": {
+            "type": "string",
+            "description": "Where the operation has got to: `downloading`, `loading_model`,\n`cancelled`, `completed`, or `error`."
+          },
+          "started_at": {
+            "type": "string",
+            "description": "RFC 3339 timestamp of when the operation started."
+          },
+          "target": {
+            "$ref": "#/components/schemas/SwitchTarget",
+            "description": "The model being loaded into the stage."
+          }
+        }
+      },
+      "SwitchDownload": {
+        "type": "object",
+        "description": "Download progress within a [`StageSwitch`].",
+        "required": [
+          "current_file",
+          "file_index",
+          "total_files",
+          "bytes_downloaded",
+          "total_bytes",
+          "percentage"
+        ],
+        "properties": {
+          "bytes_downloaded": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "current_file": {
+            "type": "string"
+          },
+          "eta_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Estimated seconds remaining, or `null` before there is enough history\nto estimate one.",
+            "minimum": 0
+          },
+          "file_index": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "percentage": {
+            "type": "number",
+            "format": "float",
+            "description": "0.0–100.0 across the whole operation."
+          },
+          "total_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "total_files": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "SwitchTarget": {
+        "type": "object",
+        "description": "The model a [`StageSwitch`] is loading.",
+        "required": [
+          "model",
+          "source"
+        ],
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      },
+      "TranscribeBody": {
+        "type": "object",
+        "description": "Pre-captured one-shot: transcribe a supplied `audio_data` buffer without\ntouching the microphone and return a single JSON `{ transcription }` (or a\ncoded error). Rejects `stream_realtime` combined with `audio_data` per the\ncontract.\nThe body of `POST /transcribe`. Every field is optional; which combination\nyou send selects one of the four behaviours the endpoint documents.\n\nDeclared, not deserialized. The handler reads the body as raw JSON so it can\n*move* a large `audio_data` buffer out of it rather than copying it into a\nsecond owned `Vec`; this type is what that body's shape is, published in the\n`OpenAPI` document and kept beside the handler that parses it.",
+        "properties": {
+          "audio_data": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "number",
+              "format": "float"
+            },
+            "description": "Mono PCM samples in `-1.0..=1.0`. Present means \"transcribe this buffer\"\n— the daemon does not touch the microphone, and answers with one JSON\nresult rather than a stream."
+          },
+          "language": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "BCP-47 tag, or `auto`, overriding the configured language for this\nrequest only.",
+            "example": "es"
+          },
+          "sample_rate": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Sample rate of `audio_data`, in Hz. Ignored on the microphone paths.",
+            "example": 16000,
+            "minimum": 0
+          },
+          "stream_realtime": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Microphone paths only, and only with `wait: true`: also emit incremental\n`preview` frames as the transcript forms. Rejected with `400` alongside\n`audio_data`, which has nothing to stream."
+          },
+          "wait": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Microphone paths only. `false` (the default) starts the recording and\nreturns immediately; `true` holds the connection open and streams the\nresult."
+          }
+        }
+      },
+      "Transcription": {
+        "type": "object",
+        "description": "A one-shot transcription result, for the pre-captured path.",
+        "required": [
+          "status",
+          "transcription"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Always `success`.",
+            "example": "success"
+          },
+          "transcription": {
+            "type": "string",
+            "description": "The recognized text. Empty when the audio held no speech — which is a\nsuccessful transcription, not a failure.",
+            "example": "hello world"
+          }
+        }
+      },
+      "UninstallResponse": {
+        "type": "object",
+        "required": [
+          "uninstalled",
+          "was_active"
+        ],
+        "properties": {
+          "uninstalled": {
+            "type": "boolean"
+          },
+          "was_active": {
+            "type": "boolean",
+            "description": "The backend was filling stage 1, which was emptied before the files\nwent."
+          },
+          "was_post_processor": {
+            "type": "boolean",
+            "description": "The backend was filling stage 2 — selected as the post-processor\nbackend, loaded or not — which was emptied before the files went.\nAbsent from an older daemon's answer, which reads as `false`."
+          }
+        }
+      },
+      "UpdateBetaOptinState": {
+        "type": "object",
+        "description": "Which release channel updates come from.",
+        "required": [
+          "status",
+          "update_beta_optin"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
+          "update_beta_optin": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateCheckEnabledBody": {
+        "type": "object",
+        "description": "Turn the periodic update check on or off",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the feature is on."
+          }
+        }
+      },
+      "UpdateCheckEnabledState": {
+        "type": "object",
+        "description": "Whether the periodic update check runs.",
+        "required": [
+          "status",
+          "update_check_enabled"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
+          "update_check_enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "UpdateRequest": {
+        "type": "object",
+        "required": [
+          "source"
+        ],
+        "properties": {
+          "source": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateResponse": {
+        "type": "object",
+        "required": [
+          "from_version",
+          "to_version",
+          "noop"
+        ],
+        "properties": {
+          "from_version": {
+            "type": "string"
+          },
+          "install_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "noop": {
+            "type": "boolean"
+          },
+          "to_version": {
+            "type": "string"
+          }
+        }
+      },
+      "VulkanHostInfo": {
+        "type": "object",
+        "description": "The highest Vulkan API version any installed driver advertises, e.g.\n`\"1.3.280\"`.",
+        "required": [
+          "api_version"
+        ],
+        "properties": {
+          "api_version": {
+            "type": "string"
+          }
+        }
+      },
+      "WriteMethodState": {
+        "type": "object",
+        "description": "How transcripts reach the focused window.",
+        "required": [
+          "status",
+          "write_method"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
+          "write_method": {
+            "type": "string"
+          }
+        }
+      },
+      "WriteMethodTest": {
+        "type": "object",
+        "description": "The outcome of writing sample text with the configured method.",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "resolved_write_method": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What that preference resolved to for this session, which can differ when\nthe compositor will not permit the preferred mechanism."
+          },
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
+          "write_method": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The configured preference."
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "session_token": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Session token from `POST /v1/auth/request`. Bound to the calling binary and valid for 30 days."
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "auth",
+      "description": "Consent handshake and token probing."
+    },
+    {
+      "name": "health",
+      "description": "Liveness and what the daemon is currently running."
+    },
+    {
+      "name": "transcribe",
+      "description": "Start, stop and stream transcription."
+    },
+    {
+      "name": "events",
+      "description": "Server-Sent Events for recording state, audio levels, model and download progress, and final transcripts."
+    },
+    {
+      "name": "pipeline",
+      "description": "The ordered stages a transcript passes through: which backend fills each, which model runs there, and on what device."
+    },
+    {
+      "name": "settings",
+      "description": "Daemon configuration: audio cues, write and notification methods, language, self-update."
+    },
+    {
+      "name": "backends",
+      "description": "Installed backends: their models, options and secrets."
+    },
+    {
+      "name": "registry",
+      "description": "The published backend catalog: browse, install, update, uninstall."
+    }
+  ]
+}

--- a/docs/protocol/scalar.html
+++ b/docs/protocol/scalar.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: GPL-3.0-only -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Super STT daemon protocol</title>
+    <!--
+      The Scalar view of openapi.json. openapi.html is the same document
+      rendered with Swagger UI and is what `just openapi-serve` opens by
+      default; this one is `just openapi-serve --scalar`.
+
+      Serve it, don't open it as a file:// URL — the page fetches openapi.json,
+      which the file: origin blocks. `just openapi-serve` does the right thing.
+
+      The renderer is loaded from a CDN, so this page needs network access the
+      first time it is opened. The spec itself is local; only the viewer is
+      remote.
+    -->
+    <style>
+      :root { color-scheme: light dark; }
+      html, body { margin: 0; height: 100%; }
+      /* The one bit of chrome we add, so the two renderings can be swapped
+         without going back to the terminal. */
+      .viewswitch {
+        background: #1b1b1b;
+        color: #d8d8d8;
+        font: 13px/1 ui-sans-serif, system-ui, -apple-system, sans-serif;
+        padding: 0.75rem 1.25rem;
+      }
+      .viewswitch a { color: #8ec7ff; }
+      #fallback {
+        display: none;
+        margin: 4rem auto;
+        max-width: 34rem;
+        padding: 0 1.5rem;
+        font: 15px/1.6 ui-sans-serif, system-ui, -apple-system, sans-serif;
+      }
+      #fallback code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.9em;
+      }
+      #fallback pre {
+        background: color-mix(in srgb, currentColor 8%, transparent);
+        border-radius: 6px;
+        overflow-x: auto;
+        padding: 0.75rem 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="viewswitch">
+      Scalar · <a href="./openapi.html">switch to the Swagger UI view</a>
+    </div>
+    <script id="api-reference" data-url="./openapi.json"></script>
+    <script>
+      // Scalar reads its options off the script tag above.
+      var configuration = {
+        theme: "default",
+        layout: "modern",
+        hideDownloadButton: false,
+        // A Unix-socket API cannot be called from a browser, so the request
+        // sender would only ever produce failures.
+        hiddenClients: true,
+        isEditable: false,
+      };
+      document.getElementById("api-reference").dataset.configuration =
+        JSON.stringify(configuration);
+    </script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.90/dist/browser/standalone.min.js"
+      onerror="document.getElementById('fallback').style.display='block'"
+    ></script>
+
+    <div id="fallback">
+      <h1>Viewer unavailable</h1>
+      <p>
+        The renderer could not be loaded, which usually means this machine is
+        offline. The specification itself is local and unaffected —
+        <a href="./openapi.json">openapi.json</a> is right here.
+      </p>
+      <p>To read it without a network, point any OpenAPI tool at the file:</p>
+      <pre><code>npx @redocly/cli preview-docs docs/protocol/openapi.json</code></pre>
+      <p>
+        Regenerate it from the daemon's router with
+        <code>just openapi</code>.
+      </p>
+    </div>
+  </body>
+</html>

--- a/justfile
+++ b/justfile
@@ -226,8 +226,8 @@ coverage-badge:
     cat coverage-html/coverage.json
 
 # Full local CI gate: format, lint, feature-combo compile, tests, install.sh
-# tests, doctests, schemas
-ci: fmt-check check check-features test test-install doctest schema-check
+# tests, doctests, schemas, protocol spec
+ci: fmt-check check check-features test test-install doctest schema-check openapi-check
 
 # Run the app for testing purposes
 run-app *args:
@@ -444,6 +444,104 @@ check-wit-sync:
 # committed schemas are stale, so run this after changing those types.
 gen-schemas:
     cargo run -p super-stt-registry-types --features schema --bin gen_schemas
+
+# Regenerate docs/protocol/openapi.json from the daemon's live /v1 router.
+# Run it after changing anything under super-stt-daemon/src/daemon/http/v1/;
+# `just openapi-check` (part of `just ci`) fails when the committed file is
+# stale. Starts no daemon and touches no keyring — the document is built from
+# the route registrations themselves.
+openapi:
+    cargo run -q -p super-stt-daemon --bin gen_openapi
+
+# CI check: the committed OpenAPI document must match what the router produces.
+# Regenerates into a temp file and diffs, so a failing check never leaves the
+# working tree modified — the fix is `just openapi`.
+openapi-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    spec=docs/protocol/openapi.json
+    before=$(mktemp)
+    cp "$spec" "$before"
+    trap 'cp "$before" "$spec"; rm -f "$before"' EXIT
+    cargo run -q -p super-stt-daemon --bin gen_openapi >/dev/null
+    if ! diff -u "$before" "$spec"; then
+        echo >&2
+        echo "openapi.json is stale — the router and the published spec disagree." >&2
+        echo "Run 'just openapi' and commit the result." >&2
+        exit 1
+    fi
+    echo "openapi.json is current"
+
+# Browse the protocol spec locally. Regenerates it first so what you read is
+# what the router currently serves, then serves docs/protocol/ over HTTP —
+# the pages fetch openapi.json, which a file:// origin would block.
+#
+# Two renderings of the same document, so neither taste has to win:
+#   --swagger  (default) the familiar Swagger UI, richer per-response examples
+#   --scalar   prose beside examples, reads better with long descriptions
+# Either page links to the other, so the choice is not final.
+# Neither offers "Try it out": the daemon is on a Unix socket, which a browser
+# cannot dial, so an interactive request form could only ever fail.
+#
+# The port is chosen by the OS unless you name one, so this never collides with
+# whatever else is already listening. The server binds before announcing, so the
+# URL it prints is always the one actually being served.
+#
+# Usage: just openapi-serve [--scalar|--swagger] [port]
+openapi-serve *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    page=openapi.html
+    port=0  # 0 asks the OS for any free port
+    # Flag and port in either order, both optional.
+    argv=({{ args }})
+    for arg in ${argv[@]+"${argv[@]}"}; do
+        case "$arg" in
+            --swagger)   page=openapi.html ;;
+            --scalar)    page=scalar.html ;;
+            *[!0-9]*|'') echo "openapi-serve: unrecognized argument '$arg'" >&2
+                         echo "usage: just openapi-serve [--scalar|--swagger] [port]" >&2
+                         exit 2 ;;
+            *)           port="$arg" ;;
+        esac
+    done
+    just openapi
+    exec python3 - "$port" "$page" <<'PYEOF'
+    import functools
+    import http.server
+    import socketserver
+    import sys
+    import threading
+    import webbrowser
+
+    port, page = int(sys.argv[1]), sys.argv[2]
+
+    class Server(socketserver.TCPServer):
+        # Rebind straight after a previous run rather than waiting out TIME_WAIT.
+        allow_reuse_address = True
+
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory="docs/protocol"
+    )
+    try:
+        httpd = Server(("127.0.0.1", port), handler)
+    except OSError as e:
+        # Only reachable for a port named on the command line; port 0 cannot
+        # collide.
+        sys.exit(f"openapi-serve: cannot bind port {port}: {e}\n"
+                 f"Omit the port and one will be chosen for you.")
+
+    with httpd:
+        url = f"http://localhost:{httpd.server_address[1]}/{page}"
+        print(f"Serving the daemon protocol at {url}  (ctrl-c to stop)", flush=True)
+        # Open once the socket is listening, so the first request cannot race
+        # the bind. Silent when there is no browser to open (headless, SSH).
+        threading.Thread(target=webbrowser.open, args=(url,), daemon=True).start()
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print()
+    PYEOF
 
 # Install the app (system installation under /usr/local)
 install-app:

--- a/super-stt-app/src/core/app/handlers/stage.rs
+++ b/super-stt-app/src/core/app/handlers/stage.rs
@@ -27,8 +27,8 @@ use cosmic::prelude::*;
 use crate::core::app::AppModel;
 use crate::daemon::backends::BackendInfo;
 use crate::daemon::client::{
-    clear_stage_backend, get_model_device, list_model_devices, list_stage_devices, set_model_device,
-    set_stage_backend, set_stage_model, unload_stage_model,
+    clear_stage_backend, get_model_device, list_model_devices, list_stage_devices,
+    set_model_device, set_stage_backend, set_stage_model, unload_stage_model,
 };
 use crate::state::device_offers::{STT_STAGE, staged_device};
 use crate::ui::messages::{Message, ModelMessage, PostProcessorMessage, StageMessage};
@@ -48,7 +48,9 @@ impl AppModel {
                 self.set_selected_backend(stage, source.clone());
                 // The card's device chips are the daemon's answer for the
                 // backend now selected, so every selection asks again.
-                source.map_or_else(Task::none, |source| Self::load_backend_devices(stage, source))
+                source.map_or_else(Task::none, |source| {
+                    Self::load_backend_devices(stage, source)
+                })
             }
             StageMessage::BackendSelectFailed {
                 stage,
@@ -78,8 +80,12 @@ impl AppModel {
                 if self.selected_backend(stage).as_deref() != Some(source.as_str()) {
                     return Task::none();
                 }
-                self.device_offers
-                    .record(stage, source.clone(), Some(model.clone()), devices.clone());
+                self.device_offers.record(
+                    stage,
+                    source.clone(),
+                    Some(model.clone()),
+                    devices.clone(),
+                );
                 // Likewise for the pick: one made since the ask wins. Matched
                 // on the backend as well as the name, or a same-named model on
                 // another backend would claim this answer.
@@ -192,7 +198,11 @@ impl AppModel {
     /// Optimistic with rollback: the card moves at once and
     /// [`StageMessage::BackendSelectFailed`] puts it back, so a refused
     /// selection never leaves the card showing a backend the daemon rejected.
-    fn select_stage_backend(&mut self, stage: u32, source: String) -> Task<cosmic::Action<Message>> {
+    fn select_stage_backend(
+        &mut self,
+        stage: u32,
+        source: String,
+    ) -> Task<cosmic::Action<Message>> {
         // Re-selecting what is already selected is not a change; round-tripping
         // it would unload the running model for nothing.
         if self.selected_backend(stage).as_deref() == Some(source.as_str()) {
@@ -210,19 +220,22 @@ impl AppModel {
         self.core.window.show_context = false;
 
         let selected = source.clone();
-        Task::perform(set_stage_backend(stage, source), move |result| match result {
-            // Re-announce the selection the daemon just took, which is what
-            // asks it for the backend's devices.
-            Ok(()) => cosmic::Action::App(Message::Stage(StageMessage::BackendSelected {
-                stage,
-                source: Some(selected.clone()),
-            })),
-            Err(e) => cosmic::Action::App(Message::Stage(StageMessage::BackendSelectFailed {
-                stage,
-                prev: prev.clone(),
-                message: e.to_string(),
-            })),
-        })
+        Task::perform(
+            set_stage_backend(stage, source),
+            move |result| match result {
+                // Re-announce the selection the daemon just took, which is what
+                // asks it for the backend's devices.
+                Ok(()) => cosmic::Action::App(Message::Stage(StageMessage::BackendSelected {
+                    stage,
+                    source: Some(selected.clone()),
+                })),
+                Err(e) => cosmic::Action::App(Message::Stage(StageMessage::BackendSelectFailed {
+                    stage,
+                    prev: prev.clone(),
+                    message: e.to_string(),
+                })),
+            },
+        )
     }
 
     /// Empty `stage`, forgetting its model with it.
@@ -324,8 +337,14 @@ impl AppModel {
         // Captured so a failed switch rolls the device back rather than leaving
         // the card on one the daemon never adopted.
         let prev_device = self.current_device.clone();
-        self.set_model_loading(model.clone(), "Initiating model switch...".to_string(), stage);
-        if stage == STT_STAGE && let Some(dev) = &device_to_set {
+        self.set_model_loading(
+            model.clone(),
+            "Initiating model switch...".to_string(),
+            stage,
+        );
+        if stage == STT_STAGE
+            && let Some(dev) = &device_to_set
+        {
             self.current_device.clone_from(dev);
         }
 
@@ -444,11 +463,13 @@ impl AppModel {
         source: String,
     ) -> Task<cosmic::Action<Message>> {
         Task::perform(list_stage_devices(stage), move |result| match result {
-            Ok(devices) => cosmic::Action::App(Message::Stage(StageMessage::BackendDevicesLoaded {
-                stage,
-                source: source.clone(),
-                devices,
-            })),
+            Ok(devices) => {
+                cosmic::Action::App(Message::Stage(StageMessage::BackendDevicesLoaded {
+                    stage,
+                    source: source.clone(),
+                    devices,
+                }))
+            }
             // The chips fall back to the catalog's own reading until an answer
             // lands, so a failed read costs the narrowing, not the row.
             Err(e) => {
@@ -537,7 +558,12 @@ mod tests {
         let installed = vec![backend("github.com/x/whisper", "whisper-tiny", &["cuda"])];
 
         assert_eq!(
-            staged_load_device(&installed, "github.com/x/gone", "whisper-tiny", Some("cuda")),
+            staged_load_device(
+                &installed,
+                "github.com/x/gone",
+                "whisper-tiny",
+                Some("cuda")
+            ),
             StagedLoad::NotInCatalog,
         );
         assert_eq!(
@@ -559,7 +585,11 @@ mod tests {
     /// sent as one.
     #[test]
     fn an_online_model_sets_no_device() {
-        let installed = vec![backend("github.com/x/openai", "gpt-4o-transcribe", &["none"])];
+        let installed = vec![backend(
+            "github.com/x/openai",
+            "gpt-4o-transcribe",
+            &["none"],
+        )];
         assert_eq!(
             staged_load_device(
                 &installed,
@@ -567,16 +597,27 @@ mod tests {
                 "gpt-4o-transcribe",
                 Some("none"),
             ),
-            StagedLoad::Load { device_to_set: None },
+            StagedLoad::Load {
+                device_to_set: None
+            },
         );
     }
 
     /// A local model sends the staged device as its own.
     #[test]
     fn a_local_model_sets_the_staged_device() {
-        let installed = vec![backend("github.com/x/whisper", "whisper-tiny", &["cpu", "gpu"])];
+        let installed = vec![backend(
+            "github.com/x/whisper",
+            "whisper-tiny",
+            &["cpu", "gpu"],
+        )];
         assert_eq!(
-            staged_load_device(&installed, "github.com/x/whisper", "whisper-tiny", Some("gpu")),
+            staged_load_device(
+                &installed,
+                "github.com/x/whisper",
+                "whisper-tiny",
+                Some("gpu")
+            ),
             StagedLoad::Load {
                 device_to_set: Some("gpu".to_string())
             },

--- a/super-stt-app/src/daemon/client/v1/settings/stage.rs
+++ b/super-stt-app/src/daemon/client/v1/settings/stage.rs
@@ -121,9 +121,18 @@ pub async fn get_stage(stage: u32) -> HttpResult<StageState> {
         )?;
         // A daemon that predates the pipeline omits the stage; read that as
         // "empty, nothing selected" rather than failing the settings load.
+        //
+        // The stage is a typed `StageReport` on the wire now, so this reads the
+        // fields the card needs straight off it rather than re-parsing JSON.
         Ok(resp
             .stage
-            .and_then(|v| serde_json::from_value(v).ok())
+            .map(|st| StageState {
+                source: st.source,
+                model: st.model,
+                loaded: st.loaded,
+                device: st.device,
+                enabled: st.enabled,
+            })
             .unwrap_or_default())
     })
     .await

--- a/super-stt-app/src/ui/views/models/post_processing.rs
+++ b/super-stt-app/src/ui/views/models/post_processing.rs
@@ -318,8 +318,8 @@ fn control_row<'a>(app: &'a AppModel, backend: &'a BackendInfo) -> Element<'a, M
     let staged_online = shown
         .as_deref()
         .is_some_and(|m| model_is_online(backend, m));
-    let staged_ok = selected.is_some()
-        && (app.staged_picks.device(PP_STAGE).is_some() || staged_online);
+    let staged_ok =
+        selected.is_some() && (app.staged_picks.device(PP_STAGE).is_some() || staged_online);
     picker_row
         .push(
             button::suggested("Load model")

--- a/super-stt-app/src/ui/views/models/select_sheet.rs
+++ b/super-stt-app/src/ui/views/models/select_sheet.rs
@@ -7,8 +7,8 @@ use cosmic::widget::{self, button, text};
 use crate::core::app::AppModel;
 use crate::daemon::backends::BackendInfo;
 use crate::state::ContextPage;
-use crate::ui::icons;
 use crate::state::device_offers::STT_STAGE;
+use crate::ui::icons;
 use crate::ui::messages::{Message, ShellMessage, StageMessage};
 
 use super::active::backend_glyph_tile;

--- a/super-stt-daemon/Cargo.toml
+++ b/super-stt-daemon/Cargo.toml
@@ -12,6 +12,12 @@
     path = "src/bin/mock_backend.rs"
     required-features = ["test-fixtures"]
 
+# Writes docs/protocol/openapi.json from the live `/v1` router. Run via
+# `just openapi`; `just openapi-check` fails when the committed file is stale.
+[[bin]]
+    name = "gen_openapi"
+    path = "src/bin/gen_openapi.rs"
+
 [dependencies]
     # Core dependencies
     anyhow.workspace = true
@@ -66,6 +72,10 @@
         features = [
             "analysis",
             "audio",
+            # The protocol types the daemon publishes in its OpenAPI document
+            # carry their own `ToSchema`, so the spec describes each one where it
+            # is defined instead of restating its fields at the router.
+            "openapi",
         ]
     }
     tar = "0.4.46"
@@ -92,6 +102,8 @@
     toml.workspace = true
     ulid = "1.2.1"
     urlencoding = "2.1.3"
+    utoipa.workspace = true
+    utoipa-axum.workspace = true
     uuid.workspace = true
     wasmtime = { version = "45.0.0", features = ["async"], optional = true }
     wasmtime-wasi = { version = "45.0.0", optional = true }

--- a/super-stt-daemon/src/bin/gen_openapi.rs
+++ b/super-stt-daemon/src/bin/gen_openapi.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Write the daemon protocol's `OpenAPI` document to `docs/protocol/openapi.json`.
+//!
+//! Run it with `just openapi` after changing anything under
+//! `src/daemon/http/v1/`; `just openapi-check` (part of `just ci`) fails when
+//! the committed file no longer matches what the router produces, so the
+//! published spec cannot fall behind the protocol.
+//!
+//! The document is built from the route registrations themselves, so this
+//! starts no daemon, opens no socket, and touches no keyring.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Resolve `docs/protocol/openapi.json` from the crate's own location, so the
+/// generator writes the same file whatever directory it is invoked from.
+fn output_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("the daemon crate always sits inside the workspace root")
+        .join("docs/protocol/openapi.json")
+}
+
+fn main() -> std::io::Result<()> {
+    let doc = super_stt_daemon::daemon::http::openapi_document();
+    let mut json = doc
+        .to_pretty_json()
+        .expect("the generated document is always serializable");
+    // A trailing newline, so the committed file is a well-formed text file and
+    // `git diff` does not report "\ No newline at end of file" on every change.
+    json.push('\n');
+
+    let path = output_path();
+    let mut file = std::fs::File::create(&path)?;
+    file.write_all(json.as_bytes())?;
+
+    let paths = doc.paths.paths.len();
+    println!("wrote {} ({paths} paths)", path.display());
+    Ok(())
+}

--- a/super-stt-daemon/src/daemon/core_tests.rs
+++ b/super-stt-daemon/src/daemon/core_tests.rs
@@ -1637,21 +1637,18 @@ async fn a_stage_reports_only_its_own_download() {
         .start_download(tracker)
         .expect("register download");
 
-    let pipeline = daemon
+    let stages = daemon
         .handle_get_pipeline()
         .await
         .pipeline
         .expect("pipeline");
-    let stages = pipeline.as_array().expect("stages");
     assert!(
-        stages[0]["switch"].is_null(),
+        stages[0].switch.is_none(),
         "stage 1 must not report the post-processor's download"
     );
-    assert_eq!(stages[1]["switch"]["target"]["model"], "s1-mini-q4_k_m");
-    assert_eq!(
-        stages[1]["switch"]["target"]["source"],
-        "github.com/super-stt/s1-mini"
-    );
+    let switch = stages[1].switch.as_ref().expect("stage 2 switch");
+    assert_eq!(switch.target.model, "s1-mini-q4_k_m");
+    assert_eq!(switch.target.source, "github.com/super-stt/s1-mini");
 }
 
 /// Cancel is addressed to a stage, so a stage with nothing of its own in

--- a/super-stt-daemon/src/daemon/http/internal/helpers/dispatch.rs
+++ b/super-stt-daemon/src/daemon/http/internal/helpers/dispatch.rs
@@ -125,6 +125,45 @@ pub(crate) async fn dispatch_command(
     json_response(&resp)
 }
 
+/// Answer a dispatched command with a *narrow* success body.
+///
+/// The command bus speaks one [`DaemonResponse`] carrying every field any
+/// command might set. An endpoint answers with the handful it actually fills,
+/// and `success` names exactly those — so the type an endpoint publishes in the
+/// `OpenAPI` document is the type its handler builds. A schema cannot claim a
+/// field the handler never sets, or omit one it does, because there is no
+/// second description to disagree with.
+///
+/// Failures keep the envelope the daemon built, status code and all: error
+/// identity is `error_code`, and mapping it is [`json_response`]'s job.
+pub(crate) fn narrowed<T: serde::Serialize>(
+    resp: DaemonResponse,
+    success: impl FnOnce(DaemonResponse) -> T,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    if resp.status != "success" {
+        return json_response(&resp).into_response();
+    }
+    let body = serde_json::to_string(&success(resp))
+        .unwrap_or_else(|_| String::from(r#"{"status":"error"}"#));
+    (StatusCode::OK, [("content-type", "application/json")], body).into_response()
+}
+
+/// [`narrowed`] for the commonest shape of all: an acknowledgement carrying the
+/// daemon's sentence and nothing else.
+pub(crate) async fn ack(
+    daemon: &SuperSTTDaemon,
+    command: &str,
+    data: Option<Value>,
+) -> axum::response::Response {
+    let resp = dispatch(daemon, build_request(command, data)).await;
+    narrowed(resp, |r| crate::daemon::http::wire::Ack {
+        status: "success",
+        message: r.message,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::status_code_for_response;

--- a/super-stt-daemon/src/daemon/http/mod.rs
+++ b/super-stt-daemon/src/daemon/http/mod.rs
@@ -5,9 +5,13 @@
 #[cfg(test)]
 mod error_envelope_contract;
 mod internal;
+mod openapi;
+#[cfg(test)]
+mod openapi_contract;
 mod server;
 mod state;
 mod v1;
+mod wire;
 
 /// Re-exported so the daemon's shutdown path can drain queued session-store
 /// writes before `process::exit` (audit 2 Tier 1 #5) without reaching into the
@@ -15,3 +19,11 @@ mod v1;
 pub(crate) use internal::auth::tokens::flush_persisted_sessions;
 pub use server::AUTO_APPROVE_ENV;
 pub use server::start_http_server;
+
+/// The generated `OpenAPI` document for the `/v1` surface. Built from the same
+/// route registrations the live router uses, so it needs no daemon and no
+/// keyring — see `src/bin/gen_openapi.rs`.
+#[must_use]
+pub fn openapi_document() -> utoipa::openapi::OpenApi {
+    v1::openapi()
+}

--- a/super-stt-daemon/src/daemon/http/openapi.rs
+++ b/super-stt-daemon/src/daemon/http/openapi.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! The `OpenAPI` document for the daemon protocol.
+//!
+//! The document is generated from the router, not written beside it: every
+//! `/v1` route is registered through [`utoipa_axum::routes!`], which reads the
+//! `#[utoipa::path]` attribute on the handler it points at. A route and its
+//! documentation are therefore one declaration — adding a route without
+//! documenting it does not compile, and changing a path changes both.
+//!
+//! `just openapi` writes the result to `docs/protocol/openapi.json`;
+//! `just openapi-check` fails when the committed file is stale, so a protocol
+//! change cannot merge without the published spec moving with it.
+//!
+//! The prose reference under `docs/protocol/` is not replaced by any of this.
+//! It explains *when* to call an endpoint and how the pieces fit; the spec
+//! states the shapes exactly, for tooling and for a client generator.
+
+use utoipa::Modify;
+use utoipa::OpenApi;
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+
+/// Base document: everything that is true of the protocol as a whole rather
+/// than of one endpoint. The paths and schemas are filled in from the router
+/// (see [`super::v1::openapi`]).
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Super STT daemon protocol",
+        description = "\
+HTTP/1.1 + JSON over a Unix domain socket at `$XDG_RUNTIME_DIR/stt/super-stt-http.sock` \
+(override with `SUPER_STT_HTTP_SOCKET`). There is no TCP listener: the socket's \
+filesystem permissions are the first layer of access control, and the daemon reads \
+`SO_PEERCRED` on each connection to identify the calling binary.
+
+Every endpoint except `POST /v1/auth/request` requires `Authorization: Bearer <token>`. \
+A token is minted only after the user approves your app in a consent popup, and is bound \
+to the approved binary — an app cannot widen its own permissions. See `docs/protocol/auth.md`.
+
+Because the transport is a Unix socket, the `servers` entry below is nominal; point your \
+client at the socket and use any `Host`. With curl:
+
+```
+curl --unix-socket \"$XDG_RUNTIME_DIR/stt/super-stt-http.sock\" \\
+     -H \"Authorization: Bearer $STT_TOKEN\" \\
+     http://stt.local/v1/ping
+```",
+        license(name = "GPL-3.0-only", identifier = "GPL-3.0-only"),
+        contact(name = "Super STT", url = "https://github.com/jorge-menjivar/super-stt"),
+    ),
+    servers((url = "http://stt.local", description = "Nominal host; the transport is the Unix socket")),
+    modifiers(&BearerAuth),
+    tags(
+        (name = "auth", description = "Consent handshake and token probing."),
+        (name = "health", description = "Liveness and what the daemon is currently running."),
+        (name = "transcribe", description = "Start, stop and stream transcription."),
+        (name = "events", description = "Server-Sent Events for recording state, audio levels, model and download progress, and final transcripts."),
+        (name = "pipeline", description = "The ordered stages a transcript passes through: which backend fills each, which model runs there, and on what device."),
+        (name = "settings", description = "Daemon configuration: audio cues, write and notification methods, language, self-update."),
+        (name = "backends", description = "Installed backends: their models, options and secrets."),
+        (name = "registry", description = "The published backend catalog: browse, install, update, uninstall."),
+    ),
+)]
+pub(crate) struct ApiDoc;
+
+/// The one security scheme: the session token from `POST /v1/auth/request`,
+/// presented as a bearer token. Declared here rather than per endpoint so the
+/// scheme has a single definition; which *scopes* each endpoint needs is stated
+/// on the endpoint, since that is where it differs.
+struct BearerAuth;
+
+impl Modify for BearerAuth {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .as_mut()
+            .expect("the derived document always carries a components object");
+        components.add_security_scheme(
+            "session_token",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .description(Some(
+                        "Session token from `POST /v1/auth/request`. Bound to the calling \
+                         binary and valid for 30 days.",
+                    ))
+                    .build(),
+            ),
+        );
+    }
+}

--- a/super-stt-daemon/src/daemon/http/openapi_contract.rs
+++ b/super-stt-daemon/src/daemon/http/openapi_contract.rs
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Contract: the published document has to be worth publishing.
+//!
+//! `just openapi-check` already proves the committed `openapi.json` matches
+//! what the router generates. That is a narrower claim than it sounds: it
+//! catches a *stale* file, not a *wrong* one. Regenerating turns any mistake
+//! into a committed mistake, and the check goes green.
+//!
+//! These tests are the other half. They assert the things a reader depends on
+//! and nothing else enforces:
+//!
+//! - the scope an endpoint advertises is the scope the router enforces on it;
+//! - every operation carries prose, not a placeholder;
+//! - every success body names a real shape, not "some JSON";
+//! - every guarded endpoint documents the failures a client will actually hit.
+//!
+//! They iterate the whole document, so adding an endpoint adds nothing here —
+//! the new endpoint is simply held to the same standard as the rest.
+//!
+//! The document is inspected as JSON rather than through utoipa's types,
+//! because JSON is what a client generator, a linter and a human actually
+//! receive.
+
+use serde_json::Value;
+
+/// The generated document, as a consumer receives it.
+fn document() -> Value {
+    serde_json::to_value(super::openapi_document()).expect("the document serializes")
+}
+
+/// Every `(path, method, operation)` in the document.
+fn operations(doc: &Value) -> Vec<(String, String, &Value)> {
+    const METHODS: [&str; 7] = ["get", "put", "post", "delete", "options", "head", "patch"];
+    let mut out = Vec::new();
+    for (path, item) in doc["paths"].as_object().expect("paths is an object") {
+        for (method, op) in item.as_object().expect("a path item is an object") {
+            if METHODS.contains(&method.as_str()) {
+                out.push((path.clone(), method.clone(), op));
+            }
+        }
+    }
+    assert!(!out.is_empty(), "the document describes no operations");
+    out
+}
+
+/// The scopes an operation advertises under the one security scheme, or `None`
+/// when it advertises no security at all.
+fn advertised_scopes(op: &Value) -> Option<Vec<String>> {
+    let requirements = op.get("security")?.as_array()?;
+    let first = requirements.first()?;
+    let scopes = first
+        .get("session_token")
+        .expect("the only security scheme is `session_token`")
+        .as_array()
+        .expect("scopes are an array");
+    Some(
+        scopes
+            .iter()
+            .map(|s| s.as_str().expect("a scope is a string").to_string())
+            .collect(),
+    )
+}
+
+/// Follow a `$ref` into `components/schemas`, or return the schema unchanged
+/// when it is inline.
+fn resolve<'a>(doc: &'a Value, schema: &'a Value) -> &'a Value {
+    let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
+        return schema;
+    };
+    let name = reference
+        .strip_prefix("#/components/schemas/")
+        .unwrap_or_else(|| panic!("unexpected $ref target: {reference}"));
+    doc["components"]["schemas"]
+        .get(name)
+        .unwrap_or_else(|| panic!("$ref names a schema that is not in the document: {name}"))
+}
+
+/// The scope each endpoint advertises must be the scope the router puts it
+/// behind.
+///
+/// These are written in two places that cannot see each other: the scope in a
+/// `#[utoipa::path]` attribute on the handler, the guard in the group the
+/// handler is registered into. Nothing else compares them, and a mismatch is
+/// silent in the worst way — the endpoint works, the documentation is wrong,
+/// and a client author requests a scope that earns them a `403` with no
+/// explanation. `/auth/request` is the one endpoint with no security at all,
+/// because it is how a caller obtains a token in the first place.
+#[test]
+fn every_operation_advertises_the_scope_its_router_enforces() {
+    let doc = document();
+    let enforced = super::v1::enforced_scopes();
+
+    let mut wrong = Vec::new();
+    for (path, method, op) in operations(&doc) {
+        let guard = enforced
+            .get(&path)
+            .unwrap_or_else(|| panic!("{method} {path} is in the document but in no scope group"));
+        let advertised = advertised_scopes(op);
+        let expected = guard.as_ref().map(|s| {
+            s.iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<_>>()
+        });
+        if advertised != expected {
+            wrong.push(format!(
+                "  {} {path}\n      router enforces: {expected:?}\n      document says:   {advertised:?}",
+                method.to_uppercase()
+            ));
+        }
+    }
+    assert!(
+        wrong.is_empty(),
+        "these endpoints document a scope the router does not enforce:\n{}",
+        wrong.join("\n")
+    );
+}
+
+/// Every path the router serves must appear in the document, and vice versa.
+///
+/// `routes!` makes this true by construction today — the path comes off the
+/// handler's own attribute. The test is here so that stays true if anyone
+/// registers a route the older way, with `.route("/x", get(handler))`, which
+/// compiles fine and publishes nothing.
+#[test]
+fn the_document_and_the_router_cover_the_same_paths() {
+    let doc = document();
+    let documented: std::collections::BTreeSet<String> = doc["paths"]
+        .as_object()
+        .expect("paths is an object")
+        .keys()
+        .cloned()
+        .collect();
+    let served: std::collections::BTreeSet<String> =
+        super::v1::enforced_scopes().keys().cloned().collect();
+
+    assert_eq!(
+        documented, served,
+        "the document and the router disagree about which paths exist"
+    );
+}
+
+/// Every operation has to say what it is and what it does.
+///
+/// A summary is what a reader scans in the sidebar; a description is the part
+/// that answers "should I be calling this?". An endpoint that ships with
+/// neither is invisible in the reference even though it is in the document.
+#[test]
+fn every_operation_carries_prose() {
+    let doc = document();
+
+    let mut bare = Vec::new();
+    for (path, method, op) in operations(&doc) {
+        let summary = op.get("summary").and_then(Value::as_str).unwrap_or("");
+        let description = op.get("description").and_then(Value::as_str).unwrap_or("");
+        // A one-word summary is a placeholder, not a summary. The shortest real
+        // one in the document is "Liveness probe".
+        if summary.len() < 8 || description.len() < 40 {
+            bare.push(format!(
+                "  {} {path}  (summary {} chars, description {} chars)",
+                method.to_uppercase(),
+                summary.len(),
+                description.len()
+            ));
+        }
+    }
+    assert!(
+        bare.is_empty(),
+        "these operations are missing prose a reader needs:\n{}",
+        bare.join("\n")
+    );
+}
+
+/// Every response has to name the shape it carries.
+///
+/// This is the property the narrow response types exist for. The daemon passes
+/// one wide `DaemonResponse` around internally, and a schema generated from
+/// *that* would tell a client `GET /volume` may return forty-two fields when it
+/// returns two. A body that resolves to a schema with no properties means an
+/// endpoint has slipped back to publishing "some JSON".
+///
+/// Two documented exceptions, both because the payload is not a JSON body at
+/// all: the event stream and the `101` of the realtime upgrade.
+#[test]
+fn every_response_names_a_real_shape() {
+    let doc = document();
+
+    let mut untyped = Vec::new();
+    for (path, method, op) in operations(&doc) {
+        for (code, response) in op["responses"]
+            .as_object()
+            .expect("responses is an object")
+            .iter()
+        {
+            let Some(content) = response.get("content") else {
+                // A response with no body at all: only the protocol-upgrade
+                // `101`, which hands the connection to the WebSocket session.
+                assert_eq!(
+                    code, "101",
+                    "{method} {path} {code} carries no body; only the upgrade may"
+                );
+                continue;
+            };
+            let Some(json) = content.get("application/json") else {
+                // `text/event-stream`: the frames are documented in prose,
+                // since SSE has no schema language.
+                assert!(
+                    content.get("text/event-stream").is_some(),
+                    "{method} {path} {code} has a body in neither JSON nor SSE"
+                );
+                continue;
+            };
+            let schema = resolve(&doc, &json["schema"]);
+            let named = schema
+                .get("properties")
+                .and_then(Value::as_object)
+                .is_some_and(|p| !p.is_empty());
+            if !named {
+                untyped.push(format!("  {} {path} → {code}", method.to_uppercase()));
+            }
+        }
+    }
+    assert!(
+        untyped.is_empty(),
+        "these responses publish an unnamed shape:\n{}",
+        untyped.join("\n")
+    );
+}
+
+/// Every guarded endpoint documents the two failures its guard produces.
+///
+/// A client hits `401` the moment its token expires and `403` the moment it
+/// asks for something outside its scopes. Both are certain to happen, both are
+/// recoverable, and a client that has not been told about them handles neither.
+/// The scope-less group is exempt from `403`: a guard that checks no scope
+/// cannot deny one.
+#[test]
+fn every_guarded_endpoint_documents_its_auth_failures() {
+    let doc = document();
+
+    let mut missing = Vec::new();
+    for (path, method, op) in operations(&doc) {
+        let Some(scopes) = advertised_scopes(op) else {
+            continue; // unauthenticated: nothing to expire, nothing to deny
+        };
+        let responses = op["responses"].as_object().expect("responses is an object");
+
+        let mut wanted = vec!["401"];
+        if !scopes.is_empty() {
+            wanted.push("403");
+        }
+        for code in wanted {
+            if !responses.contains_key(code) {
+                missing.push(format!(
+                    "  {} {path} does not document {code}",
+                    method.to_uppercase()
+                ));
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "these endpoints leave a client unable to handle an auth failure:\n{}",
+        missing.join("\n")
+    );
+}
+
+/// The document declares the one security scheme the whole surface uses.
+///
+/// Every operation's `security` references `session_token` by name. If the
+/// scheme itself went missing the references would dangle, and a generated
+/// client would have no way to send the token at all.
+#[test]
+fn the_bearer_scheme_is_defined() {
+    let doc = document();
+
+    assert_eq!(
+        doc["openapi"].as_str().map(|v| v.starts_with("3.1")),
+        Some(true),
+        "the document should be OpenAPI 3.1 — Swagger UI 4.x cannot read it, \
+         and docs/protocol/openapi.html pins 5.x on that basis"
+    );
+
+    let scheme = &doc["components"]["securitySchemes"]["session_token"];
+    assert_eq!(scheme["type"], "http", "the scheme is HTTP auth");
+    assert_eq!(scheme["scheme"], "bearer", "presented as a bearer token");
+}
+
+/// The documented error shapes must match the envelopes the daemon really
+/// builds.
+///
+/// The daemon has several error constructors, each with a slightly different
+/// shape, and each endpoint's `#[utoipa::path]` names one of two schemas for
+/// its failures. Those are hand-paired: nothing checks that the constructor an
+/// endpoint reaches for emits the keys the schema it points at declares. A key
+/// the daemon sends but the document omits is worse than an undocumented
+/// endpoint — the client author reads a complete-looking shape and writes a
+/// parser that discards the field carrying the failure's identity.
+///
+/// A sibling of `error_envelope_contract`, which checks the same envelopes
+/// survive the trip to the client. This one checks they were described.
+///
+/// Adding an error constructor? Add it here too.
+#[tokio::test]
+async fn documented_error_shapes_match_the_envelopes_the_daemon_builds() {
+    use super::internal::helpers::responses::{
+        invalid_session, model_not_loaded_response, rate_limited, reason,
+        recording_in_progress_response, scope_denied,
+    };
+    use super::v1::backends::{json_error, json_error_msg};
+    use super::v1::registry::{registry_error, registry_error_msg};
+    use axum::http::StatusCode;
+
+    async fn keys_of(resp: axum::response::Response) -> Vec<String> {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect body");
+        let value: Value = serde_json::from_slice(&bytes).expect("an error body is JSON");
+        value
+            .as_object()
+            .expect("an error body is an object")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    // Each constructor, paired with the schema the endpoints using it name.
+    let cases: Vec<(&str, &str, axum::response::Response)> = vec![
+        (
+            "json_error",
+            "ErrorEnvelope",
+            json_error(StatusCode::NOT_FOUND, "unknown_backend"),
+        ),
+        (
+            "json_error_msg",
+            "ErrorEnvelope",
+            json_error_msg(StatusCode::BAD_REQUEST, "invalid_option", "out of range"),
+        ),
+        ("scope_denied", "ErrorEnvelope", scope_denied()),
+        ("rate_limited", "ErrorEnvelope", rate_limited()),
+        (
+            "recording_in_progress",
+            "ErrorEnvelope",
+            recording_in_progress_response(),
+        ),
+        (
+            "model_not_loaded",
+            "ErrorEnvelope",
+            model_not_loaded_response(),
+        ),
+        (
+            "registry_error",
+            "RegistryError",
+            registry_error(StatusCode::NOT_FOUND, "not_found"),
+        ),
+        (
+            "registry_error_msg",
+            "RegistryError",
+            registry_error_msg(StatusCode::INTERNAL_SERVER_ERROR, "remove_failed", "denied"),
+        ),
+        (
+            "invalid_session",
+            "ReasonEnvelope",
+            invalid_session(reason::UNKNOWN),
+        ),
+    ];
+
+    let doc = document();
+    let mut undocumented = Vec::new();
+    for (constructor, schema_name, response) in cases {
+        let schema = doc["components"]["schemas"]
+            .get(schema_name)
+            .unwrap_or_else(|| panic!("{schema_name} is not published in the document"));
+        let declared: Vec<&String> = schema["properties"]
+            .as_object()
+            .expect("an envelope declares properties")
+            .keys()
+            .collect();
+
+        for key in keys_of(response).await {
+            if !declared.iter().any(|d| **d == key) {
+                undocumented.push(format!(
+                    "  {constructor} sends `{key}`, which {schema_name} does not declare"
+                ));
+            }
+        }
+    }
+    assert!(
+        undocumented.is_empty(),
+        "the daemon sends error fields the document does not describe:\n{}",
+        undocumented.join("\n")
+    );
+}

--- a/super-stt-daemon/src/daemon/http/v1/auth/request.rs
+++ b/super-stt-daemon/src/daemon/http/v1/auth/request.rs
@@ -5,6 +5,7 @@ use crate::daemon::http::internal::auth::consent::{
 };
 use crate::daemon::http::internal::helpers::responses::{auth_err, is_known_scope, reason};
 use crate::daemon::http::state::{AppState, PeerInfo};
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -12,20 +13,38 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub(crate) struct AuthRequestBody {
+    /// The name shown to the user in the consent popup. Self-reported and
+    /// therefore untrusted: the daemon identifies you by your binary, and a
+    /// previous denial sticks to that binary whatever name you send next.
+    #[schema(example = "My App")]
     pub(crate) app_name: String,
+    /// The scopes to request, at least one. Every entry must be known or the
+    /// whole request is refused; ask only for what you need, since the user
+    /// sees the list.
+    #[schema(example = json!(["transcribe", "status"]))]
     pub(crate) scopes: Vec<String>,
+    /// Your app's version. Accepted for forwards compatibility; unused today.
     #[serde(default)]
     #[allow(dead_code)] // accepted for forwards compat; not yet used
+    #[schema(example = "0.1")]
     pub(crate) version: Option<String>,
 }
 
-#[derive(Serialize)]
+/// A freshly minted session token.
+#[derive(Serialize, utoipa::ToSchema)]
 pub(crate) struct AuthOk {
+    /// Always `success`.
+    #[schema(example = "success")]
     pub(crate) status: &'static str,
+    /// Send this as `Authorization: Bearer <token>` on every other endpoint.
+    /// Bound to the approved binary — it stops working if that binary changes
+    /// on disk.
     pub(crate) session_token: String,
+    /// The scopes actually granted, sorted and deduplicated.
     pub(crate) scopes: Vec<String>,
+    /// RFC 3339 expiry, 30 days out.
     pub(crate) expires_at: String,
 }
 
@@ -85,6 +104,37 @@ fn official_client_response(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/auth/request",
+    tag = "auth",
+    summary = "Ask the user for a session token",
+    description = "\
+The consent handshake, and the only endpoint reachable without a token.
+
+The daemon reads `SO_PEERCRED` on your connection, resolves `/proc/<pid>/exe`, and \
+shows the user a popup naming that binary and the scopes you asked for. On Allow it \
+mints a 32-byte token bound to that binary and valid for 30 days.
+
+A denial is remembered for the `(binary, scopes)` pair for the rest of the daemon's \
+lifetime and answers `403` immediately without re-prompting — renaming your app does \
+not clear it, since the key is the binary. Restarting the daemon does.
+
+Setting `SUPER_STT_AUTO_APPROVE=1` in the daemon's environment skips the popup \
+entirely; it is for tests and CI, not for production.",
+    request_body = AuthRequestBody,
+    responses(
+        (status = 200, description = "The user approved. Store the token.", body = AuthOk),
+        (status = 400, description = "Body was missing or malformed (`invalid_body`), or `scopes` was empty or named an unknown scope (`invalid_scope`).", body = ReasonEnvelope),
+        (status = 403, description = "\
+The user denied or dismissed the popup (`user_denied`, `user_dismissed`), a previous \
+denial for this binary and scope set still stands (`user_denied_cached`), the \
+connecting user is not the daemon's own (`uid_mismatch`), the daemon could not \
+resolve your binary and so refused to identify you (`peer_unverifiable`), or the \
+popup could not be shown (`popup_failed`).", body = ReasonEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn auth_request(
     State(state): State<AppState>,
     peer: Option<axum::Extension<PeerInfo>>,

--- a/super-stt-daemon/src/daemon/http/v1/auth/status.rs
+++ b/super-stt-daemon/src/daemon/http/v1/auth/status.rs
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::daemon::http::internal::auth::middleware::AuthContext;
 use crate::daemon::http::internal::helpers::responses::{invalid_session, reason};
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 
-#[derive(Serialize)]
+/// What the token currently held is good for.
+#[derive(Serialize, utoipa::ToSchema)]
 pub(crate) struct AuthStatusOk {
+    /// Always `success`.
+    #[schema(example = "success")]
     pub(crate) status: &'static str,
+    /// The scopes the token was minted under.
     pub(crate) scopes: Vec<String>,
+    /// RFC 3339 expiry, so a headless client can renew before it lapses.
     pub(crate) expires_at: String,
 }
 
@@ -24,6 +30,25 @@ pub(crate) struct AuthStatusOk {
 /// Errors (`401 invalid_session` with `data.reason` of `unknown`,
 /// `expired`, or `exe_changed`) are produced upstream by
 /// `require_any_authenticated` before this handler runs.
+#[utoipa::path(
+    get,
+    path = "/auth/status",
+    tag = "auth",
+    summary = "Check the held token without prompting",
+    description = "\
+Reports what the presented token is good for, and never opens a consent popup — \
+which is what makes it the right probe for a headless or CLI client. Reaching this \
+handler at all means the token validated.
+
+Use it to fail fast on a token about to expire, rather than discovering it \
+mid-operation.",
+    security(("session_token" = [])),
+    responses(
+        (status = 200, description = "The token is valid.", body = AuthStatusOk),
+        (status = 401, description = "Token unknown, expired, or its binary changed — re-run the consent handshake.", body = ReasonEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn auth_status(ctx: Option<axum::Extension<AuthContext>>) -> Response {
     let Some(axum::Extension(ctx)) = ctx else {
         return invalid_session(reason::UNKNOWN);

--- a/super-stt-daemon/src/daemon/http/v1/backends/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/mod.rs
@@ -45,11 +45,14 @@ pub(crate) fn json_error_msg(code: StatusCode, error_code: &str, message: &str) 
 }
 
 /// House-style JSON success response with status 200.
-pub(crate) fn ok(v: &serde_json::Value) -> Response {
+///
+/// Generic over the body so each endpoint hands it the narrow type it publishes
+/// in the `OpenAPI` document, rather than a `Value` that has forgotten its shape.
+pub(crate) fn ok<T: serde::Serialize>(v: &T) -> Response {
     (
         StatusCode::OK,
         [("content-type", "application/json")],
-        v.to_string(),
+        serde_json::to_string(v).unwrap_or_else(|_| String::from(r#"{"status":"error"}"#)),
     )
         .into_response()
 }

--- a/super-stt-daemon/src/daemon/http/v1/backends/model_language.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/model_language.rs
@@ -6,25 +6,28 @@
 //! not it is currently loaded. See
 //! `docs/protocol/endpoints/v1/backends/model-language.md`.
 use super::{decode_source, find_backend, json_error};
-use crate::daemon::http::internal::helpers::dispatch::dispatch_command;
+use crate::daemon::http::internal::helpers::dispatch::{build_request, dispatch, narrowed};
 use crate::daemon::http::state::AppState;
-use axum::Router;
+use crate::daemon::http::v1::settings::wire::{FromDaemon, ModelLanguageState};
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::routing::get;
+use axum::response::Response;
 use serde::Deserialize;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-pub(crate) fn routes() -> Router<AppState> {
-    Router::new().route(
-        "/backends/{source}/models/{model}/language",
-        get(get_one).post(set).delete(clear),
-    )
+pub(crate) fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(get_one, set, clear))
 }
 
-#[derive(Deserialize)]
+/// The language this model should transcribe in.
+#[derive(Deserialize, utoipa::ToSchema)]
 struct LanguageBody {
+    /// A BCP-47 tag such as `es`, or `auto` to let the model detect it. Empty is
+    /// refused — clear an override with `DELETE`.
     #[serde(default)]
+    #[schema(example = "es")]
     language: String,
 }
 
@@ -39,7 +42,32 @@ async fn guard_missing(s: &AppState, source: &str, model: &str) -> Option<Respon
     }
 }
 
-/// `GET /backends/{source}/models/{model}/language` — the resolution block.
+#[utoipa::path(
+    get,
+    path = "/backends/{source}/models/{model}/language",
+    tag = "backends",
+    summary = "Read a model's language override",
+    description = "\
+The language this specific model transcribes in, which overrides the global \
+`/language` setting. Addressed by `(source, model)` rather than \"the active \
+model\", so it can be read whether or not the model is loaded.
+
+`null` means no override: the model follows the global setting.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+        ("model" = String, Path, description = "The model's name, as `GET /backends` spells it."),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "How this model's language resolves.", body = ModelLanguageState),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such model (`unknown_model`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn get_one(
     State(s): State<AppState>,
     Path((source, model)): Path<(String, String)>,
@@ -51,16 +79,41 @@ async fn get_one_inner(s: AppState, source: String, model: String) -> Response {
     if let Some(r) = guard_missing(&s, &source, &model).await {
         return r;
     }
-    let (code, _hdrs, body_str) = dispatch_command(
-        &s.daemon,
+    let req = build_request(
         "get_model_language",
         Some(serde_json::json!({ "source": source, "model": model })),
-    )
-    .await;
-    (code, [("content-type", "application/json")], body_str).into_response()
+    );
+    let resp = dispatch(&s.daemon, req).await;
+    narrowed(resp, ModelLanguageState::from_daemon)
 }
 
-/// `POST /backends/{source}/models/{model}/language` — set the override.
+#[utoipa::path(
+    post,
+    path = "/backends/{source}/models/{model}/language",
+    tag = "backends",
+    summary = "Set a model's language override",
+    description = "\
+Pins this model to a language regardless of the global `/language` setting. A tag \
+the model does not serve is refused rather than silently ignored.
+
+Overridden in turn by a `language` field in a single `POST /transcribe` body.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+        ("model" = String, Path, description = "The model's name, as `GET /backends` spells it."),
+    ),
+    request_body = LanguageBody,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Override set.", body = ModelLanguageState),
+        (status = 400, description = "The body was empty (`invalid_request`), or this model does not serve that language (`unsupported_language`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such model (`unknown_model`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn set(
     State(s): State<AppState>,
     Path((source, model)): Path<(String, String)>,
@@ -73,16 +126,36 @@ async fn set(
     if let Some(r) = guard_missing(&s, &source, &model).await {
         return r;
     }
-    let (code, _hdrs, body_str) = dispatch_command(
-        &s.daemon,
+    let req = build_request(
         "set_model_language",
         Some(serde_json::json!({ "source": source, "model": model, "language": body.language })),
-    )
-    .await;
-    (code, [("content-type", "application/json")], body_str).into_response()
+    );
+    let resp = dispatch(&s.daemon, req).await;
+    narrowed(resp, ModelLanguageState::from_daemon)
 }
 
-/// `DELETE /backends/{source}/models/{model}/language` — clear the override.
+#[utoipa::path(
+    delete,
+    path = "/backends/{source}/models/{model}/language",
+    tag = "backends",
+    summary = "Clear a model's language override",
+    description = "\
+Removes the per-model pin, returning this model to the global `/language` setting.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+        ("model" = String, Path, description = "The model's name, as `GET /backends` spells it."),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Override cleared.", body = ModelLanguageState),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such model (`unknown_model`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn clear(
     State(s): State<AppState>,
     Path((source, model)): Path<(String, String)>,
@@ -91,11 +164,10 @@ async fn clear(
     if let Some(r) = guard_missing(&s, &source, &model).await {
         return r;
     }
-    let (code, _hdrs, body_str) = dispatch_command(
-        &s.daemon,
+    let req = build_request(
         "clear_model_language",
         Some(serde_json::json!({ "source": source, "model": model })),
-    )
-    .await;
-    (code, [("content-type", "application/json")], body_str).into_response()
+    );
+    let resp = dispatch(&s.daemon, req).await;
+    narrowed(resp, ModelLanguageState::from_daemon)
 }

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -2,28 +2,69 @@
 use super::{decode_source, find_backend, json_error, ok};
 use crate::daemon::http::internal::helpers::dispatch::dispatch_command;
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 use crate::stt_models::backends::DiscoveredBackend;
 use crate::stt_models::backends::manifest::OptionType;
-use axum::Router;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-pub(crate) fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/backends/{source}/options/list", get(list))
-        .route(
-            "/backends/{source}/options/{name}",
-            get(get_one).post(set).delete(delete_option),
-        )
+pub(crate) fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(list))
+        .routes(routes!(get_one, set, delete_option))
 }
 
-#[derive(Deserialize)]
+/// The value to store for an option.
+#[derive(Deserialize, ToSchema)]
 struct OptionBody {
+    /// The new value. Empty is refused — clear an override with `DELETE`
+    /// instead, which is the operation that reverts to the manifest default.
     #[serde(default)]
     value: String,
+}
+
+/// One option a backend declares, with the value in effect.
+#[derive(Serialize, ToSchema)]
+struct BackendOptionValue {
+    /// The option's identifier, as the backend's manifest declares it.
+    name: String,
+    /// Human-readable label for a settings UI; falls back to `name`.
+    label: String,
+    /// The declared type — `string`, `number`, and so on.
+    #[serde(rename = "type")]
+    kind: String,
+    /// The manifest's default, or `null` when it declares none.
+    default: Option<String>,
+    /// Whether the backend refuses to load without a value.
+    required: bool,
+    /// What is actually in effect: the user's override if set, otherwise the
+    /// default.
+    value: Option<String>,
+}
+
+/// Every option a backend declares.
+#[derive(Serialize, ToSchema)]
+struct BackendOptions {
+    #[schema(example = "success")]
+    status: &'static str,
+    options: Vec<BackendOptionValue>,
+}
+
+/// One option's effective value.
+#[derive(Serialize, ToSchema)]
+struct OptionValue {
+    #[schema(example = "success")]
+    status: &'static str,
+    name: String,
+    /// What is in effect now.
+    value: Option<String>,
+    /// The manifest default, so a UI can show what clearing would revert to.
+    default: Option<String>,
 }
 
 /// Compute the effective value + metadata for a single option.
@@ -33,21 +74,46 @@ fn effective(
     b: &DiscoveredBackend,
     cfg_value: Option<&str>,
     name: &str,
-) -> Option<serde_json::Value> {
+) -> Option<BackendOptionValue> {
     let opt = b.options.iter().find(|o| o.name == name)?;
     let default = opt.default.as_ref().map(ToString::to_string);
     let value = cfg_value.map(str::to_string).or_else(|| default.clone());
-    Some(serde_json::json!({
-        "name":     opt.name,
-        "label":    opt.label.clone().unwrap_or_else(|| opt.name.clone()),
-        "type":     opt.r#type.map_or("string", OptionType::as_str),
-        "default":  default,
-        "required": opt.required,
-        "value":    value,
-    }))
+    Some(BackendOptionValue {
+        name: opt.name.clone(),
+        label: opt.label.clone().unwrap_or_else(|| opt.name.clone()),
+        kind: opt.r#type.map_or("string", OptionType::as_str).to_string(),
+        default,
+        required: opt.required,
+        value,
+    })
 }
 
-/// `GET /backends/{source}/options/list` — all declared options with effective values.
+#[utoipa::path(
+    get,
+    path = "/backends/{source}/options/list",
+    tag = "backends",
+    summary = "List a backend's options",
+    description = "\
+Every option this backend declares, each with its label, type, default, and the \
+value actually in effect. This is what a settings UI renders a form from.
+
+Options are the backend's own configuration — an endpoint URL, a model parameter — \
+declared in its manifest. Credentials are not options; those are secrets, at \
+`/backends/{source}/secrets/list`.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The backend's options.", body = BackendOptions),
+        (status = 404, description = "No installed backend has that `source` (`unknown_backend`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn list(State(s): State<AppState>, Path(source): Path<String>) -> Response {
     let source = decode_source(&source);
     let Some(b) = find_backend(&s, &source).await else {
@@ -59,10 +125,35 @@ async fn list(State(s): State<AppState>, Path(source): Path<String>) -> Response
         .iter()
         .filter_map(|o| effective(&b, cfg.backend_option(&source, &o.name), &o.name))
         .collect();
-    ok(&serde_json::json!({ "status": "success", "options": out }))
+    ok(&BackendOptions {
+        status: "success",
+        options: out,
+    })
 }
 
-/// `GET /backends/{source}/options/{name}` — effective value for one option.
+#[utoipa::path(
+    get,
+    path = "/backends/{source}/options/{name}",
+    tag = "backends",
+    summary = "Read one option's effective value",
+    description = "\
+The value in effect for a single option, alongside the manifest default so a UI can \
+show what clearing it would revert to.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+        ("name" = String, Path, description = "The option's name, as the backend's manifest declares it."),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The option's effective value.", body = OptionValue),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such option (`unknown_option`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn get_one(
     State(s): State<AppState>,
     Path((source, name)): Path<(String, String)>,
@@ -76,17 +167,51 @@ async fn get_one_inner(s: AppState, source: String, name: String) -> Response {
     };
     let cfg = s.daemon.config.read().await;
     match effective(&b, cfg.backend_option(&source, &name), &name) {
-        Some(v) => ok(&serde_json::json!({
-            "status":  "success",
-            "name":    name,
-            "value":   v["value"],
-            "default": v["default"],
-        })),
+        Some(v) => ok(&OptionValue {
+            status: "success",
+            name,
+            value: v.value,
+            default: v.default,
+        }),
         None => json_error(StatusCode::NOT_FOUND, "unknown_option"),
     }
 }
 
-/// `POST /backends/{source}/options/{name}` — set an override via `set_backend_option`.
+#[utoipa::path(
+    post,
+    path = "/backends/{source}/options/{name}",
+    tag = "backends",
+    summary = "Override an option",
+    description = "\
+Stores a value for this option, overriding the manifest default. Answers with the \
+option's new effective value, so a UI can render the result without a second read.
+
+A `base_url` value is canonicalized before storage, so the field reads back the \
+endpoint that will actually be dialed — the scheme in particular, since whether a \
+request is encrypted should not be invisible in the field the user is looking at. \
+A value that yields no host is stored as typed rather than refused; model load \
+rejects it by name. Every other option is stored verbatim, whitespace included, \
+because it may carry meaning the daemon does not interpret.
+
+A loaded model does not pick this up on its own — reload the stage with \
+`POST /pipeline/{stage}/model/reload`.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+        ("name" = String, Path, description = "The option's name, as the backend's manifest declares it."),
+    ),
+    request_body = OptionBody,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Stored; this is the new effective value.", body = OptionValue),
+        (status = 400, description = "The value was empty (`invalid_request`). Use `DELETE` to clear an override.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such option (`unknown_option`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn set(
     State(s): State<AppState>,
     Path((source, name)): Path<(String, String)>,
@@ -130,8 +255,30 @@ async fn set(
     get_one_inner(s, source, name).await
 }
 
-/// `DELETE /backends/{source}/options/{name}` — clear override (reverts to default).
-///
+#[utoipa::path(
+    delete,
+    path = "/backends/{source}/options/{name}",
+    tag = "backends",
+    summary = "Clear an option override",
+    description = "\
+Removes the stored value, reverting the option to the manifest default. Answers with \
+the effective value that results, which is the default when one is declared and \
+`null` when none is.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+        ("name" = String, Path, description = "The option's name, as the backend's manifest declares it."),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Cleared; this is the value now in effect.", body = OptionValue),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such option (`unknown_option`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 /// Renamed from `delete` to avoid shadowing `axum::routing::delete`.
 async fn delete_option(
     State(s): State<AppState>,

--- a/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/secrets.rs
@@ -1,29 +1,89 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use super::{decode_source, find_backend, json_error, json_error_msg, ok};
 use crate::daemon::http::state::AppState;
-use axum::Router;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::Response;
-use axum::routing::get;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-pub(crate) fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/backends/{source}/secrets/list", get(list))
-        .route(
-            "/backends/{source}/secrets/{name}",
-            get(get_one).post(set).delete(delete_secret),
-        )
+pub(crate) fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(list))
+        .routes(routes!(get_one, set, delete_secret))
 }
 
-#[derive(Deserialize)]
+/// The secret to store.
+#[derive(Deserialize, ToSchema)]
 struct SecretBody {
+    /// The credential itself. Written to the system keyring, never returned by
+    /// any endpoint. Empty is refused — clear a secret with `DELETE`.
     #[serde(default)]
     value: String,
 }
 
-/// `GET /backends/{source}/secrets/list` — declared secrets + configured flags, no values.
+/// One secret a backend declares, and whether it is set.
+#[derive(Serialize, ToSchema)]
+struct SecretState {
+    /// The secret's identifier, as the backend's manifest declares it.
+    name: String,
+    /// Human-readable label for a settings UI; falls back to `name`.
+    label: String,
+    /// Whether the backend refuses to load without it.
+    required: bool,
+    /// Whether a value is stored. The value itself is never returned.
+    configured: bool,
+}
+
+/// Every secret a backend declares.
+#[derive(Serialize, ToSchema)]
+struct SecretList {
+    #[schema(example = "success")]
+    status: &'static str,
+    secrets: Vec<SecretState>,
+}
+
+/// Whether one secret is set.
+#[derive(Serialize, ToSchema)]
+struct SecretConfigured {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// Absent on write and clear, which answer about the secret just addressed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    /// Whether a value is stored.
+    configured: bool,
+}
+
+#[utoipa::path(
+    get,
+    path = "/backends/{source}/secrets/list",
+    tag = "backends",
+    summary = "List a backend's secrets",
+    description = "\
+Every credential this backend declares, with whether each is currently set. \
+**Values are never returned** — not here, not anywhere. They live in the system \
+keyring, and the only operations are write and clear.
+
+This is a separate scope from `settings` precisely because it is the credential \
+surface: a token granted `settings` cannot reach it.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+         example = "github.com%2Facme%2Fopenai"),
+    ),
+    security(("session_token" = ["secrets"])),
+    responses(
+        (status = 200, description = "The declared secrets and whether each is set.", body = SecretList),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `secrets` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn list(State(s): State<AppState>, Path(source): Path<String>) -> Response {
     let source = decode_source(&source);
     let Some(backend) = find_backend(&s, &source).await else {
@@ -34,17 +94,41 @@ async fn list(State(s): State<AppState>, Path(source): Path<String>) -> Response
         let configured = crate::keyring::has_backend_secret_async(source.clone(), sec.name.clone())
             .await
             .unwrap_or(false);
-        out.push(serde_json::json!({
-            "name": sec.name,
-            "label": sec.label.clone().unwrap_or_else(|| sec.name.clone()),
-            "required": sec.required,
-            "configured": configured,
-        }));
+        out.push(SecretState {
+            name: sec.name.clone(),
+            label: sec.label.clone().unwrap_or_else(|| sec.name.clone()),
+            required: sec.required,
+            configured,
+        });
     }
-    ok(&serde_json::json!({ "status": "success", "secrets": out }))
+    ok(&SecretList {
+        status: "success",
+        secrets: out,
+    })
 }
 
-/// `GET /backends/{source}/secrets/{name}` — existence only.
+#[utoipa::path(
+    get,
+    path = "/backends/{source}/secrets/{name}",
+    tag = "backends",
+    summary = "Check whether one secret is set",
+    description = "\
+Reports existence only. There is no endpoint that returns a stored credential.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+         example = "github.com%2Facme%2Fopenai"),
+        ("name" = String, Path, description = "The secret's name, as the backend's manifest declares it."),
+    ),
+    security(("session_token" = ["secrets"])),
+    responses(
+        (status = 200, description = "Whether a value is stored.", body = SecretConfigured),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `secrets` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn get_one(
     State(s): State<AppState>,
     Path((source, name)): Path<(String, String)>,
@@ -57,12 +141,44 @@ async fn get_one(
             let configured = crate::keyring::has_backend_secret_async(source.clone(), name.clone())
                 .await
                 .unwrap_or(false);
-            ok(&serde_json::json!({ "status": "success", "name": name, "configured": configured }))
+            ok(&SecretConfigured {
+                status: "success",
+                name: Some(name),
+                configured,
+            })
         }
     }
 }
 
-/// `POST /backends/{source}/secrets/{name}` — store a value (non-empty).
+#[utoipa::path(
+    post,
+    path = "/backends/{source}/secrets/{name}",
+    tag = "backends",
+    summary = "Store a secret",
+    description = "\
+Writes the credential to the system keyring. It cannot be read back afterwards; \
+only replaced or cleared.
+
+A loaded model does not pick up a new credential on its own — reload the stage with \
+`POST /pipeline/{stage}/model/reload`.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+         example = "github.com%2Facme%2Fopenai"),
+        ("name" = String, Path, description = "The secret's name, as the backend's manifest declares it."),
+    ),
+    request_body = SecretBody,
+    security(("session_token" = ["secrets"])),
+    responses(
+        (status = 200, description = "Stored.", body = SecretConfigured),
+        (status = 400, description = "The value was empty (`invalid_request`). Use `DELETE` to clear a secret.", body = ErrorEnvelope),
+        (status = 503, description = "The keyring could not be written (`keyring_unavailable`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `secrets` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn set(
     State(s): State<AppState>,
     Path((source, name)): Path<(String, String)>,
@@ -85,7 +201,30 @@ async fn set(
     }
 }
 
-/// `DELETE /backends/{source}/secrets/{name}` — clear (reset to unset).
+#[utoipa::path(
+    delete,
+    path = "/backends/{source}/secrets/{name}",
+    tag = "backends",
+    summary = "Clear a secret",
+    description = "\
+Removes the stored credential from the keyring, returning the secret to unset. A \
+backend that requires it will refuse to load until one is stored again.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fopenai`.",
+         example = "github.com%2Facme%2Fopenai"),
+        ("name" = String, Path, description = "The secret's name, as the backend's manifest declares it."),
+    ),
+    security(("session_token" = ["secrets"])),
+    responses(
+        (status = 200, description = "Cleared.", body = SecretConfigured),
+        (status = 503, description = "The keyring could not be written (`keyring_unavailable`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `secrets` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such backend (`unknown_backend`) or no such secret (`unknown_secret`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 async fn delete_secret(
     State(s): State<AppState>,
     Path((source, name)): Path<(String, String)>,
@@ -125,7 +264,11 @@ fn secret_result(
     configured: bool,
 ) -> Response {
     if resp.status == "success" {
-        ok(&serde_json::json!({ "status": "success", "configured": configured }))
+        ok(&SecretConfigured {
+            status: "success",
+            name: None,
+            configured,
+        })
     } else {
         json_error_msg(
             StatusCode::SERVICE_UNAVAILABLE,

--- a/super-stt-daemon/src/daemon/http/v1/events.rs
+++ b/super-stt-daemon/src/daemon/http/v1/events.rs
@@ -4,6 +4,7 @@ use crate::daemon::http::internal::auth::tokens::TokenStore;
 use crate::daemon::http::internal::helpers::responses::{invalid_session, reason, scope_denied};
 use crate::daemon::http::state::{AppState, PeerInfo};
 use crate::daemon::http::v1::transcribe::format_sse_frame_str;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -60,6 +61,49 @@ fn invalid_topic(reason: &str) -> Response {
         .into_response()
 }
 
+#[utoipa::path(
+    get,
+    path = "/events",
+    tag = "events",
+    summary = "Subscribe to the event stream",
+    description = "\
+A Server-Sent Events stream of everything the daemon publishes. The response is \
+`text/event-stream` and stays open until the client disconnects, the daemon shuts \
+down, or the calling binary changes on disk (which emits a final `revoked` frame \
+and invalidates the token).
+
+The first frame is always `subscribed`, carrying a `client_id` and the topic list \
+that was accepted. A `: keepalive` comment is sent periodically so idle connections \
+are not reaped by intermediaries.
+
+**Scopes are per topic, not per endpoint.** Any valid token reaches this route; the \
+subscription is then refused whole if the token lacks the scope for *any* requested \
+topic, so ask only for what you hold.
+
+| Topic | Scope |
+|---|---|
+| `recording_started`, `recording_stopped`, `recording_state`, `transcribing_started`, `transcribing_stopped` | `recording_events` |
+| `frequency_bands` | `audio_visualization` |
+| `partial_stt`, `final_stt` | `global_transcriptions` |
+| `daemon_status_changed`, `download_progress`, `registry_install` | `daemon_status` |
+
+Under backpressure the daemon drops frames rather than buffering them without \
+bound; visualization frames are what shed in practice.",
+    params(
+        ("topics" = String, Query,
+         description = "Comma-separated topic names, at least one. Unknown or empty → `400 invalid_topic`.",
+         example = "recording_state,final_stt"),
+    ),
+    security(("session_token" = [])),
+    responses(
+        (status = 200, description = "The stream is open. Frames follow as `event:`/`data:` pairs.",
+         content_type = "text/event-stream"),
+        (status = 400, description = "`topics` was missing, empty, or named a topic that does not exist.", body = ReasonEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the scope for one of the requested topics.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 /// `GET /events?topics=...` — widget SSE subscription.
 ///
 /// The handler runs forever (until the client disconnects, the daemon
@@ -288,6 +332,6 @@ fn spawn_events_keepalive_and_exe_watch(
 }
 
 /// Server-Sent Events subscription route.
-pub(crate) fn routes() -> axum::Router<crate::daemon::http::state::AppState> {
-    axum::Router::new().route("/events", axum::routing::get(events))
+pub(crate) fn routes() -> utoipa_axum::router::OpenApiRouter<AppState> {
+    utoipa_axum::router::OpenApiRouter::new().routes(utoipa_axum::routes!(events))
 }

--- a/super-stt-daemon/src/daemon/http/v1/health.rs
+++ b/super-stt-daemon/src/daemon/http/v1/health.rs
@@ -1,17 +1,92 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::daemon::http::internal::helpers::dispatch::{build_request, dispatch, json_response};
-use crate::daemon::http::state::AppState;
-use axum::extract::State;
-use axum::response::IntoResponse;
+//! Liveness, and what the daemon is currently running.
 
-pub(crate) async fn ping(State(s): State<AppState>) -> impl IntoResponse {
-    let req = build_request("ping", None);
-    let resp = dispatch(&s.daemon, req).await;
-    json_response(&resp)
+use crate::daemon::http::internal::helpers::dispatch::{ack, build_request, dispatch, narrowed};
+use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{Ack, ErrorEnvelope, ReasonEnvelope};
+use axum::extract::State;
+use axum::response::Response;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// What `GET /status` reports.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct DaemonStatus {
+    /// Always `success`.
+    #[schema(example = "success")]
+    status: &'static str,
+    /// The accelerator the loaded model actually runs on: `cpu`, `cuda`,
+    /// `rocm`, `metal`, `vulkan`, or `remote` for a model served over the
+    /// network. `unknown` when nothing is loaded.
+    #[schema(example = "cuda")]
+    device: String,
+    /// `false` while the initial model is still loading, or after a failed
+    /// switch.
+    model_loaded: bool,
+    /// The loaded model's name. Absent when `model_loaded` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "whisper-tiny")]
+    current_model: Option<String>,
+    /// `true` while a daemon-mic cycle is active — capture *and* the
+    /// transcription and typing that follow it. A toggle hotkey reads this and
+    /// calls `POST /transcribe/stop` when true, `POST /transcribe` when false.
+    busy: bool,
 }
 
-pub(crate) async fn status(State(s): State<AppState>) -> impl IntoResponse {
-    let req = build_request("status", None);
-    let resp = dispatch(&s.daemon, req).await;
-    json_response(&resp)
+#[utoipa::path(
+    get,
+    path = "/ping",
+    tag = "health",
+    summary = "Liveness probe",
+    description = "\
+Confirms the listener is reachable and the presented token is valid. Introspects \
+no state.
+
+To check whether the *token* is still good without risking a consent popup, prefer \
+`GET /auth/status` — that is the dedicated probe.",
+    security(("session_token" = [])),
+    responses(
+        (status = 200, description = "The daemon is up. `message` is always `pong`.", body = Ack,
+         example = json!({ "status": "success", "message": "pong" })),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+        (status = 503, description = "Connection refused — the daemon is over its per-client connection cap.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn ping(State(s): State<AppState>) -> Response {
+    ack(&s.daemon, "ping", None).await
+}
+
+#[utoipa::path(
+    get,
+    path = "/status",
+    tag = "health",
+    summary = "Current model and device",
+    description = "\
+A snapshot of what the daemon is running: which model is loaded, on which \
+accelerator, and whether a recording cycle is in flight.
+
+Subscriber introspection and other operator detail are not exposed here — see \
+`GET /pipeline/1` and `GET /pipeline/{stage}/model/{model}/device`, which need the \
+`settings` scope.",
+    security(("session_token" = ["status"])),
+    responses(
+        (status = 200, description = "The daemon's current state.", body = DaemonStatus),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `status` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn status(State(s): State<AppState>) -> Response {
+    let resp = dispatch(&s.daemon, build_request("status", None)).await;
+    narrowed(resp, |r| DaemonStatus {
+        status: "success",
+        // `handle_status` fills all three on every success; the fallbacks keep
+        // the endpoint answering its own shape rather than a partial one if a
+        // future command path ever forgets.
+        device: r.device.unwrap_or_else(|| "unknown".to_string()),
+        model_loaded: r.model_loaded.unwrap_or(false),
+        current_model: r.current_model,
+        busy: r.busy.unwrap_or(false),
+    })
 }

--- a/super-stt-daemon/src/daemon/http/v1/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/mod.rs
@@ -11,84 +11,145 @@ use crate::daemon::http::internal::auth::middleware::{
     require_any_authenticated, require_rate_limit, require_secrets_scope, require_settings_scope,
     require_status_scope, require_transcribe_scope,
 };
+use crate::daemon::http::openapi::ApiDoc;
 use crate::daemon::http::state::AppState;
 use axum::Router;
 use axum::middleware;
-use axum::routing::{get, post};
+use utoipa::OpenApi;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-/// Assemble the `/v1` router with scope-aware middleware and state.
+/// The `/v1` routes, grouped by the guard they share.
 ///
-/// Endpoint groups split by required scope:
-/// - `/auth/request`: reachable WITHOUT a token (it's how you get one).
-/// - any-authenticated: `/ping`, `/auth/status`, and `GET /events` (the
-///   per-topic scope is enforced inside the events handler).
-/// - `status` scope: `GET /status`.
-/// - `transcribe` scope: the transcription routes.
-/// - `settings` scope: the configuration + registry surface.
+/// Registering a route and documenting it is one act here: every entry goes in
+/// through [`routes!`], which reads the `#[utoipa::path]` attribute off the
+/// handler it names. A handler without one does not compile, and a path spelled
+/// two ways cannot exist, because there is only one spelling.
 ///
-/// All routes are bare (`/ping`, …); the `/v1` prefix is applied via `nest`.
+/// The guards are applied separately, in [`router`], for a practical reason:
+/// `from_fn_with_state` needs a live [`AppState`], and building one opens the
+/// system keyring. Keeping route registration free of it is what lets
+/// [`openapi`] generate the document from these same registrations without a
+/// running daemon — see `src/bin/gen_openapi.rs`.
+struct ScopeGroups {
+    /// Any valid token, whatever its scopes. `GET /events` lives here because
+    /// its per-topic scope is enforced inside the handler, against the topics
+    /// actually requested.
+    any: OpenApiRouter<AppState>,
+    status: OpenApiRouter<AppState>,
+    transcribe: OpenApiRouter<AppState>,
+    /// The configuration surface, which the registry and backend-option routes
+    /// share.
+    settings: OpenApiRouter<AppState>,
+    secrets: OpenApiRouter<AppState>,
+    /// Reachable without a token — it is how a caller gets one.
+    unauthenticated: OpenApiRouter<AppState>,
+}
+
+/// Every `/v1` route, in its group. Paths are bare here (`/ping`); the `/v1`
+/// prefix is applied once, in [`assemble`].
+fn scope_groups() -> ScopeGroups {
+    ScopeGroups {
+        any: OpenApiRouter::new()
+            .routes(routes!(health::ping))
+            .routes(routes!(auth::status::auth_status))
+            .merge(events::routes()),
+        status: OpenApiRouter::new().routes(routes!(health::status)),
+        transcribe: transcribe::routes(),
+        settings: settings::routes(),
+        secrets: backends::secrets::routes(),
+        unauthenticated: OpenApiRouter::new().routes(routes!(auth::request::auth_request)),
+    }
+}
+
+/// Apply each group's guard. Rate limiting is layered under the scope check on
+/// every guarded group, so an unauthenticated flood is rejected on the cheaper
+/// test first.
+fn guarded(groups: ScopeGroups, state: &AppState) -> ScopeGroups {
+    /// `.layer(scope).layer(rate_limit)` — the pair every guarded group takes.
+    macro_rules! guard {
+        ($group:expr, $scope:expr) => {
+            $group
+                .layer(middleware::from_fn_with_state(state.clone(), $scope))
+                .layer(middleware::from_fn_with_state(
+                    state.clone(),
+                    require_rate_limit,
+                ))
+        };
+    }
+
+    ScopeGroups {
+        any: guard!(groups.any, require_any_authenticated),
+        status: guard!(groups.status, require_status_scope),
+        transcribe: guard!(groups.transcribe, require_transcribe_scope),
+        settings: guard!(groups.settings, require_settings_scope),
+        secrets: guard!(groups.secrets, require_secrets_scope),
+        // No guard: this is the endpoint that mints the token the others need.
+        unauthenticated: groups.unauthenticated,
+    }
+}
+
+/// Merge the groups under `/v1` and attach the base document. The live router
+/// and the generated spec both come through here, so the two cannot describe
+/// different route sets.
+fn assemble(groups: ScopeGroups) -> OpenApiRouter<AppState> {
+    let v1 = OpenApiRouter::new()
+        .merge(groups.any)
+        .merge(groups.status)
+        .merge(groups.transcribe)
+        .merge(groups.settings)
+        .merge(groups.secrets)
+        .merge(groups.unauthenticated);
+
+    OpenApiRouter::with_openapi(ApiDoc::openapi()).nest("/v1", v1)
+}
+
+/// The live `/v1` router, guards applied and state bound.
 pub(crate) fn router(state: AppState) -> Router {
-    let any_scope = Router::new()
-        .route("/ping", get(health::ping))
-        .route("/auth/status", get(auth::status::auth_status))
-        .merge(events::routes())
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_rate_limit,
-        ))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_any_authenticated,
-        ));
+    let (router, _spec) = assemble(guarded(scope_groups(), &state)).split_for_parts();
+    router.with_state(state)
+}
 
-    let status_scope = Router::new()
-        .route("/status", get(health::status))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_rate_limit,
-        ))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_status_scope,
-        ));
+/// The generated document for the same surface. The guards are omitted because
+/// they add no paths — what each endpoint requires is stated in its own
+/// `security` and prose.
+pub(crate) fn openapi() -> utoipa::openapi::OpenApi {
+    let (_router, spec) = assemble(scope_groups()).split_for_parts();
+    spec
+}
 
-    let transcribe_scope = transcribe::routes()
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_rate_limit,
-        ))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_transcribe_scope,
-        ));
+/// Which scope the router *enforces* on each `/v1` path, read from the grouping
+/// itself rather than restated.
+///
+/// `None` means the path is reachable without a token. `Some(vec![])` means any
+/// valid token will do, whatever its scopes.
+///
+/// This exists so the contract test can check each endpoint's advertised
+/// `security` against the guard it actually sits behind. The two are written in
+/// different places — the scope in a `#[utoipa::path]` attribute, the guard in
+/// [`guarded`] — and nothing else would notice them disagreeing. A client author
+/// told they need `settings` for an endpoint the daemon guards with `secrets`
+/// requests the wrong scope and gets a `403` they cannot explain.
+#[cfg(test)]
+pub(super) fn enforced_scopes() -> std::collections::BTreeMap<String, Option<Vec<&'static str>>> {
+    let groups = scope_groups();
+    let by_group = [
+        (groups.any, Some(vec![])),
+        (groups.status, Some(vec!["status"])),
+        (groups.transcribe, Some(vec!["transcribe"])),
+        (groups.settings, Some(vec!["settings"])),
+        (groups.secrets, Some(vec!["secrets"])),
+        (groups.unauthenticated, None),
+    ];
 
-    let settings_scope = settings::routes()
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_rate_limit,
-        ))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_settings_scope,
-        ));
-
-    let secrets_scope = backends::secrets::routes()
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_rate_limit,
-        ))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_secrets_scope,
-        ));
-
-    let v1 = Router::new()
-        .merge(any_scope)
-        .merge(status_scope)
-        .merge(transcribe_scope)
-        .merge(settings_scope)
-        .merge(secrets_scope)
-        .route("/auth/request", post(auth::request::auth_request));
-
-    Router::new().nest("/v1", v1).with_state(state)
+    let mut enforced = std::collections::BTreeMap::new();
+    for (router, scopes) in by_group {
+        // The groups hold bare paths; `assemble` is what applies the `/v1`
+        // prefix, so apply it here too to match the published document.
+        let (_router, spec) = router.split_for_parts();
+        for path in spec.paths.paths.keys() {
+            enforced.insert(format!("/v1{path}"), scopes.clone());
+        }
+    }
+    enforced
 }

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope, RegistryError};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use super_stt_shared::registry::{InstallAccepted, InstallRequest};
 
 use super::pipeline::{InflightMarker, spawn_install_pipeline};
 
@@ -250,6 +252,35 @@ fn select_install_compat(
 // ---------------------------------------------------------------------------
 
 /// `POST /registry/backends/install` — kick off a background install.
+#[utoipa::path(
+    post,
+    path = "/registry/backends/install",
+    tag = "registry",
+    summary = "Install a backend",
+    description = "\
+Installs a backend from the registry, from a git repo, or from a local path \u{2014} send \
+exactly one of `source`, `repo_url`, or `local_path`.
+
+The daemon picks the release asset matching this host's architecture and \
+accelerators, and answers `202` as soon as that choice is made: the download itself \
+continues in the background. Follow it on the `registry_install` event topic, keyed \
+by the returned `install_id`. A `warning` means the install proceeded with a caveat \
+worth showing the user.
+
+Installing neither selects the backend nor loads a model \u{2014} do that through \
+`/pipeline/{stage}`.",
+    request_body = InstallRequest,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 202, description = "Accepted; the download runs in the background.", body = InstallAccepted),
+        (status = 400, description = "Not exactly one of `source`, `repo_url`, `local_path` (`bad_request`), or no asset matches this host.", body = RegistryError),
+        (status = 404, description = "No catalog entry for that `source` (`not_found`).", body = RegistryError),
+        (status = 409, description = "An install for this backend is already in flight, or a recording is running (`backend_busy`).", body = RegistryError),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn install_registry_backend(
     State(s): State<AppState>,
     body: Option<axum::Json<InstallBody>>,

--- a/super-stt-daemon/src/daemon/http/v1/registry/list.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/list.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope, RegistryError};
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -10,12 +11,17 @@ use super_stt_shared::registry::{
 };
 
 /// Query parameters for `GET /registry/backends`.
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::IntoParams)]
 pub(crate) struct RegistryBackendsQuery {
+    /// Include entries this machine cannot run. Off by default, so the catalog
+    /// shows what is actually installable here.
     #[serde(default)]
     pub(crate) include_incompatible: bool,
+    /// Filter by backend kind.
     pub(crate) kind: Option<String>,
+    /// Filter by whether the backend calls out to a network service.
     pub(crate) online: Option<bool>,
+    /// Case-insensitive substring match over name and description.
     pub(crate) q: Option<String>,
 }
 
@@ -170,6 +176,32 @@ fn map_entry(
 }
 
 /// `GET /registry/backends` — list installable backends from the registry.
+#[utoipa::path(
+    get,
+    path = "/registry/backends",
+    tag = "registry",
+    summary = "Browse the published backend catalog",
+    description = "\
+Every backend published to the registry, with the models each serves and whether \
+this machine can run it. `compatible` is decided against the host's actual \
+accelerators and this Super STT's version, so the list reflects what is installable \
+here rather than what exists in general.
+
+`needs_client_update` separates the two ways a backend can be blocked: a host that \
+lacks the right GPU will never run it, but a Super STT one version behind is \
+something the user can fix in a minute. Surface those differently.
+
+This is what is *available*; `GET /backends` is what is installed.",
+    params(RegistryBackendsQuery),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The catalog.", body = RegistryListResponse),
+        (status = 503, description = "The catalog could not be fetched and nothing is cached (`registry_unavailable`). Retry, or force a fetch with `POST /registry/backends/refresh`.", body = RegistryError),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn list_registry_backends(
     State(s): State<AppState>,
     Query(q): Query<RegistryBackendsQuery>,

--- a/super-stt-daemon/src/daemon/http/v1/registry/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/mod.rs
@@ -6,10 +6,10 @@ pub(crate) mod refresh;
 pub(crate) mod update;
 
 use crate::daemon::http::state::AppState;
-use axum::Router;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
 /// Registry error envelope: `{ "status": "error", "error_code": <code>, "error": <code> }`
 /// at `status`.
@@ -45,21 +45,12 @@ pub(crate) fn registry_error_msg(status: StatusCode, code: &str, message: &str) 
 }
 
 /// Registry browse/refresh/install/update routes (settings-scope).
-pub(crate) fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/registry/backends", get(list::list_registry_backends))
-        .route(
-            "/registry/backends/refresh",
-            post(refresh::refresh_registry),
-        )
-        .route(
-            "/registry/backends/install",
-            post(install::install_registry_backend),
-        )
-        .route(
-            "/registry/backends/update",
-            post(update::update_registry_backend),
-        )
+pub(crate) fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(list::list_registry_backends))
+        .routes(routes!(refresh::refresh_registry))
+        .routes(routes!(install::install_registry_backend))
+        .routes(routes!(update::update_registry_backend))
 }
 
 #[cfg(test)]

--- a/super-stt-daemon/src/daemon/http/v1/registry/refresh.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/refresh.rs
@@ -1,11 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope, RegistryError};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use super_stt_shared::registry::RefreshResponse;
 use super_stt_shared::registry::events::RegistryEvent;
 
 /// `POST /registry/backends/refresh` — force-refetch the registry index.
+#[utoipa::path(
+    post,
+    path = "/registry/backends/refresh",
+    tag = "registry",
+    summary = "Re-fetch the backend catalog",
+    description = "\
+Pulls the published index again rather than serving what is cached, and reports how \
+many backends it now holds. Use it after a backend is published, or to clear an \
+`index_stale` flag.
+
+`GET /registry/backends` refreshes on its own schedule; this forces it now.",
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Refreshed.", body = RefreshResponse),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+        (status = 503, description = "The catalog could not be fetched.", body = RegistryError),
+    ),
+)]
 pub(crate) async fn refresh_registry(State(s): State<AppState>) -> impl IntoResponse {
     if let Ok(index) = s.registry_client.refresh().await {
         let payload = serde_json::to_value(RegistryEvent::RefreshCompleted {

--- a/super-stt-daemon/src/daemon/http/v1/registry/update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/update.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use super::pipeline::{InflightMarker, spawn_install_pipeline};
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope, RegistryError};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Deserialize;
 use std::sync::Arc;
+use super_stt_shared::registry::{UpdateRequest, UpdateResponse};
 
 /// Request body for `POST /registry/backends/update`.
 #[derive(Deserialize)]
@@ -124,12 +126,33 @@ fn select_update_compat(
 // ---------------------------------------------------------------------------
 
 /// `POST /registry/backends/update` — re-run install if registry has a newer version.
+#[utoipa::path(
+    post,
+    path = "/registry/backends/update",
+    tag = "registry",
+    summary = "Update an installed backend",
+    description = "\
+Upgrades an installed backend to the newest version the catalog offers for this \
+host. Answers with the versions moved between; `noop` is `true` when the installed \
+version was already current, which is a success rather than an error.
+
+Like install, the download runs in the background \u{2014} follow `install_id` on the \
+`registry_install` topic when one is returned.",
+    request_body = UpdateRequest,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Up to date already, or the upgrade was accepted.", body = UpdateResponse),
+        (status = 404, description = "No installed backend has that `source` (`not_found`).", body = RegistryError),
+        (status = 409, description = "An install is already in flight, or a recording is running (`backend_busy`).", body = RegistryError),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn update_registry_backend(
     State(s): State<AppState>,
     body: Option<axum::Json<UpdateBody>>,
 ) -> impl IntoResponse {
-    use super_stt_shared::registry::UpdateResponse;
-
     // Phase 1: parse body.
     let body = match parse_update_body(body) {
         Ok(b) => b,

--- a/super-stt-daemon/src/daemon/http/v1/settings/audio_theme.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/audio_theme.rs
@@ -1,10 +1,41 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::{AudioThemeList, AudioThemeState};
+
 settings_setter!(
     set_audio_theme,
     SetAudioThemeBody { theme: String },
     "set_audio_theme",
-    "theme"
+    "theme",
+    "/audio_theme",
+    AudioThemeState,
+    "Select the audio cue theme",
+    "Chooses which set of sounds marks the start and end of a recording. List the \
+accepted values with `GET /audio_themes`; set the loudness at `/volume`.",
+    "A theme token from `GET /audio_themes`, e.g. `classic`. An unknown token is a `400`.",
 );
-settings_dispatch!(get_audio_theme, "get_audio_theme");
-settings_dispatch!(test_audio_theme, "test_audio_theme");
-settings_dispatch!(list_audio_themes, "list_audio_themes");
+settings_dispatch!(
+    get_audio_theme,
+    "get_audio_theme",
+    get "/audio_theme",
+    AudioThemeState,
+    "Read the selected audio cue theme",
+    "Answers with the selected theme's token."
+);
+settings_dispatch!(
+    test_audio_theme,
+    "test_audio_theme",
+    post "/audio_theme/test",
+    crate::daemon::http::wire::Ack,
+    "Play the selected theme's cues",
+    "Plays the start and stop cues once, at the configured volume, so a settings UI \
+can preview a theme without starting a recording. Changes nothing."
+);
+settings_dispatch!(
+    list_audio_themes,
+    "list_audio_themes",
+    get "/audio_themes",
+    AudioThemeList,
+    "List the available audio cue themes",
+    "Every theme `POST /audio_theme` accepts. The set is fixed in the daemon build, \
+not user-extensible."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/backends.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/backends.rs
@@ -1,20 +1,73 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::daemon::http::internal::helpers::dispatch::dispatch_command;
+use crate::daemon::http::internal::helpers::dispatch::{build_request, dispatch, narrowed};
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::v1::settings::wire::{BackendCatalog, FromDaemon, GpuInventory};
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope, RegistryError};
 use axum::extract::{Path as AxumPath, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use log::{info, warn};
+use super_stt_shared::registry::UninstallResponse;
 
-pub(crate) async fn list_backends(State(s): State<AppState>) -> impl IntoResponse {
-    dispatch_command(&s.daemon, "list_backends", None).await
+#[utoipa::path(
+    get,
+    path = "/backends",
+    tag = "backends",
+    summary = "List installed backends",
+    description = "\
+Every backend installed on this machine, each with the models it serves, the options \
+it exposes, and which of its secrets are configured. Secret *values* are never \
+returned — only whether each is set.
+
+This is the full catalog, roles included. `GET /models` is the narrower read a \
+transcription-model picker wants; browsing what is *available to install* is \
+`GET /registry/backends`.",
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The installed catalog.", body = BackendCatalog),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn list_backends(State(s): State<AppState>) -> Response {
+    let resp = dispatch(&s.daemon, build_request("list_backends", None)).await;
+    narrowed(resp, BackendCatalog::from_daemon)
 }
 
+#[utoipa::path(
+    delete,
+    path = "/backends/{source}",
+    tag = "backends",
+    summary = "Uninstall a backend",
+    description = "\
+Removes an installed backend and its files from disk.
+
+If the backend was filling a pipeline stage, that stage is emptied first: any loaded \
+model is unloaded and the selection cleared, so the daemon does not end up pointing \
+at files that no longer exist. The response says which stages were affected.
+
+Refused with `409 backend_busy` while a recording or realtime session is in flight \
+— removing files out from under one would strand state it still depends on.",
+    params(
+        ("source" = String, Path,
+         description = "The backend's `source`, percent-encoded — e.g. `github.com%2Facme%2Fwhisper`.",
+         example = "github.com%2Facme%2Fwhisper"),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Removed.", body = UninstallResponse),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No installed backend claims that `source`.", body = RegistryError),
+        (status = 409, description = "A recording or realtime session is in flight (`backend_busy`).", body = RegistryError),
+        (status = 500, description = "The files could not be removed (`remove_failed`).", body = RegistryError),
+    ),
+)]
 pub(crate) async fn uninstall_backend(
     State(s): State<AppState>,
     AxumPath(source_encoded): AxumPath<String>,
-) -> impl IntoResponse {
-    use super_stt_shared::registry::UninstallResponse;
+) -> Response {
     // Uninstall is the inverse of install, so it shares the registry error
     // envelope (`{ "error": <code> }`) rather than hand-rolling its own shape.
     use crate::daemon::http::v1::registry::{registry_error, registry_error_msg};
@@ -96,6 +149,27 @@ pub(crate) async fn uninstall_backend(
         .into_response()
 }
 
-pub(crate) async fn get_gpu_info(State(s): State<AppState>) -> impl IntoResponse {
-    dispatch_command(&s.daemon, "get_gpu_info", None).await
+#[utoipa::path(
+    get,
+    path = "/gpu_info",
+    tag = "settings",
+    summary = "Inventory the host's GPUs",
+    description = "\
+What the daemon can see of this machine's accelerators: one entry per detected GPU \
+with its memory, plus the host-wide driver and runtime versions that decide which \
+backend builds will actually run here.
+
+Detection is a live probe, so this reflects the machine now rather than a cached \
+answer. A host with no GPU answers `200` with an empty list.",
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The detected GPUs and host toolchain versions.", body = GpuInventory),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn get_gpu_info(State(s): State<AppState>) -> Response {
+    let resp = dispatch(&s.daemon, build_request("get_gpu_info", None)).await;
+    narrowed(resp, GpuInventory::from_daemon)
 }

--- a/super-stt-daemon/src/daemon/http/v1/settings/custom_models_dir.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/custom_models_dir.rs
@@ -1,8 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::CustomModelsDirState;
+
 settings_setter!(
     set_custom_models_dir,
     CustomModelsDirBody { path: Option<String> },
     "set_custom_models_dir",
-    "path"
+    "path",
+    "/custom_models_dir",
+    CustomModelsDirState,
+    "Point the daemon at a models directory of your own",
+    "Overrides where the daemon looks for model files. Send `null` to clear the \
+override and fall back to the default location. Backends installed from the registry \
+are unaffected \u{2014} this is for models supplied out of band.",
+    "Absolute path to the directory, or `null` to clear the override.",
 );
-settings_dispatch!(get_custom_models_dir, "get_custom_models_dir");
+settings_dispatch!(
+    get_custom_models_dir,
+    "get_custom_models_dir",
+    get "/custom_models_dir",
+    CustomModelsDirState,
+    "Read the custom models directory",
+    "Answers with the configured path, or `null` when no override is set."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/language.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/language.rs
@@ -1,14 +1,40 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! `/language` (global) transcription-language settings routes.
+//! `/language` \u{2014} the transcription language every model uses by default.
 //!
-//! The per-model override moved to
+//! The per-model override lives at
 //! `/backends/{source}/models/{model}/language` (see
-//! `crate::daemon::http::v1::backends::model_language`).
-settings_dispatch!(get_language, "get_primary_language");
+//! `crate::daemon::http::v1::backends::model_language`), and a single request
+//! can override both by sending `language` in the `POST /transcribe` body.
+
+use super::wire::LanguageState;
+
+settings_dispatch!(
+    get_language,
+    "get_primary_language",
+    get "/language",
+    LanguageState,
+    "Read the default transcription language",
+    "A BCP-47 tag, `auto`, or `null` when nothing is configured."
+);
 settings_setter!(
     set_language,
     SetLanguageBody { language: String },
     "set_primary_language",
-    "language"
+    "language",
+    "/language",
+    LanguageState,
+    "Set the default transcription language",
+    "Sets the language every model transcribes in unless something more specific \
+overrides it: a per-model setting, or a `language` field in a single \
+`POST /transcribe` body.",
+    "A BCP-47 tag such as `es`, or `auto` to let the model detect the language.",
 );
-settings_dispatch!(clear_language, "clear_primary_language");
+settings_dispatch!(
+    clear_language,
+    "clear_primary_language",
+    delete "/language",
+    LanguageState,
+    "Clear the default transcription language",
+    "Removes the global setting, returning every model to detecting the language \
+itself. Per-model overrides are untouched."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/mod.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/mod.rs
@@ -1,73 +1,152 @@
 // SPDX-License-Identifier: GPL-3.0-only
+//! The `settings` scope: everything a client configures.
+//!
+//! Most endpoints here are one line apiece, because they are the same endpoint
+//! with a different value in it: read a setting, write a setting, acknowledge.
+//! The three macros below generate that endpoint — handler, request body, and
+//! the `#[utoipa::path]` the `OpenAPI` document is built from — so a new setting
+//! is one macro call rather than four things to keep in agreement.
+//!
+//! The path lives in the macro call and nowhere else: [`routes`] registers each
+//! handler through `routes!`, which reads the path back off the attribute. A
+//! setting cannot be served at one path and documented at another.
 
-// The settings handlers are thin wrappers over `dispatch_command`: build a
-// `DaemonRequest`, hand it to the daemon, shape the `DaemonResponse` into an
-// HTTP response. These three macros collapse that boilerplate. They are defined
-// here — before the `mod` declarations below — so textual macro scope makes
-// them visible inside every child module without an import.
-
-/// A no-payload settings handler: dispatch `$cmd` with no request body. Used by
-/// `GET` readers and verb-free actions (`test_audio_theme`, `clear_language`).
+/// A no-body handler: dispatch `$cmd` and acknowledge.
+///
+/// Used for reads whose value rides in `message`, and for the `test` endpoints
+/// that fire a cue and report what they did.
 macro_rules! settings_dispatch {
-    ($fn:ident, $cmd:literal) => {
+    (
+        $fn:ident, $cmd:literal, $method:ident $path:literal, $resp:ty,
+        $summary:literal, $description:literal $(,)?
+    ) => {
+        #[utoipa::path(
+            $method,
+            path = $path,
+            tag = "settings",
+            summary = $summary,
+            description = $description,
+            security(("session_token" = ["settings"])),
+            responses(
+                (status = 200, description = "Done.", body = $resp),
+                (status = 401, description = "Token unknown, expired, or its binary changed.",
+                 body = $crate::daemon::http::wire::ReasonEnvelope),
+                (status = 403, description = "The token lacks the `settings` scope.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+                (status = 429, description = "Per-client rate limit hit; back off and retry.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+            ),
+        )]
         pub(crate) async fn $fn(
             ::axum::extract::State(s): ::axum::extract::State<
                 $crate::daemon::http::state::AppState,
             >,
-        ) -> impl ::axum::response::IntoResponse {
-            $crate::daemon::http::internal::helpers::dispatch::dispatch_command(
-                &s.daemon, $cmd, None,
-            )
-            .await
+        ) -> ::axum::response::Response {
+            use $crate::daemon::http::internal::helpers::dispatch;
+            use $crate::daemon::http::v1::settings::wire::FromDaemon;
+            let resp = dispatch::dispatch(&s.daemon, dispatch::build_request($cmd, None)).await;
+            dispatch::narrowed(resp, <$resp>::from_daemon)
         }
     };
 }
 
-/// A single-field `POST` handler: deserialize `$body { $field: $ty }` and
-/// dispatch `$cmd` with `{ $key: field }` in the request `data`.
+/// A single-field `POST`: deserialize `$body { $field: $ty }` and dispatch
+/// `$cmd` with `{ $key: field }` in the request `data`.
 macro_rules! settings_setter {
-    ($fn:ident, $body:ident { $field:ident : $ty:ty }, $cmd:literal, $key:literal) => {
-        #[derive(::serde::Deserialize)]
+    (
+        $fn:ident, $body:ident { $field:ident : $ty:ty }, $cmd:literal, $key:literal,
+        $path:literal, $resp:ty, $summary:literal, $description:literal, $fielddoc:literal $(,)?
+    ) => {
+        #[doc = $summary]
+        #[derive(::serde::Deserialize, ::utoipa::ToSchema)]
         pub(crate) struct $body {
+            #[doc = $fielddoc]
             pub(crate) $field: $ty,
         }
+
+        #[utoipa::path(
+            post,
+            path = $path,
+            tag = "settings",
+            summary = $summary,
+            description = $description,
+            request_body = $body,
+            security(("session_token" = ["settings"])),
+            responses(
+                (status = 200, description = "Applied.", body = $resp),
+                (status = 400, description = "The value was rejected — out of range, or not one of the accepted tokens.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+                (status = 401, description = "Token unknown, expired, or its binary changed.",
+                 body = $crate::daemon::http::wire::ReasonEnvelope),
+                (status = 403, description = "The token lacks the `settings` scope.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+                (status = 429, description = "Per-client rate limit hit; back off and retry.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+            ),
+        )]
         pub(crate) async fn $fn(
             ::axum::extract::State(s): ::axum::extract::State<$crate::daemon::http::state::AppState>,
             ::axum::Json(body): ::axum::Json<$body>,
-        ) -> impl ::axum::response::IntoResponse {
-            $crate::daemon::http::internal::helpers::dispatch::dispatch_command(
-                &s.daemon,
-                $cmd,
-                Some(::serde_json::json!({ $key: body.$field })),
-            )
-            .await
+        ) -> ::axum::response::Response {
+            use $crate::daemon::http::internal::helpers::dispatch;
+            use $crate::daemon::http::v1::settings::wire::FromDaemon;
+            let req = dispatch::build_request($cmd, Some(::serde_json::json!({ $key: body.$field })));
+            let resp = dispatch::dispatch(&s.daemon, req).await;
+            dispatch::narrowed(resp, <$resp>::from_daemon)
         }
     };
 }
 
-/// A boolean-toggle `POST` handler. These legacy commands read `enabled` from
-/// the top level of `DaemonRequest` (not from `data`), so they build the
-/// request directly rather than via `dispatch_command`.
+/// A boolean-toggle `POST`. These commands read `enabled` from the top level of
+/// `DaemonRequest` rather than from `data`, so they build the request directly
+/// instead of going through `ack`.
 macro_rules! settings_toggle {
-    ($fn:ident, $body:ident, $cmd:literal) => {
-        #[derive(::serde::Deserialize)]
+    (
+        $fn:ident, $body:ident, $cmd:literal,
+        $path:literal, $resp:ty, $summary:literal, $description:literal $(,)?
+    ) => {
+        #[doc = $summary]
+        #[derive(::serde::Deserialize, ::utoipa::ToSchema)]
         pub(crate) struct $body {
+            /// Whether the feature is on.
             pub(crate) enabled: bool,
         }
+
+        #[utoipa::path(
+            post,
+            path = $path,
+            tag = "settings",
+            summary = $summary,
+            description = $description,
+            request_body = $body,
+            security(("session_token" = ["settings"])),
+            responses(
+                (status = 200, description = "Applied.", body = $resp),
+                (status = 401, description = "Token unknown, expired, or its binary changed.",
+                 body = $crate::daemon::http::wire::ReasonEnvelope),
+                (status = 403, description = "The token lacks the `settings` scope.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+                (status = 429, description = "Per-client rate limit hit; back off and retry.",
+                 body = $crate::daemon::http::wire::ErrorEnvelope),
+            ),
+        )]
         pub(crate) async fn $fn(
             ::axum::extract::State(s): ::axum::extract::State<
                 $crate::daemon::http::state::AppState,
             >,
             ::axum::Json(body): ::axum::Json<$body>,
-        ) -> impl ::axum::response::IntoResponse {
+        ) -> ::axum::response::Response {
             use $crate::daemon::http::internal::helpers::dispatch;
+            use $crate::daemon::http::v1::settings::wire::FromDaemon;
             let mut req = dispatch::build_request($cmd, None);
             req.enabled = Some(body.enabled);
             let resp = dispatch::dispatch(&s.daemon, req).await;
-            dispatch::json_response(&resp)
+            dispatch::narrowed(resp, <$resp>::from_daemon)
         }
     };
 }
+
+pub(crate) mod wire;
 
 pub(crate) mod audio_theme;
 pub(crate) mod backends;
@@ -85,97 +164,83 @@ pub(crate) mod volume;
 pub(crate) mod write_method;
 
 use crate::daemon::http::state::AppState;
-use axum::Router;
-use axum::routing::{delete, get, post};
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-/// All settings-scope routes. The registry sub-routes share the settings
-/// scope, so they are merged in here.
-pub(crate) fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/models", get(models::list_models))
-        .route(
-            "/audio_theme",
-            get(audio_theme::get_audio_theme).post(audio_theme::set_audio_theme),
-        )
-        .route("/audio_theme/test", post(audio_theme::test_audio_theme))
-        .route("/audio_themes", get(audio_theme::list_audio_themes))
-        .route("/volume", get(volume::get_volume).post(volume::set_volume))
-        .route(
-            "/recording_stop_mode",
-            get(recording_stop_mode::get_recording_stop_mode)
-                .post(recording_stop_mode::set_recording_stop_mode),
-        )
-        .route(
-            "/write_method",
-            get(write_method::get_write_method).post(write_method::set_write_method),
-        )
-        .route("/write_method/test", post(write_method::test_write_method))
-        .route(
-            "/notification_method",
-            get(notification_method::get_notification_method)
-                .post(notification_method::set_notification_method),
-        )
-        .route("/pipeline", get(pipeline::get_pipeline))
-        .route(
-            "/pipeline/{stage}",
-            get(pipeline::get_stage)
-                .post(pipeline::set_stage_backend)
-                .delete(pipeline::clear_stage_backend),
-        )
-        .route(
-            "/pipeline/{stage}/model",
-            post(pipeline::set_stage_model).delete(pipeline::clear_stage_model),
-        )
-        .route(
-            "/pipeline/{stage}/model/cancel",
-            post(pipeline::cancel_stage_model),
-        )
-        .route(
-            "/pipeline/{stage}/model/reload",
-            post(pipeline::reload_stage_model),
-        )
-        .route(
-            "/pipeline/{stage}/device/list",
-            get(pipeline::list_stage_devices),
-        )
-        .route(
-            "/pipeline/{stage}/model/{model}/device",
-            get(pipeline::get_model_device).post(pipeline::set_model_device),
-        )
-        .route(
-            "/pipeline/{stage}/model/{model}/device/list",
-            get(pipeline::list_model_devices),
-        )
-        .route(
-            "/preview_typing",
-            get(preview_typing::get_preview_typing).post(preview_typing::set_preview_typing),
-        )
-        .route(
-            "/custom_models_dir",
-            get(custom_models_dir::get_custom_models_dir)
-                .post(custom_models_dir::set_custom_models_dir),
-        )
-        .route(
-            "/update_check_enabled",
-            get(update_check_enabled::get_update_check_enabled)
-                .post(update_check_enabled::set_update_check_enabled),
-        )
-        .route(
-            "/update_beta_optin",
-            get(update_beta_optin::get_update_beta_optin)
-                .post(update_beta_optin::set_update_beta_optin),
-        )
-        .route("/update", get(self_update::get_update))
-        .route("/update/check", post(self_update::post_check))
-        .route("/backends", get(backends::list_backends))
-        .route("/backends/{source}", delete(backends::uninstall_backend))
-        .route("/gpu_info", get(backends::get_gpu_info))
-        .route(
-            "/language",
-            get(language::get_language)
-                .post(language::set_language)
-                .delete(language::clear_language),
-        )
+/// All settings-scope routes. Registry and backend-option routes share the
+/// settings scope, so they are merged in here.
+///
+/// No path appears in this function: `routes!` reads each one off the handler's
+/// `#[utoipa::path]`, which is also what the `OpenAPI` document is generated from.
+/// Handlers sharing a path are registered together, which is what makes them one
+/// path item with several methods.
+pub(crate) fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(models::list_models))
+        .routes(routes!(
+            audio_theme::get_audio_theme,
+            audio_theme::set_audio_theme
+        ))
+        .routes(routes!(audio_theme::test_audio_theme))
+        .routes(routes!(audio_theme::list_audio_themes))
+        .routes(routes!(volume::get_volume, volume::set_volume))
+        .routes(routes!(
+            recording_stop_mode::get_recording_stop_mode,
+            recording_stop_mode::set_recording_stop_mode
+        ))
+        .routes(routes!(
+            write_method::get_write_method,
+            write_method::set_write_method
+        ))
+        .routes(routes!(write_method::test_write_method))
+        .routes(routes!(
+            notification_method::get_notification_method,
+            notification_method::set_notification_method
+        ))
+        .routes(routes!(pipeline::get_pipeline))
+        .routes(routes!(
+            pipeline::get_stage,
+            pipeline::set_stage_backend,
+            pipeline::clear_stage_backend
+        ))
+        .routes(routes!(
+            pipeline::set_stage_model,
+            pipeline::clear_stage_model
+        ))
+        .routes(routes!(pipeline::cancel_stage_model))
+        .routes(routes!(pipeline::reload_stage_model))
+        .routes(routes!(pipeline::list_stage_devices))
+        .routes(routes!(
+            pipeline::get_model_device,
+            pipeline::set_model_device
+        ))
+        .routes(routes!(pipeline::list_model_devices))
+        .routes(routes!(
+            preview_typing::get_preview_typing,
+            preview_typing::set_preview_typing
+        ))
+        .routes(routes!(
+            custom_models_dir::get_custom_models_dir,
+            custom_models_dir::set_custom_models_dir
+        ))
+        .routes(routes!(
+            update_check_enabled::get_update_check_enabled,
+            update_check_enabled::set_update_check_enabled
+        ))
+        .routes(routes!(
+            update_beta_optin::get_update_beta_optin,
+            update_beta_optin::set_update_beta_optin
+        ))
+        .routes(routes!(self_update::get_update))
+        .routes(routes!(self_update::post_check))
+        .routes(routes!(backends::list_backends))
+        .routes(routes!(backends::uninstall_backend))
+        .routes(routes!(backends::get_gpu_info))
+        .routes(routes!(
+            language::get_language,
+            language::set_language,
+            language::clear_language
+        ))
         .merge(super::registry::routes())
         .merge(super::backends::options::routes())
         .merge(super::backends::model_language::routes())

--- a/super-stt-daemon/src/daemon/http/v1/settings/models.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/models.rs
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! `/models` — the models the active backend serves.
+//! `/models` \u{2014} the models the backend filling stage 1 serves.
 //!
-//! Selecting and loading a model happens through `/pipeline/{stage}/model`
-//! (see `super::pipeline`); this module is only the flat catalog read that a
-//! picker fills itself from.
-//!
-//! The `current.provider` compatibility shim that `GET /active_model` carried
-//! for clients through v0.2.0 went with that endpoint — those clients need the
-//! pipeline paths now, so there is nothing left for the shim to protect.
+//! Selecting and loading one happens through `/pipeline/{stage}/model` (see
+//! `super::pipeline`); this is only the flat catalog read that a picker fills
+//! itself from.
 
-use crate::daemon::http::internal::helpers::dispatch::dispatch_command;
-use crate::daemon::http::state::AppState;
-use axum::extract::State;
-use axum::response::IntoResponse;
+use super::wire::ModelList;
 
-pub(crate) async fn list_models(State(s): State<AppState>) -> impl IntoResponse {
-    dispatch_command(&s.daemon, "list_models", None).await
-}
+settings_dispatch!(
+    list_models,
+    "list_models",
+    get "/models",
+    ModelList,
+    "List the models the active backend can transcribe with",
+    "Scoped to the backend currently filling stage 1 \u{2014} only its models are \
+switchable. Post-processor models are excluded, since selecting one as a \
+transcription model would fail every recording; the full catalog with roles is at \
+`GET /backends`."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/notification_method.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/notification_method.rs
@@ -1,8 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::NotificationMethodState;
+
 settings_setter!(
     set_notification_method,
     SetNotificationMethodBody { method: String },
     "set_notification_method",
-    "method"
+    "method",
+    "/notification_method",
+    NotificationMethodState,
+    "Choose how failures are announced",
+    "Selects how the daemon tells the user when something goes wrong \u{2014} a desktop \
+notification, or nothing at all. This is about failures the user would otherwise \
+never see, such as a transcript that could not be written to the focused window.",
+    "One of the accepted `snake_case` method tokens. An unknown token is a `400`.",
 );
-settings_dispatch!(get_notification_method, "get_notification_method");
+settings_dispatch!(
+    get_notification_method,
+    "get_notification_method",
+    get "/notification_method",
+    NotificationMethodState,
+    "Read how failures are announced",
+    "Answers with the configured method. This governs only failures the user \
+would otherwise never learn about \u{2014} a transcript that could not be written to the \
+focused window, say \u{2014} not routine status, which rides on the event stream."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/pipeline.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/pipeline.rs
@@ -11,16 +11,19 @@
 //! resolves; the handlers themselves are the ones each stage always had, so
 //! there is a single implementation of each operation.
 
-use crate::daemon::http::internal::helpers::dispatch::{
-    build_request, dispatch, dispatch_command, json_response,
-};
+use crate::daemon::http::internal::helpers::dispatch::{build_request, dispatch, narrowed};
 use crate::daemon::http::state::AppState;
 use crate::daemon::http::v1::backends::json_error_msg;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use serde::Deserialize;
 use super_stt_shared::models::protocol::DaemonResponse;
+
+use super::wire::{
+    DeviceList, FromDaemon, ModelDevice, PipelineReport, StageEnvelope, StageMutation,
+};
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
 
 /// The commands that implement one stage's four verbs.
 ///
@@ -95,40 +98,113 @@ fn unknown_stage(stage: u32) -> Response {
 }
 
 /// `GET /pipeline` — every stage, in order.
-pub(crate) async fn get_pipeline(State(s): State<AppState>) -> impl IntoResponse {
-    dispatch_command(&s.daemon, "get_pipeline", None).await
+#[utoipa::path(
+    get,
+    path = "/pipeline",
+    tag = "pipeline",
+    summary = "Report every pipeline stage",
+    description = "\
+The ordered stages a transcript passes through. Stage 1 turns audio into text; every \
+later stage rewrites what the one before it produced.
+
+Each stage reports which backend fills it, which model is selected, whether that \
+model is up, the accelerator it actually runs on, and any load still in flight. \
+Stages are addressed by position precisely so a third can be appended without \
+inventing a third endpoint for it.",
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Every stage, stage 1 first.", body = PipelineReport),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn get_pipeline(State(s): State<AppState>) -> Response {
+    let resp = dispatch(&s.daemon, build_request("get_pipeline", None)).await;
+    narrowed(resp, PipelineReport::from_daemon)
 }
 
 /// `GET /pipeline/{stage}` — one stage, from the same report.
-pub(crate) async fn get_stage(
-    State(s): State<AppState>,
-    Path(stage): Path<u32>,
-) -> impl IntoResponse {
+#[utoipa::path(
+    get,
+    path = "/pipeline/{stage}",
+    tag = "pipeline",
+    summary = "Report one pipeline stage",
+    description = "\
+The same object `GET /pipeline` carries in its array, for a client that only cares \
+about one position. It is narrowed from that report rather than derived separately, \
+so one stage and the whole list can never disagree.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The stage.", body = StageEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn get_stage(State(s): State<AppState>, Path(stage): Path<u32>) -> Response {
     if Stage::resolve(stage).is_none() {
         return unknown_stage(stage);
     }
     let resp = dispatch(&s.daemon, build_request("get_pipeline", None)).await;
     // Narrow the array to the requested position rather than re-deriving it, so
     // one stage and the whole list can never disagree.
-    let one = resp.pipeline.as_ref().and_then(|stages| {
-        stages
-            .as_array()?
-            .iter()
-            .find(|v| v.get("stage").and_then(serde_json::Value::as_u64) == Some(u64::from(stage)))
-            .cloned()
-    });
+    let one = resp
+        .pipeline
+        .as_ref()
+        .and_then(|stages| stages.iter().find(|st| st.stage == stage).cloned());
     match one {
-        Some(v) => json_response(&DaemonResponse::success().with_stage(v)).into_response(),
+        Some(stage) => narrowed(DaemonResponse::success(), |_| StageEnvelope {
+            status: "success",
+            stage,
+        }),
         None => unknown_stage(stage),
     }
 }
 
-#[derive(Deserialize)]
+/// Which backend should fill the stage.
+#[derive(Deserialize, utoipa::ToSchema)]
 pub(crate) struct SetBackendBody {
+    /// The backend's repo id, as `GET /backends` reports it.
+    #[schema(example = "github.com/acme/whisper")]
     pub(crate) source: String,
 }
 
 /// `POST /pipeline/{stage}` — select the backend filling this stage.
+#[utoipa::path(
+    post,
+    path = "/pipeline/{stage}",
+    tag = "pipeline",
+    summary = "Select the backend filling a stage",
+    description = "\
+Points a stage at an installed backend. Selecting a backend does not load a model — \
+do that with `POST /pipeline/{stage}/model`.
+
+A backend that serves nothing this stage can run is refused: filling stage 2 with a \
+transcription-only backend would leave the user staring at an empty model picker \
+with no reason given.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    request_body = SetBackendBody,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Selected.", body = StageMutation),
+        (status = 400, description = "No installed backend has that `source`, or it serves nothing this stage can run (`invalid_backend`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn set_stage_backend(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -145,10 +221,33 @@ pub(crate) async fn set_stage_backend(
         ),
     )
     .await;
-    json_response(&resp).into_response()
+    narrowed(resp, StageMutation::from_daemon)
 }
 
 /// `DELETE /pipeline/{stage}` — deselect this stage's backend.
+#[utoipa::path(
+    delete,
+    path = "/pipeline/{stage}",
+    tag = "pipeline",
+    summary = "Empty a stage",
+    description = "\
+Deselects the stage's backend, unloading its model first if one is up. The stage \
+then does nothing: stage 1 empty means no transcription, stage 2 empty means \
+transcripts pass through unrewritten.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Emptied.", body = StageMutation),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn clear_stage_backend(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -156,20 +255,51 @@ pub(crate) async fn clear_stage_backend(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(&s.daemon, cmds.clear_backend, None)
-        .await
-        .into_response()
+    let resp = dispatch(&s.daemon, build_request(cmds.clear_backend, None)).await;
+    narrowed(resp, StageMutation::from_daemon)
 }
 
-#[derive(Deserialize)]
+/// Which model to run in the stage.
+#[derive(Deserialize, utoipa::ToSchema)]
 pub(crate) struct SetModelBody {
+    /// The model's name.
+    #[schema(example = "whisper-tiny")]
     pub(crate) model: String,
-    /// Omitted resolves to the backend selected for this stage.
+    /// The backend serving it. Omitted resolves to the backend already selected
+    /// for this stage.
     #[serde(default)]
     pub(crate) source: Option<String>,
 }
 
 /// `POST /pipeline/{stage}/model` — run a model in this stage.
+#[utoipa::path(
+    post,
+    path = "/pipeline/{stage}/model",
+    tag = "pipeline",
+    summary = "Run a model in a stage",
+    description = "\
+Loads `model` into the stage, downloading it first if this machine does not have it \
+yet. That download can be long: watch the `download_progress` event topic, or poll \
+`GET /pipeline/{stage}` and read `switch`. Abandon it with \
+`POST /pipeline/{stage}/model/cancel`.
+
+Omitting `source` uses the backend already selected for the stage.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    request_body = SetModelBody,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Accepted. The model may still be downloading — read `switch` to follow it.", body = StageMutation),
+        (status = 400, description = "No such model (`invalid_model`), or no such backend (`invalid_backend`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn set_stage_model(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -183,10 +313,33 @@ pub(crate) async fn set_stage_model(
         data["source"] = serde_json::Value::String(source);
     }
     let resp = dispatch(&s.daemon, build_request(cmds.set_model, Some(data))).await;
-    json_response(&resp).into_response()
+    narrowed(resp, StageMutation::from_daemon)
 }
 
 /// `DELETE /pipeline/{stage}/model` — stop this stage, keeping its backend.
+#[utoipa::path(
+    delete,
+    path = "/pipeline/{stage}/model",
+    tag = "pipeline",
+    summary = "Stop a stage's model",
+    description = "\
+Unloads the model, freeing its device memory, and leaves the backend selected so a \
+different model can be loaded without re-selecting it. To empty the stage entirely, \
+use `DELETE /pipeline/{stage}`.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Unloaded.", body = StageMutation),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn clear_stage_model(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -194,14 +347,39 @@ pub(crate) async fn clear_stage_model(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(&s.daemon, cmds.clear_model, None)
-        .await
-        .into_response()
+    let resp = dispatch(&s.daemon, build_request(cmds.clear_model, None)).await;
+    narrowed(resp, StageMutation::from_daemon)
 }
 
 /// `POST /pipeline/{stage}/model/cancel` — abandon the load this stage has in
 /// flight. Scoped to the stage: the stages provision independently, so one
 /// stage's cancel is not a licence to abandon another's download.
+#[utoipa::path(
+    post,
+    path = "/pipeline/{stage}/model/cancel",
+    tag = "pipeline",
+    summary = "Abandon a stage's in-flight load",
+    description = "\
+Stops the download or load this stage has in flight. Scoped to the stage: the stages \
+provision independently, so cancelling one is not a licence to abandon another's \
+download.
+
+`409 no_switch_in_progress` when the stage has nothing in flight.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Cancelled.", body = crate::daemon::http::wire::Ack),
+        (status = 409, description = "Nothing was in flight for this stage (`no_switch_in_progress`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn cancel_stage_model(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -209,13 +387,37 @@ pub(crate) async fn cancel_stage_model(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(&s.daemon, cmds.cancel_model, None)
-        .await
-        .into_response()
+    let resp = dispatch(&s.daemon, build_request(cmds.cancel_model, None)).await;
+    narrowed(resp, crate::daemon::http::wire::Ack::from_daemon)
 }
 
 /// `POST /pipeline/{stage}/model/reload` — re-instantiate in place, picking up
 /// changed secrets and options without a manual unload/load.
+#[utoipa::path(
+    post,
+    path = "/pipeline/{stage}/model/reload",
+    tag = "pipeline",
+    summary = "Re-instantiate a stage's model in place",
+    description = "\
+Tears the model down and brings it back up so it picks up changed secrets and \
+options — an API key set through `/backends/{source}/secrets`, say — without the \
+client having to unload and reload by hand.
+
+Nothing is re-downloaded; the files on disk are unchanged.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Reloaded.", body = crate::daemon::http::wire::Ack),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn reload_stage_model(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -223,13 +425,36 @@ pub(crate) async fn reload_stage_model(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(&s.daemon, cmds.reload_model, None)
-        .await
-        .into_response()
+    let resp = dispatch(&s.daemon, build_request(cmds.reload_model, None)).await;
+    narrowed(resp, crate::daemon::http::wire::Ack::from_daemon)
 }
 
 /// `GET /pipeline/{stage}/model/{model}/device` — the device `model` prefers,
 /// what it resolved to, and what this install can offer it.
+#[utoipa::path(
+    get,
+    path = "/pipeline/{stage}/model/{model}/device",
+    tag = "pipeline",
+    summary = "Read a model's device preference",
+    description = "\
+The accelerator this model is set to run on, and — when the preference is the \
+generic `gpu` — what it actually resolved to once loaded. The preference is per \
+model, not per stage: two models in the same stage can prefer different devices.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+        ("model" = String, Path, description = "The model's name, as `GET /models` or `GET /backends` spells it."),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The preference, and what it resolved to.", body = ModelDevice),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn get_model_device(
     State(s): State<AppState>,
     Path((stage, model)): Path<(u32, String)>,
@@ -237,22 +462,53 @@ pub(crate) async fn get_model_device(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(
-        &s.daemon,
+    let req = build_request(
         cmds.get_model_device,
         Some(serde_json::json!({ "model": model })),
-    )
-    .await
-    .into_response()
+    );
+    let resp = dispatch(&s.daemon, req).await;
+    narrowed(resp, ModelDevice::from_daemon)
 }
 
-#[derive(Deserialize)]
+/// Which accelerator the model should run on.
+#[derive(Deserialize, utoipa::ToSchema)]
 pub(crate) struct SetDeviceBody {
+    /// An accelerator token from the stage's or model's device list — `cpu`,
+    /// `cuda`, `vulkan`, or the generic `gpu`.
+    #[schema(example = "cuda")]
     pub(crate) device: String,
 }
 
 /// `POST /pipeline/{stage}/model/{model}/device` — run `model` on `device`,
 /// reloading it when it is the one this stage is running.
+#[utoipa::path(
+    post,
+    path = "/pipeline/{stage}/model/{model}/device",
+    tag = "pipeline",
+    summary = "Set a model's device preference",
+    description = "\
+Chooses the accelerator this model runs on. If it is the model the stage is \
+currently running, it is reloaded onto the new device; otherwise the preference is \
+stored and takes effect at the next load.
+
+List what this host can offer with `GET /pipeline/{stage}/model/{model}/device/list`.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+        ("model" = String, Path, description = "The model's name, as `GET /models` or `GET /backends` spells it."),
+    ),
+    request_body = SetDeviceBody,
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "Preference set; this is the resulting report.", body = ModelDevice),
+        (status = 400, description = "This host cannot offer that device (`invalid_device`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn set_model_device(
     State(s): State<AppState>,
     Path((stage, model)): Path<(u32, String)>,
@@ -261,17 +517,41 @@ pub(crate) async fn set_model_device(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(
-        &s.daemon,
+    let req = build_request(
         cmds.set_model_device,
         Some(serde_json::json!({ "model": model, "device": body.device })),
-    )
-    .await
-    .into_response()
+    );
+    let resp = dispatch(&s.daemon, req).await;
+    narrowed(resp, ModelDevice::from_daemon)
 }
 
 /// `GET /pipeline/{stage}/model/{model}/device/list` — the devices this
 /// install can offer `model` on this host.
+#[utoipa::path(
+    get,
+    path = "/pipeline/{stage}/model/{model}/device/list",
+    tag = "pipeline",
+    summary = "List the devices a model can run on here",
+    description = "\
+What this machine can actually offer this model — the intersection of the host's \
+accelerators and the builds the model ships. Fill a device picker from this rather \
+than from `GET /gpu_info`, which reports the hardware without regard to what the \
+model supports.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+        ("model" = String, Path, description = "The model's name, as `GET /models` or `GET /backends` spells it."),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The devices on offer.", body = DeviceList),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn list_model_devices(
     State(s): State<AppState>,
     Path((stage, model)): Path<(u32, String)>,
@@ -279,17 +559,40 @@ pub(crate) async fn list_model_devices(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(
-        &s.daemon,
+    let req = build_request(
         cmds.list_model_devices,
         Some(serde_json::json!({ "model": model })),
-    )
-    .await
-    .into_response()
+    );
+    let resp = dispatch(&s.daemon, req).await;
+    narrowed(resp, DeviceList::from_daemon)
 }
 
 /// `GET /pipeline/{stage}/device/list` — the devices the backend selected for
 /// this stage can be run on here.
+#[utoipa::path(
+    get,
+    path = "/pipeline/{stage}/device/list",
+    tag = "pipeline",
+    summary = "List the devices this stage's backend can run on",
+    description = "\
+The devices the backend filling this stage can run on this host, without naming a \
+model. Use it before a model is chosen; once one is, the per-model list is the \
+narrower and more accurate answer.",
+    params(
+        ("stage" = u32, Path,
+         description = "Pipeline position: `1` transcribes, `2` post-processes. A position that does not exist is a `404 unknown_stage`.",
+         example = 1),
+    ),
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The devices on offer.", body = DeviceList),
+        (status = 400, description = "The stage has no backend selected (`invalid_backend`).", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 404, description = "No such stage (`unknown_stage`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn list_stage_devices(
     State(s): State<AppState>,
     Path(stage): Path<u32>,
@@ -297,7 +600,6 @@ pub(crate) async fn list_stage_devices(
     let Some(cmds) = Stage::resolve(stage) else {
         return unknown_stage(stage);
     };
-    dispatch_command(&s.daemon, cmds.list_backend_devices, None)
-        .await
-        .into_response()
+    let resp = dispatch(&s.daemon, build_request(cmds.list_backend_devices, None)).await;
+    narrowed(resp, DeviceList::from_daemon)
 }

--- a/super-stt-daemon/src/daemon/http/v1/settings/preview_typing.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/preview_typing.rs
@@ -1,3 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-only
-settings_toggle!(set_preview_typing, PreviewTypingBody, "set_preview_typing");
-settings_dispatch!(get_preview_typing, "get_preview_typing");
+use super::wire::PreviewTypingState;
+
+settings_toggle!(
+    set_preview_typing,
+    PreviewTypingBody,
+    "set_preview_typing",
+    "/preview_typing",
+    PreviewTypingState,
+    "Turn live preview typing on or off",
+    "When on, a realtime-capable model's incremental transcript is typed into the \
+focused window as it forms, and corrected in place as later audio revises it. When \
+off, nothing is written until the transcript is final."
+);
+settings_dispatch!(
+    get_preview_typing,
+    "get_preview_typing",
+    get "/preview_typing",
+    PreviewTypingState,
+    "Read whether live preview typing is on",
+    "Answers with the current state. On means a realtime-capable model's partial \
+transcript is typed into the focused window as it forms; off means nothing is \
+written until the transcript is final. A model without a realtime session ignores \
+the setting either way."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/recording_stop_mode.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/recording_stop_mode.rs
@@ -1,8 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::RecordingStopModeState;
+
 settings_setter!(
     set_recording_stop_mode,
     SetRecordingStopModeBody { mode: String },
     "set_recording_stop_mode",
-    "mode"
+    "mode",
+    "/recording_stop_mode",
+    RecordingStopModeState,
+    "Choose what ends a recording",
+    "Sets whether a recording stops on an explicit signal, on a period of silence, or \
+on either. This governs daemon-mic captures started through `POST /transcribe`; it \
+has no bearing on the pre-captured path, which has no capture to end.",
+    "One of the accepted `snake_case` mode tokens. An unknown token is a `400`.",
 );
-settings_dispatch!(get_recording_stop_mode, "get_recording_stop_mode");
+settings_dispatch!(
+    get_recording_stop_mode,
+    "get_recording_stop_mode",
+    get "/recording_stop_mode",
+    RecordingStopModeState,
+    "Read what currently ends a recording",
+    "Answers with the configured mode. It governs daemon-mic captures started \
+through `POST /transcribe`; the pre-captured path has no capture to end, and a \
+`wait: true` caller can always end one by closing the connection."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/self_update.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/self_update.rs
@@ -1,12 +1,37 @@
 // SPDX-License-Identifier: GPL-3.0-only
-//! GET /v1/update and POST /v1/update/check.
-//! Contract: docs/protocol/endpoints/v1/update.md
+//! `GET /update` and `POST /update/check` — Super STT updating itself.
+//!
+//! Contract: `docs/protocol/endpoints/v1/update.md`. Distinct from the *backend*
+//! update surface under `/registry`, which updates models rather than the daemon.
 
 use axum::extract::State;
 use axum::response::IntoResponse;
 
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
+use super_stt_shared::models::self_update::SelfUpdateStatus;
 
+#[utoipa::path(
+    get,
+    path = "/update",
+    tag = "settings",
+    summary = "Read the last self-update check",
+    description = "\
+Reports what the most recent check found, without performing one. `checked_at` is \
+`null` until a check has run, and `last_check_error` says why the last attempt \
+failed if it did.
+
+Which channel is consulted follows `/update_beta_optin`; `beta_optin_effective` \
+reports the setting even before a check has resolved a channel of its own. To force \
+a check now, use `POST /update/check`.",
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The last known update state.", body = SelfUpdateStatus),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn get_update(State(s): State<AppState>) -> impl IntoResponse {
     // The configured opt-in, so `beta_optin_effective` is answered from the
     // setting before the first check has resolved a channel of its own.
@@ -14,6 +39,25 @@ pub(crate) async fn get_update(State(s): State<AppState>) -> impl IntoResponse {
     axum::Json(s.daemon.self_update.status_for(optin).await)
 }
 
+#[utoipa::path(
+    post,
+    path = "/update/check",
+    tag = "settings",
+    summary = "Check for a Super STT update now",
+    description = "\
+Runs the check immediately rather than waiting for the daemon's own schedule, and \
+answers with the result — the same shape `GET /update` reports. Works whether or not \
+the periodic check is enabled.
+
+This only *looks*. Nothing is downloaded or installed as a result.",
+    security(("session_token" = ["settings"])),
+    responses(
+        (status = 200, description = "The check ran; this is what it found. A network failure is reported in `last_check_error`, not as an HTTP error.", body = SelfUpdateStatus),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn post_check(State(s): State<AppState>) -> impl IntoResponse {
     axum::Json(s.daemon.run_self_update_check_and_notify().await)
 }

--- a/super-stt-daemon/src/daemon/http/v1/settings/update_beta_optin.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/update_beta_optin.rs
@@ -1,8 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::UpdateBetaOptinState;
+
 settings_setter!(
     set_update_beta_optin,
     SetUpdateBetaOptinBody { value: String },
     "set_update_beta_optin",
-    "value"
+    "value",
+    "/update_beta_optin",
+    UpdateBetaOptinState,
+    "Choose whether updates include prereleases",
+    "Selects which release channel the update check considers. Opting in offers beta \
+builds as they are published; opting out considers stable releases only.",
+    "One of the accepted `snake_case` opt-in tokens. An unknown token is a `400`.",
 );
-settings_dispatch!(get_update_beta_optin, "get_update_beta_optin");
+settings_dispatch!(
+    get_update_beta_optin,
+    "get_update_beta_optin",
+    get "/update_beta_optin",
+    UpdateBetaOptinState,
+    "Read the update channel opt-in",
+    "Answers with the configured opt-in \u{2014} whether the update check considers beta \
+builds or stable releases only. This is about Super STT itself, not about the \
+backends under `/registry`, which are versioned separately."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/update_check_enabled.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/update_check_enabled.rs
@@ -1,7 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::UpdateCheckEnabledState;
+
 settings_toggle!(
     set_update_check_enabled,
     UpdateCheckEnabledBody,
-    "set_update_check_enabled"
+    "set_update_check_enabled",
+    "/update_check_enabled",
+    UpdateCheckEnabledState,
+    "Turn the periodic update check on or off",
+    "Controls whether the daemon checks for new Super STT releases on its own \
+schedule. Turning it off does not disable updating \u{2014} `POST /update/check` still \
+works on demand."
 );
-settings_dispatch!(get_update_check_enabled, "get_update_check_enabled");
+settings_dispatch!(
+    get_update_check_enabled,
+    "get_update_check_enabled",
+    get "/update_check_enabled",
+    UpdateCheckEnabledState,
+    "Read whether periodic update checks are on",
+    "Answers with the current state. Off stops the daemon checking on its own \
+schedule; it does not disable updating, since `POST /update/check` still runs a \
+check on demand."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/volume.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/volume.rs
@@ -3,6 +3,21 @@ settings_setter!(
     set_volume,
     SetVolumeBody { volume: u8 },
     "set_volume",
-    "volume"
+    "volume",
+    "/volume",
+    crate::daemon::http::wire::Ack,
+    "Set the audio cue volume",
+    "Sets the loudness of the recording cues on a 0\u{2013}100 scale. `0` silences them \
+without changing which theme is selected; the theme itself is read and written at \
+`/audio_theme`.",
+    "Integer in `0..=100`. Anything outside that range is a `400`.",
 );
-settings_dispatch!(get_volume, "get_volume");
+settings_dispatch!(
+    get_volume,
+    "get_volume",
+    get "/volume",
+    crate::daemon::http::wire::Ack,
+    "Read the audio cue volume",
+    "The level rides in `message` as a bare number \u{2014} `\"75\"` \u{2014} not as a field of \
+its own, so parse it back out."
+);

--- a/super-stt-daemon/src/daemon/http/v1/settings/wire.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/wire.rs
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! What each `settings` endpoint answers with.
+//!
+//! One type per shape, built from the [`DaemonResponse`] the command bus
+//! returned. The point is that the type an endpoint *publishes* is the type its
+//! handler *builds*: [`FromDaemon`] is the only way a narrow body comes into
+//! existence here, so a schema cannot claim a field the handler never fills.
+//!
+//! Field sets are not guesses — each is the set of `with_*` calls its command
+//! handler makes. A response carrying its value in `message` rather than in a
+//! field of its own is marked as such, because a client has to parse it back
+//! out.
+
+use super::super::super::wire::Ack;
+use serde::Serialize;
+use super_stt_shared::models::backends::BackendInfo;
+use super_stt_shared::models::protocol::{DaemonResponse, GpuHostInfo, GpuInfo, StageReport};
+use super_stt_shared::models::theme::AudioTheme;
+use utoipa::ToSchema;
+
+/// Build a narrow response body from the command bus's wide one.
+///
+/// Implemented rather than derived so each type states which fields it takes
+/// and what it does when one is missing — a command that stops setting a field
+/// should surface as a documented default, not a panic.
+pub(crate) trait FromDaemon {
+    fn from_daemon(resp: DaemonResponse) -> Self;
+}
+
+impl FromDaemon for Ack {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            message: resp.message,
+        }
+    }
+}
+
+/// The selected audio cue theme.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct AudioThemeState {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// The selected theme's token.
+    #[schema(example = "classic")]
+    audio_theme: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for AudioThemeState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            audio_theme: resp.audio_theme.unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// Every audio cue theme the daemon ships.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct AudioThemeList {
+    #[schema(example = "success")]
+    status: &'static str,
+    available_audio_themes: Vec<AudioTheme>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for AudioThemeList {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            available_audio_themes: resp.available_audio_themes.unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// What ends a recording.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct RecordingStopModeState {
+    #[schema(example = "success")]
+    status: &'static str,
+    recording_stop_mode: String,
+}
+
+impl FromDaemon for RecordingStopModeState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            recording_stop_mode: resp.recording_stop_mode.unwrap_or_default(),
+        }
+    }
+}
+
+/// How transcripts reach the focused window.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct WriteMethodState {
+    #[schema(example = "success")]
+    status: &'static str,
+    write_method: String,
+}
+
+impl FromDaemon for WriteMethodState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            write_method: resp.write_method.unwrap_or_default(),
+        }
+    }
+}
+
+/// The outcome of writing sample text with the configured method.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct WriteMethodTest {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// The configured preference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    write_method: Option<String>,
+    /// What that preference resolved to for this session, which can differ when
+    /// the compositor will not permit the preferred mechanism.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_write_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for WriteMethodTest {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            write_method: resp.write_method,
+            resolved_write_method: resp.resolved_write_method,
+            message: resp.message,
+        }
+    }
+}
+
+/// How failures are announced.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct NotificationMethodState {
+    #[schema(example = "success")]
+    status: &'static str,
+    notification_method: String,
+}
+
+impl FromDaemon for NotificationMethodState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            notification_method: resp.notification_method.unwrap_or_default(),
+        }
+    }
+}
+
+/// Whether live preview typing is on.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct PreviewTypingState {
+    #[schema(example = "success")]
+    status: &'static str,
+    preview_typing_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for PreviewTypingState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            preview_typing_enabled: resp.preview_typing_enabled.unwrap_or(false),
+            message: resp.message,
+        }
+    }
+}
+
+/// The models directory override.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct CustomModelsDirState {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// The configured directory, or `null` when no override is set. Always
+    /// present — `null` is the answer, not an absent key.
+    custom_models_dir: Option<String>,
+}
+
+impl FromDaemon for CustomModelsDirState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            // Doubly optional on the bus: the outer layer is "this command did
+            // not set it", the inner is the documented nullable value.
+            custom_models_dir: resp.custom_models_dir.flatten(),
+        }
+    }
+}
+
+/// Whether the periodic update check runs.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct UpdateCheckEnabledState {
+    #[schema(example = "success")]
+    status: &'static str,
+    update_check_enabled: bool,
+}
+
+impl FromDaemon for UpdateCheckEnabledState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            update_check_enabled: resp.update_check_enabled.unwrap_or(false),
+        }
+    }
+}
+
+/// Which release channel updates come from.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct UpdateBetaOptinState {
+    #[schema(example = "success")]
+    status: &'static str,
+    update_beta_optin: String,
+}
+
+impl FromDaemon for UpdateBetaOptinState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            update_beta_optin: resp.update_beta_optin.unwrap_or_default(),
+        }
+    }
+}
+
+/// The default transcription language.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct LanguageState {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// A BCP-47 tag, `auto`, or `null` when nothing is configured. Always
+    /// present — `null` is the answer, not an absent key.
+    #[schema(example = "es")]
+    language: Option<String>,
+}
+
+impl FromDaemon for LanguageState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            language: resp
+                .language
+                .as_ref()
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
+        }
+    }
+}
+
+/// The models the backend filling stage 1 can transcribe with.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ModelList {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// `[name, source]` pairs. Post-processor models are excluded — they are not
+    /// switchable transcription models, and offering one would fail every
+    /// recording. The full catalog, roles included, is at `GET /backends`.
+    #[schema(example = json!([["whisper-tiny", "github.com/super-stt/whisper"]]))]
+    available_models: Vec<(String, String)>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for ModelList {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            available_models: resp.available_models.unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// Every installed backend, with its models, options and secrets.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct BackendCatalog {
+    #[schema(example = "success")]
+    status: &'static str,
+    backends: Vec<BackendInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for BackendCatalog {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            // The command builds a typed catalog and flattens it to `Value` at
+            // the last step; this reads it straight back, so the published
+            // schema is `BackendInfo` rather than "some JSON".
+            backends: resp
+                .backends
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// The host's GPUs and its GPU toolchain versions.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct GpuInventory {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// One entry per detected GPU; empty on a host with none.
+    gpu_info: Vec<GpuInfo>,
+    /// Driver and runtime versions, independent of any one GPU.
+    host: GpuHostInfo,
+}
+
+impl FromDaemon for GpuInventory {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            gpu_info: resp.gpu_info.unwrap_or_default(),
+            host: resp.host.unwrap_or_default(),
+        }
+    }
+}
+
+/// The whole pipeline, in order.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct PipelineReport {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// Stage 1 first. A transcript passes through these in order.
+    pipeline: Vec<StageReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for PipelineReport {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            pipeline: resp.pipeline.unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// One stage of the pipeline.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct StageEnvelope {
+    #[schema(example = "success")]
+    pub(crate) status: &'static str,
+    pub(crate) stage: StageReport,
+}
+
+/// The devices a model or a stage can run on.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct DeviceList {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// Accelerator tokens, e.g. `cpu`, `cuda`, `vulkan`.
+    #[schema(example = json!(["cpu", "cuda"]))]
+    available_devices: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for DeviceList {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            available_devices: resp.available_devices.unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// A model's device preference, what it resolved to, and what this host can
+/// offer it.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ModelDevice {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// The preference itself: `cpu`, `gpu`, or a specific accelerator. `none`
+    /// for a model that runs remotely and therefore has no local device.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    device: Option<String>,
+    /// What a `gpu` preference resolved to once a model loaded — `cuda`,
+    /// `rocm`, `metal`, `vulkan`. `null` while the preference is `gpu` but
+    /// nothing has loaded yet; equal to the preference when it is `cpu`.
+    ///
+    /// Doubly optional because the wire distinguishes three states and a client
+    /// reads them differently: the key absent means this response does not speak
+    /// to the device at all, an explicit `null` means the preference is `gpu`
+    /// and nothing has resolved it yet, and a value is the accelerator in use.
+    /// Collapsing the first two would report "unresolved" where the daemon said
+    /// nothing.
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_accel: Option<Option<String>>,
+    /// What this host can actually offer this model — the intersection of the
+    /// machine's accelerators and the builds the model ships. Empty for a model
+    /// that runs remotely.
+    #[schema(example = json!(["cpu", "cuda"]))]
+    available_devices: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for ModelDevice {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            device: resp.device,
+            resolved_accel: resp.resolved_accel,
+            available_devices: resp.available_devices.unwrap_or_default(),
+            message: resp.message,
+        }
+    }
+}
+
+/// The backend filling stage 1, as that stage's mutations report it.
+#[derive(Serialize, serde::Deserialize, ToSchema)]
+pub(crate) struct ActiveBackend {
+    /// The backend's repo id.
+    pub(crate) source: String,
+    /// Its display name.
+    pub(crate) name: String,
+    /// Whether one of its models is currently up.
+    pub(crate) model_loaded: bool,
+}
+
+/// Stage 2's state, as that stage's mutations report it.
+#[derive(Serialize, serde::Deserialize, ToSchema)]
+pub(crate) struct PostProcessorState {
+    /// The user's on/off choice, which is separate from whether the model came
+    /// up: a stage can be enabled with a failed load, and transcripts then pass
+    /// through untouched.
+    pub(crate) enabled: bool,
+    /// The selected model, or `null` when none is picked.
+    pub(crate) model: Option<String>,
+    /// The selected backend, or `null` when the stage is empty.
+    pub(crate) source: Option<String>,
+    /// Whether that model is loaded and ready.
+    pub(crate) loaded: bool,
+}
+
+/// The answer to a stage mutation.
+///
+/// The two stages answer with different keys — stage 1 with `active_backend`,
+/// stage 2 with `post_processor` — because each grew its own endpoint before
+/// the pipeline addressed stages by position. Both are documented rather than
+/// reconciled: changing either is a breaking wire change. Read the stage back
+/// with `GET /pipeline/{stage}` for the one shape both share.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct StageMutation {
+    #[schema(example = "success")]
+    status: &'static str,
+    /// Stage 1 only. `null` when the stage was emptied.
+    ///
+    /// Doubly optional for the same reason `resolved_accel` is: absent means
+    /// this was a stage 2 mutation, which reports `post_processor` instead;
+    /// `null` means stage 1 itself is now empty.
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active_backend: Option<Option<ActiveBackend>>,
+    /// Stage 2 only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post_processor: Option<PostProcessorState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+impl FromDaemon for StageMutation {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            active_backend: resp
+                .active_backend
+                .map(|v| serde_json::from_value(v).unwrap_or(None)),
+            post_processor: resp
+                .post_processor
+                .and_then(|v| serde_json::from_value(v).ok()),
+            message: resp.message,
+        }
+    }
+}
+
+/// How one model's transcription language resolves.
+///
+/// The per-model endpoints answer with this under `language`, where the global
+/// `/language` endpoints answer with a bare tag. Same field name, different
+/// shapes: the per-model answer has to explain *why* a language is in effect,
+/// since three settings can decide it.
+#[derive(Serialize, serde::Deserialize, ToSchema)]
+pub(crate) struct ModelLanguageBlock {
+    /// Whether this model can transcribe more than one language at all. A
+    /// monolingual model ignores every setting below.
+    multilingual: bool,
+    /// Which setting `effective` came from: the per-model override, the global
+    /// setting, or the model's own default.
+    source: String,
+    /// The tag actually used, after resolution. `null` when the model detects
+    /// the language itself.
+    effective: Option<String>,
+    /// The per-model override, or `null` when none is set.
+    #[serde(rename = "override")]
+    model_override: Option<String>,
+    /// The model's own default language.
+    primary: String,
+    /// Every tag this model accepts.
+    supported: Vec<String>,
+}
+
+/// The per-model language resolution.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ModelLanguageState {
+    #[schema(example = "success")]
+    status: &'static str,
+    language: ModelLanguageBlock,
+}
+
+impl FromDaemon for ModelLanguageState {
+    fn from_daemon(resp: DaemonResponse) -> Self {
+        Self {
+            status: "success",
+            language: resp
+                .language
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or(ModelLanguageBlock {
+                    multilingual: false,
+                    source: "default".to_string(),
+                    effective: None,
+                    model_override: None,
+                    primary: String::new(),
+                    supported: Vec::new(),
+                }),
+        }
+    }
+}

--- a/super-stt-daemon/src/daemon/http/v1/settings/write_method.rs
+++ b/super-stt-daemon/src/daemon/http/v1/settings/write_method.rs
@@ -1,9 +1,38 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::wire::{WriteMethodState, WriteMethodTest};
+
 settings_setter!(
     set_write_method,
     SetWriteMethodBody { method: String },
     "set_write_method",
-    "method"
+    "method",
+    "/write_method",
+    WriteMethodState,
+    "Choose how transcripts reach the focused window",
+    "Selects the mechanism the daemon uses to deliver a finished transcript \u{2014} \
+simulated typing, the clipboard, and so on. Which mechanisms work depends on the \
+session: some need a compositor that permits synthetic input. Try one with \
+`POST /write_method/test` before committing a user to it.",
+    "One of the accepted `snake_case` method tokens. An unknown token is a `400`.",
 );
-settings_dispatch!(get_write_method, "get_write_method");
-settings_dispatch!(test_write_method, "test_write_method");
+settings_dispatch!(
+    get_write_method,
+    "get_write_method",
+    get "/write_method",
+    WriteMethodState,
+    "Read how transcripts are delivered",
+    "Answers with the configured preference. What it actually resolves to in this \
+session can differ \u{2014} `POST /write_method/test` reports both."
+);
+settings_dispatch!(
+    test_write_method,
+    "test_write_method",
+    post "/write_method/test",
+    WriteMethodTest,
+    "Write sample text using the configured method",
+    "Delivers a short sample to the focused window exactly as a real transcript would \
+be, so a user can confirm the method works before relying on it. Focus the window \
+that should receive it first.\n\nThe response reports both the configured preference \
+and what it resolved to, which is how a UI shows that a preferred mechanism silently \
+fell back to another. Refused with `409` while a recording is in flight."
+);

--- a/super-stt-daemon/src/daemon/http/v1/transcribe.rs
+++ b/super-stt-daemon/src/daemon/http/v1/transcribe.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::daemon::http::internal::helpers::dispatch::{
-    build_request, build_transcribe_request, dispatch, json_response,
+    build_request, build_transcribe_request, dispatch, json_response, narrowed,
 };
 use crate::daemon::http::internal::helpers::responses::{
     model_not_loaded_response, recording_in_progress_response,
 };
 use crate::daemon::http::state::AppState;
+use crate::daemon::http::wire::{Ack, ErrorEnvelope, ReasonEnvelope};
 // Only the wasm-backends realtime handler references the daemon type / bare
 // `Response`; gated so the subprocess-only and no-backend builds stay warning-clean.
 #[cfg(feature = "wasm-backends")]
@@ -13,7 +14,6 @@ use crate::daemon::types::SuperSTTDaemon;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-#[cfg(feature = "wasm-backends")]
 use axum::response::Response;
 use std::sync::Arc;
 use super_stt_shared::models::protocol::{DaemonResponse, ErrorCode};
@@ -38,9 +38,33 @@ const MAX_REALTIME_SESSIONS: usize = 4;
 static REALTIME_SESSIONS: tokio::sync::Semaphore =
     tokio::sync::Semaphore::const_new(MAX_REALTIME_SESSIONS);
 
+#[cfg(feature = "wasm-backends")]
+#[utoipa::path(
+    get,
+    path = "/transcribe/realtime",
+    tag = "transcribe",
+    summary = "Open a realtime transcription session (WebSocket)",
+    description = "\
+An HTTP/1.1 upgrade to a WebSocket, bridged to the loaded model's realtime \
+session. Send audio frames, receive transcript frames as they form.
+
+Only realtime-capable models serve this. The daemon caps concurrent sessions and \
+answers `503` rather than queueing beyond it; a session with no incoming frame for \
+a minute is treated as dead and dropped.
+
+Being a WebSocket, the frame protocol is not describable in OpenAPI — see \
+`docs/protocol/wit/realtime.wit` for the message shapes.",
+    security(("session_token" = ["transcribe"])),
+    responses(
+        (status = 101, description = "Upgraded; the realtime session is open."),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `transcribe` scope.", body = ErrorEnvelope),
+        (status = 409, description = "No model is loaded, or the loaded model has no realtime session.", body = ErrorEnvelope),
+        (status = 503, description = "Too many concurrent realtime sessions.", body = ErrorEnvelope),
+    ),
+)]
 /// `GET /v1/transcribe/realtime` — upgrade the connection and bridge it to the
 /// active model's realtime session.
-#[cfg(feature = "wasm-backends")]
 pub(crate) async fn realtime_ws_handler(
     ws: axum::extract::ws::WebSocketUpgrade,
     State(state): State<AppState>,
@@ -247,6 +271,54 @@ fn body_flag(body: &serde_json::Value, key: &str, default: bool) -> bool {
 /// touching the microphone and return a single JSON `{ transcription }` (or a
 /// coded error). Rejects `stream_realtime` combined with `audio_data` per the
 /// contract.
+/// The body of `POST /transcribe`. Every field is optional; which combination
+/// you send selects one of the four behaviours the endpoint documents.
+///
+/// Declared, not deserialized. The handler reads the body as raw JSON so it can
+/// *move* a large `audio_data` buffer out of it rather than copying it into a
+/// second owned `Vec`; this type is what that body's shape is, published in the
+/// `OpenAPI` document and kept beside the handler that parses it.
+#[derive(serde::Deserialize, utoipa::ToSchema)]
+#[allow(dead_code)]
+pub(crate) struct TranscribeBody {
+    /// Mono PCM samples in `-1.0..=1.0`. Present means "transcribe this buffer"
+    /// — the daemon does not touch the microphone, and answers with one JSON
+    /// result rather than a stream.
+    #[serde(default)]
+    pub(crate) audio_data: Option<Vec<f32>>,
+    /// Sample rate of `audio_data`, in Hz. Ignored on the microphone paths.
+    #[serde(default)]
+    #[schema(example = 16000)]
+    pub(crate) sample_rate: Option<u32>,
+    /// BCP-47 tag, or `auto`, overriding the configured language for this
+    /// request only.
+    #[serde(default)]
+    #[schema(example = "es")]
+    pub(crate) language: Option<String>,
+    /// Microphone paths only. `false` (the default) starts the recording and
+    /// returns immediately; `true` holds the connection open and streams the
+    /// result.
+    #[serde(default)]
+    pub(crate) wait: Option<bool>,
+    /// Microphone paths only, and only with `wait: true`: also emit incremental
+    /// `preview` frames as the transcript forms. Rejected with `400` alongside
+    /// `audio_data`, which has nothing to stream.
+    #[serde(default)]
+    pub(crate) stream_realtime: Option<bool>,
+}
+
+/// A one-shot transcription result, for the pre-captured path.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub(crate) struct Transcription {
+    /// Always `success`.
+    #[schema(example = "success")]
+    status: &'static str,
+    /// The recognized text. Empty when the audio held no speech — which is a
+    /// successful transcription, not a failure.
+    #[schema(example = "hello world")]
+    transcription: String,
+}
+
 async fn transcribe_precaptured(s: &AppState, body: serde_json::Value) -> axum::response::Response {
     if body_flag(&body, "stream_realtime", false) {
         return json_response(&DaemonResponse::error_with_code(
@@ -260,7 +332,10 @@ async fn transcribe_precaptured(s: &AppState, body: serde_json::Value) -> axum::
         Err(resp) => return json_response(&resp).into_response(),
     };
     let resp = dispatch(&s.daemon, req).await;
-    json_response(&resp).into_response()
+    narrowed(resp, |r| Transcription {
+        status: "success",
+        transcription: r.transcription.unwrap_or_default(),
+    })
 }
 
 /// `POST /transcribe`. One endpoint, four use cases dispatched on the body
@@ -275,6 +350,46 @@ async fn transcribe_precaptured(s: &AppState, body: serde_json::Value) -> axum::
 /// returns `409 recording_in_progress`; a start with no model loaded returns
 /// `409 model_not_loaded` (both mic sub-paths, before the `202`/SSE envelope
 /// commits).
+#[utoipa::path(
+    post,
+    path = "/transcribe",
+    tag = "transcribe",
+    summary = "Transcribe supplied audio, or start a microphone recording",
+    description = "\
+One endpoint with four behaviours, selected by the body:
+
+| Body | Behaviour | Response |
+|---|---|---|
+| `audio_data` present | Transcribe the supplied buffer; the microphone is never opened | `200` JSON with `transcription` |
+| no `audio_data`, `wait: false` (default) | Start recording and detach; stop it with `POST /transcribe/stop` | `202` with `message: \"Recording started\"` |
+| `wait: true` | Record, then stream the result | `200 text/event-stream`, one `done` frame |
+| `wait: true`, `stream_realtime: true` | As above, plus incremental previews | `200 text/event-stream`, `preview` frames then `done` |
+
+On the streaming paths a daemon-side failure arrives as a single `error` frame, and \
+closing the connection stops the recording. Frames are:
+
+| `event:` | `data:` |
+|---|---|
+| `preview` | `{ \"text\": \"hello wor…\" }` |
+| `done` | `{ \"transcription\": \"hello world\" }` |
+| `error` | `{ \"message\": \"…\" }` |
+
+Starting while a recording is already in flight is `409 recording_in_progress` — \
+this endpoint only ever *starts* one. Read `busy` from `GET /status` and call \
+`POST /transcribe/stop` to end the running capture.",
+    request_body(content = TranscribeBody, description = "All fields optional; the combination selects the behaviour."),
+    security(("session_token" = ["transcribe"])),
+    responses(
+        (status = 200, description = "Pre-captured audio: the finished transcription.", body = Transcription),
+        (status = 202, description = "Microphone recording started and detached.", body = Ack,
+         example = json!({ "status": "success", "message": "Recording started" })),
+        (status = 400, description = "`audio_data` was not an array of numbers, or `stream_realtime` was sent with it.", body = ErrorEnvelope),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `transcribe` scope.", body = ErrorEnvelope),
+        (status = 409, description = "A recording is already in flight (`recording_in_progress`), or no model is loaded (`model_not_loaded`).", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
 pub(crate) async fn transcribe(
     State(s): State<AppState>,
     body: Option<axum::Json<serde_json::Value>>,
@@ -559,13 +674,40 @@ fn transcribe_mic_sse(
         .into_response()
 }
 
-pub(crate) async fn transcribe_stop(State(s): State<AppState>) -> impl IntoResponse {
+#[utoipa::path(
+    post,
+    path = "/transcribe/stop",
+    tag = "transcribe",
+    summary = "Stop the in-flight microphone recording",
+    description = "\
+Ends a recording started by `POST /transcribe`. Idempotent: stopping when nothing \
+is recording succeeds with `No recording in progress`.
+
+`message` says what happened — `Recording stop signal sent`, `Manual stop not \
+enabled in current mode`, or `Transcription in progress, please wait`. The \
+transcript itself does not come back here; it arrives on the `final_stt` event \
+topic, or on the stream if the recording was started with `wait: true`.",
+    security(("session_token" = ["transcribe"])),
+    responses(
+        (status = 200, description = "Stop signal sent, or nothing was recording.", body = Ack,
+         example = json!({ "status": "success", "message": "Recording stop signal sent" })),
+        (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
+        (status = 403, description = "The token lacks the `transcribe` scope.", body = ErrorEnvelope),
+        (status = 429, description = "Per-client rate limit hit; back off and retry.", body = ErrorEnvelope),
+    ),
+)]
+pub(crate) async fn transcribe_stop(State(s): State<AppState>) -> Response {
     // Idempotent: nothing to stop. Direct response — going through
     // `handle_record_command` here would start a fresh recording
     // because that path is shared with `record`'s start case.
     if !*s.daemon.busy.read().await {
-        let resp = DaemonResponse::success().with_message("No recording in progress".to_string());
-        return json_response(&resp);
+        return narrowed(
+            DaemonResponse::success().with_message("No recording in progress".to_string()),
+            |r| Ack {
+                status: "success",
+                message: r.message,
+            },
+        );
     }
 
     // Recording active — dispatch through `handle_record_command`'s
@@ -577,19 +719,19 @@ pub(crate) async fn transcribe_stop(State(s): State<AppState>) -> impl IntoRespo
     // (See `docs/protocol/endpoints/v1/transcribe/stop.md`.)
     let req = build_request("record", None);
     let resp = dispatch(&s.daemon, req).await;
-    json_response(&resp)
+    narrowed(resp, |r| Ack {
+        status: "success",
+        message: r.message,
+    })
 }
 
 /// Client-scope transcription routes. The realtime WebSocket route is
 /// registered only under the `wasm-backends` feature.
-pub(crate) fn routes() -> axum::Router<crate::daemon::http::state::AppState> {
-    let router = axum::Router::new()
-        .route("/transcribe", axum::routing::post(transcribe))
-        .route("/transcribe/stop", axum::routing::post(transcribe_stop));
+pub(crate) fn routes() -> utoipa_axum::router::OpenApiRouter<AppState> {
+    let router = utoipa_axum::router::OpenApiRouter::new()
+        .routes(utoipa_axum::routes!(transcribe))
+        .routes(utoipa_axum::routes!(transcribe_stop));
     #[cfg(feature = "wasm-backends")]
-    let router = router.route(
-        "/transcribe/realtime",
-        axum::routing::get(realtime_ws_handler),
-    );
+    let router = router.routes(utoipa_axum::routes!(realtime_ws_handler));
     router
 }

--- a/super-stt-daemon/src/daemon/http/wire.rs
+++ b/super-stt-daemon/src/daemon/http/wire.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! The envelopes many `/v1` endpoints answer with.
+//!
+//! Internally the daemon passes one [`DaemonResponse`] around: a single struct
+//! carrying every field any command might return, each `Option` and each
+//! skipped when absent. That is the right shape for a command bus — one type
+//! crosses it — but it is the wrong shape to *document*, because a schema
+//! generated from it tells a client that `GET /volume` may return forty-two
+//! fields when it returns two.
+//!
+//! So the HTTP layer, which is the protocol boundary, names what each endpoint
+//! actually answers with. The types here are the shapes shared across many
+//! endpoints; a response peculiar to one endpoint is declared next to that
+//! handler instead.
+//!
+//! [`DaemonResponse`]: super_stt_shared::models::protocol::DaemonResponse
+
+use serde::Serialize;
+use super_stt_shared::models::protocol::ErrorCode;
+use utoipa::ToSchema;
+
+/// The plain acknowledgement: an operation succeeded, with a sentence saying
+/// what happened.
+///
+/// A good number of settings endpoints answer with exactly this, on `GET` as
+/// well as `POST` — `GET /volume` reports the level inside `message` rather
+/// than as a field of its own. Where that is true the endpoint's own
+/// documentation says so, because a client has to parse the number back out.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct Ack {
+    /// Always `success`.
+    #[schema(example = "success")]
+    pub(crate) status: &'static str,
+    /// Human-readable detail. Not a stable identifier — do not switch on it.
+    ///
+    /// Optional because a few commands acknowledge without a sentence, and the
+    /// key is then absent rather than empty. Every endpoint documented as
+    /// carrying its value in the message always sets it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
+}
+
+/// The error envelope, as [`transport.md`] specifies it.
+///
+/// `error_code` is the stable, machine-readable identifier clients switch on
+/// and the field that determines the HTTP status; `message` is prose for a
+/// human and may be reworded at any time.
+///
+/// [`transport.md`]: https://github.com/jorge-menjivar/super-stt/blob/main/docs/protocol/transport.md
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ErrorEnvelope {
+    /// Always `error`.
+    #[schema(example = "error")]
+    pub(crate) status: &'static str,
+    /// The stable identifier for this failure. Absent only on an unclassified
+    /// server-side error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) error_code: Option<ErrorCode>,
+    /// Human-readable detail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
+}
+
+/// The auth-failure envelope: `message` names the failure and `data.reason`
+/// says which of its cases occurred.
+///
+/// Distinct from [`ErrorEnvelope`] because the auth surface predates
+/// `error_code` and clients read `data.reason` there. Both are documented
+/// rather than reconciled, since changing either is a breaking wire change.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ReasonEnvelope {
+    /// Always `error`.
+    #[schema(example = "error")]
+    pub(crate) status: &'static str,
+    /// The failure identifier, e.g. `invalid_session` or `auth_denied`.
+    pub(crate) message: String,
+    pub(crate) data: Reason,
+}
+
+/// The `data` object of a [`ReasonEnvelope`].
+#[derive(Serialize, ToSchema)]
+pub(crate) struct Reason {
+    /// Which case of `message` occurred — e.g. `expired`, `exe_changed`,
+    /// `user_denied`.
+    pub(crate) reason: String,
+}
+
+/// The registry surface's error envelope, which carries one extra key.
+///
+/// These endpoints shipped before `error_code` existed, spelling the failure
+/// identity as `error`. That key is still sent, because clients read it; the
+/// standard `error_code` was added alongside rather than in place of it, so the
+/// whole surface honors the "`error_code` on every error" rule without breaking
+/// anyone. Both name the same failure and always agree.
+///
+/// Documented as its own shape rather than folded into [`ErrorEnvelope`]:
+/// `error` appears *only* here, and putting it on the shared envelope would
+/// tell every other endpoint's reader to expect a key they will never receive.
+#[derive(Serialize, ToSchema)]
+pub(crate) struct RegistryError {
+    /// Always `error`.
+    #[schema(example = "error")]
+    pub(crate) status: &'static str,
+    /// The stable identifier for this failure.
+    #[schema(example = "not_found")]
+    pub(crate) error_code: String,
+    /// The same identifier under the key this surface has always used. Retained
+    /// for clients written against it; prefer `error_code`.
+    #[schema(example = "not_found")]
+    pub(crate) error: String,
+    /// Human-readable detail, when there is any to add.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
+}

--- a/super-stt-daemon/src/daemon/pipeline_handlers.rs
+++ b/super-stt-daemon/src/daemon/pipeline_handlers.rs
@@ -12,22 +12,21 @@
 //! its own endpoint always used, so there is one implementation of "select a
 //! backend" per stage, not two.
 
-use super_stt_shared::models::protocol::DaemonResponse;
+use super_stt_shared::models::protocol::{
+    DaemonResponse, POST_PROCESSOR_STAGE, StageReport, StageRole, StageSwitch, SwitchDownload,
+    SwitchTarget, TRANSCRIPTION_STAGE,
+};
 
 use crate::daemon::device_management::PipelineStage;
 use crate::daemon::types::{SuperSTTDaemon, normalize_device};
 
-/// Wire name for a stage's role, matching `ModelRole` in the manifest.
-const ROLE_TRANSCRIPTION: &str = "transcription";
-const ROLE_POST_PROCESSOR: &str = "post_processor";
-
 impl SuperSTTDaemon {
     /// Report every stage in order.
     pub async fn handle_get_pipeline(&self) -> DaemonResponse {
-        let stages = serde_json::Value::Array(vec![
+        let stages = vec![
             self.transcription_stage().await,
             self.post_processor_stage().await,
-        ]);
+        ];
         DaemonResponse::success()
             .with_pipeline(stages)
             .with_message("Pipeline retrieved successfully".to_string())
@@ -37,7 +36,7 @@ impl SuperSTTDaemon {
     ///
     /// Read from the same state `/active_backend` and `/active_model` report,
     /// so the two views cannot disagree.
-    async fn transcription_stage(&self) -> serde_json::Value {
+    async fn transcription_stage(&self) -> StageReport {
         let loaded = self.model.read().await;
         let definition = loaded.as_ref().map(|m| &m.definition);
         let (source, model) = match definition {
@@ -61,16 +60,19 @@ impl SuperSTTDaemon {
         };
         let name = self.backend_name(source.as_deref()).await;
 
-        serde_json::json!({
-            "stage": 1,
-            "role": ROLE_TRANSCRIPTION,
-            "source": source,
-            "name": name,
-            "model": model,
-            "loaded": loaded.is_some(),
-            "device": device,
-            "switch": self.stage_switch(PipelineStage::Transcription),
-        })
+        StageReport {
+            stage: TRANSCRIPTION_STAGE,
+            role: StageRole::Transcription,
+            source,
+            name,
+            model,
+            loaded: loaded.is_some(),
+            device,
+            switch: self.stage_switch(PipelineStage::Transcription),
+            // Stage 1 has no on/off choice of its own: it is on exactly when a
+            // model is up.
+            enabled: None,
+        }
     }
 
     /// In-flight load/download progress for `stage`, or `null` when that stage
@@ -80,28 +82,29 @@ impl SuperSTTDaemon {
     /// same stage: a post-processor's download would otherwise surface as
     /// stage 1's, which is exactly what the `stage` the tracker now reports is
     /// for.
-    fn stage_switch(&self, stage: PipelineStage) -> serde_json::Value {
-        let progress = self.handle_get_download_status(stage).download_progress;
-        progress.map_or(serde_json::Value::Null, |p| {
-            serde_json::json!({
-                "phase":      p.status,
-                "target":     { "model": p.model_name, "source": p.source },
-                "started_at": p.started_at,
-                "download": {
-                    "current_file":     p.current_file,
-                    "file_index":       p.file_index,
-                    "total_files":      p.total_files,
-                    "bytes_downloaded": p.bytes_downloaded,
-                    "total_bytes":      p.total_bytes,
-                    "percentage":       p.percentage,
-                    "eta_seconds":      p.eta_seconds,
-                },
-            })
+    fn stage_switch(&self, stage: PipelineStage) -> Option<StageSwitch> {
+        let p = self.handle_get_download_status(stage).download_progress?;
+        Some(StageSwitch {
+            phase: p.status,
+            target: SwitchTarget {
+                model: p.model_name,
+                source: p.source,
+            },
+            started_at: p.started_at,
+            download: SwitchDownload {
+                current_file: p.current_file,
+                file_index: p.file_index,
+                total_files: p.total_files,
+                bytes_downloaded: p.bytes_downloaded,
+                total_bytes: p.total_bytes,
+                percentage: p.percentage,
+                eta_seconds: p.eta_seconds,
+            },
         })
     }
 
     /// Stage 2: the post-processor that rewrites each final transcript.
-    async fn post_processor_stage(&self) -> serde_json::Value {
+    async fn post_processor_stage(&self) -> StageReport {
         let (enabled, model, source) = {
             let config = self.config.read().await;
             let pp = &config.post_processor;
@@ -114,20 +117,20 @@ impl SuperSTTDaemon {
             .as_ref()
             .map(|m| normalize_device(&m.instance.device()));
 
-        serde_json::json!({
-            "stage": 2,
-            "role": ROLE_POST_PROCESSOR,
-            "source": source,
-            "name": name,
-            "model": (!model.is_empty()).then_some(model),
-            "loaded": loaded.is_some(),
-            "device": device,
-            "switch": self.stage_switch(PipelineStage::PostProcessor),
+        StageReport {
+            stage: POST_PROCESSOR_STAGE,
+            role: StageRole::PostProcessor,
+            source,
+            name,
+            model: (!model.is_empty()).then_some(model),
+            loaded: loaded.is_some(),
+            device,
+            switch: self.stage_switch(PipelineStage::PostProcessor),
             // Processor stages carry the user's on/off choice separately from
             // whether the model actually came up: a selection can be enabled
             // while its load failed, and transcripts then pass through.
-            "enabled": enabled,
-        })
+            enabled: Some(enabled),
+        }
     }
 
     /// Whether an installed backend serves at least one model a given stage

--- a/super-stt-registry-types/Cargo.toml
+++ b/super-stt-registry-types/Cargo.toml
@@ -21,12 +21,19 @@
     spdx = { version = "0.13.4", default-features = false }
     thiserror.workspace = true
     toml.workspace = true
+    utoipa = { workspace = true, optional = true }
 
 [dev-dependencies]
     jsonschema = { version = "0.46.5", default-features = false }
 
 [features]
     schema = ["dep:schemars"]
+    # Derive `utoipa::ToSchema` on the index leaves the daemon re-exports as its
+    # `/registry/backends` response shapes (see `super_stt_shared::registry`), so
+    # they carry their own definition into the generated OpenAPI document rather
+    # than being re-described there. Separate from `schema`, which is schemars
+    # for the backend.toml / registry.toml JSON Schemas.
+    openapi = ["dep:utoipa"]
 
 [lints]
     workspace = true

--- a/super-stt-registry-types/src/index.rs
+++ b/super-stt-registry-types/src/index.rs
@@ -266,6 +266,7 @@ impl IndexBackend {
 /// before download. The authoritative manifest (languages, files, …) ships as
 /// the pinned `manifest` asset and is installed verbatim — it is not re-encoded
 /// here. Also the leaf type for `/registry/backends` (`RegistryModel`).
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexModel {
     pub name: String,
@@ -296,6 +297,7 @@ fn default_role() -> String {
     crate::manifest::ModelRole::default().to_string()
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexSecret {
     pub name: String,
@@ -303,6 +305,7 @@ pub struct IndexSecret {
     pub required: bool,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexOption {
     pub name: String,
@@ -367,6 +370,7 @@ pub struct IndexSubprocessAsset {
     pub parts: Vec<IndexAsset>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexStale {
     pub latest_attempted: String,

--- a/super-stt-shared/Cargo.toml
+++ b/super-stt-shared/Cargo.toml
@@ -37,12 +37,17 @@
             "time",
         ]
     }
+    utoipa = { workspace = true, optional = true }
     uuid.workspace = true
 
 [features]
     default = []
     analysis = ["spectrum-analyzer"]
     audio = ["rubato"]
+    # Derive `utoipa::ToSchema` on the protocol types the daemon publishes in its
+    # OpenAPI document. Off by default: only the daemon (and the spec generator)
+    # needs it, so the app, applet and CLI don't pay to compile utoipa's derive.
+    openapi = ["dep:utoipa", "super-stt-registry-types/openapi"]
 
 [lints]
     workspace = true

--- a/super-stt-shared/src/models/backends.rs
+++ b/super-stt-shared/src/models/backends.rs
@@ -14,6 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// A single installed backend and everything the settings UI needs to render
 /// its section.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -74,6 +75,7 @@ pub struct BackendInfo {
     pub options: Vec<BackendOption>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// One model served by a backend.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BackendModel {
@@ -138,6 +140,7 @@ fn default_role() -> String {
     "transcription".to_string()
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// A sensitive value the backend requires, stored in the system keyring.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BackendSecret {
@@ -153,6 +156,7 @@ pub struct BackendSecret {
     pub required: bool,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// A non-sensitive option the backend accepts, stored in the daemon config.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BackendOption {

--- a/super-stt-shared/src/models/protocol/error_code.rs
+++ b/super-stt-shared/src/models/protocol/error_code.rs
@@ -9,6 +9,7 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {

--- a/super-stt-shared/src/models/protocol/mod.rs
+++ b/super-stt-shared/src/models/protocol/mod.rs
@@ -13,7 +13,10 @@ mod tests;
 pub use command::Command;
 pub use daemon_status::DaemonStatusEvent;
 pub use error_code::ErrorCode;
-pub use pipeline::{POST_PROCESSOR_STAGE, TRANSCRIPTION_STAGE};
+pub use pipeline::{
+    POST_PROCESSOR_STAGE, StageReport, StageRole, StageSwitch, SwitchDownload, SwitchTarget,
+    TRANSCRIPTION_STAGE,
+};
 pub use request::DaemonRequest;
 pub use response::{
     CudaHostInfo, DaemonResponse, DownloadProgress, GpuHostInfo, GpuInfo, NotificationEvent,

--- a/super-stt-shared/src/models/protocol/pipeline.rs
+++ b/super-stt-shared/src/models/protocol/pipeline.rs
@@ -22,3 +22,253 @@ pub const POST_PROCESSOR_STAGE: u32 = 2;
 pub(crate) const fn default_stage() -> u32 {
     TRANSCRIPTION_STAGE
 }
+
+// --- The stage report -------------------------------------------------------
+//
+// `GET /pipeline` and `GET /pipeline/{stage}` answer with these. They were
+// `serde_json::Value` on both ends until the protocol grew a generated OpenAPI
+// document: the daemon built each stage with `json!` and `/pipeline/{stage}`
+// picked its stage back out of the array with `.get("stage")`, so every field
+// name existed only as a string literal at each site and nothing checked that
+// the two agreed. A published schema cannot be generated from a `Value`, and
+// the alternative — describing the shape a third time, in the spec — is the
+// same drift with one more place to forget. So the shape is a type, and the
+// spec, the builder and the reader all come off it.
+
+use serde::{Deserialize, Serialize};
+
+/// What a stage does to the transcript passing through it.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum StageRole {
+    /// Stage 1: audio in, text out.
+    Transcription,
+    /// A later stage: rewrites the text the stage before it produced.
+    PostProcessor,
+}
+
+/// One stage of the pipeline: which backend fills it, what is running there,
+/// and the load still in flight, if any.
+///
+/// Every optional field here serializes as an explicit `null` rather than being
+/// omitted — a stage reports its whole shape whatever state it is in, so a
+/// client can read `source` without first checking the key exists. `enabled` is
+/// the one exception, and is absent rather than null on a stage that has no
+/// on/off choice of its own.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StageReport {
+    /// Position in the pipeline: [`TRANSCRIPTION_STAGE`], [`POST_PROCESSOR_STAGE`].
+    pub stage: u32,
+    pub role: StageRole,
+    /// The backend filling this stage; `null` when the stage is empty.
+    pub source: Option<String>,
+    /// That backend's display name; `null` when the stage is empty.
+    pub name: Option<String>,
+    /// The model selected in this stage; `null` when none is picked.
+    pub model: Option<String>,
+    /// Whether that model is loaded and ready to run.
+    pub loaded: bool,
+    /// The accelerator the loaded model actually runs on — not the user's
+    /// preference, which is read per model through
+    /// `/pipeline/{stage}/model/{model}/device`. `null` when nothing is loaded,
+    /// since nothing runs anywhere.
+    pub device: Option<String>,
+    /// The load or download in flight for this stage; `null` when idle.
+    ///
+    /// The daemon runs one model operation at a time but not always for the
+    /// same stage, so this is reported per stage rather than globally.
+    pub switch: Option<StageSwitch>,
+    /// The user's on/off choice, for stages that carry one separately from
+    /// whether the model came up: a stage can be enabled while its load failed,
+    /// and transcripts then pass through untouched. Absent on stage 1, which
+    /// has no switch of its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+/// A model load in flight for one stage.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StageSwitch {
+    /// Where the operation has got to: `downloading`, `loading_model`,
+    /// `cancelled`, `completed`, or `error`.
+    pub phase: String,
+    /// The model being loaded into the stage.
+    pub target: SwitchTarget,
+    /// RFC 3339 timestamp of when the operation started.
+    pub started_at: String,
+    /// Byte and file progress, for the `downloading` phase.
+    pub download: SwitchDownload,
+}
+
+/// The model a [`StageSwitch`] is loading.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct SwitchTarget {
+    pub model: String,
+    pub source: String,
+}
+
+/// Download progress within a [`StageSwitch`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct SwitchDownload {
+    pub current_file: String,
+    pub file_index: usize,
+    pub total_files: usize,
+    pub bytes_downloaded: u64,
+    pub total_bytes: u64,
+    /// 0.0–100.0 across the whole operation.
+    pub percentage: f32,
+    /// Estimated seconds remaining, or `null` before there is enough history
+    /// to estimate one.
+    pub eta_seconds: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        POST_PROCESSOR_STAGE, StageReport, StageRole, StageSwitch, SwitchDownload, SwitchTarget,
+        TRANSCRIPTION_STAGE,
+    };
+
+    fn empty_stage(stage: u32, role: StageRole) -> StageReport {
+        StageReport {
+            stage,
+            role,
+            source: None,
+            name: None,
+            model: None,
+            loaded: false,
+            device: None,
+            switch: None,
+            enabled: None,
+        }
+    }
+
+    /// An empty stage reports every field it has, as an explicit `null`.
+    ///
+    /// This is deliberate and load-bearing: a client reads `source` to decide
+    /// whether a stage is filled, and it can only do that without first
+    /// checking the key exists if the key is always there. Adding
+    /// `skip_serializing_if` to these fields would be invisible in Rust and
+    /// would quietly change that contract.
+    #[test]
+    fn an_empty_stage_reports_nulls_rather_than_absent_keys() {
+        let json = serde_json::to_value(empty_stage(TRANSCRIPTION_STAGE, StageRole::Transcription))
+            .expect("serializes");
+        let object = json.as_object().expect("a stage is an object");
+
+        for key in ["source", "name", "model", "device", "switch"] {
+            assert!(object.contains_key(key), "an empty stage omits {key}");
+            assert!(object[key].is_null(), "{key} should be null when unset");
+        }
+        assert_eq!(object["loaded"], false);
+    }
+
+    /// `enabled` is the one field that is absent rather than null, and only on
+    /// the stage that has no on/off choice of its own.
+    ///
+    /// The client distinguishes the two: `StageState::is_enabled` falls back to
+    /// `loaded` when `enabled` is absent. A stage 1 that started sending
+    /// `"enabled": false` would read as "switched off" rather than "has no
+    /// switch", and the card would show a running model as disabled.
+    #[test]
+    fn only_a_stage_with_a_switch_reports_enabled() {
+        let stage_one =
+            serde_json::to_value(empty_stage(TRANSCRIPTION_STAGE, StageRole::Transcription))
+                .expect("serializes");
+        assert!(
+            stage_one.get("enabled").is_none(),
+            "stage 1 has no on/off choice, so it must not report one"
+        );
+
+        let mut two = empty_stage(POST_PROCESSOR_STAGE, StageRole::PostProcessor);
+        two.enabled = Some(false);
+        let stage_two = serde_json::to_value(two).expect("serializes");
+        assert_eq!(
+            stage_two["enabled"], false,
+            "stage 2 carries its choice separately from whether the model came up"
+        );
+    }
+
+    /// The role crosses the wire in `snake_case`, not as its Rust name.
+    #[test]
+    fn roles_use_their_wire_spelling() {
+        let json =
+            serde_json::to_value(empty_stage(POST_PROCESSOR_STAGE, StageRole::PostProcessor))
+                .expect("serializes");
+        assert_eq!(json["role"], "post_processor");
+        assert_eq!(
+            serde_json::to_value(StageRole::Transcription).expect("serializes"),
+            "transcription"
+        );
+    }
+
+    /// A stage survives the round trip whole, switch included.
+    ///
+    /// `/pipeline/{stage}` narrows one stage out of the array `/pipeline`
+    /// returns, so the two views agree only for as long as the type they share
+    /// carries everything. A field lost in serialization would take the whole
+    /// switch report with it and the download progress a UI polls for.
+    #[test]
+    fn a_stage_mid_download_round_trips() {
+        let report = StageReport {
+            stage: POST_PROCESSOR_STAGE,
+            role: StageRole::PostProcessor,
+            source: Some("github.com/super-stt/s1-mini".to_string()),
+            name: Some("S1 Mini".to_string()),
+            model: Some("s1-mini-q4_k_m".to_string()),
+            loaded: false,
+            device: None,
+            switch: Some(StageSwitch {
+                phase: "downloading".to_string(),
+                target: SwitchTarget {
+                    model: "s1-mini-q4_k_m".to_string(),
+                    source: "github.com/super-stt/s1-mini".to_string(),
+                },
+                started_at: "2026-09-03T12:00:00Z".to_string(),
+                download: SwitchDownload {
+                    current_file: "model.gguf".to_string(),
+                    file_index: 1,
+                    total_files: 3,
+                    bytes_downloaded: 1024,
+                    total_bytes: 4096,
+                    percentage: 25.0,
+                    eta_seconds: Some(30),
+                },
+            }),
+            enabled: Some(true),
+        };
+
+        let json = serde_json::to_string(&report).expect("serializes");
+        let back: StageReport = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, report, "a stage lost something on the wire");
+
+        // The nesting the download poller walks, spelled out: it reads
+        // `switch.download.percentage` and `switch.target.model` by name.
+        let value: serde_json::Value = serde_json::from_str(&json).expect("parses");
+        assert_eq!(value["switch"]["target"]["model"], "s1-mini-q4_k_m");
+        assert_eq!(value["switch"]["download"]["percentage"], 25.0);
+        assert_eq!(value["switch"]["download"]["eta_seconds"], 30);
+    }
+
+    /// An estimate the daemon cannot make yet is `null`, not a zero that would
+    /// render as "0 seconds remaining".
+    #[test]
+    fn an_unknown_eta_is_null() {
+        let download = SwitchDownload {
+            current_file: "model.gguf".to_string(),
+            file_index: 0,
+            total_files: 1,
+            bytes_downloaded: 0,
+            total_bytes: 4096,
+            percentage: 0.0,
+            eta_seconds: None,
+        };
+        let json = serde_json::to_value(download).expect("serializes");
+        assert!(json["eta_seconds"].is_null());
+    }
+}

--- a/super-stt-shared/src/models/protocol/response.rs
+++ b/super-stt-shared/src/models/protocol/response.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use super::pipeline::StageReport;
 use crate::models::theme::AudioTheme;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -94,16 +95,15 @@ pub struct DaemonResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_processor: Option<Value>,
 
-    // The transcription pipeline (GET /pipeline): the ordered stages, each
-    // `{ stage, role, source, name, model, loaded }`. See
+    // The transcription pipeline (GET /pipeline): the ordered stages. See
     // docs/protocol/endpoints/v1/pipeline.md.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pipeline: Option<Value>,
+    pub pipeline: Option<Vec<StageReport>>,
 
     // One stage of it (GET /pipeline/{stage}): the same object the array
     // carries, for a client that only cares about one position.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stage: Option<Value>,
+    pub stage: Option<StageReport>,
 
     // GPU inventory (GET /gpu_info): array of `GpuInfo` objects.
     // See docs/protocol/endpoints/v1/gpu_info.md.
@@ -170,6 +170,7 @@ pub struct DaemonResponse {
     pub language: Option<Value>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DownloadProgress {
     pub model_name: String,
@@ -200,6 +201,7 @@ pub struct DownloadProgress {
     pub error: Option<String>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NotificationEvent {
     #[serde(rename = "type")]
@@ -394,13 +396,13 @@ impl DaemonResponse {
     }
 
     #[must_use]
-    pub fn with_pipeline(mut self, pipeline: Value) -> Self {
+    pub fn with_pipeline(mut self, pipeline: Vec<StageReport>) -> Self {
         self.pipeline = Some(pipeline);
         self
     }
 
     #[must_use]
-    pub fn with_stage(mut self, stage: Value) -> Self {
+    pub fn with_stage(mut self, stage: StageReport) -> Self {
         self.stage = Some(stage);
         self
     }
@@ -496,6 +498,7 @@ impl DaemonResponse {
     }
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// One GPU as reported by [`GET /gpu_info`](../../../docs/protocol/endpoints/v1/gpu_info.md).
 /// `vendor` is a lowercase `snake_case` tag (`nvidia` / `amd` / `intel` /
 /// `apple` / `unknown`). `total_bytes` is dedicated VRAM for discrete GPUs and
@@ -518,6 +521,7 @@ pub struct GpuInfo {
     pub arch_target: Option<String>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// Host-wide GPU toolchain/driver versions reported on
 /// [`GET /gpu_info`](../../../docs/protocol/endpoints/v1/gpu_info.md), independent
 /// of any one GPU. Each field is `null` when that accelerator's runtime isn't
@@ -533,12 +537,14 @@ pub struct GpuHostInfo {
     pub vulkan: Option<VulkanHostInfo>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// The installed NVIDIA driver's CUDA version, e.g. `"13.3"`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CudaHostInfo {
     pub driver_version: String,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// The installed `ROCm` userspace release, e.g. `"6.2.4"`. Advisory only — see
 /// `docs/protocol/endpoints/v1/gpu_info.md`; `arch_target` is what a build must
 /// actually match.
@@ -547,6 +553,7 @@ pub struct RocmHostInfo {
     pub version: String,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 /// The highest Vulkan API version any installed driver advertises, e.g.
 /// `"1.3.280"`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/super-stt-shared/src/models/self_update.rs
+++ b/super-stt-shared/src/models/self_update.rs
@@ -4,6 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SelfUpdateStatus {
     pub current_version: String,
@@ -15,6 +16,7 @@ pub struct SelfUpdateStatus {
     pub installer_asset: Option<InstallerAsset>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InstallerAsset {
     pub name: String,

--- a/super-stt-shared/src/models/wire_enum.rs
+++ b/super-stt-shared/src/models/wire_enum.rs
@@ -4,8 +4,9 @@
 //! `RecordingStopMode`, `WriteMethod`, and `AudioTheme` each cross the wire and
 //! the config file as a stable `snake_case` token. Previously each carried three
 //! hand-maintained forms (`PascalCase` serde, kebab `Display`, aliased `FromStr`)
-//! that had drifted. [`wire_enum_strings!`] generates `Display`, `FromStr`, and
-//! serde `Serialize`/`Deserialize` from a single table so they can't.
+//! that had drifted. [`wire_enum_strings!`] generates `Display`, `FromStr`,
+//! serde `Serialize`/`Deserialize`, and (under the `openapi` feature) the
+//! `utoipa` schema from a single table so they can't.
 //!
 //! **Unknown-value policy.** `FromStr` and `Deserialize` reject an unrecognized
 //! token (so REST endpoints answer `400`, not a silent default). Config-load
@@ -64,7 +65,159 @@ macro_rules! wire_enum_strings {
                 s.parse().map_err(::serde::de::Error::custom)
             }
         }
+
+        // The OpenAPI schema comes off the same table as `Serialize` and
+        // `FromStr`, for the same reason those do. `#[derive(ToSchema)]` reads
+        // the *Rust* variant names, so it would publish `SciFi` as an accepted
+        // value of a field that only ever accepts `sci_fi` — a spec that
+        // disagrees with the endpoint it documents, and silently, since nothing
+        // type-checks a schema against a hand-written `Serialize`.
+        #[cfg(feature = "openapi")]
+        impl ::utoipa::PartialSchema for $ty {
+            fn schema() -> ::utoipa::openapi::RefOr<::utoipa::openapi::schema::Schema> {
+                ::utoipa::openapi::ObjectBuilder::new()
+                    .schema_type(::utoipa::openapi::Type::String)
+                    .enum_values(::std::option::Option::Some(
+                        Self::WIRE_VARIANTS.iter().copied(),
+                    ))
+                    .into()
+            }
+        }
+
+        #[cfg(feature = "openapi")]
+        impl ::utoipa::ToSchema for $ty {
+            fn name() -> ::std::borrow::Cow<'static, str> {
+                ::std::borrow::Cow::Borrowed(::std::stringify!($ty))
+            }
+        }
     };
 }
 
 pub(crate) use wire_enum_strings;
+
+#[cfg(test)]
+mod tests {
+    use crate::models::notification_method::NotificationMethod;
+    use crate::models::recording_stop_mode::RecordingStopMode;
+    use crate::models::theme::AudioTheme;
+    use crate::models::update_beta_optin::UpdateBetaOptIn;
+    use crate::models::write_method::WriteMethod;
+
+    /// Assert the forms this macro generates all agree, for one enum.
+    ///
+    /// The table is the single source, so the check is that nothing has been
+    /// hand-written back out of step with it: what `Serialize` emits, what
+    /// `FromStr` accepts, and — under the `openapi` feature — what the schema
+    /// publishes as the accepted values.
+    macro_rules! assert_wire_forms_agree {
+        ($ty:ty) => {{
+            let variants = <$ty>::WIRE_VARIANTS;
+            assert!(!variants.is_empty(), "a wire enum with no variants");
+
+            for wire in variants {
+                let parsed: $ty = wire.parse().unwrap_or_else(|e| {
+                    panic!(
+                        "{} does not accept its own token {wire:?}: {e}",
+                        stringify!($ty)
+                    )
+                });
+
+                // Serialize must produce the token FromStr took, or a value
+                // round-tripped through the daemon comes back as a different
+                // variant — or as an error on the far side.
+                let json = serde_json::to_string(&parsed).expect("serializes");
+                assert_eq!(
+                    json,
+                    format!("\"{wire}\""),
+                    "{} serializes {wire:?} as {json}",
+                    stringify!($ty),
+                );
+
+                // Display is the config-file form and must not drift from the
+                // wire form either.
+                assert_eq!(
+                    parsed.to_string(),
+                    *wire,
+                    "{} displays {wire:?} differently",
+                    stringify!($ty),
+                );
+
+                let back: $ty = serde_json::from_str(&json).expect("deserializes");
+                assert_eq!(
+                    back.as_wire_str(),
+                    *wire,
+                    "{} does not round-trip {wire:?}",
+                    stringify!($ty),
+                );
+            }
+        }};
+    }
+
+    #[test]
+    fn every_wire_enum_agrees_with_its_table() {
+        assert_wire_forms_agree!(AudioTheme);
+        assert_wire_forms_agree!(RecordingStopMode);
+        assert_wire_forms_agree!(WriteMethod);
+        assert_wire_forms_agree!(NotificationMethod);
+        assert_wire_forms_agree!(UpdateBetaOptIn);
+    }
+
+    /// An unrecognized token is refused rather than silently defaulted, so a
+    /// REST endpoint answers `400` instead of quietly storing something else.
+    #[test]
+    fn an_unknown_token_is_refused() {
+        assert!(
+            "SciFi".parse::<AudioTheme>().is_err(),
+            "the Rust name is not a wire token"
+        );
+        assert!(serde_json::from_str::<AudioTheme>("\"SciFi\"").is_err());
+        assert!("".parse::<AudioTheme>().is_err());
+        assert!("classic ".parse::<AudioTheme>().is_err(), "no trimming");
+    }
+
+    /// The published schema must offer exactly the tokens the type accepts.
+    ///
+    /// This is the reason the macro generates the schema instead of the type
+    /// deriving `ToSchema`: a derive reads the *Rust* variant names, so it would
+    /// publish `SciFi` as an accepted value of a field that only ever accepts
+    /// `scifi`. Nothing type-checks a schema against a hand-written `Serialize`,
+    /// so the disagreement would ship silently — a generated client would send
+    /// a value the daemon rejects.
+    #[cfg(feature = "openapi")]
+    #[test]
+    fn every_wire_enum_publishes_exactly_its_tokens() {
+        fn published<T: utoipa::PartialSchema>() -> Vec<String> {
+            let schema = serde_json::to_value(T::schema()).expect("the schema serializes");
+            assert_eq!(
+                schema["type"], "string",
+                "a wire enum is a string on the wire"
+            );
+            schema["enum"]
+                .as_array()
+                .expect("the schema lists its accepted values")
+                .iter()
+                .map(|v| v.as_str().expect("a token is a string").to_string())
+                .collect()
+        }
+
+        macro_rules! assert_schema_matches_table {
+            ($ty:ty) => {
+                assert_eq!(
+                    published::<$ty>(),
+                    <$ty>::WIRE_VARIANTS
+                        .iter()
+                        .map(|s| (*s).to_string())
+                        .collect::<Vec<_>>(),
+                    "{} publishes values it does not accept",
+                    stringify!($ty),
+                );
+            };
+        }
+
+        assert_schema_matches_table!(AudioTheme);
+        assert_schema_matches_table!(RecordingStopMode);
+        assert_schema_matches_table!(WriteMethod);
+        assert_schema_matches_table!(NotificationMethod);
+        assert_schema_matches_table!(UpdateBetaOptIn);
+    }
+}

--- a/super-stt-shared/src/registry/mod.rs
+++ b/super-stt-shared/src/registry/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod events;
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryListResponse {
     pub schema_version: u32,
@@ -16,6 +17,7 @@ pub struct RegistryListResponse {
 // grouped into a sub-struct, which here would reshape the wire payload to suit
 // an internal API guideline.
 #[allow(clippy::struct_excessive_bools)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegistryBackend {
     pub id: String,
@@ -73,6 +75,7 @@ pub use super_stt_registry_types::index::{
     IndexModel as RegistryModel, IndexOption as RegistryOption, IndexSecret as RegistrySecret,
 };
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Compatibility {
     pub compatible: bool,
@@ -92,6 +95,7 @@ pub struct Compatibility {
     pub needs_client_update: bool,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SelectedAsset {
     pub target: String,
@@ -114,6 +118,7 @@ pub struct SelectedAsset {
 
 pub use super_stt_registry_types::index::IndexStale;
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InstallRequest {
@@ -122,6 +127,7 @@ pub enum InstallRequest {
     ByLocalPath { local_path: String },
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallAccepted {
     pub install_id: String,
@@ -132,11 +138,13 @@ pub struct InstallAccepted {
     pub warning: Option<String>,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateRequest {
     pub source: String,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -146,6 +154,7 @@ pub struct UpdateResponse {
     pub noop: bool,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RefreshResponse {
     pub schema_version: u32,
@@ -153,6 +162,7 @@ pub struct RefreshResponse {
     pub backend_count: usize,
 }
 
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UninstallResponse {
     pub uninstalled: bool,


### PR DESCRIPTION
The daemon protocol had a careful prose reference under `docs/protocol/` and no machine-readable description at all — so nothing could generate a client, and nothing checked the prose against the code.

## The document is generated, not maintained

Every `/v1` route registers through `utoipa-axum`'s `routes!`, which reads the path off the handler's own `#[utoipa::path]`. **A route and its documentation are one declaration**: a path cannot be spelled two ways because there is only one spelling, and a handler without an attribute does not compile.

- `just openapi` writes `docs/protocol/openapi.json` from those registrations
- `just openapi-check` fails when the committed file is stale — in `just ci` and in the `test` job
- The generator starts no daemon and opens no keyring: route registration is deliberately kept free of the state the guards need, so the spec can be built without one

**44 paths, 65 operations, 86 schemas.**

## Responses are narrow by construction

Internally the daemon passes one `DaemonResponse` around — 42 optional fields, of which any endpoint fills a handful. A schema generated from *that* would tell a client `GET /volume` may return all 42 when it returns two.

Each endpoint now builds the type it publishes, so a schema cannot claim a field the handler never sets. Field sets came from extracting every command handler's `with_*` calls, not from guessing.

Two things had to become types to be describable at all:

- **`StageReport`** — the pipeline stage was `json!` on one side and `.get("stage")` on the other, so its field names existed only as string literals at each site. `/pipeline/{stage}` now narrows by field instead of by string.
- **`wire_enum_strings!`** now generates its `utoipa` schema from the same table as `Serialize` and `FromStr`. Deriving `ToSchema` would have published `SciFi` as an accepted value of a field that only ever accepts `scifi` — and nothing type-checks a schema against a hand-written `Serialize`.

## Tests

`openapi-check` catches a *stale* file, never a *wrong* one: regenerating turns any mistake into a committed mistake with a green check. The contract tests are the other half —

- **the scope each endpoint advertises is the scope its router enforces.** These live in two places that cannot see each other, and a mismatch is silent in the worst way: the endpoint works, the docs are wrong, and a client author requests a scope that earns them a `403` they cannot explain.
- the document and the router cover the same paths
- every response names a real shape (the narrow-types property)
- every guarded endpoint documents its `401`/`403`
- the documented error envelopes match the ones the daemon actually builds

Plus, in `super-stt-shared`: the `wire_enum` three-way agreement, and `StageReport`'s wire shape (null-vs-absent, `enabled` only on stage 2).

**Two tests failed on first run and both were real bugs:**

1. `registry_error` sends a legacy `error` key that no documented shape declared — the registry endpoints' documented failure shape was missing the field clients actually read. Fixed with a `RegistryError` type.
2. `GET /registry/backends` had an undocumented `503 registry_unavailable`.

## Reading it

Two views, cross-linked by a switch button:

| | |
|---|---|
| `/protocol/` and `/protocol/openapi.html` | Swagger UI — the default |
| `/protocol/scalar.html` | Scalar |

`just openapi-serve [--scalar]` serves them locally on an OS-chosen port; CI publishes both to gh-pages beside the coverage report. Neither offers "Try it out" — the daemon listens on a Unix socket, which a browser cannot dial.

The prose reference is unchanged and still linked from both READMEs. It explains *when* to call an endpoint and how the pieces fit; the spec states the shapes exactly, for tooling.

## Notes for review

- Three `super-stt-app` files carry **reformat-only** changes. They were already unformatted on `main` (verified with `rustfmt --check` against `git show`); without the fix `just fmt-check` fails on this branch.
- New deps: `utoipa` + `utoipa-axum` on the daemon; `utoipa` behind an `openapi` feature on `super-stt-shared` and `super-stt-registry-types`, off by default so the app, applet and CLI don't pay to compile the derive.
- Both viewers load their renderer from a CDN, so the pages need network the first time. Each falls back to a message pointing at the local `openapi.json`. Vendoring is a follow-up if offline docs matter.

`just ci` passes locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vxTCGA6CEe8Xnpw3XgzSf