### PR TITLE
Make the daemon's HTTP test coverage real

### DIFF
--- a/super-stt-daemon/Cargo.toml
+++ b/super-stt-daemon/Cargo.toml
@@ -113,6 +113,12 @@
 [dev-dependencies]
     futures-util.workspace = true
     hound.workspace = true
+    # Integration tests route their own (client-side) keyring access to the
+    # in-memory mock. `session::install_mock_keyring_if_requested` is the
+    # production entry point for that, but it is gated on an env var, and
+    # setting one from a threaded test process is unsound under edition 2024 —
+    # so `tests/common` calls the builder directly. See `common::install_mock_keyring`.
+    keyring.workspace = true
     http-body-util = "0.1"
     hyper = { version = "1", features = ["client", "http1"] }
     hyper-util = { version = "0.1", features = ["tokio"] }

--- a/super-stt-daemon/tests/common/mod.rs
+++ b/super-stt-daemon/tests/common/mod.rs
@@ -146,3 +146,28 @@ impl BackendFixture<'_> {
         }
     }
 }
+
+// ---------- client-side keyring ----------------------------------------------
+
+/// Route *this process's* keyring access to the in-memory mock.
+///
+/// The daemon subprocess gets the mock from `SUPER_STT_KEYRING_MOCK=1` in its
+/// environment. A test that drives a client helper — anything reaching
+/// `session::obtain`/`save`/`forget` — does that work in the test process
+/// itself, which has no such routing and so reaches the real secret service:
+/// it writes entries into the developer's keyring, and on a headless CI runner
+/// it blocks on an unlock prompt that never comes. That is what kept the widget
+/// subscription tests behind `#[ignore]`.
+///
+/// `session::install_mock_keyring_if_requested` is the production entry point,
+/// but it is gated on reading that env var, and *setting* an env var from a
+/// process that already has threads running is unsound under edition 2024. So
+/// this calls the same builder directly. Idempotent, and safe to call from
+/// every test: the default builder must be set before any keyring access, and
+/// `Once` makes the first caller win while the rest wait.
+pub fn install_mock_keyring() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+    });
+}

--- a/super-stt-daemon/tests/common/mod.rs
+++ b/super-stt-daemon/tests/common/mod.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! Shared harness for the tests that spawn a real `super-stt-daemon`.
+//!
+//! Every one of them holds the child in a guard whose `Drop` stops it. How it
+//! is stopped is not a detail — see [`shutdown`].
+
+use std::process::Child;
+use std::time::{Duration, Instant};
+
+/// How long a daemon gets to finish its graceful shutdown before we stop
+/// waiting and `SIGKILL` it, so a wedged child can't hang the suite.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(10);
+
+/// How often to re-check whether the child has exited while waiting.
+const SHUTDOWN_POLL: Duration = Duration::from_millis(25);
+
+/// Stop a spawned daemon the way anything else stops one: `SIGINT`, then wait
+/// for it to exit on its own.
+///
+/// The obvious spelling — [`Child::kill`] — sends `SIGKILL`, which no process
+/// can handle. That costs more than an unclean exit. Under `cargo llvm-cov` the
+/// daemon is an *instrumented* binary that writes its `.profraw` from an
+/// `atexit` hook, and a `SIGKILL`'d process never runs one. The profile is
+/// simply never written, so every endpoint the test just exercised is reported
+/// as uncovered: the whole `/v1` surface read as 0% while these tests passed
+/// against it.
+///
+/// `SIGINT` instead runs the daemon's Ctrl+C path in `daemon_main::run`, which
+/// unloads the model, drains queued session-store writes, and leaves through
+/// `std::process::exit` — flushing the profile on the way out. It is also the
+/// shutdown the daemon is written for, so these tests now exercise it rather
+/// than a path production never takes: an ungracefully killed daemon orphans
+/// its `systemd --user` backend units, which is why `daemon_main` has to sweep
+/// for them at startup.
+pub fn shutdown(child: &mut Child) {
+    // Has it already gone? A test that kills its own daemon mid-run (see
+    // `widget_smoke`, which drops one on purpose to watch a client notice)
+    // reaches this having already reaped it, and the pid may since have been
+    // recycled onto an unrelated process. Never signal that.
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+
+    let Ok(pid) = i32::try_from(child.id()) else {
+        // Not a pid `kill(2)` can name. Nothing to do but the blunt thing.
+        let _ = child.kill();
+        let _ = child.wait();
+        return;
+    };
+
+    // The result is dropped on purpose: the only failure worth acting on is
+    // "the child is already gone", which the wait loop below handles anyway.
+    //
+    // SAFETY: `pid` is our own child, and nothing has reaped it yet — the only
+    // `wait` calls are below — so the pid cannot have been recycled onto an
+    // unrelated process.
+    let _ = unsafe { libc::kill(pid, libc::SIGINT) };
+
+    let deadline = Instant::now() + SHUTDOWN_GRACE;
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => std::thread::sleep(SHUTDOWN_POLL),
+            // Already reaped, or a pid we can no longer ask about; either way
+            // there is nothing left to wait for.
+            Err(_) => return,
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/super-stt-daemon/tests/common/mod.rs
+++ b/super-stt-daemon/tests/common/mod.rs
@@ -3,6 +3,12 @@
 //!
 //! Every one of them holds the child in a guard whose `Drop` stops it. How it
 //! is stopped is not a detail — see [`shutdown`].
+//!
+//! This module is compiled into each test binary that declares `mod common;`,
+//! and every one of them uses only the part it needs — so anything the others
+//! use reads as dead code here. Hence the crate-level allow rather than a
+//! per-item one.
+#![allow(dead_code)]
 
 use std::process::Child;
 use std::time::{Duration, Instant};
@@ -69,4 +75,74 @@ pub fn shutdown(child: &mut Child) {
 
     let _ = child.kill();
     let _ = child.wait();
+}
+
+// ---------- backend fixtures -------------------------------------------------
+
+use std::path::{Path, PathBuf};
+
+/// Where the daemon discovers installed backends, under an isolated
+/// `XDG_DATA_HOME`. Written down once here because a fixture that lands
+/// anywhere else is simply not found, and the daemon reports that the same way
+/// it reports having no backends at all.
+#[must_use]
+pub fn backends_dir(data_home: &Path) -> PathBuf {
+    data_home.join("super-stt").join("backends")
+}
+
+/// The prebuilt mock component (`just build-mock-wasm-backend`), or `None` when
+/// it has not been built. A test that needs a backend which actually *answers*
+/// — rather than one that merely exists on disk — stages this as its
+/// entrypoint; it serves canned `/v1` responses, including a `transcribe` that
+/// returns [`MOCK_TRANSCRIPTION`].
+#[must_use]
+pub fn mock_component() -> Option<PathBuf> {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+        "tests/fixtures/mock-wasm-backend/target/wasm32-wasip2/release/mock_wasm_backend.wasm",
+    );
+    p.exists().then_some(p)
+}
+
+/// The transcript [`mock_component`] returns from `POST /v1/transcribe`. Kept
+/// beside the path that stages it so an assertion cannot drift from the
+/// component it is asserting against.
+pub const MOCK_TRANSCRIPTION: &str = "mock transcription";
+
+/// A backend as the daemon finds it on disk: a `backend.toml` and the
+/// entrypoint that manifest names.
+///
+/// Two kinds of fixture come out of this, and the difference is `component`.
+/// With `None` the entrypoint is an empty placeholder — enough for discovery,
+/// which reads the manifest and never execs the file, and all a test needs when
+/// it is asking *about* a backend (what it advertises, what version is
+/// installed, what options it declares). With `Some`, real component bytes are
+/// staged, and the backend can be selected, loaded and asked to transcribe.
+pub struct BackendFixture<'a> {
+    /// Directory under [`backends_dir`]. Only has to be unique.
+    pub dir_name: &'a str,
+    /// The whole `backend.toml`. Written verbatim, so a test can express
+    /// exactly the manifest it means — including one that is deliberately odd.
+    pub manifest: &'a str,
+    /// The file name the manifest's `entrypoint` names.
+    pub entrypoint: &'a str,
+    /// Component bytes to stage, or `None` for an empty placeholder.
+    pub component: Option<&'a Path>,
+}
+
+impl BackendFixture<'_> {
+    /// Write this backend into `data_home` so the daemon discovers it at
+    /// startup. Call before spawning the daemon: discovery runs once, during
+    /// `post_init`.
+    pub fn install(&self, data_home: &Path) {
+        let dir = backends_dir(data_home).join(self.dir_name);
+        std::fs::create_dir_all(&dir).expect("create fixture backend dir");
+        std::fs::write(dir.join("backend.toml"), self.manifest).expect("write backend.toml");
+        match self.component {
+            Some(src) => {
+                std::fs::copy(src, dir.join(self.entrypoint)).expect("stage mock component");
+            }
+            None => std::fs::write(dir.join(self.entrypoint), b"")
+                .expect("write placeholder entrypoint"),
+        }
+    }
 }

--- a/super-stt-daemon/tests/http_smoke.rs
+++ b/super-stt-daemon/tests/http_smoke.rs
@@ -17,6 +17,8 @@
 //! cargo test -p super-stt --test http_smoke -- --nocapture
 //! ```
 
+mod common;
+
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -34,8 +36,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         let _ = std::fs::remove_dir_all(&self.xdg_runtime_dir);
     }
 }

--- a/super-stt-daemon/tests/http_smoke.rs
+++ b/super-stt-daemon/tests/http_smoke.rs
@@ -69,6 +69,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // it comes up idle and fast, without spawning a real backend at startup.
     let data_home = xdg.join("data");
     std::fs::create_dir_all(&data_home).expect("create xdg/data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = xdg.join("cache");
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let http_socket = xdg.join("stt").join("super-stt-http.sock");
 
@@ -77,6 +83,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("XDG_RUNTIME_DIR", &xdg)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .env("SUPER_STT_AUTO_APPROVE", "1") // bypass consent popup
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/super-stt-daemon/tests/http_smoke_backend_options.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_options.rs
@@ -15,6 +15,8 @@
 //! open-ended, and `styling` offers a closed set, so both sides of the
 //! `choices` gate are exercisable.
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -42,8 +44,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_backend_options.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_options.rs
@@ -127,6 +127,12 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
 
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     // Seed the fixture backend so the daemon has something with declared options.
     seed_fixture_backend(&data_home);
@@ -137,6 +143,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -146,7 +153,12 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home.clone()],
+        cleanup_paths: vec![
+            http_socket.clone(),
+            config_home,
+            data_home.clone(),
+            cache_home,
+        ],
         data_home,
     };
 

--- a/super-stt-daemon/tests/http_smoke_backend_secrets.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_secrets.rs
@@ -13,6 +13,8 @@
 //! isolated `XDG_DATA_HOME/super-stt/backends/` tree so the daemon discovers
 //! it on startup. It declares one secret (`openai_api_key`) and one model.
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -37,8 +39,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_backend_secrets.rs
+++ b/super-stt-daemon/tests/http_smoke_backend_secrets.rs
@@ -105,6 +105,12 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
 
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     // Seed the fixture backend so the daemon has something with declared secrets.
     seed_fixture_backend(&data_home);
@@ -115,6 +121,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -124,7 +131,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_backends.rs
+++ b/super-stt-daemon/tests/http_smoke_backends.rs
@@ -68,6 +68,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // Empty, isolated data dir → no backends discovered; daemon comes up idle.
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1")
@@ -75,6 +81,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -84,7 +91,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_backends.rs
+++ b/super-stt-daemon/tests/http_smoke_backends.rs
@@ -21,6 +21,8 @@
 //! Uses `SUPER_STT_AUTO_APPROVE=1` (no GUI) and `SUPER_STT_KEYRING_MOCK=1`
 //! (in-memory keyring), so it's part of the default `cargo test` flow.
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -41,8 +43,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_events.rs
+++ b/super-stt-daemon/tests/http_smoke_events.rs
@@ -24,6 +24,8 @@
 //! Hermetic: `SUPER_STT_AUTO_APPROVE=1` (no GUI) + `SUPER_STT_KEYRING_MOCK=1`
 //! (in-memory keyring), so it runs in the default `cargo test` flow.
 
+mod common;
+
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -44,8 +46,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_events.rs
+++ b/super-stt-daemon/tests/http_smoke_events.rs
@@ -68,6 +68,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1")
@@ -75,6 +81,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -84,7 +91,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_full.rs
+++ b/super-stt-daemon/tests/http_smoke_full.rs
@@ -28,6 +28,8 @@
 //! cargo test -p super-stt --test http_smoke_full -- --ignored --nocapture
 //! ```
 
+mod common;
+
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -80,8 +82,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
         }

--- a/super-stt-daemon/tests/http_smoke_gui.rs
+++ b/super-stt-daemon/tests/http_smoke_gui.rs
@@ -24,6 +24,8 @@
 //! - When the helper exits without a decision (SIGTERM → dismissed-on-
 //!   close path), the daemon translates that to the proper error.
 
+mod common;
+
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -77,8 +79,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         let _ = std::fs::remove_dir_all(&self.xdg_runtime_dir);
     }
 }

--- a/super-stt-daemon/tests/http_smoke_language.rs
+++ b/super-stt-daemon/tests/http_smoke_language.rs
@@ -103,6 +103,12 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
 
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     seed_fixture_backend(&data_home);
 
@@ -112,6 +118,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -121,7 +128,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_language.rs
+++ b/super-stt-daemon/tests/http_smoke_language.rs
@@ -18,6 +18,8 @@
 //! daemon comes up idle (no model auto-loaded) — the per-model language
 //! endpoint resolves against the discovered backend, so it works regardless.
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -38,8 +40,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_pipeline.rs
+++ b/super-stt-daemon/tests/http_smoke_pipeline.rs
@@ -190,6 +190,12 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
 
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     // Seed the fixture backend so the daemon has something with declared options.
     seed_fixture_backend(&data_home);
@@ -200,6 +206,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -209,7 +216,7 @@ async fn start_daemon(scopes: &[&str]) -> (DaemonGuard, PathBuf, String) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_pipeline.rs
+++ b/super-stt-daemon/tests/http_smoke_pipeline.rs
@@ -29,6 +29,8 @@
 //! validation, which happen before any component is loaded, so a load failure
 //! on the post-processor is expected and asserted as a non-fatal note.
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -60,8 +62,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_ratelimit.rs
+++ b/super-stt-daemon/tests/http_smoke_ratelimit.rs
@@ -20,6 +20,8 @@
 //!
 //! Hermetic: `SUPER_STT_AUTO_APPROVE=1` + `SUPER_STT_KEYRING_MOCK=1`.
 
+mod common;
+
 use http_body_util::{BodyExt, Empty};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -45,8 +47,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_ratelimit.rs
+++ b/super-stt-daemon/tests/http_smoke_ratelimit.rs
@@ -69,6 +69,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1")
@@ -76,6 +82,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -85,7 +92,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_realtime.rs
+++ b/super-stt-daemon/tests/http_smoke_realtime.rs
@@ -15,6 +15,8 @@
 //! (in-memory keyring), so it runs in the default `cargo test` flow.
 #![cfg(feature = "wasm-backends")]
 
+mod common;
+
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -52,8 +54,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_realtime.rs
+++ b/super-stt-daemon/tests/http_smoke_realtime.rs
@@ -114,6 +114,12 @@ async fn start_daemon(scopes: &[&str], component: Option<&Path>) -> (DaemonGuard
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
     if let Some(component) = component {
         seed_realtime_backend(&data_home, component);
     }
@@ -124,6 +130,7 @@ async fn start_daemon(scopes: &[&str], component: Option<&Path>) -> (DaemonGuard
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -133,7 +140,7 @@ async fn start_daemon(scopes: &[&str], component: Option<&Path>) -> (DaemonGuard
     // below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_settings.rs
+++ b/super-stt-daemon/tests/http_smoke_settings.rs
@@ -502,6 +502,28 @@ async fn settings_scope_endpoints() {
     )
     .await;
 
+    // --- GET /gpu_info: a live probe of the host's accelerators. Settings
+    // scope guards it, but it is not a stored preference — it reports what
+    // this machine has right now. A host with no GPU (every CI runner) is a
+    // 200 with an empty list, never a 404 or a 500, so the shape below is
+    // what a client can rely on everywhere.
+    let (s, body) = raw_get_json(&http_socket, "/gpu_info", &settings_token).await;
+    assert_eq!(s, StatusCode::OK, "GET /gpu_info: {body}");
+    assert_eq!(body["status"], "success", "{body}");
+    let gpus = body["gpu_info"]
+        .as_array()
+        .unwrap_or_else(|| panic!("gpu_info must be an array, got: {body}"));
+    // Each entry names a GPU and its memory; nothing here assumes one exists.
+    for gpu in gpus {
+        assert!(gpu["name"].is_string(), "gpu entry without a name: {gpu}");
+    }
+    // `host` is the driver/runtime inventory, reported whether or not any GPU
+    // was found — it is what decides which backend builds will run here.
+    assert!(
+        body["host"].is_object(),
+        "host toolchain versions must be present even with no GPU: {body}"
+    );
+
     // --- GET /update: a read-only snapshot. `latest_version` must still be
     // null: `GITHUB_API_BASE` points at a refused loopback port (see
     // `start_daemon`), so no candidate can ever resolve, whether this is the

--- a/super-stt-daemon/tests/http_smoke_settings.rs
+++ b/super-stt-daemon/tests/http_smoke_settings.rs
@@ -33,7 +33,10 @@ impl Drop for DaemonGuard {
     fn drop(&mut self) {
         common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
+            // The list holds the socket file and the three XDG dirs, so try
+            // both; whichever does not apply is a no-op.
             let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
         }
     }
 }
@@ -63,6 +66,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // daemon comes up idle (which the assertions below tolerate).
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1") // in-memory keyring (no secret-service prompt in tests/CI)
@@ -70,6 +79,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         // Point the daemon's self-update forge client at a guaranteed-refused
         // loopback port (`accept_base_url` allows loopback `http://`), so
         // `POST /update/check` below fails deterministically and offline
@@ -85,7 +95,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone()],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_settings.rs
+++ b/super-stt-daemon/tests/http_smoke_settings.rs
@@ -9,6 +9,8 @@
 //! Uses `SUPER_STT_AUTO_APPROVE=1` so no GUI is needed — it's part of
 //! the default `cargo test` flow.
 
+mod common;
+
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -29,8 +31,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
         }

--- a/super-stt-daemon/tests/http_smoke_settings_protocol.rs
+++ b/super-stt-daemon/tests/http_smoke_settings_protocol.rs
@@ -25,6 +25,8 @@
 //! One daemon spawn for the whole file. Spawning per case would multiply a
 //! ~200ms startup by every path in the table.
 
+mod common;
+
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -45,8 +47,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
         }

--- a/super-stt-daemon/tests/http_smoke_settings_protocol.rs
+++ b/super-stt-daemon/tests/http_smoke_settings_protocol.rs
@@ -49,7 +49,10 @@ impl Drop for DaemonGuard {
     fn drop(&mut self) {
         common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
+            // The list holds the socket file and the three XDG dirs, so try
+            // both; whichever does not apply is a no-op.
             let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
         }
     }
 }
@@ -79,6 +82,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // daemon comes up idle (which the assertions below tolerate).
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1") // in-memory keyring (no secret-service prompt in tests/CI)
@@ -86,6 +95,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         // Point the daemon's self-update forge client at a guaranteed-refused
         // loopback port (`accept_base_url` allows loopback `http://`), so
         // `POST /update/check` below fails deterministically and offline
@@ -101,7 +111,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone()],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_stage_flow.rs
+++ b/super-stt-daemon/tests/http_smoke_stage_flow.rs
@@ -30,6 +30,8 @@
 //! `SUPER_STT_AUTO_APPROVE=1` (no GUI), so it runs in the default flow.
 #![cfg(feature = "wasm-backends")]
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -69,8 +71,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/http_smoke_stage_flow.rs
+++ b/super-stt-daemon/tests/http_smoke_stage_flow.rs
@@ -148,6 +148,12 @@ async fn start_daemon(component: &Path) -> (DaemonGuard, PathBuf, String) {
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
     seed_mock_backend(&data_home, component);
 
     let child = Command::new(DAEMON_BIN)
@@ -156,6 +162,7 @@ async fn start_daemon(component: &Path) -> (DaemonGuard, PathBuf, String) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -165,7 +172,7 @@ async fn start_daemon(component: &Path) -> (DaemonGuard, PathBuf, String) {
     // below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_transcribe.rs
+++ b/super-stt-daemon/tests/http_smoke_transcribe.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//! `POST /v1/transcribe` with audio the caller already has.
+//!
+//! The endpoint has four use cases dispatched on the body, and three of them
+//! need a microphone. This one does not: a top-level `audio_data` array means
+//! "transcribe this buffer", and the daemon must not touch the mic. That makes
+//! it the one transcription path a hermetic test can drive end to end — through
+//! the real backend host, into a component that answers, and back out as JSON.
+//!
+//! What it needs is a backend that actually runs, so this stages the prebuilt
+//! mock component (`just build-mock-wasm-backend`) rather than the manifest-only
+//! fixtures the other smoke tests use, selects it, loads it, and then asks it to
+//! transcribe. Without the component built the test says so and returns, the
+//! same as the other mock-backed tests.
+
+mod common;
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::client::conn::http1::handshake;
+use hyper::{Method, Request, StatusCode};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use super_stt_shared::daemon::http_client;
+use tokio::net::UnixStream;
+use tokio::time::sleep;
+
+const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
+
+/// The fixture backend's `source`, which is how a stage selects it.
+const FIXTURE_SOURCE: &str = "github.com/super-stt/mock";
+
+/// The model the fixture serves at stage 1.
+const FIXTURE_MODEL: &str = "echo-stt";
+
+/// One transcription model, backed by the mock component. `contract = "v2"` is
+/// what the component speaks; `none` is not offered because a stage that loads
+/// needs a device it can resolve.
+const FIXTURE_MANIFEST: &str = r#"[backend]
+source = "github.com/super-stt/mock"
+name = "Mock STT"
+version = "1.0.0"
+kind = "wasm"
+entrypoint = "mock.wasm"
+contract = "v2"
+id = "app.super-stt.mock"
+description = "A backend that answers, so a transcript can come back."
+license = "GPL-3.0-only"
+
+[network]
+allowed_hosts = []
+
+[[models]]
+name = "echo-stt"
+primary_language = "en"
+supported_languages = ["en"]
+supported_devices = ["cpu"]
+"#;
+
+struct DaemonGuard {
+    child: Child,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        common::shutdown(&mut self.child);
+        for p in &self.cleanup_paths {
+            let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
+        }
+    }
+}
+
+fn next_test_uniq() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static UNIQ: AtomicU64 = AtomicU64::new(0);
+    UNIQ.fetch_add(1, Ordering::Relaxed)
+}
+
+async fn start_daemon(component: &Path) -> (DaemonGuard, PathBuf, String) {
+    let unique = format!("stt-transcribe-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let http_socket = tmp.join(format!("{unique}-http.sock"));
+    let config_home = tmp.join(format!("{unique}-config"));
+    let data_home = tmp.join(format!("{unique}-data"));
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    for d in [&config_home, &data_home, &cache_home] {
+        std::fs::create_dir_all(d).expect("create test xdg dir");
+    }
+
+    common::BackendFixture {
+        dir_name: "mock-stt",
+        manifest: FIXTURE_MANIFEST,
+        entrypoint: "mock.wasm",
+        // Real bytes: this backend is asked to answer, not just to exist.
+        component: Some(component),
+    }
+    .install(&data_home);
+
+    let child = Command::new(DAEMON_BIN)
+        .env("SUPER_STT_KEYRING_MOCK", "1")
+        .env("SUPER_STT_AUTO_APPROVE", "1")
+        .env("SUPER_STT_HTTP_SOCKET", &http_socket)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn super-stt-daemon");
+
+    let guard = DaemonGuard {
+        child,
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
+    };
+
+    let deadline = Instant::now() + Duration::from_mins(2);
+    while Instant::now() < deadline {
+        if Path::new(&http_socket).exists()
+            && let Ok(auth) = http_client::auth_request(
+                http_socket.clone(),
+                "transcribe-smoke",
+                &["settings", "transcribe"],
+            )
+            .await
+        {
+            return (guard, http_socket, auth.session_token);
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    panic!("daemon HTTP listener not ready within 120s");
+}
+
+async fn raw_request(
+    socket_path: &PathBuf,
+    method: Method,
+    path: &str,
+    token: &str,
+    body: Option<serde_json::Value>,
+) -> (StatusCode, serde_json::Value) {
+    let stream = UnixStream::connect(socket_path).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Full<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let body_bytes = body
+        .map(|b| serde_json::to_vec(&b).expect("encode body"))
+        .unwrap_or_default();
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(format!("http://stt.local/v1{path}"))
+        .header("host", "stt.local")
+        .header("authorization", format!("Bearer {token}"));
+    if !body_bytes.is_empty() {
+        builder = builder
+            .header("content-type", "application/json")
+            .header("content-length", body_bytes.len().to_string());
+    }
+    let req = builder
+        .body(Full::new(Bytes::from(body_bytes)))
+        .expect("build req");
+
+    let resp = sender.send_request(req).await.expect("send req");
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+async fn get(p: &PathBuf, path: &str, token: &str) -> (StatusCode, serde_json::Value) {
+    raw_request(p, Method::GET, path, token, None).await
+}
+
+async fn post(
+    p: &PathBuf,
+    path: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    raw_request(p, Method::POST, path, token, Some(body)).await
+}
+
+/// Select the fixture backend at stage 1 and load its model, then wait for the
+/// stage to report it running. The load is asynchronous — the endpoint answers
+/// before it finishes — so this polls the way `http_smoke_stage_flow` does.
+async fn load_stage_one(sock: &PathBuf, token: &str) {
+    let (status, body) = post(
+        sock,
+        "/pipeline/1",
+        token,
+        serde_json::json!({ "source": FIXTURE_SOURCE }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "select backend: {body}");
+
+    let (status, body) = post(
+        sock,
+        "/pipeline/1/model",
+        token,
+        serde_json::json!({ "model": FIXTURE_MODEL }),
+    )
+    .await;
+    assert!(status.is_success(), "load model answered {status}: {body}");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let (_, body) = get(sock, "/pipeline/1/model", token).await;
+        last = body["model"].clone();
+        if last["loaded"] == true {
+            return;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    panic!("stage 1 never came up within 30s; last slot: {last}");
+}
+
+/// A quarter-second of silence at 16 kHz. The mock answers with a fixed
+/// transcript whatever it is handed, so the samples only have to be a plausible
+/// buffer — but they do have to survive the round trip as `f32`.
+fn silence() -> Vec<f32> {
+    vec![0.0; 4000]
+}
+
+/// The whole point: hand the daemon a buffer and get a transcript back, with no
+/// microphone anywhere in it.
+///
+/// This is the one path through `/transcribe` that runs the real backend host
+/// end to end — request built, dispatched to a loaded component, and narrowed
+/// back to the documented `{status, transcription}` body.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn precaptured_audio_comes_back_as_a_transcript() {
+    let Some(component) = common::mock_component() else {
+        eprintln!("skipping: mock component not built (run `just build-mock-wasm-backend`)");
+        return;
+    };
+    let (_guard, sock, token) = start_daemon(&component).await;
+    load_stage_one(&sock, &token).await;
+
+    let (status, body) = post(
+        &sock,
+        "/transcribe",
+        &token,
+        serde_json::json!({ "audio_data": silence(), "sample_rate": 16000 }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "POST /transcribe: {body}");
+    assert_eq!(body["status"], "success", "{body}");
+    assert_eq!(
+        body["transcription"],
+        common::MOCK_TRANSCRIPTION,
+        "the transcript must come from the component that was loaded: {body}"
+    );
+}
+
+/// A per-request `language` rides along with the buffer. The mock ignores it,
+/// so what this pins is that naming a language does not make the request
+/// invalid — the override is read off the top level and carried, not rejected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn precaptured_audio_accepts_a_language_override() {
+    let Some(component) = common::mock_component() else {
+        eprintln!("skipping: mock component not built (run `just build-mock-wasm-backend`)");
+        return;
+    };
+    let (_guard, sock, token) = start_daemon(&component).await;
+    load_stage_one(&sock, &token).await;
+
+    let (status, body) = post(
+        &sock,
+        "/transcribe",
+        &token,
+        serde_json::json!({ "audio_data": silence(), "sample_rate": 16000, "language": "en" }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "POST /transcribe with language: {body}"
+    );
+    assert_eq!(body["transcription"], common::MOCK_TRANSCRIPTION, "{body}");
+}
+
+/// `stream_realtime` asks for incremental frames off the microphone, and
+/// `audio_data` says there is no microphone in this request. The two cannot both
+/// be honored, so the daemon refuses rather than silently dropping one — a
+/// client that sent both is confused about which call it is making.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn precaptured_audio_refuses_a_realtime_stream() {
+    let Some(component) = common::mock_component() else {
+        eprintln!("skipping: mock component not built (run `just build-mock-wasm-backend`)");
+        return;
+    };
+    let (_guard, sock, token) = start_daemon(&component).await;
+
+    let (status, body) = post(
+        &sock,
+        "/transcribe",
+        &token,
+        serde_json::json!({ "audio_data": silence(), "stream_realtime": true }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["status"], "error", "{body}");
+    assert_eq!(
+        body["message"], "stream_realtime_with_audio_data",
+        "the refusal must name which pair of fields conflicted: {body}"
+    );
+}
+
+/// `audio_data` that is not a list of numbers is a `400`, not a panic and — the
+/// part that matters — not a fallback to opening the microphone. A malformed
+/// buffer must fail as a bad request, never as a silent recording.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn audio_data_that_is_not_samples_is_rejected() {
+    let Some(component) = common::mock_component() else {
+        eprintln!("skipping: mock component not built (run `just build-mock-wasm-backend`)");
+        return;
+    };
+    let (_guard, sock, token) = start_daemon(&component).await;
+
+    let (status, body) = post(
+        &sock,
+        "/transcribe",
+        &token,
+        serde_json::json!({ "audio_data": ["not", "numbers"] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["status"], "error", "{body}");
+    assert!(
+        body["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("audio_data")),
+        "the message must say which field was bad: {body}"
+    );
+}
+
+/// Pre-captured audio with nothing loaded to transcribe it. The daemon has to
+/// answer with the error the command bus produced rather than a `200` carrying
+/// an empty transcript — an empty string is a legitimate transcription of
+/// silence, so a client cannot tell the two apart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn precaptured_audio_with_no_model_loaded_is_an_error() {
+    let Some(component) = common::mock_component() else {
+        eprintln!("skipping: mock component not built (run `just build-mock-wasm-backend`)");
+        return;
+    };
+    // Deliberately no `load_stage_one`: the backend is installed but nothing
+    // has been selected or loaded.
+    let (_guard, sock, token) = start_daemon(&component).await;
+
+    let (status, body) = post(
+        &sock,
+        "/transcribe",
+        &token,
+        serde_json::json!({ "audio_data": silence(), "sample_rate": 16000 }),
+    )
+    .await;
+
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "no model loaded must not answer 2xx, got {status}: {body}"
+    );
+    assert_eq!(body["status"], "error", "{body}");
+}

--- a/super-stt-daemon/tests/http_smoke_transport.rs
+++ b/super-stt-daemon/tests/http_smoke_transport.rs
@@ -56,6 +56,12 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1")
@@ -63,6 +69,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
         .env("SUPER_STT_HTTP_SOCKET", &http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -72,7 +79,7 @@ async fn start_daemon() -> (DaemonGuard, PathBuf) {
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone(), config_home, data_home],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/http_smoke_transport.rs
+++ b/super-stt-daemon/tests/http_smoke_transport.rs
@@ -12,6 +12,8 @@
 //! Uses `SUPER_STT_AUTO_APPROVE=1` (no GUI) + `SUPER_STT_KEYRING_MOCK=1`
 //! (in-memory keyring), so it runs in the default `cargo test` flow.
 
+mod common;
+
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -32,8 +34,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
             let _ = std::fs::remove_dir_all(p);

--- a/super-stt-daemon/tests/registry_http.rs
+++ b/super-stt-daemon/tests/registry_http.rs
@@ -19,6 +19,8 @@
 //! cargo test -p super-stt-daemon --test registry_http -- --ignored --nocapture
 //! ```
 
+mod common;
+
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::body::Bytes;
 use hyper::client::conn::http1::handshake;
@@ -42,8 +44,7 @@ struct DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
         }

--- a/super-stt-daemon/tests/registry_http.rs
+++ b/super-stt-daemon/tests/registry_http.rs
@@ -11,13 +11,12 @@
 //!   in the install pipeline surfaces as a `registry.install.failed` SSE
 //!   event.
 //!
-//! Both tests carry `#[ignore]` so they are skipped by the automated
-//! `cargo test --lib` run (which hangs on a locked keyring). Run them
-//! manually with:
-//!
-//! ```bash
-//! cargo test -p super-stt-daemon --test registry_http -- --ignored --nocapture
-//! ```
+//! These once carried `#[ignore]`, on the grounds that a real daemon needs a
+//! responsive system keyring and CI's hangs on an unlock prompt. The harness
+//! below has since set `SUPER_STT_KEYRING_MOCK=1` — the in-memory store the
+//! rest of the smoke tests run against — so there is no prompt to hang on, and
+//! the whole `/registry` surface was being skipped for a reason that no longer
+//! held. They run with the suite.
 
 mod common;
 
@@ -332,7 +331,6 @@ fn fixture_index_correct_hash(asset_url: &str) -> String {
 /// `compatibility.compatible == true` for a wasm backend (wasm is always
 /// compatible on any host) and `id == "openai"`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "spawns real daemon; requires a responsive system keyring"]
 async fn list_registry_backends_returns_compat() {
     let mut mock_server = mockito::Server::new_async().await;
 
@@ -392,7 +390,6 @@ async fn list_registry_backends_returns_compat() {
 /// - Drain the SSE stream (with a timeout) looking for
 ///   `registry.install.failed` carrying `error == "asset_hash_mismatch"`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "spawns real daemon; requires a responsive system keyring"]
 async fn install_pipeline_rejects_hash_mismatch() {
     // Two independent mockito servers: one for the registry index, one for
     // the asset download. Using separate servers avoids path-collision issues
@@ -424,10 +421,17 @@ async fn install_pipeline_rejects_hash_mismatch() {
     let registry_url = format!("{}/index.json", index_server.url());
     let (_guard, http_socket) = start_daemon_with_registry(&registry_url).await;
 
-    // Mint a settings-scope token.
-    let auth = http_client::auth_request(http_socket.clone(), "registry-test", &["settings"])
-        .await
-        .expect("auth_request should succeed");
+    // `settings` for the install POST, `daemon_status` for the SSE topic:
+    // `/events` scopes per *topic*, and `registry_install` sits under
+    // `daemon_status`. A settings-only token opens the stream with a `403`,
+    // which is what this test did while it was `#[ignore]`d.
+    let auth = http_client::auth_request(
+        http_socket.clone(),
+        "registry-test",
+        &["settings", "daemon_status"],
+    )
+    .await
+    .expect("auth_request should succeed");
     let token = auth.session_token;
 
     // Open SSE subscription BEFORE posting the install so no events are
@@ -458,32 +462,49 @@ async fn install_pipeline_rejects_hash_mismatch() {
         .to_owned();
     assert!(!install_id.is_empty(), "install_id must not be empty");
 
-    // Collect SSE bytes until the failed event arrives (timeout 30 s).
-    let sse_bytes = tokio::time::timeout(Duration::from_secs(30), async {
-        sse_resp
-            .into_body()
-            .collect()
-            .await
-            .expect("collect sse body")
-            .to_bytes()
-    })
-    .await
-    .unwrap_or_default(); // On timeout we work with whatever arrived.
+    // Read the stream frame by frame until the failed event shows up.
+    //
+    // Not `collect()`: an SSE stream does not end, so collecting the whole
+    // body never resolves, and a `timeout` around it drops the future along
+    // with every byte it had buffered — leaving nothing to match on. This
+    // test reported "frames seen: []" for exactly that reason the first time
+    // it was run after its `#[ignore]` came off.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut sse_bytes: Vec<u8> = Vec::new();
+    let mut body = sse_resp.into_body();
 
-    let frames = extract_sse_data_for_event(&sse_bytes, "registry_install");
-    let failed_frame = frames.iter().find(|data| {
-        let v: serde_json::Value = serde_json::from_str(data).unwrap_or_default();
-        v["type"] == "registry.install.failed" && v["install_id"] == install_id.as_str()
-    });
+    let failed = loop {
+        if let Some(found) = extract_sse_data_for_event(&sse_bytes, "registry_install")
+            .into_iter()
+            .find(|data| {
+                let v: serde_json::Value = serde_json::from_str(data).unwrap_or_default();
+                v["type"] == "registry.install.failed" && v["install_id"] == install_id.as_str()
+            })
+        {
+            break found;
+        }
 
-    let failed = failed_frame.unwrap_or_else(|| {
-        panic!(
-            "no registry.install.failed event for install_id={install_id} within 30 s; \
-             frames seen: {frames:?}"
-        )
-    });
+        match tokio::time::timeout_at(deadline, body.frame()).await {
+            Ok(Some(Ok(frame))) => {
+                if let Some(chunk) = frame.data_ref() {
+                    sse_bytes.extend_from_slice(chunk);
+                }
+            }
+            Ok(Some(Err(e))) => panic!("SSE stream errored while waiting: {e}"),
+            Ok(None) => panic!(
+                "SSE stream closed before registry.install.failed for \
+                 install_id={install_id}; saw: {:?}",
+                String::from_utf8_lossy(&sse_bytes)
+            ),
+            Err(_) => panic!(
+                "no registry.install.failed event for install_id={install_id} within 30 s; \
+                 saw: {:?}",
+                String::from_utf8_lossy(&sse_bytes)
+            ),
+        }
+    };
 
-    let v: serde_json::Value = serde_json::from_str(failed).expect("parse failed frame");
+    let v: serde_json::Value = serde_json::from_str(&failed).expect("parse failed frame");
     assert_eq!(
         v["error"], "asset_hash_mismatch",
         "wrong error variant: {v}"

--- a/super-stt-daemon/tests/registry_http.rs
+++ b/super-stt-daemon/tests/registry_http.rs
@@ -46,7 +46,10 @@ impl Drop for DaemonGuard {
     fn drop(&mut self) {
         common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
+            // The list holds the socket file and the three XDG dirs, so try
+            // both; whichever does not apply is a no-op.
             let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
         }
     }
 }
@@ -67,6 +70,12 @@ async fn start_daemon_with_registry(registry_url: &str) -> (DaemonGuard, PathBuf
     let data_home = tmp.join(format!("{unique}-data"));
     std::fs::create_dir_all(&config_home).expect("create test config dir");
     std::fs::create_dir_all(&data_home).expect("create test data dir");
+    // Isolate the cache too. The registry client persists its index (and its
+    // ETag) under XDG_CACHE_HOME; sharing one file across concurrently
+    // spawned test daemons has them overwrite each other's catalog, and
+    // unisolated it is the developer's own.
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    std::fs::create_dir_all(&cache_home).expect("create test cache dir");
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1") // in-memory keyring (no secret-service prompt in tests/CI)
@@ -75,6 +84,7 @@ async fn start_daemon_with_registry(registry_url: &str) -> (DaemonGuard, PathBuf
         .env("SUPER_STT_REGISTRY_URL", registry_url)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -84,7 +94,7 @@ async fn start_daemon_with_registry(registry_url: &str) -> (DaemonGuard, PathBuf
     // panic below must still kill and reap the daemon, not leak it.
     let guard = DaemonGuard {
         child,
-        cleanup_paths: vec![http_socket.clone()],
+        cleanup_paths: vec![http_socket.clone(), config_home, data_home, cache_home],
     };
 
     let deadline = Instant::now() + Duration::from_mins(2);

--- a/super-stt-daemon/tests/registry_http.rs
+++ b/super-stt-daemon/tests/registry_http.rs
@@ -68,6 +68,19 @@ fn next_test_uniq() -> u64 {
 /// Spawn a hermetic daemon configured to use `registry_url` instead of the
 /// live registry URL. Returns the guard and the Unix socket path.
 async fn start_daemon_with_registry(registry_url: &str) -> (DaemonGuard, PathBuf) {
+    start_daemon_with_registry_and_backend(registry_url, None).await
+}
+
+/// As [`start_daemon_with_registry`], but with `installed` seeded into the
+/// daemon's backends directory before it starts.
+///
+/// Seeding has to happen before the spawn: the daemon discovers backends once,
+/// during `post_init`, so a manifest written afterwards is not found until the
+/// next start.
+async fn start_daemon_with_registry_and_backend(
+    registry_url: &str,
+    installed: Option<&str>,
+) -> (DaemonGuard, PathBuf) {
     let unique = format!("stt-reg-{}-{}", std::process::id(), next_test_uniq());
     let tmp = std::env::temp_dir();
     let http_socket = tmp.join(format!("{unique}-http.sock"));
@@ -81,6 +94,19 @@ async fn start_daemon_with_registry(registry_url: &str) -> (DaemonGuard, PathBuf
     // unisolated it is the developer's own.
     let cache_home = tmp.join(format!("{unique}-cache"));
     std::fs::create_dir_all(&cache_home).expect("create test cache dir");
+
+    if let Some(manifest) = installed {
+        common::BackendFixture {
+            dir_name: "fixture-openai",
+            manifest,
+            entrypoint: "openai.wasm",
+            // Discovery reads the manifest and never execs the entrypoint, and
+            // nothing here asks the backend to run — only what version of it is
+            // installed.
+            component: None,
+        }
+        .install(&data_home);
+    }
 
     let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1") // in-memory keyring (no secret-service prompt in tests/CI)
@@ -295,8 +321,13 @@ fn fixture_index_wasm(asset_url: &str) -> String {
 }
 
 /// Same fixture but with a correct sha256 for the wasm-magic bytes
-/// `\x00\x61\x73\x6d` (never actually used here, kept for reference).
-fn fixture_index_correct_hash(asset_url: &str) -> String {
+/// `\x00\x61\x73\x6d`, at whatever version the caller wants to publish.
+///
+/// The version is a parameter because `/registry/backend/update` decides what
+/// to do by comparing it against the version installed on disk: newer is an
+/// update, equal (or older) is a no-op. Both answers need the same catalog with
+/// a different number in it.
+fn fixture_index_at_version(asset_url: &str, version: &str) -> String {
     serde_json::json!({
         "schema_version": 1,
         "generated_at": "2026-01-01T00:00:00Z",
@@ -304,8 +335,8 @@ fn fixture_index_correct_hash(asset_url: &str) -> String {
         "backends": [{
             "id": "openai",
             "source": "github.com/x/y",
-            "version": "1.0.0",
-            "tag": "v1.0.0",
+            "version": version,
+            "tag": format!("v{version}"),
             "name": "OpenAI",
             "description": null,
             "license": "Apache-2.0",
@@ -330,6 +361,39 @@ fn fixture_index_correct_hash(asset_url: &str) -> String {
     })
     .to_string()
 }
+
+/// The catalog at `1.0.0` — the same version [`FIXTURE_BACKEND_MANIFEST`]
+/// installs, so tests that are not about updating see nothing on offer.
+fn fixture_index_correct_hash(asset_url: &str) -> String {
+    fixture_index_at_version(asset_url, "1.0.0")
+}
+
+/// The catalog's `github.com/x/y` as an *installed* backend at `1.0.0`.
+///
+/// `source` is what ties the two together: it is the key
+/// `/registry/backend/update` matches on to find the installed version, and the
+/// same key `/registry/backend/list` uses to decide `update_available`. A
+/// fixture whose `source` does not match the index entry is simply a different
+/// backend, and every update against it answers `not_installed`.
+const FIXTURE_BACKEND_MANIFEST: &str = r#"[backend]
+source = "github.com/x/y"
+name = "OpenAI"
+version = "1.0.0"
+kind = "wasm"
+entrypoint = "openai.wasm"
+contract = "v1"
+description = "Installed at 1.0.0, so the catalog can offer something newer."
+license = "Apache-2.0"
+
+[network]
+allowed_hosts = ["api.openai.com"]
+
+[[models]]
+name = "whisper-1"
+primary_language = "en"
+supported_languages = ["en"]
+supported_devices = ["none"]
+"#;
 
 // ---------- tests -------------------------------------------------------------
 
@@ -811,4 +875,161 @@ async fn update_rejects_a_missing_body() {
     let (status, body) = raw_post_no_body(sock, "/registry/backend/update", token).await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
     assert_eq!(body["error"], "missing_body", "{body}");
+}
+
+/// A daemon with `github.com/x/y` installed at `1.0.0` and a catalog offering
+/// `catalog_version`. Returns the fixture plus the asset server, which has to
+/// outlive the daemon that may fetch from it.
+async fn start_with_installed_backend(catalog_version: &str) -> CatalogFixture {
+    let mut server = mockito::Server::new_async().await;
+    let asset_url = format!("{}/openai.wasm", server.url());
+    let index_mock = server
+        .mock("GET", "/index.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(fixture_index_at_version(&asset_url, catalog_version))
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    // The update pipeline downloads in the background once the endpoint has
+    // answered. Serve the bytes the catalog's sha256 is for, so the fetch that
+    // follows the `202` is a real one rather than a connection error in the log.
+    let _asset_mock = server
+        .mock("GET", "/openai.wasm")
+        .with_status(200)
+        .with_header("content-type", "application/wasm")
+        .with_body(&[0x00, 0x61, 0x73, 0x6d][..])
+        .create_async()
+        .await;
+
+    let registry_url = format!("{}/index.json", server.url());
+    let (daemon, socket) =
+        start_daemon_with_registry_and_backend(&registry_url, Some(FIXTURE_BACKEND_MANIFEST)).await;
+
+    let token = http_client::auth_request(socket.clone(), "registry-test", &["settings"])
+        .await
+        .expect("auth_request should succeed under SUPER_STT_AUTO_APPROVE=1")
+        .session_token;
+
+    CatalogFixture {
+        _daemon: daemon,
+        socket,
+        token,
+        _index_mock: index_mock,
+        _server: server,
+    }
+}
+
+/// The catalog offering something newer than what is on disk: the update is
+/// accepted, `202`, with an `install_id` to follow and both versions named so a
+/// client can say what it is upgrading from and to.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_accepts_a_newer_catalog_version() {
+    let fx = start_with_installed_backend("2.0.0").await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/update",
+        token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::ACCEPTED, "{body}");
+    assert_eq!(body["from_version"], "1.0.0", "{body}");
+    assert_eq!(body["to_version"], "2.0.0", "{body}");
+    assert_eq!(body["noop"], false, "{body}");
+    assert!(
+        body["install_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("ins_")),
+        "an accepted update must name the install to follow: {body}"
+    );
+}
+
+/// The catalog offering the version already installed is a no-op: `200`, not
+/// `202`, and no `install_id` — there is nothing to follow.
+///
+/// The interesting half is that `noop` is a *refusal to act*, not just a label.
+/// A client that polled an `install_id` here would wait forever.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_is_a_noop_when_the_catalog_matches_what_is_installed() {
+    let fx = start_with_installed_backend("1.0.0").await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/update",
+        token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a no-op is not an accepted job: {body}"
+    );
+    assert_eq!(body["noop"], true, "{body}");
+    assert_eq!(body["from_version"], "1.0.0", "{body}");
+    assert_eq!(body["to_version"], "1.0.0", "{body}");
+    assert!(body["install_id"].is_null(), "{body}");
+}
+
+/// A catalog *older* than what is installed is refused the same way — as a
+/// no-op, never as an update.
+///
+/// This is the downgrade guard (audit Tier 1 #31). Before the shared semver
+/// check, a lower registry version "updated" happily and walked the install
+/// backwards. Nothing else in the suite covers it: the equal-version case above
+/// passes whether the check is `!=` or `is_newer`, and only this one fails if
+/// the comparison loosens.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_refuses_to_walk_backwards_to_an_older_catalog_version() {
+    let fx = start_with_installed_backend("0.9.0").await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/update",
+        token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a downgrade must not be accepted: {body}"
+    );
+    assert_eq!(body["noop"], true, "{body}");
+    assert_eq!(
+        body["to_version"], "1.0.0",
+        "a no-op reports the installed version on both sides, never the older \
+         one it declined to install: {body}"
+    );
+    assert!(body["install_id"].is_null(), "{body}");
+}
+
+/// With the backend installed, the catalog listing says so: `installed_version`
+/// is filled in and `update_available` reflects the comparison the update
+/// endpoint would make. The two read the same manifest through the same helper,
+/// so a client can trust Browse and the update to agree.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn list_reports_installed_version_and_offers_the_update() {
+    let fx = start_with_installed_backend("2.0.0").await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_get_json(sock, "/registry/backend/list", token).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let backend = &body["backends"][0];
+    assert_eq!(backend["source"], "github.com/x/y", "{body}");
+    assert_eq!(backend["installed_version"], "1.0.0", "{body}");
+    assert_eq!(backend["version"], "2.0.0", "{body}");
+    assert_eq!(
+        backend["update_available"], true,
+        "the catalog is newer, so Browse must offer it: {body}"
+    );
 }

--- a/super-stt-daemon/tests/registry_http.rs
+++ b/super-stt-daemon/tests/registry_http.rs
@@ -1,22 +1,28 @@
 // SPDX-License-Identifier: GPL-3.0-only
 //! HTTP integration tests for the `/registry/*` endpoints.
 //!
-//! These tests spawn the real `super-stt-daemon` binary, wire it to a
-//! mockito HTTP server in place of the live registry, and exercise the
-//! two core paths:
+//! These tests spawn the real `super-stt-daemon` binary and wire it to a
+//! mockito HTTP server in place of the live registry, so the whole surface is
+//! exercised without reaching the published catalog:
 //!
 //! - `GET  /v1/registry/backend/list`  — index fetched, compat evaluated, list
 //!   returned.
 //! - `POST /v1/registry/backend/install` + `GET /v1/events` — hash mismatch
 //!   in the install pipeline surfaces as a `registry.install.failed` SSE
 //!   event.
+//! - `POST /v1/registry/backend/refresh` — re-fetch, and what an unreachable
+//!   catalog answers.
+//! - `POST /v1/registry/backend/preview` — resolve a source without
+//!   installing it, and the ways a body can be malformed.
+//! - `POST /v1/registry/backend/update` — the version lookup's failure modes,
+//!   and that a failed update releases its inflight marker.
 //!
-//! These once carried `#[ignore]`, on the grounds that a real daemon needs a
-//! responsive system keyring and CI's hangs on an unlock prompt. The harness
-//! below has since set `SUPER_STT_KEYRING_MOCK=1` — the in-memory store the
-//! rest of the smoke tests run against — so there is no prompt to hang on, and
-//! the whole `/registry` surface was being skipped for a reason that no longer
-//! held. They run with the suite.
+//! The first two once carried `#[ignore]`, on the grounds that a real daemon
+//! needs a responsive system keyring and CI's hangs on an unlock prompt. The
+//! harness below has since set `SUPER_STT_KEYRING_MOCK=1` — the in-memory
+//! store the rest of the smoke tests run against — so there is no prompt to
+//! hang on, and the whole `/registry` surface was being skipped for a reason
+//! that no longer held. They run with the suite.
 
 mod common;
 
@@ -510,4 +516,299 @@ async fn install_pipeline_rejects_hash_mismatch() {
         "wrong error variant: {v}"
     );
     assert_eq!(v["source"], "github.com/x/y", "wrong source in event: {v}");
+}
+
+/// A POST carrying no body at all — no `content-type`, no bytes. The
+/// `Option<Json<_>>` extractor answers `None` for this, which the handlers
+/// turn into `missing_body`; sending `{}` instead would take a different
+/// branch, so this needs its own helper.
+async fn raw_post_no_body(
+    socket_path: &PathBuf,
+    path: &str,
+    token: &str,
+) -> (StatusCode, serde_json::Value) {
+    let stream = UnixStream::connect(socket_path).await.expect("connect");
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let (mut sender, conn) = handshake::<_, Empty<Bytes>>(io).await.expect("handshake");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(format!("http://stt.local/v1{path}"))
+        .header("host", "stt.local")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Empty::<Bytes>::new())
+        .expect("build req");
+
+    let resp = sender.send_request(req).await.expect("send req");
+    let status = resp.status();
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect")
+        .to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, body)
+}
+
+/// A daemon wired to a mock catalog, and everything a test needs to talk to it.
+///
+/// The two `mockito` handles are held, not used: a `Mock` de-registers itself
+/// when dropped and a `ServerGuard` shuts the server down, so letting either go
+/// early pulls the catalog out from under a daemon that is still running. That
+/// is invisible to anything reading a *cached* index and fatal to
+/// `/registry/backend/refresh`, whose whole job is to fetch it again.
+///
+/// Field order is drop order: the daemon stops before the server it talks to.
+struct CatalogFixture {
+    _daemon: DaemonGuard,
+    socket: PathBuf,
+    token: String,
+    _index_mock: mockito::Mock,
+    _server: mockito::ServerGuard,
+}
+
+/// Spawn a daemon against an index server serving `fixture_index_correct_hash`,
+/// and mint a `settings`-scope token. The shape every test below opens with.
+async fn start_with_catalog() -> CatalogFixture {
+    let mut server = mockito::Server::new_async().await;
+    let asset_url = format!("{}/openai.wasm", server.url());
+    let index_mock = server
+        .mock("GET", "/index.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(fixture_index_correct_hash(&asset_url))
+        // The daemon fetches at startup and again on every refresh.
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let registry_url = format!("{}/index.json", server.url());
+    let (daemon, socket) = start_daemon_with_registry(&registry_url).await;
+
+    let token = http_client::auth_request(socket.clone(), "registry-test", &["settings"])
+        .await
+        .expect("auth_request should succeed under SUPER_STT_AUTO_APPROVE=1")
+        .session_token;
+
+    CatalogFixture {
+        _daemon: daemon,
+        socket,
+        token,
+        _index_mock: index_mock,
+        _server: server,
+    }
+}
+
+// ---------- POST /registry/backend/refresh -----------------------------------
+
+/// The catalog is re-fetched and the count reported back. `backend_count` is
+/// what a client renders after a publish, so it has to be the count of the
+/// index just fetched rather than of whatever was cached.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refresh_reports_the_refetched_catalog() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_no_body(sock, "/registry/backend/refresh", token).await;
+    assert_eq!(status, StatusCode::OK, "POST refresh: {body}");
+    assert_eq!(body["backend_count"], 1, "{body}");
+    assert_eq!(body["schema_version"], 1, "{body}");
+    assert_eq!(body["generated_at"], "2026-01-01T00:00:00Z", "{body}");
+}
+
+/// An index the daemon cannot fetch is `503 registry_unavailable`, not a `500`
+/// and not an empty `200`: "the catalog is unreachable" and "the catalog is
+/// empty" are different answers and a client shows different things for them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn refresh_reports_an_unreachable_catalog_as_unavailable() {
+    let mut index_server = mockito::Server::new_async().await;
+    let _index_mock = index_server
+        .mock("GET", "/index.json")
+        .with_status(500)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+
+    let registry_url = format!("{}/index.json", index_server.url());
+    let (_guard, sock) = start_daemon_with_registry(&registry_url).await;
+    let token = http_client::auth_request(sock.clone(), "registry-test", &["settings"])
+        .await
+        .expect("auth_request")
+        .session_token;
+
+    let (status, body) = raw_post_no_body(&sock, "/registry/backend/refresh", &token).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+    assert_eq!(body["error"], "registry_unavailable", "{body}");
+    // transport.md: every error carries the machine-readable code too.
+    assert_eq!(body["error_code"], "registry_unavailable", "{body}");
+}
+
+// ---------- POST /registry/backend/preview -----------------------------------
+
+/// A catalog `source` is described in the same shape `/registry/backend/list`
+/// returns, and nothing is installed as a result — the whole point of the
+/// endpoint being that it runs before the install's point of no return.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn preview_describes_a_catalog_source_without_installing_it() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/preview",
+        token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "POST preview: {body}");
+
+    assert_eq!(body["backend"]["id"], "openai", "{body}");
+    assert_eq!(body["backend"]["source"], "github.com/x/y", "{body}");
+    assert!(
+        body["backend"]["compatibility"]["compatible"]
+            .as_bool()
+            .unwrap_or(false),
+        "a wasm backend is compatible on any host: {body}"
+    );
+    // A catalog source is the trusted route, so no `unverified_source`.
+    assert!(body["warning"].is_null(), "{body}");
+    assert!(
+        body["backend"]["installed_version"].is_null(),
+        "nothing is installed on a fresh daemon: {body}"
+    );
+
+    // Preview writes nothing: the backend list still holds no install, and a
+    // second identical call answers the same. (Two calls are one call.)
+    let (status, again) = raw_post_json(
+        sock,
+        "/registry/backend/preview",
+        token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "second preview: {again}");
+    assert_eq!(again, body, "preview is not idempotent");
+}
+
+/// `source` / `repo_url` / `local_path` are exactly-one-of. Neither zero nor
+/// two is a request the daemon can act on, and both have to say so before any
+/// resolution happens.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn preview_requires_exactly_one_source_field() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    for body in [
+        serde_json::json!({}),
+        serde_json::json!({ "source": "github.com/x/y", "repo_url": "github.com/a/b" }),
+    ] {
+        let (status, resp) =
+            raw_post_json(sock, "/registry/backend/preview", &token, body.clone()).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "for {body}: {resp}");
+        assert_eq!(resp["error"], "bad_request", "for {body}: {resp}");
+        assert_eq!(
+            resp["message"], "provide exactly one of source, repo_url, local_path",
+            "for {body}: {resp}"
+        );
+    }
+
+    // No body at all is its own code — the client sent nothing, rather than
+    // sending something the daemon could not act on.
+    let (status, resp) = raw_post_no_body(sock, "/registry/backend/preview", token).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{resp}");
+    assert_eq!(resp["error"], "missing_body", "{resp}");
+}
+
+/// A `source` the catalog does not carry is `404`, not an empty `200`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn preview_404s_for_a_source_the_catalog_lacks() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/preview",
+        token,
+        serde_json::json!({ "source": "github.com/nobody/nothing" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert_eq!(body["error"], "not_found", "{body}");
+}
+
+// ---------- POST /registry/backend/update ------------------------------------
+
+/// Updating something that was never installed is `not_installed`, and that is
+/// deliberately a different code from `not_found`: the first says "install it
+/// first", the second says "no such backend anywhere". A client that conflated
+/// them would offer the wrong recovery.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_distinguishes_not_installed_from_not_found() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    // In the catalog, absent from disk.
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/update",
+        token,
+        serde_json::json!({ "source": "github.com/x/y" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert_eq!(body["error"], "not_installed", "{body}");
+
+    // In neither.
+    let (status, body) = raw_post_json(
+        sock,
+        "/registry/backend/update",
+        token,
+        serde_json::json!({ "source": "github.com/nobody/nothing" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert_eq!(body["error"], "not_found", "{body}");
+}
+
+/// The inflight marker must be released on every early return, not just the
+/// happy path. If a failed update left its marker behind, the next attempt for
+/// that source would answer `409 update_in_progress` forever — recoverable only
+/// by restarting the daemon. Two failing updates in a row is what catches it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_releases_its_inflight_marker_when_it_fails() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    for attempt in 1..=2 {
+        let (status, body) = raw_post_json(
+            &sock,
+            "/registry/backend/update",
+            token,
+            serde_json::json!({ "source": "github.com/x/y" }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "attempt {attempt} should still be not_installed, not a stuck 409: {body}"
+        );
+        assert_eq!(body["error"], "not_installed", "attempt {attempt}: {body}");
+    }
+}
+
+/// `POST /registry/backend/update` with no body is `missing_body`, and is
+/// rejected before the inflight marker is taken — there is no source to key it
+/// on yet.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn update_rejects_a_missing_body() {
+    let fx = start_with_catalog().await;
+    let (sock, token) = (&fx.socket, &fx.token);
+
+    let (status, body) = raw_post_no_body(sock, "/registry/backend/update", token).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["error"], "missing_body", "{body}");
 }

--- a/super-stt-daemon/tests/widget_smoke.rs
+++ b/super-stt-daemon/tests/widget_smoke.rs
@@ -5,11 +5,9 @@
 //! recovers from a daemon restart end-to-end — i.e. the applet won't
 //! get permanently stuck on stale data when the daemon goes away.
 //!
-//! Run with:
-//!
-//! ```bash
-//! cargo test -p super-stt-daemon --test widget_smoke -- --nocapture
-//! ```
+//! Hermetic: the daemon gets isolated XDG dirs and an in-memory keyring, and
+//! the client side of the session mint is mocked too, so this runs as part of
+//! the ordinary suite rather than needing a desktop session.
 
 mod common;
 
@@ -27,12 +25,21 @@ use tokio::time::sleep;
 
 const DAEMON_BIN: &str = env!("CARGO_BIN_EXE_super-stt-daemon");
 
-/// Stable `AppId` used across the test run. We don't need a per-run
-/// unique id here: the daemon-side persisted token survives restart by
-/// design, and that's exactly what we want to verify. We do
-/// `session::forget` in the test's drop guard so we don't leak entries
-/// on the developer's keyring.
-const TEST_APP_ID: AppId = AppId("widget-smoke-test");
+/// One `AppId` per test, because the session cache they share is
+/// process-wide.
+///
+/// `session::save` writes an in-memory cache that `obtain` consults before the
+/// keyring, and it is keyed by `AppId` alone. With a single id across the file,
+/// `subscription_recovers_from_invalid_session` — which deliberately plants a
+/// token the daemon has never seen — would hand that dead token to whichever
+/// other test looked next. These ran `--test-threads=1` while they were
+/// `#[ignore]`d, which hid it; running with the suite does not.
+///
+/// Each is stable across a restart *within* its own test, which is what
+/// `subscription_recovers_from_daemon_restart` needs to verify.
+const APP_ID_RESTART: AppId = AppId("widget-smoke-restart");
+const APP_ID_IDLE: AppId = AppId("widget-smoke-idle");
+const APP_ID_INVALID: AppId = AppId("widget-smoke-invalid");
 const TEST_APP_NAME: &str = "widget-smoke-test";
 const TEST_SCOPES: &[&str] = &["recording_events", "audio_visualization"];
 const TEST_TOPICS: &[&str] = &["recording_state", "frequency_bands"];
@@ -52,16 +59,21 @@ impl Drop for DaemonGuard {
     fn drop(&mut self) {
         common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
+            // Sockets are files, the XDG homes are directories; whichever does
+            // not apply is a no-op.
             let _ = std::fs::remove_file(p);
+            let _ = std::fs::remove_dir_all(p);
         }
     }
 }
 
-/// Forget the test's keyring entry on test exit so we don't leak.
-struct KeyringCleanupGuard;
+/// Forget the test's session entry on exit. With the mock keyring installed
+/// this never reaches the developer's secret service, but the *cache* it also
+/// clears is process-wide, so dropping it still matters.
+struct KeyringCleanupGuard(AppId);
 impl Drop for KeyringCleanupGuard {
     fn drop(&mut self) {
-        let _ = session::forget(TEST_APP_ID);
+        let _ = session::forget(self.0);
     }
 }
 
@@ -83,26 +95,37 @@ fn unique_socket_paths(label: &str) -> (PathBuf, PathBuf) {
     )
 }
 
-fn spawn_daemon(_legacy_socket: &Path, http_socket: &Path) -> Child {
-    // Isolate XDG_CONFIG_HOME so the test daemon doesn't overwrite
-    // the developer's real config when applying `--audio-theme` /
-    // `--device` CLI overrides.
-    let config_home = std::env::temp_dir().join(format!(
-        "stt-widget-cfg-{}-{}",
-        std::process::id(),
-        next_test_uniq()
-    ));
-    std::fs::create_dir_all(&config_home).expect("create test config dir");
+/// Spawn a hermetic daemon. Returns the child and the XDG dirs it was given, so
+/// the caller's guard can sweep them.
+///
+/// All three dirs are isolated, not just the config: an unisolated
+/// `XDG_DATA_HOME` has the daemon discover whatever backends the developer has
+/// installed (so the test is not hermetic and not reproducible), and an
+/// unisolated `XDG_CACHE_HOME` has it read and overwrite the developer's real
+/// registry index.
+fn spawn_daemon(_legacy_socket: &Path, http_socket: &Path) -> (Child, Vec<PathBuf>) {
+    let unique = format!("stt-widget-{}-{}", std::process::id(), next_test_uniq());
+    let tmp = std::env::temp_dir();
+    let config_home = tmp.join(format!("{unique}-config"));
+    let data_home = tmp.join(format!("{unique}-data"));
+    let cache_home = tmp.join(format!("{unique}-cache"));
+    for d in [&config_home, &data_home, &cache_home] {
+        std::fs::create_dir_all(d).expect("create test xdg dir");
+    }
 
-    Command::new(DAEMON_BIN)
+    let child = Command::new(DAEMON_BIN)
         .env("SUPER_STT_KEYRING_MOCK", "1") // in-memory keyring (no secret-service prompt in tests/CI)
         .env("SUPER_STT_AUTO_APPROVE", "1")
         .env("SUPER_STT_HTTP_SOCKET", http_socket)
         .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_DATA_HOME", &data_home)
+        .env("XDG_CACHE_HOME", &cache_home)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn super-stt-daemon")
+        .expect("spawn super-stt-daemon");
+
+    (child, vec![config_home, data_home, cache_home])
 }
 
 async fn wait_for_daemon_ready(http_socket: &Path) {
@@ -161,35 +184,33 @@ where
 /// the *second* `Connected`. Any of those phases failing means the
 /// applet would be stuck on stale data after a daemon restart.
 ///
-/// `#[ignore]` because this spawns the real daemon, which writes to
-/// the developer's system keyring on each mint. Run explicitly with:
-///
-/// ```bash
-/// cargo test -p super-stt-daemon --test widget_smoke -- --ignored --test-threads=1
-/// ```
-///
-/// (A locked or unresponsive secret-service will hang the daemon's
-/// first session-mint flush — there's no infrastructure for an
-/// in-process keyring shim from an integration test crate.)
+/// This once carried `#[ignore]`, on the grounds that minting a session writes
+/// to the developer's system keyring and a locked secret-service would hang —
+/// "there's no infrastructure for an in-process keyring shim from an
+/// integration test crate". There is: the daemon takes
+/// `SUPER_STT_KEYRING_MOCK=1`, which `spawn_daemon` has set for a while, and
+/// the client side of the mint is routed by [`common::install_mock_keyring`].
+/// Neither side reaches the real secret service, so it runs with the suite.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "spawns real daemon; requires a responsive system keyring"]
 async fn subscription_recovers_from_daemon_restart() {
-    let _keyring_guard = KeyringCleanupGuard;
+    common::install_mock_keyring();
+    let _keyring_guard = KeyringCleanupGuard(APP_ID_RESTART);
     let (legacy_socket, http_socket) = unique_socket_paths("widget-restart");
 
     // 1. Boot the daemon and confirm /auth/request works under
     //    SUPER_STT_AUTO_APPROVE so the subscription's session::obtain
     //    will succeed silently.
+    let (child, xdg_dirs) = spawn_daemon(&legacy_socket, &http_socket);
     let mut guard = DaemonGuard {
-        child: spawn_daemon(&legacy_socket, &http_socket),
-        cleanup_paths: vec![legacy_socket.clone(), http_socket.clone()],
+        child,
+        cleanup_paths: [vec![legacy_socket.clone(), http_socket.clone()], xdg_dirs].concat(),
     };
     wait_for_daemon_ready(&http_socket).await;
 
     // 2. Drive the subscription with tight timings so the test doesn't
     //    sit on the default backoff for tens of seconds.
     let mut config =
-        WidgetSubscriptionConfig::new(TEST_APP_ID, TEST_APP_NAME, TEST_SCOPES, TEST_TOPICS);
+        WidgetSubscriptionConfig::new(_keyring_guard.0, TEST_APP_NAME, TEST_SCOPES, TEST_TOPICS);
     config.idle_timeout = Duration::from_secs(5);
     config.initial_backoff = DEFAULT_INITIAL_BACKOFF;
     config.max_backoff = DEFAULT_MAX_BACKOFF;
@@ -232,9 +253,12 @@ async fn subscription_recovers_from_daemon_restart() {
     // 5. Restart the daemon. The subscription should reconnect within
     //    a backoff window without external intervention.
     eprintln!("[smoke] restarting daemon");
+    // Assigning over `guard` drops the old one, which sweeps the dirs the
+    // stopped daemon was using. The restart gets a fresh set.
+    let (child, xdg_dirs) = spawn_daemon(&legacy_socket, &http_socket);
     guard = DaemonGuard {
-        child: spawn_daemon(&legacy_socket, &http_socket),
-        cleanup_paths: vec![legacy_socket.clone(), http_socket.clone()],
+        child,
+        cleanup_paths: [vec![legacy_socket.clone(), http_socket.clone()], xdg_dirs].concat(),
     };
     wait_for_daemon_ready(&http_socket).await;
 
@@ -258,17 +282,17 @@ async fn subscription_recovers_from_daemon_restart() {
 /// Idle-timeout sanity: if the daemon doesn't send anything within
 /// the configured idle window, the subscription must surface a
 /// `Disconnected { reason: idle_timeout(...) }` rather than block
-/// forever. See note on `subscription_recovers_from_daemon_restart`
-/// re: `#[ignore]`.
+/// forever.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "spawns real daemon; requires a responsive system keyring"]
 async fn subscription_emits_idle_timeout_when_daemon_goes_quiet() {
-    let _keyring_guard = KeyringCleanupGuard;
+    common::install_mock_keyring();
+    let _keyring_guard = KeyringCleanupGuard(APP_ID_IDLE);
     let (legacy_socket, http_socket) = unique_socket_paths("widget-idle");
 
+    let (child, xdg_dirs) = spawn_daemon(&legacy_socket, &http_socket);
     let _guard = DaemonGuard {
-        child: spawn_daemon(&legacy_socket, &http_socket),
-        cleanup_paths: vec![legacy_socket.clone(), http_socket.clone()],
+        child,
+        cleanup_paths: [vec![legacy_socket.clone(), http_socket.clone()], xdg_dirs].concat(),
     };
     wait_for_daemon_ready(&http_socket).await;
 
@@ -276,7 +300,7 @@ async fn subscription_emits_idle_timeout_when_daemon_goes_quiet() {
     // and there are no recordings in flight, so a 2 s deadline will
     // fire before any natural traffic.
     let mut config =
-        WidgetSubscriptionConfig::new(TEST_APP_ID, TEST_APP_NAME, TEST_SCOPES, TEST_TOPICS);
+        WidgetSubscriptionConfig::new(_keyring_guard.0, TEST_APP_NAME, TEST_SCOPES, TEST_TOPICS);
     config.idle_timeout = Duration::from_secs(2);
 
     let mut stream: std::pin::Pin<
@@ -312,17 +336,20 @@ async fn subscription_emits_idle_timeout_when_daemon_goes_quiet() {
 /// `invalid_session` recovery: forge a stale token in the keyring and
 /// confirm the subscription drops it (`session::forget`) and re-mints
 /// via the consent path on the next iteration. Without this fix the
-/// subscription would loop forever on the same dead token. See note on
-/// `subscription_recovers_from_daemon_restart` re: `#[ignore]`.
+/// subscription would loop forever on the same dead token.
+///
+/// The planted token rides the process-wide session cache, which is why this
+/// test needs an `AppId` of its own — see [`APP_ID_INVALID`].
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "spawns real daemon + writes to system keyring; requires responsive secret-service"]
 async fn subscription_recovers_from_invalid_session() {
-    let _keyring_guard = KeyringCleanupGuard;
+    common::install_mock_keyring();
+    let _keyring_guard = KeyringCleanupGuard(APP_ID_INVALID);
     let (legacy_socket, http_socket) = unique_socket_paths("widget-invalid");
 
+    let (child, xdg_dirs) = spawn_daemon(&legacy_socket, &http_socket);
     let _guard = DaemonGuard {
-        child: spawn_daemon(&legacy_socket, &http_socket),
-        cleanup_paths: vec![legacy_socket.clone(), http_socket.clone()],
+        child,
+        cleanup_paths: [vec![legacy_socket.clone(), http_socket.clone()], xdg_dirs].concat(),
     };
     wait_for_daemon_ready(&http_socket).await;
 
@@ -330,11 +357,11 @@ async fn subscription_recovers_from_invalid_session() {
     // `events_stream` call will get 401 invalid_session; the helper
     // must `session::forget` and re-`obtain` (which under
     // SUPER_STT_AUTO_APPROVE returns a fresh real token).
-    session::save(TEST_APP_ID, "deadbeef_never_minted_by_daemon")
+    session::save(APP_ID_INVALID, "deadbeef_never_minted_by_daemon")
         .expect("plant fake token in keyring");
 
     let mut config =
-        WidgetSubscriptionConfig::new(TEST_APP_ID, TEST_APP_NAME, TEST_SCOPES, TEST_TOPICS);
+        WidgetSubscriptionConfig::new(_keyring_guard.0, TEST_APP_NAME, TEST_SCOPES, TEST_TOPICS);
     config.idle_timeout = Duration::from_secs(5);
 
     let mut stream: std::pin::Pin<

--- a/super-stt-daemon/tests/widget_smoke.rs
+++ b/super-stt-daemon/tests/widget_smoke.rs
@@ -11,6 +11,8 @@
 //! cargo test -p super-stt-daemon --test widget_smoke -- --nocapture
 //! ```
 
+mod common;
+
 use futures_util::StreamExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -48,8 +50,7 @@ impl DaemonGuard {
 
 impl Drop for DaemonGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        common::shutdown(&mut self.child);
         for p in &self.cleanup_paths {
             let _ = std::fs::remove_file(p);
         }


### PR DESCRIPTION
The `/v1` endpoints looked untested. Most of them were not — the coverage was being thrown away before it was ever written.

## The cause

Every test that spawns a real `super-stt-daemon` stopped it with `Child::kill`, which is `SIGKILL`. An instrumented binary writes its `.profraw` from an `atexit` hook, and nothing can handle `SIGKILL`, so the daemon's profile was never written.

Running `http_smoke` alone under coverage makes it plain: the test **passes** — mints a token, pings, reads status, transcribes, asserts the 401s — and the daemon reports `0.00% (0/18272 regions, 0/1624 functions)`. Not one line. That is why a 1229-line pipeline smoke test sat next to `pipeline/*.rs` at 0%.

## What turned up on the way

Three more bugs, each found by fixing the one before it:

- **No harness isolated `XDG_CACHE_HOME`.** Every test daemon shared one registry-index cache — the developer's real one. Concurrent tests overwrote each other's catalog, and a suite run left `~/.cache/super-stt/registry-index.json` holding the test fixture, pointing at a dead `127.0.0.1` asset URL.
- **`registry_http`'s two tests were `#[ignore]`d for a reason that had expired**, and were broken rather than merely skipped: one requested the wrong scope for its SSE topic (`403`), and both drained the stream with `collect()`, which never resolves on an endless stream — the 30s timeout discarded every buffered byte.
- **`widget_smoke`'s three were `#[ignore]`d for the same expired reason**, shared one `AppId` against a process-wide session cache (so the test that plants a dead token would hand it to whichever test looked next — masked by `--test-threads=1`), and had no `XDG_DATA_HOME`/`XDG_CACHE_HOME` isolation at all.

## Result

| | before | after |
|---|---|---|
| `ping`, `gpu_info`, `update`, `macros`, `settings/mod`, `registry/{mod,refresh}`, `pipeline/{mod,backend}`, `v1/mod` | 0–80% | **100%** |
| `registry/update` | 43% | **88%** |
| `wire` | 0% | **96%** |
| `pipeline/{language,device,stage,model}` | 0–5% | **92–95%** |
| `backends/{mod,options,secrets}` | 3–19% | **85–92%** |
| `widget_subscription` | 50% | **82%** |
| `events` | 2% | **77%** |
| `transcribe` | 3% | **52%** |
| workspace | — | **66.7% regions / 66.3% lines** |

New coverage where fixing the harness was not enough: the registry `refresh`/`preview`/`update` endpoints (including the Tier 1 #31 downgrade guard, which nothing tested), `/gpu_info`, and pre-captured transcription driven end to end through the real WASM host.

## Reading it

Seven commits, in dependency order — the cache fix is what makes the un-ignored registry tests pass, and the backend fixture builds on the shared `common/` module from the first. Each commit compiles and its tests pass.

**Note for whoever watches the badge:** coverage will jump in one step when this lands. That is the `SIGKILL` fix, not a sudden burst of testing.

Gates: `just fmt-check`, `just check`, `just test` (1351 passing, 0 failures), `just coverage` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeBbCJCZLLCTPDCF9yM4rv