### PR TITLE
Let an option declare the values it takes

### DIFF
--- a/docs/protocol/backend/config.md
+++ b/docs/protocol/backend/config.md
@@ -224,6 +224,14 @@ label       = "Remove filler sounds"
 description = "Drop um, uh and similar from the transcript."
 type        = "bool"
 default     = true
+
+[[options]]
+name        = "styling"
+label       = "Styling"
+description = "The register the transcript is rewritten in."
+type        = "string"
+default     = "semi-formal"
+choices     = ["casual", "semi-casual", "semi-formal", "formal"]
 ```
 
 A `bool` option is rendered as a switch, so it has no Save button: flipping it
@@ -232,13 +240,27 @@ override rather than writing a value identical to it. Declare a `default` for
 every `bool` — without one the switch starts off, and turning it off again has
 nothing to revert to.
 
+An option that declares `choices` is rendered as a dropdown, and behaves the
+same way: picking writes, and picking the `default` back off the list clears
+the override. Declare them whenever the option takes a closed set of values.
+Writing the allowed values into the `description` instead leaves the user a
+text field, and a value that is merely close enough is stored and sent to the
+backend as if it were valid.
+
+The daemon refuses a write of any value not on the list, so `choices` is a
+contract and not only a hint: `POST /backend/{id}/option/{name}` answers
+`400 invalid_value`. A `bool` must not declare `choices` — it is already a
+switch over the two values its type names — and the `default`, when there is
+one, has to be on the list. Both are refused at publication.
+
 | Field         | Type           | Required | Notes                                                  |
 |---------------|----------------|----------|--------------------------------------------------------|
 | `name`        | string         | yes      | snake_case identifier the backend reads the value by. `[a-z][a-z0-9_]*`, unique within the table. |
 | `label`       | string         | no       | Human-readable label shown in the settings UI. Falls back to `name` when absent. |
 | `description` | string         | yes      | Help text shown beside the input in the settings UI.   |
 | `type`        | string         | no       | `string`, `integer`, or `bool`. Drives the input the UI renders: `bool` gets a switch that writes on the flip, everything else a text field the user saves. Default `string`. |
-| `default`     | matches `type` | no       | Value used when the user sets none. Forbidden on `base_url` — see below. |
+| `default`     | matches `type` | no       | Value used when the user sets none. Forbidden on `base_url` — see below. When `choices` is present, must be one of them. |
+| `choices`     | array of `type` | no      | The values this option accepts. Renders a dropdown, and the daemon refuses to store anything else. Omit it for an open-ended option. Entries must be unique, and a `bool` must not declare any. |
 | `required`    | bool           | no       | Whether a value must be set before the backend can load. Default `false`. |
 
 #### `base_url` and egress
@@ -724,6 +746,10 @@ supported_devices   = ["none"]
   loaded with defaults.
 - Whether a model is online/remote is decided solely by `supported_devices`
   (the `none` sentinel).
+- An option's `choices`, when declared, must be unique, must contain the
+  option's `default` if it declares one, and must not appear on a `bool`. The
+  registry indexer refuses to publish a manifest breaking any of these, and
+  the daemon refuses to store a value the list does not offer.
 - Secret and option `name`s are **snake_case** identifiers matching
   `[a-z][a-z0-9_]*` (e.g. `openai_api_key`, `base_url`), unique within their
   table. The `name` is the wire identifier the backend reads the value by;

--- a/docs/protocol/endpoints/v1/backends/options.md
+++ b/docs/protocol/endpoints/v1/backends/options.md
@@ -64,7 +64,17 @@ Authorization: Bearer stt_…64hex…
       "type":     "string",
       "default":  "https://api.openai.com",
       "required": false,
+      "choices":  [],                       // open-ended; a text field
       "value":    "https://api.openai.com"  // effective value (override or default)
+    },
+    {
+      "name":     "styling",
+      "label":    "Styling",
+      "type":     "string",
+      "default":  "semi-formal",
+      "required": false,
+      "choices":  ["casual", "semi-formal", "formal"],  // closed set; a dropdown
+      "value":    "formal"
     }
   ]
 }
@@ -77,6 +87,7 @@ Authorization: Bearer stt_…64hex…
 | `…[].label`    | string           | Human-readable label; falls back to `name` when absent.        |
 | `…[].type`     | string           | Declared value type (e.g. `string`).                           |
 | `…[].default`  | any              | Manifest default; the effective value when no override is set. |
+| `…[].choices`  | array            | The values this option accepts. Empty means any value of `type`, which a client renders as a text field; a non-empty list is a dropdown, and a `POST` of anything outside it is refused. |
 | `…[].required` | boolean          | Whether the backend needs it to operate.                      |
 | `…[].value`    | any              | Effective value: the override if set, else `default`.          |
 
@@ -124,7 +135,7 @@ Content-Type: application/json
 
 | Field   | Type   | Required | Notes                                                  |
 |---------|--------|----------|--------------------------------------------------------|
-| `value` | string | yes      | New override value. Use `DELETE` to reset to default.  |
+| `value` | string | yes      | New override value. Use `DELETE` to reset to default. When the option declares `choices`, must be one of them. |
 
 **Response (200):**
 
@@ -166,7 +177,8 @@ Authorization: Bearer stt_…64hex…
 
 | HTTP | `message`         | Meaning                                              |
 |------|-------------------|------------------------------------------------------|
-| 400  | `invalid_request` | Malformed body.                                      |
+| 400  | `invalid_request` | Malformed body, or an empty `value`.                 |
+| 400  | `invalid_value`   | The option declares `choices` and the posted value is not one of them. The `message` names the values on offer. |
 | 401  | `invalid_session` | Token unknown / expired / `exe_changed`.             |
 | 403  | `scope_denied`    | Token lacks the `settings` scope.                    |
 | 404  | `unknown_backend` | No installed backend has that `source`.             |

--- a/docs/protocol/openapi.json
+++ b/docs/protocol/openapi.json
@@ -499,7 +499,7 @@
             }
           },
           "400": {
-            "description": "The value was empty (`invalid_request`). Use `DELETE` to clear an override.",
+            "description": "The value was empty (`invalid_request`), or the option declares `choices` and the value is not one of them (`invalid_value`). Use `DELETE` to clear an override.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5734,6 +5734,13 @@
           "name"
         ],
         "properties": {
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The values this option accepts, when it accepts a closed set. Empty\nmeans any value of `type`, so a client renders a free-text field;\na non-empty list is a dropdown, and the daemon refuses a write of\nanything outside it."
+          },
           "default": {
             "type": [
               "string",
@@ -5780,9 +5787,17 @@
           "name",
           "label",
           "type",
+          "choices",
           "required"
         ],
         "properties": {
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The values this option accepts, when it accepts a closed set. Empty\nmeans any value of `type`, which is what a client renders a free-text\nfield for; a non-empty list is a dropdown, and the only values a write\nwill be allowed to store."
+          },
           "default": {
             "type": [
               "string",

--- a/super-stt-app/src/core/app/handlers/backend.rs
+++ b/super-stt-app/src/core/app/handlers/backend.rs
@@ -54,6 +54,7 @@ impl AppModel {
             | BackendMessage::BackendOptionInputChanged { .. }
             | BackendMessage::BackendOptionSaved { .. }
             | BackendMessage::BackendOptionToggled { .. }
+            | BackendMessage::BackendOptionChosen { .. }
             | BackendMessage::BackendOptionReset { .. } => self.handle_backend_config(message),
         }
     }
@@ -137,6 +138,17 @@ impl AppModel {
             .find(|b| b.source == source)
             .and_then(|b| b.options.iter().find(|o| o.name == name))
             .and_then(BackendOption::bool_default)
+    }
+
+    /// The `default` an option declares, as stored. The dropdown's twin of
+    /// [`Self::option_bool_default`], and reverting reads the same way there:
+    /// picking the default back off the list clears the override.
+    fn option_default(&self, source: &str, name: &str) -> Option<String> {
+        self.backends
+            .iter()
+            .find(|b| b.source == source)
+            .and_then(|b| b.options.iter().find(|o| o.name == name))
+            .and_then(|o| o.default.clone())
     }
 
     /// Handle per-backend secret and option configuration messages.
@@ -246,6 +258,19 @@ impl AppModel {
 
             // Explicit reset: clear the stored override and reload so the
             // option reverts to its daemon default.
+            BackendMessage::BackendOptionChosen {
+                source,
+                name,
+                value,
+            } => {
+                self.action_error = None;
+                if self.option_default(&source, &name).as_ref() == Some(&value) {
+                    option_write(clear_backend_option(source, name))
+                } else {
+                    option_write(set_backend_option(source, name, value))
+                }
+            }
+
             BackendMessage::BackendOptionReset { source, name } => {
                 self.action_error = None;
                 option_write(clear_backend_option(source, name))

--- a/super-stt-app/src/ui/messages.rs
+++ b/super-stt-app/src/ui/messages.rs
@@ -455,6 +455,13 @@ pub enum BackendMessage {
         name: String,
         value: bool,
     },
+    /// A value was picked from an option's dropdown. Like the switch, a
+    /// dropdown has nothing to press afterwards, so choosing writes.
+    BackendOptionChosen {
+        source: String,
+        name: String,
+        value: String,
+    },
     BackendOptionReset {
         source: String,
         name: String,

--- a/super-stt-app/src/ui/views/models/chips.rs
+++ b/super-stt-app/src/ui/views/models/chips.rs
@@ -851,6 +851,7 @@ mod capability_tests {
             description: String::new(),
             r#type: Some("string".to_string()),
             default: None,
+            choices: Vec::new(),
             required: false,
             value: value.map(ToString::to_string),
         }];

--- a/super-stt-app/src/ui/views/models/configure.rs
+++ b/super-stt-app/src/ui/views/models/configure.rs
@@ -50,6 +50,14 @@ pub fn configure_sheet<'a>(backend: &'a BackendInfo, app: &'a AppModel) -> Eleme
                 section = section.add(bool_option_row(&backend.source, option));
                 continue;
             }
+            // An option offering a closed set is the same case as the switch,
+            // widened: nothing to type, so nothing to type wrong, and picking
+            // is the write. It is what an option whose allowed values lived in
+            // its help text always wanted to be.
+            if option.has_choices() {
+                section = section.add(choice_option_row(&backend.source, option));
+                continue;
+            }
             let key = (backend.source.clone(), option.name.clone());
             let input = app
                 .backend_option_inputs
@@ -190,6 +198,45 @@ pub(super) fn bool_option_row<'a>(
         item = item.description(option.description.clone());
     }
     item.control(toggle).into()
+}
+
+/// One option row for an option that declares `choices`: the label and
+/// description beside a dropdown of the values the backend accepts.
+///
+/// Like the switch, and unlike the text field, there is no Save button —
+/// picking is the write. And as with the switch, picking the declared default
+/// clears the override rather than storing a copy of it, which is what keeps
+/// the Reset affordance unnecessary here.
+///
+/// A stored value the backend no longer offers leaves the dropdown showing its
+/// placeholder rather than a wrong selection, so the user picks again.
+pub(super) fn choice_option_row<'a>(
+    source: &'a str,
+    option: &'a BackendOption,
+) -> Element<'a, Message> {
+    let display = option.label.clone().unwrap_or_else(|| option.name.clone());
+    let source = source.to_string();
+    let name = option.name.clone();
+    let choices = option.choices.clone();
+
+    let dropdown = widget::dropdown(
+        option.choices.as_slice(),
+        option.choice_index(),
+        move |index| {
+            Message::Backend(BackendMessage::BackendOptionChosen {
+                source: source.clone(),
+                name: name.clone(),
+                value: choices[index].clone(),
+            })
+        },
+    )
+    .placeholder("Select");
+
+    let mut item = settings::item::builder(display);
+    if !option.description.is_empty() {
+        item = item.description(option.description.clone());
+    }
+    item.control(dropdown).into()
 }
 
 /// One option-entry row for a backend (e.g. `base_url`): the label/description

--- a/super-stt-app/src/ui/views/models/status.rs
+++ b/super-stt-app/src/ui/views/models/status.rs
@@ -94,6 +94,7 @@ mod unmet_requirements_tests {
             description: String::new(),
             r#type: None,
             default: None,
+            choices: Vec::new(),
             required,
             value: value.map(str::to_string),
         }

--- a/super-stt-daemon/src/daemon/backend_config_handlers.rs
+++ b/super-stt-daemon/src/daemon/backend_config_handlers.rs
@@ -118,6 +118,7 @@ impl SuperSTTDaemon {
                             description: o.description.clone(),
                             r#type: o.r#type.map(|t| t.as_str().to_string()),
                             default,
+                            choices: o.choices.iter().map(ToString::to_string).collect(),
                             required: o.required,
                             value,
                         }

--- a/super-stt-daemon/src/daemon/http/v1/backends/options.rs
+++ b/super-stt-daemon/src/daemon/http/v1/backends/options.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use super::{decode_source, find_backend, json_error, ok};
+use super::{decode_source, find_backend, json_error, json_error_msg, ok};
 use crate::daemon::http::internal::helpers::dispatch::dispatch_command;
 use crate::daemon::http::state::AppState;
 use crate::daemon::http::wire::{ErrorEnvelope, ReasonEnvelope};
@@ -40,6 +40,11 @@ struct BackendOptionValue {
     kind: String,
     /// The manifest's default, or `null` when it declares none.
     default: Option<String>,
+    /// The values this option accepts, when it accepts a closed set. Empty
+    /// means any value of `type`, which is what a client renders a free-text
+    /// field for; a non-empty list is a dropdown, and the only values a write
+    /// will be allowed to store.
+    choices: Vec<String>,
     /// Whether the backend refuses to load without a value.
     required: bool,
     /// What is actually in effect: the user's override if set, otherwise the
@@ -83,6 +88,7 @@ fn effective(
         label: opt.label.clone().unwrap_or_else(|| opt.name.clone()),
         kind: opt.r#type.map_or("string", OptionType::as_str).to_string(),
         default,
+        choices: opt.choices.iter().map(ToString::to_string).collect(),
         required: opt.required,
         value,
     })
@@ -205,7 +211,7 @@ A loaded model does not pick this up on its own — reload the stage with \
     security(("session_token" = ["settings"])),
     responses(
         (status = 200, description = "Stored; this is the new effective value.", body = OptionValue),
-        (status = 400, description = "The value was empty (`invalid_request`). Use `DELETE` to clear an override.", body = ErrorEnvelope),
+        (status = 400, description = "The value was empty (`invalid_request`), or the option declares `choices` and the value is not one of them (`invalid_value`). Use `DELETE` to clear an override.", body = ErrorEnvelope),
         (status = 404, description = "No such backend (`unknown_backend`) or no such option (`unknown_option`).", body = ErrorEnvelope),
         (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
         (status = 403, description = "The token lacks the `settings` scope.", body = ErrorEnvelope),
@@ -241,6 +247,14 @@ async fn set_option(
         return json_error(StatusCode::BAD_REQUEST, "invalid_request");
     }
     if let Some(r) = guard_missing(&s, &source, &name).await {
+        return r;
+    }
+    // An option that declares `choices` accepts those and nothing else. The
+    // dropdown a settings UI renders cannot offer anything else either, so
+    // this is for the clients that write straight to the API — and for the
+    // stored value to stay one the backend understands, since it is injected
+    // into the load headers verbatim.
+    if let Some(r) = guard_not_a_choice(&s, &source, &name, value).await {
         return r;
     }
     let (code, _hdrs, body_str) = dispatch_command(
@@ -320,6 +334,35 @@ fn canonical_base_url(value: &str) -> String {
 #[cfg(not(feature = "wasm-backends"))]
 fn canonical_base_url(value: &str) -> String {
     value.trim().to_string()
+}
+
+/// Returns an error `Response` when the option declares a closed set of values
+/// and `value` is not one of them, `None` when the write can proceed.
+///
+/// Runs after [`guard_missing`], so a missing backend or option is already
+/// reported and this only ever looks at an option that exists.
+async fn guard_not_a_choice(
+    s: &AppState,
+    source: &str,
+    name: &str,
+    value: &str,
+) -> Option<Response> {
+    let backend = find_backend(s, source).await?;
+    let opt = backend.options.iter().find(|o| o.name == name)?;
+    if opt.accepts(value) {
+        return None;
+    }
+    let offered = opt
+        .choices
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(json_error_msg(
+        StatusCode::BAD_REQUEST,
+        "invalid_value",
+        &format!("option `{name}` accepts one of: {offered}"),
+    ))
 }
 
 /// Returns an error `Response` when the backend or the named option is missing,

--- a/super-stt-daemon/src/daemon/test_fixtures.rs
+++ b/super-stt-daemon/src/daemon/test_fixtures.rs
@@ -46,6 +46,8 @@ pub(crate) fn openai_backend(
             description: "Base URL".to_string(),
             r#type: Some(OptionType::String),
             default: base_url_default.map(|d| OptionDefault::String(d.to_string())),
+            // An endpoint override is open-ended by nature, so no closed set.
+            choices: Vec::new(),
             required: false,
         }],
         models,

--- a/super-stt-daemon/tests/http_smoke_backend_options.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_options.rs
@@ -11,8 +11,9 @@
 //!
 //! The fixture backend (`fixture-openai/backend.toml`) is written into the
 //! isolated `XDG_DATA_HOME/super-stt/backends/` tree so the daemon discovers
-//! it on startup. It declares one option (`base_url`) with default
-//! `"https://api.openai.com"`.
+//! it on startup. It declares three options: `base_url` and `region` are
+//! open-ended, and `styling` offers a closed set, so both sides of the
+//! `choices` gate are exercisable.
 
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
@@ -96,6 +97,14 @@ label = "Region"
 description = "Upstream region."
 type = "string"
 default = "us-east-1"
+
+[[options]]
+name = "styling"
+label = "Styling"
+description = "The register."
+type = "string"
+default = "formal"
+choices = ["casual", "formal"]
 
 [[models]]
 name = "whisper-1"
@@ -353,7 +362,7 @@ async fn option_list_returns_declared_options() {
     assert_eq!(s, StatusCode::OK, "GET options: {body}");
     assert_eq!(body["status"], "success", "list status: {body}");
     let options = body["options"].as_array().expect("options array");
-    assert_eq!(options.len(), 2, "two declared options: {body}");
+    assert_eq!(options.len(), 3, "three declared options: {body}");
     let o0 = &options[0];
     assert_eq!(o0["name"], "base_url", "option name: {body}");
     assert!(
@@ -363,6 +372,79 @@ async fn option_list_returns_declared_options() {
     let o1 = &options[1];
     assert_eq!(o1["name"], "region", "option name: {body}");
     assert_eq!(o1["value"], "us-east-1", "default value in list: {body}");
+    assert_eq!(
+        o1["choices"],
+        serde_json::json!([]),
+        "an open-ended option offers no list, which is what a client renders \
+         a text field from: {body}"
+    );
+    let o2 = &options[2];
+    assert_eq!(o2["name"], "styling", "option name: {body}");
+    assert_eq!(
+        o2["choices"],
+        serde_json::json!(["casual", "formal"]),
+        "the values the option accepts, in manifest order: {body}"
+    );
+}
+
+/// An option that declares `choices` accepts those and nothing else. The
+/// settings app renders a dropdown that cannot offer anything else, so this is
+/// the guard for every other client — and for the stored value staying one the
+/// backend understands, since it is injected into the load headers verbatim.
+#[tokio::test]
+async fn an_option_with_choices_takes_only_those() {
+    let (_guard, sock, token) = start_daemon(&["settings"]).await;
+    let opt_path = format!("/backend/{FIXTURE_SOURCE_ENC}/option/styling");
+
+    let (s, body) = post_req(
+        &sock,
+        &opt_path,
+        &token,
+        serde_json::json!({ "value": "casual" }),
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "an offered value stores: {body}");
+    assert_eq!(body["value"], "casual", "body: {body}");
+
+    let (s, body) = post_req(
+        &sock,
+        &opt_path,
+        &token,
+        serde_json::json!({ "value": "formalish" }),
+    )
+    .await;
+    assert_eq!(
+        s,
+        StatusCode::BAD_REQUEST,
+        "a value off the list must be refused: {body}"
+    );
+    assert_eq!(body["error_code"], "invalid_value", "body: {body}");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("casual, formal"),
+        "the refusal names what is on offer: {body}"
+    );
+
+    // Refused, so the earlier value is still what is in effect.
+    let (s, body) = get(&sock, &opt_path, &token).await;
+    assert_eq!(s, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["value"], "casual",
+        "a refused write changes nothing: {body}"
+    );
+
+    // An option declaring no list still takes anything.
+    let region = format!("/backend/{FIXTURE_SOURCE_ENC}/option/region");
+    let (s, body) = post_req(
+        &sock,
+        &region,
+        &token,
+        serde_json::json!({ "value": "eu-west-9" }),
+    )
+    .await;
+    assert_eq!(s, StatusCode::OK, "an open-ended option is ungated: {body}");
 }
 
 /// GET on an undeclared option name returns 404 `unknown_option`.

--- a/super-stt-indexer/src/manifest.rs
+++ b/super-stt-indexer/src/manifest.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use thiserror::Error;
 
 pub use super_stt_registry_types::manifest::{
-    Kind, Manifest, ManifestError as ParseError, SubprocessAsset,
+    Kind, Manifest, ManifestError as ParseError, OptionType, SubprocessAsset,
 };
 
 #[derive(Debug, Error)]
@@ -47,6 +47,22 @@ pub enum ManifestError {
          realtime path"
     )]
     PostProcessorRealtime(String),
+    /// An option's `default` is not one of the values its `choices` allow.
+    #[error(
+        "option `{0}` declares `default = {1:?}` but its `choices` do not offer \
+         it: the value a user never changes would be one the option rejects"
+    )]
+    DefaultNotAChoice(String, String),
+    /// A `bool` option declared choices. It is rendered as a switch, and a
+    /// switch has exactly the two values the type already names.
+    #[error(
+        "option `{0}` is a `bool` and must not declare `choices`: a boolean is \
+         rendered as a switch, whose values are already true and false"
+    )]
+    BoolWithChoices(String),
+    /// The same value appears twice in one option's `choices`.
+    #[error("option `{0}` lists the choice {1:?} more than once")]
+    DuplicateChoice(String, String),
 }
 
 pub fn validate(
@@ -118,6 +134,35 @@ pub fn validate(
     }) {
         return Err(ManifestError::BaseUrlDefault);
     }
+    // A closed set of values has to be internally consistent, and the settings
+    // UI renders it as a dropdown that cannot express a contradiction: a
+    // default outside the list, or a duplicate entry, would be a list the user
+    // can neither choose from nor return to. Caught at publication because the
+    // daemon reads a manifest it cannot fix.
+    for o in &m.options {
+        if o.choices.is_empty() {
+            continue;
+        }
+        if o.r#type == Some(OptionType::Bool) {
+            return Err(ManifestError::BoolWithChoices(o.name.clone()));
+        }
+        let mut seen: Vec<String> = Vec::with_capacity(o.choices.len());
+        for choice in &o.choices {
+            let choice = choice.to_string();
+            if seen.contains(&choice) {
+                return Err(ManifestError::DuplicateChoice(o.name.clone(), choice));
+            }
+            seen.push(choice);
+        }
+        if let Some(default) = &o.default
+            && !o.accepts(&default.to_string())
+        {
+            return Err(ManifestError::DefaultNotAChoice(
+                o.name.clone(),
+                default.to_string(),
+            ));
+        }
+    }
     // Mirrors the daemon's discovery-time rule, so a contradiction is caught at
     // publication rather than skipping the backend on every user's machine.
     if let Some(model) = m
@@ -152,6 +197,94 @@ mod tests {
 
     fn with_id(id: &str) -> String {
         VALID.replace("[backend]", &format!("[backend]\n    id = \"{id}\""))
+    }
+
+    fn with_option(body: &str) -> String {
+        format!("{VALID}\n[[options]]\n{body}\n")
+    }
+
+    fn validate_option(body: &str) -> Result<(), ManifestError> {
+        let m = Manifest::parse(&with_option(body)).expect("parses");
+        validate(&m, &Version::new(1, 0, 0), "github.com/x/y", None)
+    }
+
+    /// A closed set of values is only useful if it is coherent, and the
+    /// registry is where an author finds out — the daemon reads a manifest it
+    /// cannot fix, and the settings UI renders a dropdown that cannot express
+    /// a default sitting outside its own list.
+    #[test]
+    fn a_choice_list_must_offer_its_own_default() {
+        validate_option(
+            r#"
+            name = "styling"
+            description = "The register."
+            default = "formal"
+            choices = ["casual", "formal"]
+            "#,
+        )
+        .expect("a default on the list validates");
+
+        let err = validate_option(
+            r#"
+            name = "styling"
+            description = "The register."
+            default = "brisk"
+            choices = ["casual", "formal"]
+            "#,
+        )
+        .expect_err("a default off the list is refused");
+        assert!(
+            matches!(err, ManifestError::DefaultNotAChoice(ref n, ref d) if n == "styling" && d == "brisk"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_bool_option_cannot_offer_choices() {
+        let err = validate_option(
+            r#"
+            name = "tidy"
+            description = "Tidy up."
+            type = "bool"
+            default = true
+            choices = [true, false]
+            "#,
+        )
+        .expect_err("a switch does not get a list");
+        assert!(
+            matches!(err, ManifestError::BoolWithChoices(ref n) if n == "tidy"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_choice_offered_twice_is_refused() {
+        let err = validate_option(
+            r#"
+            name = "styling"
+            description = "The register."
+            choices = ["formal", "formal"]
+            "#,
+        )
+        .expect_err("a duplicate row cannot be chosen");
+        assert!(
+            matches!(err, ManifestError::DuplicateChoice(ref n, ref c) if n == "styling" && c == "formal"),
+            "got: {err}"
+        );
+    }
+
+    /// Every manifest published before the field, and every option that is
+    /// genuinely open-ended, declares no list and is unaffected.
+    #[test]
+    fn an_option_offering_nothing_is_left_alone() {
+        validate_option(
+            r#"
+            name = "custom_model"
+            description = "Any model name."
+            default = "whisper-large-v3"
+            "#,
+        )
+        .expect("an open-ended option validates");
     }
 
     #[test]

--- a/super-stt-registry-types/src/manifest.rs
+++ b/super-stt-registry-types/src/manifest.rs
@@ -549,10 +549,29 @@ pub struct Opt {
     /// Value used when the user sets none. Should match `type`.
     #[serde(default)]
     pub default: Option<OptionDefault>,
+    /// The values this option accepts, when it accepts a closed set. Empty
+    /// means any value of the declared `type`.
+    ///
+    /// Declaring them is what turns a free-text field into a dropdown, and
+    /// what lets the daemon refuse a value the backend would not understand.
+    /// An option whose allowed values were only ever written into its
+    /// `description` accepted anything the user typed, and shipped it.
+    #[serde(default)]
+    pub choices: Vec<OptionDefault>,
     /// Whether a value must be set before the backend can load. Default
     /// `false`.
     #[serde(default)]
     pub required: bool,
+}
+
+impl Opt {
+    /// Whether `value`, in the string form the daemon stores and injects, is
+    /// one this option accepts. An option declaring no choices accepts
+    /// anything, so this is the check itself, not a precondition for it.
+    #[must_use]
+    pub fn accepts(&self, value: &str) -> bool {
+        self.choices.is_empty() || self.choices.iter().any(|c| c.to_string() == value)
+    }
 }
 
 /// The input type of an option.
@@ -1805,6 +1824,64 @@ mod tests {
             m.options[1].default,
             Some(OptionDefault::String("30".into()))
         );
+    }
+
+    /// A `choices` list parses by TOML type the way `default` does, and an
+    /// option that declares none accepts anything — which is what keeps every
+    /// manifest written before the field a valid one.
+    #[test]
+    fn choices_parse_and_gate_the_values_an_option_takes() {
+        let m = Manifest::parse(
+            r#"
+            [backend]
+            source = "github.com/x/y"
+            name = "Y"
+            version = "1.0.0"
+            kind = "wasm"
+            entrypoint = "y.wasm"
+            contract = "v1"
+            description = "Test backend."
+
+            [[options]]
+            name = "styling"
+            description = "The register."
+            default = "formal"
+            choices = ["casual", "formal"]
+
+            [[options]]
+            name = "beam"
+            description = "Beam width."
+            type = "integer"
+            choices = [1, 4]
+
+            [[options]]
+            name = "base_url"
+            description = "Anything goes."
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            m.options[0].choices,
+            vec![
+                OptionDefault::String("casual".into()),
+                OptionDefault::String("formal".into())
+            ]
+        );
+        assert!(m.options[0].accepts("casual"));
+        assert!(!m.options[0].accepts("formalish"));
+
+        // Integers are compared in the string form the daemon stores and
+        // injects, so a numeric choice gates the same way a string one does.
+        assert_eq!(
+            m.options[1].choices,
+            vec![OptionDefault::Integer(1), OptionDefault::Integer(4)]
+        );
+        assert!(m.options[1].accepts("4"));
+        assert!(!m.options[1].accepts("3"));
+
+        // No list, no gate: every option written before this field existed.
+        assert!(m.options[2].choices.is_empty());
+        assert!(m.options[2].accepts("https://gateway.example.com/v1"));
     }
 
     /// Unknown fields and tables are ignored — older daemons must tolerate

--- a/super-stt-registry-types/src/schema.rs
+++ b/super-stt-registry-types/src/schema.rs
@@ -142,6 +142,14 @@ fn inject_definition_rules(defs: &mut serde_json::Map<String, Value>) {
         }),
     );
 
+    // A value offered twice is a dropdown with two identical rows, one of
+    // which cannot be chosen. The indexer refuses to publish it; the schema
+    // says so where the author is typing.
+    opt["properties"]["choices"]
+        .as_object_mut()
+        .expect("choices property")
+        .insert("uniqueItems".into(), json!(true));
+
     // `supported_devices` must be non-empty (discovery rejects an empty
     // list); serde can't express minItems, so inject it here.
     let model = defs.get_mut("ModelEntry").expect("ModelEntry def");

--- a/super-stt-registry-types/tests/schema_validation.rs
+++ b/super-stt-registry-types/tests/schema_validation.rs
@@ -408,9 +408,14 @@ fn conditional_property_names_exist() {
     let opt_props = defs["Opt"]["properties"]
         .as_object()
         .expect("Opt properties");
-    for key in ["name", "default"] {
+    for key in ["name", "default", "choices"] {
         assert!(opt_props.contains_key(key), "Opt missing `{key}`");
     }
+    assert_eq!(
+        opt_props["choices"]["uniqueItems"],
+        serde_json::json!(true),
+        "a choice offered twice must not validate"
+    );
 }
 
 /// Every table a `CONTRACT_FIELDS` row may name resolves to a definition the

--- a/super-stt-shared/src/models/backends.rs
+++ b/super-stt-shared/src/models/backends.rs
@@ -174,6 +174,12 @@ pub struct BackendOption {
     pub r#type: Option<String>,
     #[serde(default)]
     pub default: Option<String>,
+    /// The values this option accepts, when it accepts a closed set. Empty
+    /// means any value of `type`, so a client renders a free-text field;
+    /// a non-empty list is a dropdown, and the daemon refuses a write of
+    /// anything outside it.
+    #[serde(default)]
+    pub choices: Vec<String>,
     #[serde(default)]
     pub required: bool,
     /// Current effective value (override or default) reported by the daemon.
@@ -214,6 +220,29 @@ impl BackendOption {
     #[must_use]
     pub fn bool_default(&self) -> Option<bool> {
         self.default.as_deref().map(parse_bool)
+    }
+
+    /// Whether this option offers a closed set of values, so a client shows a
+    /// dropdown rather than a text field.
+    ///
+    /// A `bool` never does: it is a switch, whose two values the type already
+    /// names. A manifest declaring both is refused at publication, and this
+    /// keeps an older one that slipped through rendering as the switch.
+    #[must_use]
+    pub fn has_choices(&self) -> bool {
+        !self.choices.is_empty() && !self.is_bool()
+    }
+
+    /// Where this option's effective value sits in [`Self::choices`].
+    ///
+    /// `None` when nothing is set, and also when the stored value is not one
+    /// of the offered ones — a backend that dropped a choice its user had
+    /// picked. The dropdown then shows no selection rather than the wrong one,
+    /// and the user picks again.
+    #[must_use]
+    pub fn choice_index(&self) -> Option<usize> {
+        let current = self.value.as_deref().or(self.default.as_deref())?;
+        self.choices.iter().position(|c| c == current)
     }
 }
 
@@ -354,9 +383,61 @@ mod tests {
             description: String::new(),
             r#type: r#type.map(Into::into),
             default: default.map(Into::into),
+            choices: Vec::new(),
             required: false,
             value: value.map(Into::into),
         }
+    }
+
+    fn with_choices(
+        r#type: Option<&str>,
+        default: Option<&str>,
+        value: Option<&str>,
+        choices: &[&str],
+    ) -> BackendOption {
+        let mut opt = option(r#type, default, value);
+        opt.choices = choices.iter().map(|c| (*c).to_string()).collect();
+        opt
+    }
+
+    /// A closed set is what a client renders a dropdown from, so it has to be
+    /// distinguishable from the open-ended case by the payload alone.
+    #[test]
+    fn only_an_option_offering_values_gets_a_dropdown() {
+        assert!(with_choices(Some("string"), None, None, &["a", "b"]).has_choices());
+        assert!(!option(Some("string"), None, None).has_choices());
+        assert!(
+            !with_choices(Some("bool"), None, None, &["a", "b"]).has_choices(),
+            "a bool is a switch, whatever else it declares"
+        );
+    }
+
+    /// The dropdown shows the effective value, and shows nothing at all when
+    /// that value is not on the list — a backend that dropped a choice its
+    /// user had picked. Selecting the wrong row would be worse than selecting
+    /// none.
+    #[test]
+    fn the_dropdown_selects_the_effective_value_or_nothing() {
+        let offered = ["casual", "formal"];
+        assert_eq!(
+            with_choices(Some("string"), Some("casual"), Some("formal"), &offered).choice_index(),
+            Some(1),
+            "the override wins over the default"
+        );
+        assert_eq!(
+            with_choices(Some("string"), Some("casual"), None, &offered).choice_index(),
+            Some(0),
+            "and the default stands in for it"
+        );
+        assert_eq!(
+            with_choices(Some("string"), None, Some("formalish"), &offered).choice_index(),
+            None,
+            "a value no longer offered selects nothing"
+        );
+        assert_eq!(
+            with_choices(Some("string"), None, None, &offered).choice_index(),
+            None
+        );
     }
 
     /// Only an explicit `bool` gets a switch: an untyped option is a string by


### PR DESCRIPTION
## Why

An option that accepts a closed set had no way to say so. The s1-mini backend
enumerates the allowed values of its `styling`, `structure` and `context`
options in their help text:

```toml
[[options]]
    name = "styling"
    description = "The register. One of: casual (...), semi-casual (...), semi-formal (...), formal (...)."
    type = "string"
    default = "semi-formal"
