### PR TITLE
Grant the protocol docs job write access to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
   protocol:
     name: Protocol docs
     runs-on: ubuntu-latest
+    # The repository's default workflow token is read-only, so the gh-pages push
+    # below needs this granted explicitly — the same block, for the same reason,
+    # as the `coverage` job. Job-level rather than workflow-level so the jobs
+    # that only read stay read-only.
+    #
+    # Its absence does not show up on a pull request: the publish step is gated
+    # on a push to main, so a PR runs this job green without ever exercising the
+    # push. Only main can catch it, which is how it got merged missing.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
The `Protocol docs` job assembled the site correctly and then failed on the push:

```
remote: Permission to jorge-menjivar/super-stt.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

This repository's default workflow token is **read-only** (`default_workflow_permissions: "read"`). The `coverage` job grants itself `contents: write` at job level for exactly this reason — I copied its publish script when adding this job, but not the `permissions:` block sitting above it.

Job-level rather than workflow-level, matching `coverage`, so the jobs that only read stay read-only. I checked that the set of jobs pushing to `gh-pages` and the set granting `contents: write` are now the same two.

## Why this merged broken twice

The publish step is gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`. **A pull request runs this job green without ever exercising the push it is gating** — so neither #408 nor #409 could have caught it, and won't catch the next fault in that step either. Only a push to `main` reaches it.

Worth knowing when reviewing: this PR's own checks passing proves nothing about the thing being fixed. The real verification is the `Protocol docs` job on `main` after merge, and https://jorge-menjivar.github.io/super-stt/protocol/ resolving shortly after.

## Note

This commit also appears as an ancestor of `v1-tree-mirrors-api-paths` — it landed there by accident while both branches were in flight. Rebasing that branch onto `main` after this merges will drop the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vxTCGA6CEe8Xnpw3XgzSf