### PR TITLE
Fix installing a backend from a repository URL

### DIFF
--- a/docs/protocol/endpoints/v1/registry/install.md
+++ b/docs/protocol/endpoints/v1/registry/install.md
@@ -35,10 +35,22 @@ registry entry without a `manifest` pin is not installable.
 
 **Custom-repo install:**
 ```json
-{ "repo_url": "github.com/your-name/your-backend", "forge": "github" }
+{ "repo_url": "github.com/your-name/your-backend" }
 ```
 
-The daemon queries the declared forge's API for the repo's latest release,
+`forge` names which forge API to speak and is optional: when it is absent the
+daemon reads the host out of `repo_url` and picks the adapter serving it
+(`github.com` -> `github`). A host no adapter serves is a `400
+unsupported_forge`, never a guess — the GitHub adapter addresses a repo by
+owner and name alone, so guessing it for another host would query
+`api.github.com` for that owner/repo. Send `forge` explicitly to reach a host
+outside that map, such as a GitHub Enterprise install behind `GITHUB_API_BASE`:
+
+```json
+{ "repo_url": "github.mycorp.example/your-name/your-backend", "forge": "github" }
+```
+
+The daemon queries that forge's API for the repo's latest release,
 downloads its `backend.toml` release asset, runs the same selection algorithm
 over the declared binary assets, and installs the manifest verbatim. **The
 manifest and assets are not hash-verified against any registry** — TLS to the
@@ -182,7 +194,7 @@ Typed `error` values:
 
 | Status | Cause |
 |---|---|
-| `400` | Body has zero or more than one of `source` / `repo_url` / `local_path`. Body: `{"error":"bad_request"}`. For Custom-repo, `repo_url` not a `<host>/<owner>/<repo>` reference: `{"error":"bad_repo_url"}`. Custom-repo `forge` missing: `{"error":"bad_request"}` (an unrecognized `forge` value is rejected earlier as a malformed body). For Import-from-dir, `local_path` not an absolute path: `{"error":"bad_local_path"}`. |
+| `400` | Body has zero or more than one of `source` / `repo_url` / `local_path`. Body: `{"error":"bad_request"}`. For Custom-repo, `repo_url` not a `<host>/<owner>/<repo>` reference: `{"error":"bad_repo_url"}`; no forge adapter serves the host in `repo_url` and no `forge` was sent to pick one: `{"error":"unsupported_forge"}` (an unrecognized `forge` value is rejected earlier as a malformed body). For Import-from-dir, `local_path` not an absolute path: `{"error":"bad_local_path"}`. |
 | `404` | `source` not in the cached or refreshed index, or Custom-repo repo/release/`backend.toml` not found at the forge: `{"error":"not_found"}`. For Import-from-dir, `<local_path>`, its `backend.toml`, or the file `[backend].entrypoint` names does not exist: `{"error":"not_found"}`. |
 | `409` | An install for this `source` is already in flight. Body: `{"error":"install_in_progress"}`. |
 | `422` | No compatible asset on this host: `{"error":"incompatible"}`. For Custom-repo, `backend.toml` invalid: `{"error":"manifest_invalid"}` or `{"error":"manifest_too_large"}`; a declared asset is missing from the release: `{"error":"asset_missing"}`; the manifest's `source` is not the repo it was fetched from or namespaced under it (identity spoofing): `{"error":"source_mismatch"}`. For Import-from-dir, `<local_path>/backend.toml` failed to parse or yields an unsafe install id: `{"error":"manifest_invalid"}`. |

--- a/super-stt-app/src/ui/views/models/add_sheet.rs
+++ b/super-stt-app/src/ui/views/models/add_sheet.rs
@@ -20,15 +20,54 @@ pub fn add_backend_sheet(app: &AppModel) -> Element<'_, Message> {
     let muted = muted_text_color();
 
     // From a repository: URL input + Install, with the unverified-source note.
