### PR TITLE
Give the app an id D-Bus can serve, so it stops exiting at launch

### DIFF
--- a/super-stt-app/resources/super-stt-app.desktop
+++ b/super-stt-app/resources/super-stt-app.desktop
@@ -6,6 +6,9 @@ Icon=super-stt-app
 Exec=super-stt-app
 Terminal=false
 StartupNotify=true
+# Must match AppModel::APP_ID: the window announces that as its
+# Wayland app_id, and it differs from this file's name.
+StartupWMClass=ai.menjivar.SuperSTT
 Categories=AudioVideo;Audio;
 Keywords=speech;transcription;stt;voice;audio;speech-to-text;
 MimeType=

--- a/super-stt-app/resources/super-stt-app.metainfo.xml
+++ b/super-stt-app/resources/super-stt-app.metainfo.xml
@@ -1,18 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>ai.menjivar.super-stt-app</id>
+  <id>ai.menjivar.SuperSTT</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3</project_license>
-  <name>Super Stt App</name>
-  <summary>An application for the COSMIC™ desktop</summary>
+  <name>Super STT</name>
+  <summary>High-performance speech-to-text application</summary>
+  <description>
+    <p>
+      Super STT types what you say into whatever app is focused. Bind a
+      shortcut, speak, and the text appears where you are working.
+    </p>
+    <p>
+      A background daemon installs speech models from a library of local
+      and cloud backends and keeps one loaded, so transcription starts
+      right away. This app is where you pick a backend, load a model, and
+      configure the daemon.
+    </p>
+  </description>
+  <developer id="ai.menjivar">
+    <name>Jorge Menjivar</name>
+  </developer>
   <icon type="stock">super-stt-app</icon>
+  <url type="homepage">https://github.com/jorge-menjivar/super-stt</url>
   <url type="vcs-browser">https://github.com/jorge-menjivar/super-stt</url>
   <launchable type="desktop-id">super-stt-app.desktop</launchable>
   <provides>
-    <id>ai.menjivar.super-stt-app</id>
-    <binaries>
-      <binary>super-stt-app</binary>
-    </binaries>
+    <binary>super-stt-app</binary>
   </provides>
   <requires>
     <display_length compare="ge">360</display_length>

--- a/super-stt-app/src/core/app/mod.rs
+++ b/super-stt-app/src/core/app/mod.rs
@@ -237,7 +237,17 @@ impl cosmic::Application for AppModel {
     type Message = Message;
 
     /// Unique identifier in RDNN (reverse domain name notation) format.
-    const APP_ID: &'static str = "ai.menjivar.super-stt-app";
+    ///
+    /// Keep it free of hyphens. `run_single_instance` derives the D-Bus
+    /// object path from this id by swapping `.` for `/`, and D-Bus path
+    /// elements only accept `[A-Za-z0-9_]`. A hyphen makes serving the
+    /// activation interface fail, and libcosmic answers that failure by
+    /// exiting the process with status 1 before the window ever opens.
+    ///
+    /// It is also the window's Wayland `app_id`, so `StartupWMClass` in
+    /// `resources/super-stt-app.desktop` has to be kept equal to it for the
+    /// window to match its desktop entry.
+    const APP_ID: &'static str = "ai.menjivar.SuperSTT";
 
     fn core(&self) -> &cosmic::Core {
         &self.core


### PR DESCRIPTION
`just run-app` has been dying on startup since #424: the window never
opened, and the run ended with nothing but the last INFO line and exit
code 1.

## Why

That PR moved the app onto `run_single_instance`, which derives a D-Bus
object path from `APP_ID` by swapping `.` for `/` and nothing else. Our
id is `ai.menjivar.super-stt-app`, so the path came out as
`/ai/menjivar/super-stt-app` — not a valid object path, since path
elements only accept `[A-Za-z0-9_]`. `busctl introspect` on it answers
"Invalid argument".

Serving the activation interface therefore failed, and libcosmic answers
that failure with a bare `std::process::exit(1)`. That is why there was
nothing to read: no panic, no `Error:` line, and the single clue
(`Failed to serve dbus`) logged by `cosmic`, which our `RUST_LOG` filter
was hiding.

## How

`APP_ID` is now `ai.menjivar.SuperSTT`, hyphen-free, spelled the way the
daemon already spells `com.github.jorge_menjivar.SuperSTT`. The const
carries a comment on why hyphens can't come back.

Two things follow from the id:

- **Window matching.** The id is also the window's Wayland app_id, which
  has never matched `super-stt-app.desktop`, leaving the window without
  its entry. The entry now carries `StartupWMClass=ai.menjivar.SuperSTT`,
  which is the mechanism for exactly this case.
- **Metainfo.** The AppStream component id follows, with `launchable`
  keeping it tied to the desktop entry. The file was also failing
  validation on COSMIC-template leftovers, independently of the id: a
  missing `description` (an error), the name "Super Stt App", a summary
  describing a generic COSMIC application, a `provides` block claiming
  its own id, and a `binaries` wrapper that isn't a provides type. Fixed
  in the second commit, with copy taken from the desktop entry and the
  README.

## Testing

The failure and the fix were both checked against a running app:

- Before: exit 1 at startup; with `COSMIC_SINGLE_INSTANCE=false` the app
  came up fine, isolating the single-instance path.
- After: the app stays up and owns `ai.menjivar.SuperSTT` on the session
  bus, and a second launch exits 0 while the first reacts to the
  activation, so opening the app from the update notification does what
  #424 intended.
- `WAYLAND_DEBUG=1` shows the toplevel emitting
  `set_app_id("ai.menjivar.SuperSTT")`, matching the new
  `StartupWMClass`.

`just fmt-check` and `just check` pass. `desktop-file-validate` passes,
and `appstreamcli validate` now passes clean where it previously failed.

Neither file is validated in CI today, so this class of rot goes
unnoticed; adding both validators to a workflow is a small follow-up if
it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRcSsgjTnFPZJzyuizBMX7
