### PR TITLE
Show the transcribing animation whichever way the event race falls

### DIFF
--- a/docs/protocol/endpoints/v1/events.md
+++ b/docs/protocol/endpoints/v1/events.md
@@ -86,6 +86,14 @@ For one daemon-mic capture the lifecycle events fire in this order:
 the visualization signal drops at mic-stop, independent of the transcription
 that follows.
 
+That is the order the daemon *publishes* them in. Each topic of a subscription
+is forwarded on its own task, so two events from different topics can still
+reach the client in either order — notably
+`recording_state{is_recording:false}` and `transcribing_started`, which are
+published microseconds apart. Fold lifecycle events into your state without
+assuming their relative arrival order: treat a mic-stop as "capture ended", not
+as "the cycle is over", and return to idle only on `transcribing_stopped`.
+
 **Lifecycle terminal and optional events:**
 - `transcribing_started` is emitted only when model decode actually begins
   (Phase 4). It is skipped entirely when the cycle fails during audio capture,

--- a/super-stt-cosmic-applet/src/app/init.rs
+++ b/super-stt-cosmic-applet/src/app/init.rs
@@ -9,7 +9,7 @@ use super::SuperSttApplet;
 use crate::app::Message;
 use crate::config::AppletConfig;
 use crate::daemon::{RetryStrategy, ping_daemon};
-use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
+use crate::models::state::{DaemonConnectionState, IsOpen, RecordingPhase};
 use crate::models::theme::{IconAlignment, VisualizationSide};
 use crate::ui::components::sound_visualization::VisualizationComponent;
 use crate::ui::components::working_animation_component::WorkingAnimationComponent;