-    let can_install = !app.registry.custom_repo_input.trim().is_empty();
-    let install_btn = if can_install {
-        button::suggested("Install").on_press(Message::ModelsPage(
-            ModelsPageMessage::InstallBackendFromRepoUrl(app.registry.custom_repo_input.clone()),
-        ))
+    //
+    // A custom-repo install is tracked under the string that was sent, which on
+    // this path is exactly the text in the box — every other install is keyed
+    // by a registry `source` and draws its state on a Browse card. So without
+    // these two lookups the drawer showed nothing at all: a rejected install
+    // reached only the log, which is where the reporter of issue #423 had to go
+    // to find out why the button did nothing.
+    let url = app.registry.custom_repo_input.as_str();
+    let in_flight = app.registry.installs.get(url);
+    let start_error = app.registry.install_errors.get(url);
+
+    let install_btn: Element<'_, Message> = if let Some(s) = in_flight {
+        let label = match &s.error {
+            Some(_) => "Failed".to_string(),
+            None => format!(
+                "Installing\u{2026} ({})",
+                super::download::phase_label(s.phase)
+            ),
+        };
+        button::standard(label).into()
+    } else if url.trim().is_empty() {
+        button::suggested("Install").into()
     } else {
         button::suggested("Install")
+            .on_press(Message::ModelsPage(
+                ModelsPageMessage::InstallBackendFromRepoUrl(url.to_string()),
+            ))
+            .into()
     };
-    let repo_section = column![
+
+    // Same vocabulary as the Browse card: "Failed to start" for a request the
+    // daemon rejected outright, "Failed" for one that died mid-install.
+    let (failure, progress): (Option<String>, Option<String>) = if let Some(s) = in_flight {
+        match (&s.error, s.bytes_total) {
+            (Some(err), _) => (Some(format!("Failed: {err}")), None),
+            (None, Some(total)) if total > 0 => {
+                (None, Some(format!("{}%", (s.bytes_done * 100) / total)))
+            }
+            _ => (None, None),
+        }
+    } else {
+        (
+            start_error.map(|err| format!("Failed to start: {err}")),
+            None,
+        )
+    };
+
+    let mut repo_section = column![
         text::title4("From a repository"),
         text::body(
             "Paste a Git repository URL. Super STT resolves the latest release, \
@@ -36,12 +75,11 @@ pub fn add_backend_sheet(app: &AppModel) -> Element<'_, Message> {
         )
         .class(cosmic::theme::Text::Color(muted)),
         row![
-            widget::text_input(
-                "https://github.com/owner/backend",
-                &app.registry.custom_repo_input
-            )
-            .on_input(|x| Message::ModelsPage(ModelsPageMessage::RegistryCustomRepoInputChanged(x)))
-            .width(Length::Fill),
+            widget::text_input("https://github.com/owner/backend", url)
+                .on_input(|x| Message::ModelsPage(
+                    ModelsPageMessage::RegistryCustomRepoInputChanged(x)
+                ))
+                .width(Length::Fill),
             install_btn,
         ]
         .spacing(spacing.space_xs)
@@ -52,12 +90,28 @@ pub fn add_backend_sheet(app: &AppModel) -> Element<'_, Message> {
         ]
         .spacing(spacing.space_xs)
         .align_y(Alignment::Center),
-    ]
-    .spacing(spacing.space_s)
-    .apply(widget::container)
-    .class(cosmic::theme::Container::List)
-    .padding(spacing.space_m)
-    .width(Length::Fill);
+    ];
+
+    if let Some(msg) = failure {
+        repo_section = repo_section.push(
+            row![
+                icons::phosphor_destructive(icons::WARNING, 15.0),
+                text::caption(msg),
+            ]
+            .spacing(spacing.space_xs)
+            .align_y(Alignment::Center),
+        );
+    } else if let Some(pct) = progress {
+        repo_section =
+            repo_section.push(text::caption(pct).class(cosmic::theme::Text::Color(muted)));
+    }
+
+    let repo_section = repo_section
+        .spacing(spacing.space_s)
+        .apply(widget::container)
+        .class(cosmic::theme::Container::List)
+        .padding(spacing.space_m)
+        .width(Length::Fill);
 
     // From a folder: import a local backend directory.
     let dir_section = column![

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -39,6 +39,7 @@ fn custom_repo_error_response(
             (StatusCode::UNPROCESSABLE_ENTITY, "manifest_invalid")
         }
         ResolveError::SourceSpoof { .. } => (StatusCode::UNPROCESSABLE_ENTITY, "source_mismatch"),
+        ResolveError::NoRelease { .. } => (StatusCode::NOT_FOUND, "not_found"),
         ResolveError::AssetMissing(_) => (StatusCode::UNPROCESSABLE_ENTITY, "asset_missing"),
         ResolveError::Forge(err) => {
             // 404 from the forge means the repo, release, or backend.toml at the

--- a/super-stt-daemon/src/daemon/http/v1/registry/install.rs
+++ b/super-stt-daemon/src/daemon/http/v1/registry/install.rs
@@ -7,6 +7,7 @@ use axum::response::IntoResponse;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use super_stt_registry_types::forge::Forge;
 use super_stt_shared::registry::{InstallAccepted, InstallRequest};
 
 use super::pipeline::{InflightMarker, spawn_install_pipeline};
@@ -17,7 +18,7 @@ pub(crate) struct InstallBody {
     pub(crate) source: Option<String>,
     pub(crate) repo_url: Option<String>,
     pub(crate) local_path: Option<String>,
-    pub(crate) forge: Option<super_stt_registry_types::forge::Forge>,
+    pub(crate) forge: Option<Forge>,
 }
 
 /// Map a [`custom_repo::ResolveError`] to a synchronous HTTP status + body
@@ -138,6 +139,52 @@ fn acquire_install_inflight(s: &AppState, source_key: &str) -> Result<InflightMa
     )
 }
 
