### PR TITLE
Attribute the Phosphor icons this repo redistributes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,6 +33,18 @@ Copyright (c) System76, Inc.
 Licensed under the Mozilla Public License 2.0
 Source: https://github.com/pop-os/libcosmic
 
+Phosphor Icons
+--------------
+Copyright (c) 2023 Phosphor Icons
+Licensed under the MIT License
+Source: https://github.com/phosphor-icons/core
+
+Unlike the entries above, these are redistributed in this repository rather
+than fetched at build time: the nineteen SVGs under
+super-stt-app/resources/icons/phosphor/ are copied verbatim from that project's
+raw/regular/ directory and embedded in the settings app. The MIT license text
+they are provided under sits beside them in that directory.
+
 Rust Ecosystem Libraries
 ------------------------
 This project uses various Rust crates from the ecosystem, each with their own

--- a/super-stt-app/resources/icons/phosphor/LICENSE
+++ b/super-stt-app/resources/icons/phosphor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Phosphor Icons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The nineteen SVGs under `super-stt-app/resources/icons/phosphor/` are Phosphor Icons, copied verbatim from that project's `raw/regular/` directory and embedded in the settings app with `include_bytes!`. They are MIT, which asks that the copyright and permission notice travel with the copies. Neither `NOTICE` nor the icons directory mentioned Phosphor at all.

## What changed

1. **`NOTICE`** gains a Phosphor Icons entry beside the Candle and libcosmic ones — copyright, license, source URL. It also records something those entries don't need to: these files are redistributed from this repository rather than fetched at build time.
2. **`super-stt-app/resources/icons/phosphor/LICENSE`** — the upstream MIT text, fetched verbatim, placed with the files it covers.

The second file is the part that actually discharges the obligation. A dependency's license can be left in the dependency; these bytes ship from here, so the notice has to ship with them. A `NOTICE` line on its own would name the requirement without meeting it.

No code changes — the only consumer of that directory is `include_bytes!` on specific named `.svg` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND4AMqJMdoBSVnghSCc6ox