### PR TITLE
Open the app from the update-available notification

### DIFF
--- a/super-stt-app/src/core/app/init.rs
+++ b/super-stt-app/src/core/app/init.rs
@@ -85,7 +85,7 @@ impl AppModel {
     /// Initializes the application with any given flags and startup commands.
     pub(super) fn init_model(
         core: cosmic::Core,
-        _flags: (),
+        _flags: crate::Flags,
     ) -> (Self, Task<cosmic::Action<Message>>) {
         let nav = build_nav();
 

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -231,7 +231,7 @@ impl cosmic::Application for AppModel {
     type Executor = cosmic::executor::Default;
 
     /// Data that your application receives to its init method.
-    type Flags = ();
+    type Flags = crate::Flags;
 
     /// Messages which the application and its widgets will emit.
     type Message = Message;

--- a/super-stt-app/src/main.rs
+++ b/super-stt-app/src/main.rs
@@ -5,6 +5,17 @@ mod i18n;
 mod state;
 mod ui;
 
+/// No CLI flags; the type exists only to satisfy `run_single_instance`'s
+/// `CosmicFlags` bound. `action()` stays `None`, so a second launch
+/// activates the running window rather than routing an action to it.
+#[derive(Debug, Clone)]
+pub struct Flags;
+
+impl cosmic::app::CosmicFlags for Flags {
+    type SubCommand = String;
+    type Args = Vec<String>;
+}
+
 fn main() -> cosmic::iced::Result {
     super_stt_shared::logging::init();
 
@@ -26,6 +37,8 @@ fn main() -> cosmic::iced::Result {
             .min_height(180.0),
     );
 
-    // Starts the application's event loop with `()` as the application's flags.
-    cosmic::app::run::<core::AppModel>(settings, ())
+    // Run as a single-instance D-Bus-activated app. A second launch (e.g.
+    // from the update notification's "Open Super STT" action) activates
+    // and focuses the existing window instead of opening a duplicate.
+    cosmic::app::run_single_instance::<core::AppModel>(settings, Flags)
 }

--- a/super-stt-daemon/src/daemon/self_update_handlers.rs
+++ b/super-stt-daemon/src/daemon/self_update_handlers.rs
@@ -43,16 +43,30 @@ impl SuperSTTDaemon {
                 let method = self.config.read().await.transcription.notification_method;
                 if matches!(method, NotificationMethod::Dbus | NotificationMethod::Auto) {
                     let mut notifier = self.notifier.lock().await;
-                    if notifier
-                        .send(
+                    let sent = notifier
+                        .send_with_actions(
                             &format!("Super STT {tag} is available"),
                             "Open Super STT to install the update.",
+                            &[(
+                                crate::output::notification::OPEN_APP_ACTION_KEY,
+                                "Open Super STT",
+                            )],
                         )
-                        .await
-                        .is_ok()
-                    {
-                        drop(notifier);
+                        .await;
+                    let conn = notifier.connection();
+                    drop(notifier);
+                    if let Ok(id) = sent {
                         self.self_update.record_notified(&tag).await;
+                        // The bubble carries an "Open Super STT" action; a
+                        // click on it (or the bubble itself, on servers that
+                        // bind the default action) should bring the app up.
+                        // Spawned so the check path isn't blocked waiting on
+                        // a click that may never come.
+                        if let Some(conn) = conn {
+                            tokio::spawn(async move {
+                                Self::wait_for_update_notification_click(conn, id).await;
+                            });
+                        }
                     }
                 } else {
                     // Off/Typed: typing an update notice into the focused
@@ -63,6 +77,24 @@ impl SuperSTTDaemon {
             }
         }
         status
+    }
+
+    /// Wait for the user to click the "Open Super STT" action on the update
+    /// notification `id`, then launch the app. The app is single-instance
+    /// (its `org.freedesktop.DbusActivation` interface), so launching it
+    /// while it is already running activates and focuses the existing window
+    /// instead of opening a second one.
+    async fn wait_for_update_notification_click(conn: zbus::Connection, id: u32) {
+        let Some(key) = crate::output::notification::Notifier::wait_for_action(&conn, id).await
+        else {
+            return;
+        };
+        if key != crate::output::notification::OPEN_APP_ACTION_KEY {
+            return;
+        }
+        if let Err(e) = tokio::process::Command::new("super-stt-app").spawn() {
+            log::warn!("failed to launch Super STT app from update notification: {e}");
+        }
     }
 }
 

--- a/super-stt-daemon/src/output/notification.rs
+++ b/super-stt-daemon/src/output/notification.rs
@@ -14,6 +14,7 @@
 use crate::output::notice::Failure;
 use crate::output::typer::Typer;
 use anyhow::{Context, Result};
+use futures::StreamExt;
 use log::{debug, info, warn};
 use std::collections::HashMap;
 use super_stt_shared::models::notification_method::NotificationMethod;
@@ -33,6 +34,12 @@ const APP_ICON: &str = "super-stt-app";
 const URGENCY_NORMAL: u8 = 1;
 /// Let the notification server pick the timeout.
 const EXPIRE_DEFAULT: i32 = -1;
+
+/// The action key offered on update-available bubbles. The spec's
+/// `default` action is what most servers bind to clicking the bubble
+/// itself, so it is the one that makes "click the notification to open
+/// the app" work everywhere.
+pub(crate) const OPEN_APP_ACTION_KEY: &str = "default";
 
 /// Sends failure notices to the session's notification server.
 ///
@@ -77,6 +84,27 @@ impl Notifier {
     /// Never in practice: the `expect` below only unwraps the connection slot
     /// this same call just populated a few lines above.
     pub async fn send(&mut self, summary: &str, body: &str) -> Result<()> {
+        self.send_with_actions(summary, body, &[]).await.map(|_| ())
+    }
+
+    /// Deliver `summary` and `body` as a desktop notification carrying
+    /// `actions` (pairs of action key and label), returning the notification
+    /// id the server assigned. When the user picks one, the notification
+    /// server emits `ActionInvoked` on the same bus; the caller is
+    /// responsible for listening for it (see
+    /// [`crate::daemon::self_update_handlers`]).
+    ///
+    /// # Errors
+    /// As [`Self::send`].
+    ///
+    /// # Panics
+    /// As [`Self::send`].
+    pub async fn send_with_actions(
+        &mut self,
+        summary: &str,
+        body: &str,
+        actions: &[(&str, &str)],
+    ) -> Result<u32> {
         match &mut self.inner {
             Inner::Dbus(slot) => {
                 if slot.is_none() {
@@ -93,7 +121,10 @@ impl Notifier {
 
                 let mut hints: HashMap<&str, Value<'_>> = HashMap::new();
                 hints.insert("urgency", Value::U8(URGENCY_NORMAL));
-                let actions: Vec<&str> = Vec::new();
+                let actions: Vec<&str> = actions
+                    .iter()
+                    .flat_map(|(key, label)| [*key, *label])
+                    .collect();
 
                 // Notify(app_name, replaces_id, app_icon, summary, body,
                 //        actions, hints, expire_timeout) -> id
@@ -116,7 +147,7 @@ impl Notifier {
 
                 self.last_id = id;
                 debug!("Delivered failure notification (id {id})");
-                Ok(())
+                Ok(id)
             }
             #[cfg(test)]
             Inner::Fake { fail, sent } => {
@@ -126,7 +157,7 @@ impl Notifier {
                 sent.lock()
                     .unwrap()
                     .push((summary.to_string(), body.to_string()));
-                Ok(())
+                Ok(0)
             }
         }
     }
@@ -146,6 +177,41 @@ impl Notifier {
             },
             sent,
         )
+    }
+
+    /// Resolve when the user activates an action on the notification `id`,
+    /// returning the action key (e.g. [`OPEN_APP_ACTION_KEY`]). The
+    /// `ActionInvoked` signal carries the id of the bubble the action came
+    /// from, so only that bubble resolves the wait — another app's
+    /// notifications are ignored.
+    ///
+    /// The subscription is built lazily per call on `conn`; a failure to
+    /// subscribe resolves `None` (the click simply does nothing, which is how
+    /// the bubble behaved before actions existed).
+    ///
+    /// # Errors
+    /// Never: every failure path resolves `None` rather than erroring, since
+    /// a missed click is not worth surfacing.
+    pub async fn wait_for_action(conn: &Connection, id: u32) -> Option<String> {
+        let proxy = zbus::Proxy::new(conn, NOTIFY_BUS, NOTIFY_PATH, NOTIFY_IFACE)
+            .await
+            .ok()?;
+        let mut signals = proxy.receive_signal("ActionInvoked").await.ok()?;
+        let signal = signals.next().await?;
+        let (signal_id, key): (u32, String) = signal.body().deserialize().ok()?;
+        (signal_id == id).then_some(key)
+    }
+
+    /// A clone of the cached session-bus connection, if one has been
+    /// established by a prior send. Used by callers that must wait for an
+    /// `ActionInvoked` without holding the notifier's mutex across the wait.
+    #[must_use]
+    pub fn connection(&self) -> Option<Connection> {
+        match &self.inner {
+            Inner::Dbus(slot) => slot.clone(),
+            #[cfg(test)]
+            Inner::Fake { .. } => None,
+        }
     }
 }
 


### PR DESCRIPTION
The update-available notification was passive: it told you a new version existed and then left you to find the app yourself.

- The daemon's update notification now carries an **Open Super STT** action, registered as the spec's `default` action so clicking the notification body works on servers that support it.
- A spawned task listens for `ActionInvoked` on that notification's id and launches `super-stt-app`.
- `super-stt-app` now runs single-instance via D-Bus activation, so the click focuses the existing window instead of opening a second copy.

## Testing

`just fmt-check`, `just check`, and `just test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXZDCGoAUBrn9rwMJFZDEy
