### PR TITLE
Shrink the id backlog to the three entries that still lack one

### DIFF
--- a/super-stt-registry-types/tests/schema_validation.rs
+++ b/super-stt-registry-types/tests/schema_validation.rs
@@ -113,9 +113,9 @@ fn the_schema_still_accepts_the_legacy_provider_key() {
     );
 }
 
-/// The schema requires an `id` of every entry. Six predate the requirement and
-/// cannot be fixed from this file: an entry that declares an `id` pins the
-/// release to it, and none of those six backends publishes a manifest
+/// The schema requires an `id` of every entry. Three predate the requirement
+/// and cannot be fixed from this file: an entry that declares an `id` pins the
+/// release to it, and none of those three backends publishes a manifest
 /// declaring one — so adding it here would turn a missing id into an
 /// `IdMismatch` and drop the backend out of the catalog. Fixing one means
 /// adding `[backend].id` to that backend's own repo, cutting a release, and
@@ -124,14 +124,7 @@ fn the_schema_still_accepts_the_legacy_provider_key() {
 /// They are named here so the backlog is visible and shrinking: delete a name
 /// when its entry gains an `id`. Anything *else* the schema objects to — a new
 /// entry with no id, a malformed key — fails this test.
-const ENTRIES_STILL_WITHOUT_AN_ID: &[&str] = &[
-    "deepgram",
-    "mistral",
-    "openai",
-    "qwen3_asr",
-    "voxtral",
-    "whisper",
-];
+const ENTRIES_STILL_WITHOUT_AN_ID: &[&str] = &["deepgram", "qwen3_asr", "voxtral"];
 
 #[test]
 fn accepts_registry_toml() {


### PR DESCRIPTION
`main` CI is red on both `Test (beta)` and `Test (nightly)`, in the `Check generated TOML schemas are current` step:

```
---- accepts_registry_toml stdout ----
assertion `left == right` failed: the set of entries without an `id` changed;
update ENTRIES_STILL_WITHOUT_AN_ID (shrinking it is the point)
  left: ["deepgram", "qwen3_asr", "voxtral"]
 right: ["deepgram", "mistral", "openai", "qwen3_asr", "voxtral", "whisper"]
```

Adding S1-mini (#418) also gave `mistral`, `openai` and `whisper` an `id` in `registry/registry.toml`, but left `ENTRIES_STILL_WITHOUT_AN_ID` untouched. This is the failure the constant is designed to produce, so the fix is to shrink it.

The three new ids are real, not a pin that would drop a backend out of the catalog. Each backend's latest release publishes a `backend.toml` declaring the same id:

| entry | release | published `[backend].id` |
| --- | --- | --- |
| mistral | v0.1.1 | `app.super-stt.mistral` |
| openai | v0.1.2 | `app.super-stt.openai` |
| whisper | v0.1.1 | `app.super-stt.whisper` |

`deepgram`, `qwen3_asr` and `voxtral` still publish no id, so they stay on the list.

`just schema-check` and `just fmt-check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2LQkDknCyraE92UXHFunq