+/// The forge to query for a Custom-repo install: whichever one the client
+/// declared, else the one serving the host in `repo_url`.
+///
+/// A pasted repository URL already names its host, and the Add-a-backend sheet
+/// has no second thing to ask the operator for, so requiring `forge` alongside
+/// it made that install path unusable from the app rather than safer. Falling
+/// back to a *forge* would be the unsafe move — the GitHub adapter ignores
+/// `RepoRef::host` and would query `api.github.com` for a GitLab URL's
+/// owner/repo — so an unserved host is a hard error here, and declaring `forge`
+/// stays the way to reach one (GitHub Enterprise via `GITHUB_API_BASE`).
+/// `registry.toml` entries are unaffected: an entry author still declares
+/// `forge`, and the indexer never infers it.
+///
+/// # Errors
+/// The same `(status, error token)` pair the other resolve helpers produce,
+/// plus the message to put beside it: `bad_repo_url` when `repo_url` is not a
+/// `<host>/<owner>/<repo>` reference, `unsupported_forge` when no adapter
+/// serves its host.
+fn install_forge(
+    declared: Option<Forge>,
+    repo_url: &str,
+) -> Result<Forge, (StatusCode, &'static str, String)> {
+    if let Some(forge) = declared {
+        return Ok(forge);
+    }
+    // Parsed here only to read the host; `custom_repo::resolve` parses again
+    // for its own use. The failure routes through the same mapping it would
+    // have, so a malformed URL answers identically whether or not `forge` was
+    // declared.
+    let repo = super_stt_forge::RepoRef::parse(repo_url).map_err(|_| {
+        let e = crate::registry::custom_repo::ResolveError::BadRepoUrl(repo_url.to_owned());
+        let (status, error) = custom_repo_error_response(&e);
+        (status, error, e.to_string())
+    })?;
+    super_stt_forge::forge_for_host(&repo.host).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "unsupported_forge",
+            format!(
+                "no forge adapter serves `{}`; declare `forge` to pick one",
+                repo.host
+            ),
+        )
+    })
+}
+
 /// Phase 3 — Resolve the registry entry from whichever of
 /// `source` / `repo_url` / `local_path` was supplied.
 ///