```

Every one renders as a free-text box, because the settings app had exactly two
branches: a switch for `bool`, a text field with Save for everything else.
Typing `formalish` was accepted, stored, and injected into the load headers as
though it were a value the backend knows. Nothing validated an option value
anywhere: the write path checked only that it was non-empty and that the
option was declared.

## What changed

`[[options]]` gains `choices`, an array of values of the option's declared
`type`:

```toml
[[options]]
name        = "styling"
label       = "Styling"
description = "The register the transcript is rewritten in."
type        = "string"
default     = "semi-formal"
choices     = ["casual", "semi-casual", "semi-formal", "formal"]
```

Declaring it renders a dropdown. Omitting it changes nothing, which is what
every manifest written before this field, and every genuinely open-ended
option like `base_url` or `custom_model`, already relies on.

The dropdown behaves like the `bool` switch rather than like the text field.
Picking is the write, so there is no Save button, and picking the declared
default clears the override instead of storing a copy of it. A stored value
the backend has since dropped from its list selects nothing rather than the
wrong row, so the user picks again.

## Enforced on both sides of publication

The registry indexer refuses a manifest whose `default` sits outside its own
list, whose list repeats a value, or that declares `choices` on a `bool` — a
switch already names its two values.

The daemon refuses the write itself, answering `400 invalid_value` and naming
what is on offer. The settings dropdown cannot offer anything else, so this is
the guard for every other client, and for the stored value staying one the
backend understands.

The generated backend JSON schema learns the field automatically, plus a
`uniqueItems` constraint mirroring the duplicate rule, so an author sees the
mistake in their editor. This matters because the schema sets
`additionalProperties: false`, and a `choices` key it did not know about would
be flagged invalid.

## Tests

- Manifest parsing: choices bind by TOML type the way `default` does, integer
  choices gate against the stored string form, and an option declaring none
  accepts anything.
- Indexer: each of the three publication rules, and an open-ended option left
  alone.
- Shared catalog type: which options get a dropdown, and the selection falling
  back from override to default to nothing when the value is no longer offered.
- HTTP smoke: the option list reports the closed set and the empty one, an
  offered value stores, an off-list value is refused by code with the offer in
  the message, a refused write changes nothing, and an ungated option still
  takes anything.

Every gate passes: `just check`, `check-features`, `fmt-check`, `schema-check`,
`openapi-check`, `config-compat` and `doctest`, with the workspace suite green
at 1232 tests.

## Follow-up, not in scope

The pre-install Browse catalog (`IndexOption`) does not carry `choices`. It
renders no option inputs, so nothing needs it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpvW1KkroRceterawRwyuY