### PR TITLE
Publish the protocol docs without rebuilding them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,27 +164,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: taiki-e/install-action@v2.87.0
-        with:
-          tool: just
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libdbus-1-dev libasound2-dev pkg-config
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      # Build from the router rather than trusting the committed file, so what
-      # is published is what this commit's daemon actually serves. The `test`
-      # job's openapi-check is what keeps the committed copy honest.
-      - name: Generate the OpenAPI document
-        run: just openapi
-
+      # No Rust, and no build: this job copies files the repo already contains.
+      #
+      # It used to run `just openapi` so that what it published came from the
+      # router rather than the committed file. That bought nothing —
+      # `openapi-check` in the `test` job already proves those are the same
+      # thing on this commit — and it cost a way to fail, which it promptly
+      # did: building the daemon needs its full system dependency set (it links
+      # xkbcommon through enigo), and a trimmed list broke this job while every
+      # other check stayed green.
+      #
+      # Deliberately not `needs: test`. On a push to main that matrix is beta
+      # and nightly, so gating on it would let an unrelated nightly regression
+      # stop the docs publishing. Nothing here can publish an internally
+      # inconsistent site: it ships the committed document as-is, and a stale
+      # one means `openapi-check` is already failing loudly on the same run.
       - name: Assemble the site
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes the `Protocol docs` job, which has been failing on `main` since #408. Every other check passed — including `just openapi-check`, so the spec itself was never in question.

## What broke

```
rust-lld: error: unable to find library -lxkbcommon
error: could not compile `super-stt-daemon` (bin "gen_openapi")
```

The job ran `just openapi` to regenerate the document before publishing. That links the daemon, and I had trimmed the job's system dependencies to `libdbus-1-dev libasound2-dev pkg-config` on the assumption it needed less than the other jobs. It doesn't — the daemon links `xkbcommon` through `enigo`. Three minutes of compiling, then a link failure.

## The fix

Delete the build rather than re-guess the dependency list.

The rebuild was never load-bearing. Its stated reason was to publish what the router produces rather than trusting the committed file — but `openapi-check` in the `test` job already proves those are the same thing, on the same commit. It bought nothing and cost a failure mode.

The job now copies three committed files. No Rust, no toolchain, no cache, no apt. Verified against a clean `git archive` of `HEAD`: 44 paths, index titled "Swagger UI".

## Not gated on `test`, deliberately

I first wrote this with `needs: test` and then removed it. On a push to `main` that matrix is **beta and nightly**, so gating would let an unrelated nightly regression silently stop the docs publishing.

Nothing here can publish an internally inconsistent site: it ships the committed document as-is. A stale one would mean `openapi-check` is already failing loudly in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vxTCGA6CEe8Xnpw3XgzSf