@@ -162,13 +209,9 @@ async fn resolve_install_entry(
         };
         Ok(found)
     } else if let Some(ref repo_url) = body.repo_url {
-        let Some(forge) = body.forge else {
-            return Err(Box::new(super::registry_error_msg(
-                StatusCode::BAD_REQUEST,
-                "bad_request",
-                "custom-repo install requires `forge`",
-            )));
-        };
+        let forge = install_forge(body.forge, repo_url).map_err(|(status, error, msg)| {
+            Box::new(super::registry_error_msg(status, error, &msg))
+        })?;
         let client = super_stt_forge::client(forge);
         match crate::registry::custom_repo::resolve(client.as_ref(), repo_url).await {
             Ok(entry) => Ok(entry),
@@ -273,7 +316,7 @@ Installing neither selects the backend nor loads a model \u{2014} do that throug
     security(("session_token" = ["settings"])),
     responses(
         (status = 202, description = "Accepted; the download runs in the background.", body = InstallAccepted),
-        (status = 400, description = "Not exactly one of `source`, `repo_url`, `local_path` (`bad_request`), or no asset matches this host.", body = RegistryError),
+        (status = 400, description = "Not exactly one of `source`, `repo_url`, `local_path` (`bad_request`), a `repo_url` that is not a `<host>/<owner>/<repo>` reference (`bad_repo_url`), a `repo_url` on a host no forge adapter serves and no `forge` to pick one (`unsupported_forge`), or no asset matches this host.", body = RegistryError),
         (status = 404, description = "No catalog entry for that `source` (`not_found`).", body = RegistryError),
         (status = 409, description = "An install for this backend is already in flight, or a recording is running (`backend_busy`).", body = RegistryError),
         (status = 401, description = "Token unknown, expired, or its binary changed.", body = ReasonEnvelope),
@@ -352,4 +395,55 @@ pub(crate) async fn install_registry_backend(
         serde_json::to_string(&resp_body).unwrap_or_default(),
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Forge, install_forge};
+    use axum::http::StatusCode;
+
+    /// The regression this helper exists for: the Add-a-backend sheet posts a
+    /// pasted `repo_url` and nothing else, and requiring `forge` beside it made
+    /// every such install answer `400` without reaching the forge at all.
+    #[test]
+    fn a_pasted_github_url_needs_no_declared_forge() {
+        for url in [
+            "https://github.com/owner/backend",
+            "github.com/owner/backend",
+            "https://github.com/owner/backend.git",
+            "https://GitHub.com/owner/backend/",
+        ] {
+            assert_eq!(install_forge(None, url).ok(), Some(Forge::Github), "{url}");
+        }
+    }
+
+    /// The escape hatch for a host the map does not know: a GitHub Enterprise
+    /// server, reached by pointing `GITHUB_API_BASE` at its API.
+    #[test]
+    fn a_declared_forge_wins_over_the_host() {
+        assert_eq!(
+            install_forge(Some(Forge::Github), "github.mycorp.example/owner/backend").ok(),
+            Some(Forge::Github)
+        );
+    }
+
+    /// Guessing GitHub here would not fail loudly: the adapter addresses a repo
+    /// by owner and name alone, so it would fetch a *different* project of the
+    /// same name from api.github.com and install it.
+    #[test]
+    fn an_unserved_host_is_rejected_rather_than_guessed() {
+        let (status, error, _) = install_forge(None, "https://gitlab.com/owner/backend")
+            .expect_err("no adapter serves gitlab.com");
+        assert_eq!(
+            (status, error),
+            (StatusCode::BAD_REQUEST, "unsupported_forge")
+        );
+    }
+
+    #[test]
+    fn a_malformed_repo_url_answers_bad_repo_url() {
+        let (status, error, _) =
+            install_forge(None, "owner/backend").expect_err("not <host>/<owner>/<repo>");
+        assert_eq!((status, error), (StatusCode::BAD_REQUEST, "bad_repo_url"));
+    }
 }

--- a/super-stt-daemon/src/registry/custom_repo.rs
+++ b/super-stt-daemon/src/registry/custom_repo.rs
@@ -26,6 +26,10 @@ pub enum ResolveError {
     BadRepoUrl(String),
     #[error("forge: {0}")]
     Forge(#[from] super_stt_forge::ForgeError),
+    #[error(
+        "no published release at `{repo}`. The repo may be private, missing, or have no release yet; a fork does not inherit the upstream's releases"
+    )]
+    NoRelease { repo: String },
     #[error("backend.toml exceeds {MAX_MANIFEST_BYTES} bytes")]
     ManifestTooLarge,
     #[error("backend.toml is not valid UTF-8: {0}")]
@@ -58,7 +62,19 @@ pub async fn resolve(
     repo_url: &str,
 ) -> Result<IndexBackend, ResolveError> {
     let repo = RepoRef::parse(repo_url).map_err(|_| ResolveError::BadRepoUrl(repo_url.into()))?;
-    let release = client.latest_release(&repo).await?;
+    // A 404 here is the ordinary case, not a forge outage: the repo has no
+    // published release yet, or is private, or does not exist. Left as a
+    // transport error it reaches the operator as a raw `api.github.com` URL,
+    // which names nothing they typed and nothing they can act on.
+    let release = client.latest_release(&repo).await.map_err(|e| {
+        if e.http_status() == Some(reqwest::StatusCode::NOT_FOUND) {
+            ResolveError::NoRelease {
+                repo: repo.canonical(),
+            }
+        } else {
+            ResolveError::Forge(e)
+        }
+    })?;
 
     // The manifest is the `backend.toml` release asset — the exact bytes the
     // daemon installs verbatim. Read and validate those, and pin the asset
@@ -242,6 +258,37 @@ mod tests {
         // Prefix-only overlap must not pass (requires a `/` boundary).
         let err = ensure_source_matches_repo("github.com/a/bbb", &repo).unwrap_err();
         assert!(matches!(err, ResolveError::SourceSpoof { .. }));
+    }
+
+    /// A repo with no published release — a fork, most often, since GitHub
+    /// gives a fork none of the upstream's. The forge answers `404`, and left
+    /// as a transport error that reached the operator as
+    /// `…(https://api.github.com/repos/o/b/releases/latest) (HTTP 404)`, which
+    /// names neither what they pasted nor anything to do about it.
+    #[tokio::test]
+    async fn a_repo_with_no_published_release_names_the_repo_not_the_api_url() {
+        super_stt_forge::install_crypto_provider();
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/repos/o/b/releases/latest")
+            .with_status(404)
+            .create_async()
+            .await;
+        let gh = super_stt_forge::Github::new(server.url(), None);
+
+        let err = resolve(&gh, "https://github.com/o/b")
+            .await
+            .expect_err("no release to install");
+
+        let ResolveError::NoRelease { ref repo } = err else {
+            panic!("a 404 on the latest release must not stay a transport error: {err}");
+        };
+        assert_eq!(repo, "github.com/o/b");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("api.github.com"),
+            "the message must not leak the forge API URL: {msg}"
+        );
     }
 
     #[test]

--- a/super-stt-forge/src/lib.rs
+++ b/super-stt-forge/src/lib.rs
@@ -160,6 +160,23 @@ pub fn client(forge: Forge) -> Box<dyn ForgeClient> {
     }
 }
 
+/// The forge serving `host`, for a caller resolving a repository URL a person
+/// pasted rather than reading a declared `forge` — the Custom-repo install
+/// path, where the URL already names its host and there is nothing else for a
+/// client to restate. Matched case-insensitively.
+///
+/// This is a lookup, not a default: a host no adapter serves returns `None`
+/// and the caller must fail rather than guess. Declaring `forge` explicitly
+/// stays the way to reach a host that is not in this map — a GitHub Enterprise
+/// install, say, whose API base comes from `GITHUB_API_BASE`.
+#[must_use]
+pub fn forge_for_host(host: &str) -> Option<Forge> {
+    match host.trim().to_ascii_lowercase().as_str() {
+        "github.com" => Some(Forge::Github),
+        _ => None,
+    }
+}
+
 /// Whether an operator-provided API base URL may be used: `https://`, or a
 /// loopback `http://` for local testing. Anything else is rejected so adapters
 /// fall back to their secure default. Shared with the daemon's registry client
@@ -187,6 +204,28 @@ mod base_url_tests {
         assert!(!accept_base_url("http://evil.example.com"));
         assert!(!accept_base_url("ftp://x"));
         assert!(!accept_base_url("https://"));
+    }
+}
+
+#[cfg(test)]
+mod forge_for_host_tests {
+    use super::forge_for_host;
+    use super_stt_registry_types::forge::Forge;
+
+    #[test]
+    fn maps_known_hosts_case_insensitively() {
+        assert_eq!(forge_for_host("github.com"), Some(Forge::Github));
+        assert_eq!(forge_for_host("GitHub.com"), Some(Forge::Github));
+        assert_eq!(forge_for_host("  github.com  "), Some(Forge::Github));
+    }
+
+    #[test]
+    fn an_unserved_host_is_none_not_a_fallback() {
+        // A GitLab URL must not resolve to the GitHub adapter, which ignores
+        // `RepoRef::host` and would query api.github.com for that owner/repo.
+        for host in ["gitlab.com", "codeberg.org", "github.mycorp.com", ""] {
+            assert_eq!(forge_for_host(host), None, "{host}");
+        }
     }
 }
 

