### PR TITLE
Regenerate the OpenAPI document for 0.2.4-beta.2

### DIFF
--- a/docs/protocol/openapi.json
+++ b/docs/protocol/openapi.json
@@ -11,7 +11,7 @@
       "name": "GPL-3.0-only",
       "identifier": "GPL-3.0-only"
     },
-    "version": "0.2.4-beta.1"
+    "version": "0.2.4-beta.2"
   },
   "servers": [
     {


### PR DESCRIPTION
## Summary

CI on `main` fails at `openapi-check` since the version bump: the spec embeds the crate version, and the committed `docs/protocol/openapi.json` still said `0.2.4-beta.1`. This is `just openapi` run once; only the version line moves.

## Test plan

- `just openapi-check` reports the document current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9E2cHkhtV3tenDvoiy21L