@@ -80,7 +80,7 @@ impl SuperSttApplet {
 
         let applet = Self {
             core,
-            recording_state: RecordingState::Idle,
+            phase: RecordingPhase::default(),
             daemon_state: DaemonConnectionState::Connecting,
             popup: None,
             socket_path: get_http_socket_path(),
@@ -90,7 +90,6 @@ impl SuperSttApplet {
             udp_restart_counter: 0,
             visualization,
             working_animation,
-            working_anim_start: None,
             config,
             icon_alignment_model,
             icon_alignment_start,

--- a/super-stt-cosmic-applet/src/app/mod.rs
+++ b/super-stt-cosmic-applet/src/app/mod.rs
@@ -6,10 +6,7 @@ mod subscription;
 mod update;
 mod view;
 
-use std::{
-    path::PathBuf,
-    time::{Duration, Instant},
-};
+use std::{path::PathBuf, time::Duration};
 
 use cosmic::{
     Element, app as cosmic_app,
@@ -21,7 +18,7 @@ pub use messages::*;
 
 use crate::config::AppletConfig;
 use crate::daemon::RetryStrategy;
-use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
+use crate::models::state::{DaemonConnectionState, IsOpen, RecordingPhase};
 use crate::models::theme::VisualizationSide;
 use crate::ui::components::sound_visualization::VisualizationComponent;
 use crate::ui::components::working_animation_component::WorkingAnimationComponent;
@@ -29,7 +26,9 @@ use subscription::{PING_INTERVAL_SECS, UdpSubscriptionId, applet_events_subscrip
 
 pub struct SuperSttApplet {
     core: cosmic::app::Core,
-    recording_state: RecordingState,
+    /// Which phase of a recording cycle the daemon is in, plus the clock
+    /// behind the transcribing animation.
+    phase: RecordingPhase,
     daemon_state: DaemonConnectionState,
     popup: Option<window::Id>,
     socket_path: PathBuf,
@@ -39,9 +38,6 @@ pub struct SuperSttApplet {
     udp_restart_counter: u64,
     visualization: VisualizationComponent,
     working_animation: WorkingAnimationComponent,
-    /// Wall-clock start of the current Processing phase; `Some` only while
-    /// transcribing, used to derive the animation's elapsed time.
-    working_anim_start: Option<Instant>,
     config: AppletConfig,
     icon_alignment_model: SingleSelectModel,
     icon_alignment_start: Entity,
@@ -94,9 +90,7 @@ impl cosmic::Application for SuperSttApplet {
             cosmic::iced::time::every(Duration::from_secs(PING_INTERVAL_SECS))
                 .map(|_| Message::PingTimeout),
         ];
-        if self.daemon_state == DaemonConnectionState::Connected
-            && matches!(self.recording_state, RecordingState::Processing)
-        {
+        if self.daemon_state == DaemonConnectionState::Connected && self.phase.is_transcribing() {
             subs.push(
                 cosmic::iced::time::every(Duration::from_millis(33))
                     .map(|_| Message::WorkingAnimationTick),

--- a/super-stt-cosmic-applet/src/app/update.rs
+++ b/super-stt-cosmic-applet/src/app/update.rs
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::time::Instant;
-
 use cosmic::{
     app as cosmic_app,
     iced::window,
@@ -13,7 +11,7 @@ use super::SuperSttApplet;
 use crate::app::Message;
 use crate::daemon::identity::APP_ID;
 use crate::daemon::{RetryStrategy, ping_daemon};
-use crate::models::state::{DaemonConnectionState, IsOpen, RecordingState};
+use crate::models::state::{CycleEvent, DaemonConnectionState, IsOpen};
 use crate::models::theme::{
     IconAlignment, VisualizationColor, VisualizationTheme, WorkingAnimationTheme,
 };
@@ -32,25 +30,17 @@ impl SuperSttApplet {
             Message::SetVisualizationTheme(theme) => self.set_visualization_theme(theme),
             Message::SetWorkingAnimation(theme) => self.set_working_animation(theme),
             Message::WidgetRecordingState(is_recording) => {
-                self.widget_recording_state(is_recording)
+                self.apply_cycle_event(CycleEvent::RecordingFlag(is_recording))
             }
             Message::WidgetFrequencyBands {
                 bands,
                 total_energy,
             } => self.widget_frequency_bands(&bands, total_energy),
             Message::WidgetTranscribingStarted => {
-                // Guard against out-of-order delivery: only enter Processing
-                // mid-cycle, never resurrect it after transcribing_stopped
-                // already returned us to Idle.
-                if !matches!(self.recording_state, RecordingState::Idle) {
-                    self.set_recording_state(RecordingState::Processing);
-                }
-                cosmic_app::Task::none()
+                self.apply_cycle_event(CycleEvent::TranscribingStarted)
             }
             Message::WidgetTranscribingStopped => {
-                self.set_recording_state(RecordingState::Idle);
-                self.visualization.clear();
-                cosmic_app::Task::none()
+                self.apply_cycle_event(CycleEvent::TranscribingStopped)
             }
             Message::WidgetRevoked(reason) => self.widget_revoked(&reason),
             Message::WidgetOtherEvent(_) | Message::WidgetSubscriptionError(_) => {
@@ -73,9 +63,8 @@ impl SuperSttApplet {
             }
             Message::SetColorThemeEntity(entity) => self.set_color_theme(entity),
             Message::WorkingAnimationTick => {
-                if let Some(start) = self.working_anim_start {
-                    self.working_animation
-                        .set_elapsed(start.elapsed().as_secs_f32() * 1000.0);
+                if let Some(elapsed_ms) = self.phase.animation_elapsed_ms() {
+                    self.working_animation.set_elapsed(elapsed_ms);
                 }
                 cosmic_app::Task::none()
             }
@@ -205,31 +194,16 @@ impl SuperSttApplet {
         cosmic_app::Task::none()
     }
 
-    /// Set the recording state, managing the working-animation clock: start it
-    /// when entering Processing, stop it otherwise. Centralizes the lifecycle
-    /// so every transition keeps the animation in sync.
-    fn set_recording_state(&mut self, new: RecordingState) {
-        if matches!(new, RecordingState::Processing) {
-            if self.working_anim_start.is_none() {
-                self.working_anim_start = Some(Instant::now());
-                self.working_animation.reset();
-            }
-        } else {
-            self.working_anim_start = None;
+    /// Fold one recording-cycle event into [`RecordingPhase`] and carry out
+    /// whatever it leaves for the drawing components. The transitions live in
+    /// the phase itself, which folds these events in without assuming the
+    /// order they arrive in.
+    fn apply_cycle_event(&mut self, event: CycleEvent) -> cosmic_app::Task<Message> {
+        let change = self.phase.apply(event);
+        if change.animation_restarted {
+            self.working_animation.reset();
         }
-        self.recording_state = new;
-    }
-
-    /// Handle a `recording_state` event. The transition itself lives in
-    /// [`RecordingState::with_recording_flag`], which folds the event in
-    /// without assuming it arrives before `transcribing_started`.
-    fn widget_recording_state(&mut self, is_recording: bool) -> cosmic_app::Task<Message> {
-        let mic_was_live = !matches!(self.recording_state, RecordingState::Idle);
-        let new_state = self.recording_state.with_recording_flag(is_recording);
-        self.set_recording_state(new_state);
-        if mic_was_live && !is_recording {
-            // Mic capture ended, so the live bars are stale whether or not
-            // `transcribing_started` already moved us to Processing.
+        if change.visualization_stale {
             self.visualization.clear();
         }
         cosmic_app::Task::none()

--- a/super-stt-cosmic-applet/src/app/update.rs
+++ b/super-stt-cosmic-applet/src/app/update.rs
@@ -220,20 +220,16 @@ impl SuperSttApplet {
         self.recording_state = new;
     }
 
+    /// Handle a `recording_state` event. The transition itself lives in
+    /// [`RecordingState::with_recording_flag`], which folds the event in
+    /// without assuming it arrives before `transcribing_started`.
     fn widget_recording_state(&mut self, is_recording: bool) -> cosmic_app::Task<Message> {
-        let was_recording = matches!(self.recording_state, RecordingState::Recording);
-        let new_state = if is_recording {
-            RecordingState::Recording
-        } else if was_recording {
-            // Just left Recording — show a brief Processing state while
-            // the daemon transcribes.
-            RecordingState::Processing
-        } else {
-            RecordingState::Idle
-        };
-
+        let mic_was_live = !matches!(self.recording_state, RecordingState::Idle);
+        let new_state = self.recording_state.with_recording_flag(is_recording);
         self.set_recording_state(new_state);
-        if was_recording && !is_recording {
+        if mic_was_live && !is_recording {
+            // Mic capture ended, so the live bars are stale whether or not
+            // `transcribing_started` already moved us to Processing.
             self.visualization.clear();
         }
         cosmic_app::Task::none()

--- a/super-stt-cosmic-applet/src/app/view.rs
+++ b/super-stt-cosmic-applet/src/app/view.rs
@@ -11,7 +11,7 @@ use cosmic::{
 use super::SuperSttApplet;
 use super::layout::AppletLayout;
 use crate::app::Message;
-use crate::models::state::{DaemonConnectionState, RecordingState};
+use crate::models::state::DaemonConnectionState;
 use crate::ui::views::{PopupContentParams, create_popup_content};
 
 // Cache icon bytes to avoid allocation on every render.
@@ -23,10 +23,9 @@ impl SuperSttApplet {
     pub(super) fn view_applet(&self) -> Element<'_, Message> {
         // Show visualizations only when the daemon is actively recording
         // and the user has visualizations enabled.
-        let should_show_visualizations = matches!(self.recording_state, RecordingState::Recording)
-            && self.config.ui.show_visualization;
-        let should_show_working = matches!(self.recording_state, RecordingState::Processing)
-            && self.config.ui.show_visualization;
+        let should_show_visualizations =
+            self.phase.is_recording() && self.config.ui.show_visualization;
+        let should_show_working = self.phase.is_transcribing() && self.config.ui.show_visualization;
 
         // One box for every state, so switching between the icon and the
         // visualizations never resizes the panel around us.

--- a/super-stt-cosmic-applet/src/models/state.rs
+++ b/super-stt-cosmic-applet/src/models/state.rs
@@ -1,9 +1,29 @@
 // SPDX-License-Identifier: GPL-3.0-only
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RecordingState {
     Idle,
     Recording,
     Processing,
+}
+
+impl RecordingState {
+    /// Fold a `recording_state` event into the current state.
+    ///
+    /// The daemon publishes `recording_state{is_recording:false}` and
+    /// `transcribing_started` on two different topics, and forwards every
+    /// topic of a subscription on its own task, so the two frames can reach
+    /// the applet in either order. When the transcribing frame wins that race
+    /// the applet is already `Processing`, and reading the mic stop as "not
+    /// recording, so idle" would cancel the transcribing animation for the
+    /// rest of the cycle. `Processing` therefore stays put here;
+    /// `transcribing_stopped` is the only event that returns us to `Idle`.
+    pub fn with_recording_flag(&self, is_recording: bool) -> Self {
+        match (self, is_recording) {
+            (_, true) => Self::Recording,
+            (Self::Recording | Self::Processing, false) => Self::Processing,
+            (Self::Idle, false) => Self::Idle,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,4 +45,50 @@ pub enum IsOpen {
     VisualizationTheme,
     WorkingAnimation,
     VisualizationColors,
+}
+
+#[cfg(test)]
+mod recording_state_tests {
+    use super::RecordingState;
+
+    #[test]
+    fn mic_start_always_enters_recording() {
+        for state in [
+            RecordingState::Idle,
+            RecordingState::Recording,
+            RecordingState::Processing,
+        ] {
+            assert_eq!(state.with_recording_flag(true), RecordingState::Recording);
+        }
+    }
+
+    #[test]
+    fn mic_stop_from_recording_enters_processing() {
+        assert_eq!(
+            RecordingState::Recording.with_recording_flag(false),
+            RecordingState::Processing,
+        );
+    }
+
+    #[test]
+    fn mic_stop_after_transcribing_started_stays_processing() {
+        // Regression guard: `transcribing_started` and
+        // `recording_state{is_recording:false}` race on the wire, and when the
+        // transcribing frame lands first this event used to knock the applet
+        // back to `Idle`, so the transcribing animation never appeared. Which
+        // way the race falls is per connection, so with two applets on the
+        // panel one side would animate and the other would not.
+        assert_eq!(
+            RecordingState::Processing.with_recording_flag(false),
+            RecordingState::Processing,
+        );
+    }
+
+    #[test]
+    fn mic_stop_while_idle_stays_idle() {
+        assert_eq!(
+            RecordingState::Idle.with_recording_flag(false),
+            RecordingState::Idle,
+        );
+    }
 }

--- a/super-stt-cosmic-applet/src/models/state.rs
+++ b/super-stt-cosmic-applet/src/models/state.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
-#[derive(Debug, Clone, PartialEq, Eq)]
+use std::time::Instant;
+
+/// Where the applet believes the daemon is in a recording cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordingState {
     Idle,
     Recording,
@@ -17,12 +20,125 @@ impl RecordingState {
     /// recording, so idle" would cancel the transcribing animation for the
     /// rest of the cycle. `Processing` therefore stays put here;
     /// `transcribing_stopped` is the only event that returns us to `Idle`.
-    pub fn with_recording_flag(&self, is_recording: bool) -> Self {
+    fn with_recording_flag(self, is_recording: bool) -> Self {
         match (self, is_recording) {
             (_, true) => Self::Recording,
             (Self::Recording | Self::Processing, false) => Self::Processing,
             (Self::Idle, false) => Self::Idle,
         }
+    }
+}
+
+/// One lifecycle event from the daemon's `/events` stream, as the applet's
+/// cycle state machine sees it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CycleEvent {
+    /// `recording_state` — mic capture started (`true`) or ended (`false`).
+    RecordingFlag(bool),
+    /// `transcribing_started` — model decode of the captured audio began.
+    TranscribingStarted,
+    /// `transcribing_stopped` — the cycle is over, success or failure.
+    TranscribingStopped,
+}
+
+/// What a transition leaves for the caller to do to the drawing components,
+/// which the phase itself knows nothing about.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PhaseChange {
+    /// The animation clock just started, so the working-animation component
+    /// has to be reset before it draws its first frame.
+    pub animation_restarted: bool,
+    /// Live audio has stopped, so the visualization is holding stale bars.
+    pub visualization_stale: bool,
+}
+
+/// The recording cycle as the applet tracks it: which phase we are in, plus
+/// the clock that drives the transcribing animation.
+///
+/// Each event of a cycle is a separate `/events` topic and the daemon
+/// forwards every topic of a subscription on its own task, so they arrive in
+/// any order. [`Self::apply`] is written to be order-insensitive, and the
+/// tests drive every interleaving of a cycle through it.
+#[derive(Debug)]
+pub struct RecordingPhase {
+    state: RecordingState,
+    /// Wall-clock start of the current transcribing phase; `Some` only while
+    /// the animation runs, used to derive its elapsed time.
+    animation_start: Option<Instant>,
+}
+
+impl Default for RecordingPhase {
+    fn default() -> Self {
+        Self {
+            state: RecordingState::Idle,
+            animation_start: None,
+        }
+    }
+}
+
+impl RecordingPhase {
+    /// Mic capture is live, so the applet draws the audio visualization.
+    pub fn is_recording(&self) -> bool {
+        self.state == RecordingState::Recording
+    }
+
+    /// The daemon is decoding, so the applet draws the working animation.
+    pub fn is_transcribing(&self) -> bool {
+        self.state == RecordingState::Processing
+    }
+
+    /// How long the working animation has been running, in milliseconds.
+    /// `None` whenever it isn't running.
+    pub fn animation_elapsed_ms(&self) -> Option<f32> {
+        self.animation_start
+            .map(|start| start.elapsed().as_secs_f32() * 1000.0)
+    }
+
+    /// Fold one lifecycle event in, returning the work the caller owes the
+    /// drawing components.
+    pub fn apply(&mut self, event: CycleEvent) -> PhaseChange {
+        match event {
+            CycleEvent::RecordingFlag(is_recording) => {
+                // Mic capture ended, so the live bars are stale whether or
+                // not `transcribing_started` already moved us to Processing.
+                let visualization_stale = !is_recording && self.state != RecordingState::Idle;
+                let next = self.state.with_recording_flag(is_recording);
+                let mut change = self.enter(next);
+                change.visualization_stale = visualization_stale;
+                change
+            }
+            CycleEvent::TranscribingStarted => {
+                // The mirror of the race handled in `with_recording_flag`:
+                // only enter Processing mid-cycle, never resurrect it after
+                // `transcribing_stopped` already returned us to Idle.
+                if self.state == RecordingState::Idle {
+                    return PhaseChange::default();
+                }
+                self.enter(RecordingState::Processing)
+            }
+            CycleEvent::TranscribingStopped => {
+                let mut change = self.enter(RecordingState::Idle);
+                change.visualization_stale = true;
+                change
+            }
+        }
+    }
+
+    /// Move to `next`, starting or stopping the animation clock with it. The
+    /// clock survives a Processing → Processing transition, so a second event
+    /// that lands in the same phase doesn't restart the animation mid-cycle.
+    fn enter(&mut self, next: RecordingState) -> PhaseChange {
+        let mut change = PhaseChange::default();
+        if next == RecordingState::Processing {
+            if self.animation_start.is_none() {
+                self.animation_start = Some(Instant::now());
+                change.animation_restarted = true;
+            }
+        } else {
+            self.animation_start = None;
+        }
+        self.state = next;
+        change
     }
 }
 
@@ -90,5 +206,183 @@ mod recording_state_tests {
             RecordingState::Idle.with_recording_flag(false),
             RecordingState::Idle,
         );
+    }
+}
+
+#[cfg(test)]
+mod recording_phase_tests {
+    //! The daemon publishes the events of one cycle in a fixed order but
+    //! forwards each topic on its own task, so the applet can see them in any
+    //! order. These tests drive the orderings the wire can actually produce
+    //! and pin two properties: the animation is up for the whole transcribing
+    //! phase, and it is never left running once the cycle closes.
+    use super::{
+        CycleEvent,
+        CycleEvent::{RecordingFlag, TranscribingStarted, TranscribingStopped},
+        RecordingPhase,
+    };
+
+    /// The three events that close a cycle, in the order the daemon publishes
+    /// them. Each is its own topic, so any permutation can reach the applet.
+    const CLOSING_ORDERS: [[CycleEvent; 3]; 6] = [
+        [
+            RecordingFlag(false),
+            TranscribingStarted,
+            TranscribingStopped,
+        ],
+        [
+            RecordingFlag(false),
+            TranscribingStopped,
+            TranscribingStarted,
+        ],
+        [
+            TranscribingStarted,
+            RecordingFlag(false),
+            TranscribingStopped,
+        ],
+        [
+            TranscribingStarted,
+            TranscribingStopped,
+            RecordingFlag(false),
+        ],
+        [
+            TranscribingStopped,
+            RecordingFlag(false),
+            TranscribingStarted,
+        ],
+        [
+            TranscribingStopped,
+            TranscribingStarted,
+            RecordingFlag(false),
+        ],
+    ];
+
+    /// A phase that has just seen `recording_state{is_recording:true}`.
+    fn recording() -> RecordingPhase {
+        let mut phase = RecordingPhase::default();
+        let change = phase.apply(RecordingFlag(true));
+        assert!(phase.is_recording());
+        assert!(!change.animation_restarted);
+        phase
+    }
+
+    #[test]
+    fn transcribing_animation_runs_whichever_way_the_mic_stop_race_falls() {
+        // The regression this suite exists for: `transcribing_started` and
+        // `recording_state{is_recording:false}` are published microseconds
+        // apart on two topics, so either can arrive first. Both applets on a
+        // panel hold their own `/events` connection and so race separately,
+        // which is what made the animation show up on one side only.
+        for order in [
+            [RecordingFlag(false), TranscribingStarted],
+            [TranscribingStarted, RecordingFlag(false)],
+        ] {
+            let mut phase = recording();
+            let restarts = order
+                .iter()
+                .filter(|event| phase.apply(**event).animation_restarted)
+                .count();
+
+            assert!(
+                phase.is_transcribing(),
+                "{order:?} left the transcribing animation off",
+            );
+            assert!(
+                phase.animation_elapsed_ms().is_some(),
+                "{order:?} left the animation clock stopped",
+            );
+            assert!(
+                !phase.is_recording(),
+                "{order:?} kept drawing the audio visualization",
+            );
+            assert_eq!(restarts, 1, "{order:?} restarted the animation {restarts}x");
+        }
+    }
+
+    #[test]
+    fn every_interleaving_of_a_cycle_ends_idle() {
+        // The mirror property: no ordering may leave the applet animating
+        // forever, which is what dropping the `transcribing_started` guard
+        // would cause when `transcribing_stopped` arrives first.
+        for order in CLOSING_ORDERS {
+            let mut phase = recording();
+            for event in order {
+                phase.apply(event);
+            }
+
+            assert!(!phase.is_transcribing(), "{order:?} stayed in transcribing");
+            assert!(!phase.is_recording(), "{order:?} stayed in recording");
+            assert!(
+                phase.animation_elapsed_ms().is_none(),
+                "{order:?} left the animation clock running",
+            );
+        }
+    }
+
+    #[test]
+    fn every_interleaving_clears_the_visualization() {
+        // Whichever event ends the cycle has to retire the audio bars, or the
+        // applet redraws the last frame of a finished take.
+        for order in CLOSING_ORDERS {
+            let mut phase = recording();
+            let cleared = order
+                .iter()
+                .any(|event| phase.apply(*event).visualization_stale);
+
+            assert!(cleared, "{order:?} never marked the visualization stale");
+        }
+    }
+
+    #[test]
+    fn a_late_transcribing_started_is_ignored() {
+        let mut phase = recording();
+        phase.apply(TranscribingStopped);
+
+        let change = phase.apply(TranscribingStarted);
+
+        assert!(!phase.is_transcribing(), "a closed cycle came back to life");
+        assert!(!change.animation_restarted);
+        assert!(phase.animation_elapsed_ms().is_none());
+    }
+
+    #[test]
+    fn a_silent_take_closes_without_animating() {
+        // Nothing was spoken, so the daemon skips `transcribing_started`
+        // entirely and closes the cycle straight after the mic stops.
+        let mut phase = recording();
+
+        assert!(phase.apply(RecordingFlag(false)).visualization_stale);
+        assert!(phase.is_transcribing());
+        phase.apply(TranscribingStopped);
+
+        assert!(!phase.is_transcribing());
+        assert!(phase.animation_elapsed_ms().is_none());
+    }
+
+    #[test]
+    fn each_cycle_restarts_the_animation() {
+        let mut phase = recording();
+        for event in CLOSING_ORDERS[0] {
+            phase.apply(event);
+        }
+
+        phase.apply(RecordingFlag(true));
+        let change = phase.apply(TranscribingStarted);
+
+        assert!(
+            change.animation_restarted,
+            "the second cycle reused the first cycle's animation clock",
+        );
+    }
+
+    #[test]
+    fn a_stray_mic_stop_while_idle_changes_nothing() {
+        let mut phase = RecordingPhase::default();
+
+        let change = phase.apply(RecordingFlag(false));
+
+        assert!(!phase.is_recording());
+        assert!(!phase.is_transcribing());
+        assert_eq!(change, super::PhaseChange::default());
     }
 }

--- a/super-stt-cosmic-applet/src/ui/components/sound_visualization.rs
+++ b/super-stt-cosmic-applet/src/ui/components/sound_visualization.rs
@@ -312,3 +312,255 @@ fn extract_dominant_frequency_from_bands(bands: &[f32]) -> (f32, f32) {
 
     (estimated_freq, confidence)
 }
+
+#[cfg(test)]
+mod frequency_math_tests {
+    //! The band math between the daemon's frequency payload and the
+    //! renderers. `draw` needs a live renderer, but everything that decides
+    //! *what* is drawn — the simulated spectrum, the pitch-to-wave mapping,
+    //! and the dominant-frequency estimate — is plain arithmetic.
+    use super::*;
+
+    fn mean(bands: &[f32], range: std::ops::Range<usize>) -> f32 {
+        let len = range.len();
+        bands[range].iter().sum::<f32>() / usize_to_f32(len)
+    }
+
+    #[test]
+    fn silence_simulates_a_silent_spectrum() {
+        let data = simulate_frequency_data(0.0);
+
+        assert_eq!(data.bands.len(), 64);
+        assert!(data.bands.iter().all(|band| *band == 0.0));
+        assert_eq!(data.total_energy, 0.0);
+    }
+
+    #[test]
+    fn the_simulated_spectrum_is_speech_shaped() {
+        // The point of simulating at all is that a bare audio level draws a
+        // flat block. Energy has to peak in the vowel/consonant bands and
+        // taper at both extremes or the equalizer looks like a level meter.
+        let data = simulate_frequency_data(1.0);
+
+        let low = mean(&data.bands, 0..6);
+        let mid = mean(&data.bands, 19..51);
+        let high = mean(&data.bands, 58..64);
+
+        assert!(mid > low * 2.0, "mid {mid} should tower over low {low}");
+        assert!(mid > high * 2.0, "mid {mid} should tower over high {high}");
+        assert!(data.bands.iter().all(|band| *band >= 0.0));
+    }
+
+    #[test]
+    fn simulated_data_asks_for_the_default_wave_frequency() {
+        // Nothing was measured, so the confidence has to stay under the
+        // threshold and leave the smoother on its default.
+        let data = simulate_frequency_data(0.8);
+
+        assert!(data.frequency_confidence < FREQUENCY_CONFIDENCE_THRESHOLD);
+    }
+
+    #[test]
+    fn wave_frequency_mapping_covers_the_configured_range() {
+        let slowest = map_audio_frequency_to_wave_frequency(MIN_AUDIO_FREQUENCY);
+        let fastest = map_audio_frequency_to_wave_frequency(MAX_AUDIO_FREQUENCY);
+
+        assert!((slowest - MIN_VISUALIZATION_WAVE_FREQUENCY).abs() < 1e-3);
+        assert!((fastest - MAX_VISUALIZATION_WAVE_FREQUENCY).abs() < 1e-3);
+    }
+
+    #[test]
+    fn wave_frequency_mapping_clamps_audio_outside_the_speech_range() {
+        // Room rumble and sibilance land outside the mapped band; they pin to
+        // the ends instead of driving the wave off its range.
+        assert_eq!(
+            map_audio_frequency_to_wave_frequency(0.0),
+            map_audio_frequency_to_wave_frequency(MIN_AUDIO_FREQUENCY),
+        );
+        assert_eq!(
+            map_audio_frequency_to_wave_frequency(48_000.0),
+            map_audio_frequency_to_wave_frequency(MAX_AUDIO_FREQUENCY),
+        );
+    }
+
+    #[test]
+    fn wave_frequency_rises_with_pitch_and_favours_the_low_end() {
+        let mut previous = f32::MIN;
+        for hz in [80.0, 200.0, 400.0, 800.0, 1600.0] {
+            let wave = map_audio_frequency_to_wave_frequency(hz);
+            assert!(wave > previous, "{hz} Hz did not raise the wave frequency");
+            previous = wave;
+        }
+
+        // The square-root shaping is what gives a low voice visible movement:
+        // the middle of the audio range maps above the middle of the wave
+        // range, not onto it.
+        let audio_middle = (MIN_AUDIO_FREQUENCY + MAX_AUDIO_FREQUENCY) / 2.0;
+        let wave_middle =
+            (MIN_VISUALIZATION_WAVE_FREQUENCY + MAX_VISUALIZATION_WAVE_FREQUENCY) / 2.0;
+        assert!(map_audio_frequency_to_wave_frequency(audio_middle) > wave_middle);
+    }
+
+    #[test]
+    fn too_few_bands_falls_back_to_a4_with_no_confidence() {
+        // Below 32 bands the index-to-Hz mapping is meaningless, so the
+        // estimate has to be declared worthless rather than guessed.
+        assert_eq!(
+            extract_dominant_frequency_from_bands(&[1.0; 31]),
+            (440.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn a_low_peak_maps_into_the_linear_range() {
+        let mut bands = vec![0.0; 64];
+        bands[2] = 1.0;
+
+        let (hz, confidence) = extract_dominant_frequency_from_bands(&bands);
+
+        assert!((50.0..=800.0).contains(&hz), "got {hz} Hz");
+        assert!(confidence > 0.0);
+    }
+
+    #[test]
+    fn a_high_peak_maps_into_the_logarithmic_range() {
+        let mut bands = vec![0.0; 64];
+        bands[60] = 1.0;
+
+        let (hz, _) = extract_dominant_frequency_from_bands(&bands);
+
+        assert!((800.0..=16_000.0).contains(&hz), "got {hz} Hz");
+    }
+
+    #[test]
+    fn a_clear_peak_beats_a_flat_spectrum_on_confidence() {
+        let mut peaked = vec![0.01; 64];
+        peaked[10] = 1.0;
+
+        let (_, flat_confidence) = extract_dominant_frequency_from_bands(&[0.5; 64]);
+        let (_, peak_confidence) = extract_dominant_frequency_from_bands(&peaked);
+
+        assert!(
+            peak_confidence > flat_confidence,
+            "a spectrum with no peak ({flat_confidence}) must not outrank one with a peak ({peak_confidence})",
+        );
+        assert!(peak_confidence >= FREQUENCY_CONFIDENCE_THRESHOLD);
+        assert!(flat_confidence < FREQUENCY_CONFIDENCE_THRESHOLD);
+    }
+
+    #[test]
+    fn silence_has_no_dominant_frequency() {
+        let (_, confidence) = extract_dominant_frequency_from_bands(&[0.0; 64]);
+
+        assert_eq!(confidence, 0.0);
+    }
+}
+
+#[cfg(test)]
+mod visualization_component_tests {
+    //! The component's own state: what a daemon `frequency_bands` event does
+    //! to the smoothed wave frequency the renderers read, and what a mic stop
+    //! leaves behind.
+    use super::*;
+    use crate::models::theme::{VisualizationColorConfig, VisualizationSide, VisualizationTheme};
+
+    fn component() -> VisualizationComponent {
+        VisualizationComponent::new(
+            0.0,
+            false,
+            VisualizationTheme::Waveform,
+            VisualizationSide::Full,
+            VisualizationColorConfig::default(),
+        )
+    }
+
+    /// Bands with a single strong low peak — confident enough to move the
+    /// smoother off its default.
+    fn peaked_bands() -> Vec<f32> {
+        let mut bands = vec![0.01; 64];
+        bands[3] = 1.0;
+        bands
+    }
+
+    #[test]
+    fn a_spectrum_with_no_peak_keeps_the_default_wave_frequency() {
+        let mut component = component();
+
+        component.update_frequency_bands(&[0.05; 64], 0.1);
+
+        assert!(
+            (component.smoothed_visualization_frequency - DEFAULT_VISUALIZATION_WAVE_FREQUENCY)
+                .abs()
+                < f32::EPSILON,
+            "a low-confidence estimate must not steer the wave",
+        );
+    }
+
+    #[test]
+    fn a_confident_spectrum_eases_the_wave_frequency_toward_its_target() {
+        let mut component = component();
+        let before = component.smoothed_visualization_frequency;
+
+        component.update_frequency_bands(&peaked_bands(), 1.0);
+
+        let after = component.smoothed_visualization_frequency;
+        let target =
+            map_audio_frequency_to_wave_frequency(component.frequency_data.dominant_frequency);
+        assert!(
+            (after - target).abs() < (before - target).abs(),
+            "smoothing moved away from the target: {before} -> {after}, target {target}",
+        );
+        assert!(
+            (after - target).abs() > f32::EPSILON,
+            "smoothing jumped straight to the target instead of easing into it",
+        );
+    }
+
+    #[test]
+    fn the_smoothed_frequency_is_what_the_renderers_read() {
+        let mut component = component();
+
+        component.update_frequency_bands(&peaked_bands(), 1.0);
+
+        assert_eq!(
+            component.frequency_data.dynamic_wave_frequency,
+            Some(component.smoothed_visualization_frequency),
+        );
+    }
+
+    #[test]
+    fn the_bands_and_energy_reach_the_renderers_unchanged() {
+        let mut component = component();
+        let bands = peaked_bands();
+
+        component.update_frequency_bands(&bands, 0.42);
+
+        assert_eq!(component.frequency_data.bands, bands);
+        assert!((component.frequency_data.total_energy - 0.42).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn clearing_retires_the_last_take() {
+        // Run on every mic stop: whatever is left over must not be drawn into
+        // the next recording, and the wave has to start from the default
+        // again rather than from the last speaker's pitch.
+        let mut component = component();
+        component.update_frequency_bands(&peaked_bands(), 1.0);
+
+        component.clear();
+
+        assert!(
+            component
+                .frequency_data
+                .bands
+                .iter()
+                .all(|band| *band == 0.0)
+        );
+        assert_eq!(component.audio_level, 0.0);
+        assert!(
+            (component.smoothed_visualization_frequency - DEFAULT_VISUALIZATION_WAVE_FREQUENCY)
+                .abs()
+                < f32::EPSILON,
+        );
+    }
+}

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/mod.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/mod.rs
@@ -246,3 +246,91 @@ mod visible_band_range_tests {
         assert_eq!(visible_band_range(&VisualizationSide::Left, 0), (0, 0));
     }
 }
+
+#[cfg(test)]
+mod visualization_config_tests {
+    //! The height math every bar renderer shares. Its whole job is keeping an
+    //! element inside the panel: the applet draws into a fixed-size strip of
+    //! someone else's panel, so a bar that overshoots is drawn over its
+    //! neighbours rather than clipped.
+    use super::VisualizationConfig;
+    use cosmic::iced::{Padding, border::Radius, core::Rectangle};
+
+    fn config(min_element_height: f32, height_safety_margin: f32) -> VisualizationConfig {
+        VisualizationConfig {
+            margins: Padding {
+                top: 2.0,
+                right: 4.0,
+                bottom: 6.0,
+                left: 8.0,
+            },
+            corner_radius: Radius::new(2.0),
+            min_element_height,
+            height_safety_margin,
+        }
+    }
+
+    #[test]
+    fn effective_bounds_inset_every_margin() {
+        let bounds = config(4.0, 0.0).effective_bounds(Rectangle {
+            x: 10.0,
+            y: 20.0,
+            width: 100.0,
+            height: 50.0,
+        });
+
+        assert_eq!((bounds.x, bounds.y), (18.0, 22.0));
+        assert_eq!(bounds.width, 100.0 - (8.0 + 4.0));
+        assert_eq!(bounds.height, 50.0 - (2.0 + 6.0));
+    }
+
+    #[test]
+    fn heights_never_collapse_to_zero() {
+        // A panel shorter than the safety margin still has to draw something:
+        // a zero height is an invisible bar, not a small one.
+        let config = config(4.0, 40.0);
+
+        assert_eq!(config.max_element_height(10.0), 1.0);
+        assert_eq!(config.min_element_height(0.0), 1.0);
+    }
+
+    #[test]
+    fn the_minimum_element_height_is_capped_by_the_canvas() {
+        // On a short panel a quarter of the canvas wins over the configured
+        // minimum, so a quiet band can never fill the whole applet.
+        let config = config(20.0, 0.0);
+
+        assert_eq!(config.min_element_height(40.0), 10.0);
+        assert_eq!(config.min_element_height(200.0), 20.0);
+    }
+
+    #[test]
+    fn clamped_element_height_keeps_a_bar_between_its_floor_and_ceiling() {
+        let config = config(4.0, 6.0);
+        let canvas = 60.0;
+
+        assert_eq!(
+            config.clamped_element_height(1000.0, canvas),
+            config.max_element_height(canvas),
+        );
+        assert_eq!(
+            config.clamped_element_height(0.0, canvas),
+            config.min_element_height(canvas),
+        );
+        assert_eq!(config.clamped_element_height(20.0, canvas), 20.0);
+    }
+
+    #[test]
+    fn the_ceiling_wins_when_it_sits_below_the_floor() {
+        // A safety margin that eats the whole canvas leaves the floor above
+        // the ceiling. The ceiling has to win, or the bar is drawn outside
+        // the panel.
+        let config = config(20.0, 100.0);
+
+        assert_eq!(config.clamped_element_height(50.0, 60.0), 1.0);
+        assert_eq!(
+            config.clamped_element_height(50.0, 60.0),
+            config.max_element_height(60.0)
+        );
+    }
+}

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
@@ -265,3 +265,297 @@ fn build_paths(wave_points: &[Point], bottom_y: f32) -> (path::Path, path::Path)
 
     (stroke_builder.build(), fill_builder.build())
 }
+
+#[cfg(test)]
+mod waveform_tests {
+    //! The waveform is the one visualization built from a spline rather than
+    //! from rectangles, so its geometry has failure modes the bar renderers
+    //! don't: a Catmull-Rom curve overshoots around a spike, and the left and
+    //! right applets have to meet at the seam without a step. These pin the
+    //! pure math behind `draw`, which needs a live renderer and can't be
+    //! exercised here.
+    use super::*;
+    use crate::util::usize_to_f32;
+    use cosmic::iced::widget::canvas::path::lyon_path::PathEvent;
+
+    fn bounds(width: f32, height: f32) -> Rectangle {
+        Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width,
+            height,
+        }
+    }
+
+    fn frequency_data(bands: Vec<f32>) -> FrequencyData {
+        FrequencyData {
+            bands,
+            ..FrequencyData::default()
+        }
+    }
+
+    fn heights(points: &[(f32, f32)]) -> Vec<f32> {
+        points.iter().map(|(_, height)| *height).collect()
+    }
+
+    #[test]
+    fn the_two_halves_meet_at_the_seam() {
+        // A Left applet and a Right applet draw one wave across a gap. Left
+        // pads only its outer edge and runs its last band up to x = 1.0;
+        // Right starts at x = 0.0 on its first band and pads only its own
+        // outer edge. Pad the inner edges too and the wave would dive to the
+        // baseline in the middle of the panel.
+        let viz = WaveformVisualization::default();
+        let data = frequency_data(vec![FREQUENCY_NORMALIZATION_MAX; 4]);
+        let bounds = bounds(120.0, 40.0);
+
+        let full = viz.build_control_points(&data, &VisualizationSide::Full, bounds);
+        assert_eq!(full.first().unwrap().0, -0.1);
+        assert_eq!(full.last().unwrap().0, 1.1);
+
+        let left = viz.build_control_points(&data, &VisualizationSide::Left, bounds);
+        assert_eq!(left.first().unwrap().0, -0.1);
+        assert_eq!(left.last().unwrap().0, 1.0);
+        assert!(
+            left.last().unwrap().1 > 0.0,
+            "left dropped to the baseline at the seam"
+        );
+
+        let right = viz.build_control_points(&data, &VisualizationSide::Right, bounds);
+        assert_eq!(right.first().unwrap().0, 0.0);
+        assert!(
+            right.first().unwrap().1 > 0.0,
+            "right dropped to the baseline at the seam"
+        );
+        assert_eq!(right.last().unwrap().0, 1.1);
+    }
+
+    #[test]
+    fn amplitudes_are_normalized_and_capped_at_the_drawable_height() {
+        let viz = WaveformVisualization::default();
+        let bounds = bounds(120.0, 40.0);
+        let data = frequency_data(vec![
+            FREQUENCY_NORMALIZATION_MAX,
+            FREQUENCY_NORMALIZATION_MAX / 2.0,
+            FREQUENCY_NORMALIZATION_MAX * 100.0,
+            0.0,
+        ]);
+
+        let points = viz.build_control_points(&data, &VisualizationSide::Full, bounds);
+
+        // Index 0 is the leading virtual zero, so the bands start at 1.
+        assert!((points[1].1 - 40.0).abs() < 1e-3);
+        assert!((points[2].1 - 20.0).abs() < 1e-3);
+        assert!(
+            (points[3].1 - 40.0).abs() < 1e-3,
+            "a band past the normalization max has to cap, not run off the panel",
+        );
+        assert_eq!(points[4].1, 0.0);
+    }
+
+    #[test]
+    fn control_points_advance_left_to_right() {
+        let viz = WaveformVisualization::default();
+        let data = frequency_data(vec![1.0; 8]);
+
+        let points = viz.build_control_points(&data, &VisualizationSide::Full, bounds(120.0, 40.0));
+
+        assert!(
+            points.windows(2).all(|pair| pair[1].0 > pair[0].0),
+            "the spline needs strictly increasing x to find its segments",
+        );
+    }
+
+    #[test]
+    fn smoothing_keeps_the_ends_pinned() {
+        // The virtual zeros are what make the wave fade in and out at the
+        // panel edges. Smoothing must not lift them off the baseline.
+        let mut points = vec![
+            (-0.1, 0.0),
+            (0.25, 30.0),
+            (0.5, 12.0),
+            (0.75, 4.0),
+            (1.1, 0.0),
+        ];
+
+        smooth_control_points(&mut points);
+
+        assert_eq!(points.first().unwrap().1, 0.0);
+        assert_eq!(points.last().unwrap().1, 0.0);
+    }
+
+    #[test]
+    fn smoothing_spreads_a_spike_without_overshooting_it() {
+        let original = vec![
+            (0.0, 0.0),
+            (0.25, 0.0),
+            (0.5, 30.0),
+            (0.75, 0.0),
+            (1.0, 0.0),
+        ];
+        let mut points = original.clone();
+
+        smooth_control_points(&mut points);
+
+        assert!(points[2].1 < 30.0, "the peak has to come down");
+        assert!(
+            points[1].1 > 0.0 && points[3].1 > 0.0,
+            "and its neighbours have to come up",
+        );
+        // Each pass is a convex combination, so no height can leave the range
+        // it started in — that is what keeps a smoothed wave inside the panel.
+        let ceiling = heights(&original).into_iter().fold(f32::MIN, f32::max);
+        assert!(heights(&points).iter().all(|h| (0.0..=ceiling).contains(h)));
+    }
+
+    #[test]
+    fn smoothing_leaves_a_flat_wave_alone() {
+        let mut points: Vec<(f32, f32)> = (0..6).map(|i| (usize_to_f32(i), 5.0)).collect();
+
+        smooth_control_points(&mut points);
+
+        assert!(heights(&points).iter().all(|h| (h - 5.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn smoothing_survives_a_wave_too_short_to_smooth() {
+        for len in 0..3 {
+            let mut points: Vec<(f32, f32)> = (0..len).map(|i| (usize_to_f32(i), 10.0)).collect();
+
+            smooth_control_points(&mut points);
+
+            assert_eq!(points.len(), len);
+        }
+    }
+
+    #[test]
+    fn the_curve_is_sampled_once_per_horizontal_pixel() {
+        let viz = WaveformVisualization::default();
+        let data = frequency_data(vec![1.0; 8]);
+        let bounds = Rectangle {
+            x: 10.0,
+            y: 5.0,
+            width: 120.0,
+            height: 40.0,
+        };
+        let control = viz.build_control_points(&data, &VisualizationSide::Full, bounds);
+
+        let wave = compute_wave_points(&control, bounds);
+
+        assert_eq!(wave.len(), 121);
+        assert!((wave.first().unwrap().x - 10.0).abs() < 1e-3);
+        assert!((wave.last().unwrap().x - 130.0).abs() < 1e-3);
+        assert!(
+            wave.windows(2).all(|pair| pair[1].x >= pair[0].x),
+            "sample x must never go backwards",
+        );
+    }
+
+    #[test]
+    fn a_spline_overshoot_is_clamped_inside_the_panel() {
+        // Catmull-Rom overshoots on both sides of a sharp step. Unclamped,
+        // the curve would be drawn above the applet and below its baseline.
+        let bounds = bounds(60.0, 40.0);
+        let control = vec![(-0.1, 0.0), (0.2, 0.0), (0.4, 40.0), (0.6, 0.0), (1.1, 0.0)];
+
+        let wave = compute_wave_points(&control, bounds);
+
+        let bottom_y = bounds.y + bounds.height;
+        for point in &wave {
+            assert!(
+                point.y >= bounds.y - 1e-3 && point.y <= bottom_y + 1e-3,
+                "sample at x={} left the panel at y={}",
+                point.x,
+                point.y,
+            );
+        }
+    }
+
+    #[test]
+    fn a_silent_wave_sits_flat_on_the_baseline() {
+        let bounds = bounds(60.0, 40.0);
+        let control = vec![(-0.1, 0.0), (0.5, 0.0), (1.1, 0.0)];
+
+        let wave = compute_wave_points(&control, bounds);
+
+        let bottom_y = bounds.y + bounds.height;
+        assert!(wave.iter().all(|point| (point.y - bottom_y).abs() < 1e-4));
+    }
+
+    #[test]
+    fn coincident_control_points_do_not_produce_nan() {
+        // Both divisions in the sampler are guarded against a zero span; an
+        // unguarded one would put NaN into the path and blank the applet.
+        let wave = compute_wave_points(&[(0.5, 0.0), (0.5, 10.0), (0.5, 0.0)], bounds(60.0, 40.0));
+
+        assert!(
+            wave.iter()
+                .all(|point| point.x.is_finite() && point.y.is_finite())
+        );
+    }
+
+    #[test]
+    fn the_fill_path_closes_along_the_baseline() {
+        let bottom_y = 40.0;
+        let wave = vec![
+            Point { x: 0.0, y: 30.0 },
+            Point { x: 1.0, y: 20.0 },
+            Point { x: 2.0, y: 25.0 },
+        ];
+
+        let (stroke, fill) = build_paths(&wave, bottom_y);
+
+        let fill_events: Vec<PathEvent> = fill.raw().iter().collect();
+        let Some(PathEvent::Begin { at }) = fill_events.first() else {
+            panic!("the fill path never began");
+        };
+        assert!(
+            (at.y - bottom_y).abs() < 1e-4,
+            "the filled area has to start on the baseline, not on the curve",
+        );
+        assert!(
+            fill_events
+                .iter()
+                .any(|event| matches!(event, PathEvent::End { close: true, .. })),
+            "an unclosed fill leaves the area under the curve unpainted",
+        );
+
+        assert!(
+            stroke
+                .raw()
+                .iter()
+                .any(|event| matches!(event, PathEvent::End { close: false, .. })),
+            "the outline is an open curve, not a closed shape",
+        );
+    }
+
+    #[test]
+    fn the_stroke_path_follows_the_wave() {
+        let wave = vec![
+            Point { x: 0.0, y: 30.0 },
+            Point { x: 1.0, y: 20.0 },
+            Point { x: 2.0, y: 25.0 },
+        ];
+
+        let (stroke, _) = build_paths(&wave, 40.0);
+
+        let lines = stroke
+            .raw()
+            .iter()
+            .filter(|event| matches!(event, PathEvent::Line { .. }))
+            .count();
+        assert_eq!(
+            lines,
+            wave.len() - 1,
+            "one segment between each pair of samples"
+        );
+    }
+
+    #[test]
+    fn no_wave_points_means_no_paths() {
+        let (stroke, fill) = build_paths(&[], 40.0);
+
+        assert_eq!(stroke.raw().iter().count(), 0);
+        assert_eq!(fill.raw().iter().count(), 0);
+    }
+}

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
@@ -240,11 +240,7 @@ fn compute_wave_points(control_points: &[(f32, f32)], effective_bounds: Rectangl
 fn build_paths(wave_points: &[Point], bottom_y: f32) -> (path::Path, path::Path) {
     let mut stroke_builder = path::Builder::new();
     if let Some(first) = wave_points.first() {
-        // Nudge the first point so a perfectly flat wave still strokes.
-        stroke_builder.line_to(Point {
-            x: first.x,
-            y: first.y - 0.000_001,
-        });
+        stroke_builder.move_to(*first);
         for point in wave_points.iter().skip(1) {
             stroke_builder.line_to(*point);
         }
@@ -553,6 +549,14 @@ mod waveform_tests {
 
         let (stroke, _) = build_paths(&wave, 40.0);
 
+        let Some(PathEvent::Begin { at }) = stroke.raw().iter().next() else {
+            panic!("the stroke path never began");
+        };
+        assert_eq!(
+            (at.x, at.y),
+            (wave[0].x, wave[0].y),
+            "the outline has to start on the curve it traces",
+        );
         let lines = stroke
             .raw()
             .iter()

--- a/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
+++ b/super-stt-cosmic-applet/src/ui/components/visualizations/waveform.rs
@@ -162,6 +162,12 @@ fn smooth_control_points(points: &mut Vec<(f32, f32)>) {
 /// Sample the Catmull-Rom spline through `control_points` at one point per
 /// horizontal pixel, returning canvas-space points along the curve.
 fn compute_wave_points(control_points: &[(f32, f32)], effective_bounds: Rectangle) -> Vec<Point> {
+    // No control points, no curve. The segment search below indexes
+    // `control_points.len() - 1`, which underflows on an empty slice.
+    if control_points.is_empty() {
+        return Vec::new();
+    }
+
     let render_points = f32_to_usize(effective_bounds.width);
     let bottom_y = effective_bounds.y + effective_bounds.height;
 
@@ -480,6 +486,14 @@ mod waveform_tests {
 
         let bottom_y = bounds.y + bounds.height;
         assert!(wave.iter().all(|point| (point.y - bottom_y).abs() < 1e-4));
+    }
+
+    #[test]
+    fn no_control_points_yields_no_samples() {
+        // `build_control_points` always emits at least one virtual pad, so
+        // this is unreachable today — but the sampler indexes `len() - 1`,
+        // which underflows the moment that stops being true.
+        assert!(compute_wave_points(&[], bounds(60.0, 40.0)).is_empty());
     }
 
     #[test]

--- a/super-stt-cosmic-applet/src/ui/components/working_animation_component.rs
+++ b/super-stt-cosmic-applet/src/ui/components/working_animation_component.rs
@@ -98,3 +98,46 @@ impl Program<Message, Theme, Renderer> for WorkingAnimationComponent {
         vec![frame.into_geometry()]
     }
 }
+
+#[cfg(test)]
+mod working_animation_component_tests {
+    use super::*;
+
+    fn component() -> WorkingAnimationComponent {
+        WorkingAnimationComponent::new(
+            WorkingAnimationTheme::Droplet,
+            VisualizationSide::Full,
+            VisualizationColorConfig::default(),
+        )
+    }
+
+    #[test]
+    fn a_new_animation_starts_at_its_first_frame() {
+        assert_eq!(component().elapsed_ms, 0.0);
+    }
+
+    #[test]
+    fn resetting_rewinds_to_the_first_frame() {
+        // The applet resets the component whenever the transcribing clock
+        // starts, so a second recording opens on frame zero instead of
+        // wherever the previous one stopped.
+        let mut component = component();
+        component.set_elapsed(4_200.0);
+
+        component.reset();
+
+        assert_eq!(component.elapsed_ms, 0.0);
+    }
+
+    #[test]
+    fn switching_theme_keeps_the_clock_running() {
+        // Picking a different animation mid-cycle must not restart it: the
+        // clock lives in the applet, and the component only follows it.
+        let mut component = component();
+        component.set_elapsed(1_500.0);
+
+        component.update_theme(WorkingAnimationTheme::Comet);
+
+        assert_eq!(component.elapsed_ms, 1_500.0);
+    }
+}


### PR DESCRIPTION
## The bug

With an applet on the left and the right of the panel, the "transcribing" animation would often appear on only one side. Which side was random, and the visualizations were unaffected.

## The cause

The daemon publishes `recording_state{is_recording:false}` and then `transcribing_started` back to back (`super-stt-daemon/src/daemon/recording/mod.rs:282`), but they sit on two different topics, and `GET /events` forwards every topic of a subscription on its **own tokio task** (`super-stt-daemon/src/daemon/http/v1/events.rs:241`). Both tasks wake at the same instant and race to write into the connection's SSE channel, so the two frames arrive in either order.

The applet derived its next state purely from "was I Recording?":

1. `recording_state(false)` first: `Recording → Processing`, then `transcribing_started` keeps `Processing`. The animation shows.
2. `transcribing_started` first: `Recording → Processing`, then `recording_state(false)` saw `was_recording == false`, fell through to the `else` branch and set `Idle`. That cleared `working_anim_start`, the view dropped back to the icon, and the 33 ms tick subscription never started.

Each applet holds its own `/events` connection, so each flips its own coin per recording — hence one side animating and the other not. Visualizations were unaffected because `frequency_bands` never touches this state machine.

I checked three days of journal logs for `backpressured` / `lagged` warnings first to rule out the SSE frame-drop path: zero hits.

## The fix (commit 1)

- The mic-stop fold is now order-insensitive: `Processing` stays `Processing`, and only `transcribing_stopped` returns the applet to `Idle`. This mirrors the guard `transcribing_started` already carried for the opposite race.
- The stale visualization bars are cleared on a mic-stop from either phase.
- The lifecycle table in `docs/protocol/endpoints/v1/events.md` promised an ordering the wire does not guarantee across topics; it now says so, with the rule clients need.

## The tests (commit 2)

The transitions and the animation clock lived in `update.rs` behind `cosmic::app::Core`, so nothing about them could be exercised without a compositor — the fix could only carry tests over the fold helper, leaving the clock (the half that decides whether the animation draws) uncovered.

`RecordingPhase` in `models/state.rs` now owns the phase and the clock, takes one `CycleEvent` at a time, and returns the work it leaves for the drawing components. `update.rs` keeps the libcosmic half; the state machine is a plain type a test can drive.

The suite then walks a cycle the way the wire delivers it — all six orderings of the three closing events — and pins two properties:

- the animation is up for the whole transcribing phase whichever way the mic-stop race falls;
- no ordering leaves it running once the cycle closes.

Plus the silent-take path (no `transcribing_started` at all), the late `transcribing_started`, and the per-cycle clock restart.

Both guards are verified to be load-bearing: reverting the mic-stop fold fails `transcribing_animation_runs_whichever_way_the_mic_stop_race_falls` with `[TranscribingStarted, RecordingFlag(false)] left the transcribing animation off`, and dropping the `transcribing_started` guard fails `every_interleaving_of_a_cycle_ends_idle` and `a_late_transcribing_started_is_ignored`.

## Visualization coverage (commit 3)

Independent of the fix, and splittable if you'd rather it landed on its own. The visualizers had three geometry tests between them, none touching the code that turns a frequency payload into a shape. `draw` needs a live renderer, but everything feeding it is arithmetic:

- **shared height math** — margins, the 1px floors, and the case where a safety margin puts the floor above the ceiling and the ceiling has to win, since an element that overshoots is drawn over the neighbouring applets rather than clipped;
- **the waveform spline** — the seam where a Left and a Right applet meet (inner edges unpadded, outer edges padded), the normalization cap, the convex-combination bound smoothing can't escape, the clamp that catches Catmull-Rom's overshoot around a spike, the guarded divisions behind a NaN-free path, and the built stroke/fill paths read back through lyon;
- **the band math** — the speech-shaped simulated spectrum, the pitch to wave-frequency mapping with its clamps and square-root shaping, and the dominant-frequency estimate across its linear and logarithmic halves;
- **component state** — the smoothed frequency the renderers read, and what a mic stop retires.

Mutation-checked: dropping the overshoot clamp fails `a_spline_overshoot_is_clamped_inside_the_panel`, and dropping the square-root shaping fails `wave_frequency_rises_with_pitch_and_favours_the_low_end`.

Comet, dots, pulse and both equalizers keep all their math inside `draw`, so nothing there is reachable without a compositor or an extraction — left alone.

## Two waveform fixes the tests turned up (commits 4 and 5)

1. **`compute_wave_points` underflowed on an empty control-point slice** — it indexes `control_points.len() - 1` to find each sample's segment, which panics in debug and wild-indexes in release. Unreachable today (`build_control_points` emits a virtual pad on at least one end for every side), so this is a guard, not a repair.
2. **The `- 0.000_001` nudge in `build_paths` never did either of its jobs.** It offset the outline's first vertex to "keep a perfectly flat wave strokeable". `40.0 - 0.000_001` is `40.0` in f32, so on any panel whose baseline sits at 32px or beyond the offset rounds away entirely; below that it survives but moves a vertex by a millionth of a pixel, which changes neither a rendered pixel nor the path's topology. The outline now begins on the first sample, via `move_to` to match the fill path.

(The PR previously said the nudge was lost past ~8px. The real threshold is ~32px — verified against f32 rounding.)

## Testing

`just fmt-check`, `just check -p super-stt-cosmic-applet` and `just test -p super-stt-cosmic-applet` all pass (82 tests).

## Known gap

An applet that starts up mid-transcription is `Idle`, so the `transcribing_started` guard correctly ignores the event and that one cycle shows no animation. It self-corrects on the next recording; fixing it properly needs a cycle id on the events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tx9HiqxNqLhsx188A7ps5d


