### PR TITLE
Stop the download log from claiming a cached file was downloaded

### DIFF
--- a/super-stt-daemon/src/download_progress.rs
+++ b/super-stt-daemon/src/download_progress.rs
@@ -217,6 +217,10 @@ impl DownloadProgressTracker {
         }
     }
 
+    /// Advance the tracker to the next file. Purely a state update — the
+    /// caller logs, because only it knows whether the file is being fetched
+    /// or was already on disk (cached files come through here too, so the
+    /// progress bar advances without claiming a download happened).
     pub fn start_file(&self, filename: &str, file_index: usize) {
         *self.current_file.write() = filename.to_string();
         self.file_index.store(file_index, Ordering::Relaxed);
@@ -234,12 +238,6 @@ impl DownloadProgressTracker {
         // store, so the UI never observes the transient.
         self.bytes_downloaded.store(0, Ordering::Relaxed);
         self.total_bytes.store(0, Ordering::Relaxed);
-        info!(
-            "Downloading file {}/{}: {}",
-            file_index + 1,
-            self.total_files.load(Ordering::Relaxed),
-            filename
-        );
     }
 
     pub fn is_cancelled(&self) -> bool {

--- a/super-stt-daemon/src/stt_models/download.rs
+++ b/super-stt-daemon/src/stt_models/download.rs
@@ -117,20 +117,34 @@ async fn download_one(
     // Per-file counters: both totals are this file's size so the UI shows
     // "X.X / X.X MB" at 100%, then the file_index advances next iteration.
     if let Some(len) = usable_existing(dest, item.sha256.as_deref()).await? {
-        info!("Already present: {}", dest.display());
         if let Some(t) = tracker {
+            info!(
+                "File {}/{} already present, skipping download: {}",
+                file_index + 1,
+                t.total_files.load(Ordering::Relaxed),
+                dest.display()
+            );
             t.start_file(&name, file_index);
             t.bytes_downloaded.store(len, Ordering::Relaxed);
             t.total_bytes.store(len, Ordering::Relaxed);
             t.broadcast_progress();
+        } else {
+            info!("Already present: {}", dest.display());
         }
         return Ok(());
     }
 
     let url = &item.url;
-    info!("Downloading {url} -> {}", dest.display());
     if let Some(t) = tracker {
+        info!(
+            "Downloading file {}/{}: {url} -> {}",
+            file_index + 1,
+            t.total_files.load(Ordering::Relaxed),
+            dest.display()
+        );
         t.start_file(&name, file_index);
+    } else {
+        info!("Downloading {url} -> {}", dest.display());
     }
     let response = client.get(url).send().await?;
     if !response.status().is_success() {


### PR DESCRIPTION
Loading a model whose files are already on disk logged this:

```
provisioning s1-mini-q4_k_m: 2 files into .../app.super-stt.s1-mini
Already present: .../s1-mini-q4_k_m.gguf
Downloading file 1/2: s1-mini-q4_k_m.gguf
Already present: .../tokenizer.json
Downloading file 2/2: tokenizer.json
```

Nothing was downloaded — `download_one` short-circuits on a usable existing file — but the log said otherwise, which reads like the daemon re-fetches 484 MB of weights on every start.

The cause: a cached file still goes through the tracker so the progress bar advances past it rather than freezing, and `start_file` logged `Downloading file N/M` unconditionally.

- `start_file` is now a plain state update; it no longer logs, since only the caller knows whether a fetch actually happened.
- The two branches in `download_one` log for themselves: `File 1/2 already present, skipping download: <path>` on a cache hit, `Downloading file 1/2: <url> -> <path>` on a real fetch.
- The file counter is preserved in both, and the tracker-less path (unit tests, one-off calls) keeps its existing messages.

No behavior change — only what gets printed.

## Testing

`just fmt-check`, `just check`, and `just test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXZDCGoAUBrn9rwMJFZDEy