--- a/super-stt-registry-types/src/forge.rs
+++ b/super-stt-registry-types/src/forge.rs
@@ -5,12 +5,19 @@
 //! unrecognized value is a hard parse error, never a silent fallback. Today
 //! only GitHub is implemented; new forges are added as enum variants paired
 //! with an adapter in the `super-stt-forge` crate.
+//!
+//! A Custom-repo install is the one place a forge is not declared by an entry
+//! author: the operator pastes a repository URL, so the daemon looks the forge
+//! up from that URL's host via `super_stt_forge::forge_for_host`. That is a
+//! lookup over the hosts adapters actually serve, not a default — an unserved
+//! host still fails, and an explicit `forge` still wins.
 
 use serde::{Deserialize, Serialize};
 
 /// The forge hosting a backend's releases.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum Forge {
     /// GitHub (`api.github.com`, or a GitHub Enterprise base via

--- a/super-stt-shared/src/registry/mod.rs
+++ b/super-stt-shared/src/registry/mod.rs
@@ -122,9 +122,20 @@ pub use super_stt_registry_types::index::IndexStale;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InstallRequest {
-    BySource { source: String },
-    ByRepoUrl { repo_url: String },
-    ByLocalPath { local_path: String },
+    BySource {
+        source: String,
+    },
+    ByRepoUrl {
+        repo_url: String,
+        /// Which forge API to speak. Optional: the daemon reads the host out
+        /// of `repo_url` when it is absent, and only a host no adapter serves
+        /// needs it spelled out.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forge: Option<super_stt_registry_types::forge::Forge>,
+    },
+    ByLocalPath {
+        local_path: String,
+    },
 }
 
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]


### PR DESCRIPTION
Fixes #423.

## The bug

The Add-a-backend drawer posts a pasted `repo_url` and nothing else, but
[#235](https://github.com/jorge-menjivar/super-stt/pull/235) made
`POST /registry/backend/install` reject that body without a `forge` beside it.
Its design spec planned for "the app's custom-repo UI is updated to send it
(defaulting the selector to GitHub)" — that step never landed, so every
custom-repo install has answered `400 custom-repo install requires \`forge\``
since v0.2.0-beta.1, without reaching the forge at all.

`InstallRequest::ByRepoUrl` never carried the field either, so the published
OpenAPI contract had been advertising a body the daemon rejected.

## The fix

**Read the forge off the repo URL.** A pasted URL already names its host, and
the drawer has no second thing to ask the operator for. An explicit `forge`
still wins, and a host no adapter serves is a hard `400 unsupported_forge`
rather than a guess — the GitHub adapter addresses a repo by owner and name
alone, so defaulting it for a `gitlab.com` URL would fetch a same-named project
off `api.github.com` and install that. `registry.toml` is untouched: an entry
author still declares `forge`, and the indexer never infers it.

Two follow-ups, because reaching the forge exposed how little the failures say.
The reporter's URL is a fork with zero releases (GitHub gives a fork none of the
upstream's), and finding that out meant reading a raw REST URL out of a log:

**Name the repo, not the API URL.** A forge 404 on `latest_release` becomes a
typed `NoRelease`, so the message reads *"no published release at
`github.com/owner/repo`. The repo may be private, missing, or have no release
yet; a fork does not inherit the upstream's releases"* instead of
`…(https://api.github.com/repos/owner/repo/releases/latest) (HTTP 404)`. Still
`404 not_found` on the wire.

**Show install state in the drawer.** A custom-repo install is tracked under the
string that was sent — here, the pasted URL. Every other install is keyed by a
registry `source` and draws its state on a Browse card, so this one drew
nowhere. The button now reads "Installing… (downloading)" and a failure lands
under the input, in the Browse card's wording.

## Protocol change

`forge` goes from required to optional on the custom-repo body, and `400`
gains an `unsupported_forge` token. Both are documented in
`docs/protocol/endpoints/v1/registry/install.md`, and `InstallRequest` now
carries the field so the generated OpenAPI document describes it.

This lands daemon-side, so an existing app binary starts working as soon as the
daemon updates.

## Testing

`just ci` passes. Seven new tests: four on the forge resolution (a pasted GitHub
URL needs no `forge`, a declared one wins, `gitlab.com` is rejected rather than
guessed, a malformed URL still answers `bad_repo_url`), two on the host lookup,
and one asserting a release-less repo names the repo and never leaks
`api.github.com`. Each commit compiles on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND4AMqJMdoBSVnghSCc6ox
